### PR TITLE
 [MO] - [unit + integration co tests] -> method wide parallelism

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -216,7 +216,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     }
 
     @Override
-    public synchronized Future<KafkaStatus> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
+    public Future<KafkaStatus> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
         Promise<KafkaStatus> createOrUpdatePromise = Promise.promise();
         ReconciliationState reconcileState = createReconciliationState(reconciliation, kafkaAssembly);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -216,7 +216,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     }
 
     @Override
-    public Future<KafkaStatus> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
+    public synchronized Future<KafkaStatus> createOrUpdate(Reconciliation reconciliation, Kafka kafkaAssembly) {
         Promise<KafkaStatus> createOrUpdatePromise = Promise.promise();
         ReconciliationState reconcileState = createReconciliationState(reconciliation, kafkaAssembly);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -32,6 +32,8 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -41,7 +43,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
@@ -89,6 +90,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
+@ParallelSuite
 public class CertificateRenewalTest {
 
     public static final String NAMESPACE = "test";
@@ -250,7 +252,7 @@ public class CertificateRenewalTest {
     }
 
 
-    @Test
+    @ParallelTest
     public void testReconcileCasGeneratesCertsInitially(VertxTestContext context) {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
@@ -280,7 +282,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileCasWhenCustomCertsAreMissingThrows(VertxTestContext context) {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
                 .withValidityDays(100)
@@ -297,7 +299,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileCasNoCertsGetGeneratedOutsideRenewalPeriod(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         assertNoCertsGetGeneratedOutsideRenewalPeriod(context, true);
@@ -373,7 +375,7 @@ public class CertificateRenewalTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testGenerateTruststoreFromOldSecrets(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -449,7 +451,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testNewCertsGetGeneratedWhenInRenewalPeriodAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -534,7 +536,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoOutsideOfMaintenanceWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -635,7 +637,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testNewCertsGetGeneratedWhenInRenewalPeriodAutoWithinMaintenanceWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -735,7 +737,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testNewKeyGetGeneratedWhenInRenewalPeriodAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -838,7 +840,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testNewKeyGeneratedWhenInRenewalPeriodAutoOutsideOfTimeWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -938,7 +940,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testNewKeyGeneratedWhenInRenewalPeriodAutoWithinTimeWindow(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -1062,7 +1064,7 @@ public class CertificateRenewalTest {
                 .generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(newClusterCaCert)));
     }
 
-    @Test
+    @ParallelTest
     public void testExpiredCertsGetRemovedAuto(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -1158,7 +1160,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCustomCertsNotReconciled(VertxTestContext context)
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         CertificateAuthority certificateAuthority = new CertificateAuthorityBuilder()
@@ -1202,7 +1204,7 @@ public class CertificateRenewalTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testRenewalOfDeploymentCertificatesWithNullSecret() throws IOException {
         CertAndKey newCertAndKey = new CertAndKey("new-key".getBytes(), "new-cert".getBytes(), "new-truststore".getBytes(), "new-keystore".getBytes(), "new-password");
         ClusterCa clusterCaMock = mock(ClusterCa.class);
@@ -1224,7 +1226,7 @@ public class CertificateRenewalTest {
         assertThat(newSecret.getData(), hasEntry("deployment.password", newCertAndKey.storePasswordAsBase64String()));
     }
 
-    @Test
+    @ParallelTest
     public void testRenewalOfDeploymentCertificatesWithRenewingCa() throws IOException {
         Secret initialSecret = new SecretBuilder()
                 .withNewMetadata()
@@ -1258,7 +1260,7 @@ public class CertificateRenewalTest {
         assertThat(newSecret.getData(), hasEntry("deployment.password", newCertAndKey.storePasswordAsBase64String()));
     }
 
-    @Test
+    @ParallelTest
     public void testRenewalOfDeploymentCertificatesDelayedRenewal() throws IOException {
         Secret initialSecret = new SecretBuilder()
                 .withNewMetadata()
@@ -1292,7 +1294,7 @@ public class CertificateRenewalTest {
         assertThat(newSecret.getData(), hasEntry("deployment.password", newCertAndKey.storePasswordAsBase64String()));
     }
 
-    @Test
+    @ParallelTest
     public void testRenewalOfDeploymentCertificatesDelayedRenewalOutsideOfMaintenanceWindow() throws IOException {
         Secret initialSecret = new SecretBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -39,6 +39,8 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -444,7 +446,7 @@ public class ConnectorMockTest {
                 ConnectorMockTest.<KafkaConnector>statusIsForCurrentGeneration().and(notReady(reason, message)));
     }
 
-    @Test
+    @ParallelTest
     public void testConnectNotReadyWithoutSpec() {
         String connectName = "cluster";
         KafkaConnect connect = new KafkaConnectBuilder()
@@ -458,7 +460,7 @@ public class ConnectorMockTest {
         waitForConnectNotReady(connectName, "InvalidResourceException", "Spec cannot be null");
     }
 
-    @Test
+    @ParallelTest
     public void testConnectorNotReadyWithoutStrimziClusterLabel() {
         String connectorName = "connector";
 
@@ -476,7 +478,7 @@ public class ConnectorMockTest {
                 "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No connect cluster in which to create this connector.");
     }
 
-    @Test
+    @ParallelTest
     public void testConnectorNotReadyWhenConnectDoesNotExist() {
         String connectorName = "connector";
 
@@ -492,7 +494,7 @@ public class ConnectorMockTest {
                 "KafkaConnect resource 'cluster' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace ns.");
     }
 
-    @Test
+    @ParallelTest
     public void testConnectorNotReadyWithoutSpec() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -521,7 +523,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName, "InvalidResourceException", "spec property is required");
     }
 
-    @Test
+    @ParallelTest
     public void testConnectorNotReadyWhenConnectNotConfiguredForConnectors() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -552,7 +554,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, delete connector, delete connect */
-    @Test
+    @ParallelTest
     public void testConnectConnectorConnectorConnect() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -616,7 +618,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connector, create connect, delete connector, delete connect */
-    @Test
+    @IsolatedTest
     public void testConnectorConnectConnectorConnect() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -677,7 +679,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, delete connect, delete connector */
-    @Test
+    @ParallelTest
     public void testConnectConnectorConnectConnector() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -741,7 +743,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connector, create connect, delete connect, delete connector */
-    @Test
+    @ParallelTest
     public void testConnectorConnectConnectConnector() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -808,7 +810,7 @@ public class ConnectorMockTest {
      * check the connector is deleted from the old cluster
      * check the connector is added to the new cluster
      * */
-    @Test
+    @ParallelTest
     public void testChangeStrimziClusterLabel(VertxTestContext context) throws InterruptedException {
         String oldConnectClusterName = "cluster1";
         String newConnectClusterName = "cluster2";
@@ -900,7 +902,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, delete connector, delete connect */
-    @Test
+    @IsolatedTest
     public void testConnectorNotReadyWhenExceptionFromConnectRestApi() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -955,7 +957,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, pause connector, resume connector */
-    @Test
+    @ParallelTest
     public void testConnectorPauseResume() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1043,7 +1045,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, restart connector */
-    @Test
+    @ParallelTest
     public void testConnectorRestart() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1117,7 +1119,7 @@ public class ConnectorMockTest {
 
 
     /** Create connect, create connector, add restart annotation, fail to restart connector, check for condition */
-    @Test
+    @ParallelTest
     public void testConnectorRestartFail() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1195,7 +1197,7 @@ public class ConnectorMockTest {
 
 
     /** Create connect, create connector, restart connector task */
-    @Test
+    @ParallelTest
     public void testConnectorRestartTask() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1268,7 +1270,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, restart connector task */
-    @Test
+    @ParallelTest
     public void testConnectorRestartTaskFail() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1345,7 +1347,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, Scale to 0 */
-    @Test
+    @ParallelTest
     public void testConnectScaleToZero() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1411,7 +1413,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, break the REST API */
-    @Test
+    @ParallelTest
     public void testConnectRestAPIIssues() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1478,7 +1480,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName, "ConnectTimeoutException", "connection timed out");
     }
 
-    @Test
+    @ParallelTest
     public void testConnectorUnknownField() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1519,7 +1521,7 @@ public class ConnectorMockTest {
         waitForConnectorCondition(connectorName, "Warning", "UnknownFields");
     }
 
-    @Test
+    @ParallelTest
     public void testConnectorReconciliationPausedUnpaused() {
         String connectName = "cluster";
         String connectorName = "connector";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -52,7 +52,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -31,6 +31,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -40,7 +41,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
@@ -140,7 +140,7 @@ public class JbodStorageTest {
                 ResourceUtils.dummyClusterOperatorConfig(VERSIONS, 2_000));
     }
 
-    @Test
+    @ParallelTest
     public void testJbodStorageCreatesPersistentVolumeClaimsMatchingKafkaVolumes(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME))
@@ -174,7 +174,7 @@ public class JbodStorageTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileWithNewVolumeAddedToJbodStorage(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 
@@ -217,7 +217,7 @@ public class JbodStorageTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileWithVolumeRemovedFromJbodStorage(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 
@@ -255,7 +255,7 @@ public class JbodStorageTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileWithUpdateVolumeIdJbod(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -228,7 +229,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
                 .build();
     }
 
-    @Test
+    @ParallelTest
     public void testPodToRestartIsEmptyWhenCustomCertAnnotationsHaveMatchingThumbprints(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
@@ -243,7 +244,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testPodToRestartNonemptyWhenCustomCertTlsListenerThumbprintAnnotationsNotMatchingThumbprint(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
@@ -269,7 +270,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testPodToRestartTrueWhenCustomCertExternalListenerThumbprintAnnotationsNotMatchingThumbprint(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
@@ -296,7 +297,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testPodToRestartIsEmptyAndNoCustomCertAnnotationsWhenNoCustomCertificates(VertxTestContext context) {
         kafka = new KafkaBuilder(createKafka())
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -47,7 +47,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -77,7 +78,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testNoManualRollingUpdate(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -145,7 +146,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testStatefulSetManualRollingUpdate(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -231,7 +232,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testPodManualRollingUpdate(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -36,7 +36,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -69,6 +69,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,17 +100,6 @@ public class KafkaAssemblyOperatorMockTest {
     private static Vertx vertx;
 
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
-
-    private int zkReplicas;
-    private SingleVolumeStorage zkStorage;
-
-    private int kafkaReplicas;
-    private Storage kafkaStorage;
-
-    private ResourceRequirements resources;
-    private KubernetesClient client;
-
-    private KafkaAssemblyOperator operator;
 
     /*
      * Params contains the parameterized fields of different configurations of a Kafka and Zookeeper Strimzi cluster
@@ -198,17 +188,6 @@ public class KafkaAssemblyOperatorMockTest {
         return result;
     }
 
-    public void setFields(KafkaAssemblyOperatorMockTest.Params params) {
-        this.zkReplicas = params.zkReplicas;
-        this.zkStorage = params.zkStorage;
-
-        this.kafkaReplicas = params.kafkaReplicas;
-        this.kafkaStorage = params.kafkaStorage;
-
-        this.resources = params.resources;
-    }
-
-    private Kafka cluster;
 
     @BeforeAll
     public static void before() {
@@ -221,24 +200,59 @@ public class KafkaAssemblyOperatorMockTest {
         ResourceUtils.cleanUpTemporaryTLSFiles();
     }
 
+    class TestData {
+
+        private final String namespaceName;
+        private final String clusterName;
+        private final Kafka kafkaCluster;
+        private final KubernetesClient client;
+        private final KafkaAssemblyOperator operator;
+
+        public TestData(String namespaceName, String clusterName, Kafka kafkaCluster, KubernetesClient client, KafkaAssemblyOperator operator) {
+            this.namespaceName = namespaceName;
+            this.clusterName = clusterName;
+            this.kafkaCluster = kafkaCluster;
+            this.client = client;
+            this.operator = operator;
+        }
+
+        public Kafka getKafkaCluster() {
+            return kafkaCluster;
+        }
+        public KubernetesClient getClient() {
+            return client;
+        }
+        public KafkaAssemblyOperator getOperator() {
+            return operator;
+        }
+
+        public String getNamespaceName() {
+            return namespaceName;
+        }
+        public String getClusterName() {
+            return clusterName;
+        }
+    }
+
     /*
      * init is equivalent to a @BeforeEach method
      * since this is a parameterized set, the tests params are only available at test start
      * This must be called before each test
      */
-    private void init(Params params) {
-        setFields(params);
+    private TestData init(Params params) {
+        final String namespaceName = NAMESPACE + "-" + new Random().nextInt(Integer.MAX_VALUE);
+        final String clusterName = CLUSTER_NAME + "-" + new Random().nextInt(Integer.MAX_VALUE);
 
-        cluster = new KafkaBuilder()
+        Kafka cluster = new KafkaBuilder()
                 .withNewMetadata()
-                    .withName(CLUSTER_NAME)
-                    .withNamespace(NAMESPACE)
+                    .withName(clusterName)
+                    .withNamespace(namespaceName)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()
-                        .withReplicas(kafkaReplicas)
-                        .withStorage(kafkaStorage)
+                        .withReplicas(params.kafkaReplicas)
+                        .withStorage(params.kafkaStorage)
                         .withNewListeners()
                             .addNewGenericKafkaListener()
                                 .withName("plain")
@@ -254,11 +268,11 @@ public class KafkaAssemblyOperatorMockTest {
                             .endGenericKafkaListener()
                         .endListeners()
                         .withMetrics(singletonMap("foo", "bar"))
-                        .withResources(resources)
+                        .withResources(params.resources)
                     .endKafka()
                     .withNewZookeeper()
-                        .withReplicas(zkReplicas)
-                        .withStorage(zkStorage)
+                        .withReplicas(params.zkReplicas)
+                        .withStorage(params.zkStorage)
                         .withMetrics(singletonMap("foo", "bar"))
                     .endZookeeper()
                     .withNewEntityOperator()
@@ -272,20 +286,22 @@ public class KafkaAssemblyOperatorMockTest {
 
         CustomResourceDefinition kafkaAssemblyCrd = Crds.kafka();
 
-        client = new MockKube()
+        KubernetesClient client = new MockKube()
                 .withCustomResourceDefinition(kafkaAssemblyCrd, Kafka.class, KafkaList.class)
                     .withInitialInstances(Collections.singleton(cluster))
                 .end()
                 .build();
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, kubernetesVersion);
-        ResourceOperatorSupplier supplier = supplierWithMocks();
+        ResourceOperatorSupplier supplier = supplierWithMocks(client);
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
-        operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(),
+        KafkaAssemblyOperator operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(),
                 new PasswordGenerator(10, "a", "a"), supplier, config);
+
+        return new TestData(namespaceName, clusterName, cluster, client, operator);
     }
 
-    private ResourceOperatorSupplier supplierWithMocks() {
+    private ResourceOperatorSupplier supplierWithMocks(KubernetesClient client) {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, client);
         return new ResourceOperatorSupplier(vertx, client, leaderFinder,
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
@@ -293,27 +309,28 @@ public class KafkaAssemblyOperatorMockTest {
                 2_000);
     }
 
-    private void assertResourceRequirements(VertxTestContext context, String statefulSetName) {
+    private void assertResourceRequirements(VertxTestContext context, String statefulSetName, TestData testData, Params params) {
         context.verify(() -> {
-            StatefulSet statefulSet = client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+            StatefulSet statefulSet = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSetName).get();
             assertThat(statefulSet, is(notNullValue()));
             ResourceRequirements requirements = statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getResources();
-            if (resources != null && resources.getRequests() != null) {
-                assertThat(requirements.getRequests(), hasEntry("cpu", resources.getRequests().get("cpu")));
-                assertThat(requirements.getRequests(), hasEntry("memory", resources.getRequests().get("memory")));
+            if (params.resources != null && params.resources.getRequests() != null) {
+                assertThat(requirements.getRequests(), hasEntry("cpu", params.resources.getRequests().get("cpu")));
+                assertThat(requirements.getRequests(), hasEntry("memory", params.resources.getRequests().get("memory")));
             }
-            if (resources != null && resources.getLimits() != null) {
-                assertThat(requirements.getLimits(), hasEntry("cpu", resources.getLimits().get("cpu")));
-                assertThat(requirements.getLimits(), hasEntry("memory", resources.getLimits().get("memory")));
+            if (params.resources != null && params.resources.getLimits() != null) {
+                assertThat(requirements.getLimits(), hasEntry("cpu", params.resources.getLimits().get("cpu")));
+                assertThat(requirements.getLimits(), hasEntry("memory", params.resources.getLimits().get("memory")));
             }
         });
     }
 
-    private Future<Void> initialReconcile(VertxTestContext context) {
+    private Future<Void> initialReconcile(VertxTestContext context, TestData testData, Params params) {
         LOGGER.info("Reconciling initially -> create");
-        return operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
+
+        return testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                StatefulSet kafkaSts = client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get();
+                StatefulSet kafkaSts = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.kafkaClusterName(testData.getClusterName())).get();
                 kafkaSts.setStatus(new StatefulSetStatus());
 
                 assertThat(kafkaSts, is(notNullValue()));
@@ -321,69 +338,75 @@ public class KafkaAssemblyOperatorMockTest {
                 assertThat(kafkaSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
                 assertThat(kafkaSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
 
-                StatefulSet zkSts = client.apps().statefulSets().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME)).get();
+                StatefulSet zkSts = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(ZookeeperCluster.zookeeperClusterName(testData.getClusterName())).get();
                 assertThat(zkSts, is(notNullValue()));
                 assertThat(zkSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "0"));
                 assertThat(zkSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
 
-                assertThat(client.configMaps().inNamespace(NAMESPACE).withName(KafkaCluster.metricAndLogConfigsName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.configMaps().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperMetricAndLogConfigsName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertResourceRequirements(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaKeySecretName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clientsCaCertSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
+                assertThat(testData.getClient().configMaps().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.metricAndLogConfigsName(testData.getClusterName())).get(), is(notNullValue()));
+                assertThat(testData.getClient().configMaps().inNamespace(testData.getNamespaceName()).withName(ZookeeperCluster.zookeeperMetricAndLogConfigsName(testData.getClusterName())).get(), is(notNullValue()));
+                assertResourceRequirements(context, KafkaCluster.kafkaClusterName(testData.getClusterName()), testData, params);
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.clientsCaKeySecretName(testData.getClusterName())).get(), is(notNullValue()));
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.clientsCaCertSecretName(testData.getClusterName())).get(), is(notNullValue()));
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.clusterCaCertSecretName(testData.getClusterName())).get(), is(notNullValue()));
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.brokersSecretName(testData.getClusterName())).get(), is(notNullValue()));
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(ZookeeperCluster.nodesSecretName(testData.getClusterName())).get(), is(notNullValue()));
             })));
+    }
+
+    private void createKafkaCluster() {
+
     }
 
     /** Create a cluster from a Kafka */
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcile(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         Checkpoint async = context.checkpoint();
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding())
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> async.flag()));
     }
 
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesAllDeletedSecrets(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         initialReconcileThenDeleteSecretsThenReconcile(context,
-                KafkaCluster.clientsCaKeySecretName(CLUSTER_NAME),
-                KafkaCluster.clientsCaCertSecretName(CLUSTER_NAME),
-                KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME),
-                KafkaCluster.brokersSecretName(CLUSTER_NAME),
-                ZookeeperCluster.nodesSecretName(CLUSTER_NAME),
-                ClusterOperator.secretName(CLUSTER_NAME));
+                testData,
+                params,
+                KafkaCluster.clientsCaKeySecretName(testData.getClusterName()),
+                KafkaCluster.clientsCaCertSecretName(testData.getClusterName()),
+                KafkaCluster.clusterCaCertSecretName(testData.getClusterName()),
+                KafkaCluster.brokersSecretName(testData.getClusterName()),
+                ZookeeperCluster.nodesSecretName(testData.getClusterName()),
+                ClusterOperator.secretName(testData.getClusterName()));
     }
 
     /**
      * Test the operator re-creates secrets if they get deleted
      */
-    private void initialReconcileThenDeleteSecretsThenReconcile(VertxTestContext context, String... secrets) {
+    private void initialReconcileThenDeleteSecretsThenReconcile(VertxTestContext context, TestData testData, Params params, String... secrets) {
         Checkpoint async = context.checkpoint();
 
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 for (String secret: secrets) {
-                    client.secrets().inNamespace(NAMESPACE).withName(secret).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                    testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(secret).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                     assertThat("Expected secret " + secret + " to not exist",
-                            client.secrets().inNamespace(NAMESPACE).withName(secret).get(), is(nullValue()));
+                            testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(secret).get(), is(nullValue()));
                 }
                 LOGGER.info("Reconciling again -> update");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 for (String secret: secrets) {
                     assertThat("Expected secret " + secret + " to have been recreated",
-                            client.secrets().inNamespace(NAMESPACE).withName(secret).get(), is(notNullValue()));
+                            testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(secret).get(), is(notNullValue()));
                 }
                 async.flag();
             })));
@@ -392,23 +415,23 @@ public class KafkaAssemblyOperatorMockTest {
     /**
      * Test the operator re-creates services if they get deleted
      */
-    private void initialReconcileThenDeleteServicesThenReconcile(VertxTestContext context, String... services) {
+    private void initialReconcileThenDeleteServicesThenReconcile(VertxTestContext context, TestData testData, Params params, String... services) {
         Checkpoint async = context.checkpoint();
 
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 for (String service : services) {
-                    client.services().inNamespace(NAMESPACE).withName(service).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                    testData.getClient().services().inNamespace(testData.getNamespaceName()).withName(service).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                     assertThat("Expected service " + service + " to be not exist",
-                            client.services().inNamespace(NAMESPACE).withName(service).get(), is(nullValue()));
+                            testData.getClient().services().inNamespace(testData.getNamespaceName()).withName(service).get(), is(nullValue()));
                 }
                 LOGGER.info("Reconciling again -> update");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 for (String service: services) {
                     assertThat("Expected service " + service + " to have been recreated",
-                            client.services().inNamespace(NAMESPACE).withName(service).get(), is(notNullValue()));
+                            testData.getClient().services().inNamespace(testData.getNamespaceName()).withName(service).get(), is(notNullValue()));
                 }
                 async.flag();
             })));
@@ -417,56 +440,60 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedZookeeperServices(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         initialReconcileThenDeleteServicesThenReconcile(context,
-                ZookeeperCluster.serviceName(CLUSTER_NAME),
-                ZookeeperCluster.headlessServiceName(CLUSTER_NAME));
+                testData,
+                params,
+                ZookeeperCluster.serviceName(testData.getClusterName()),
+                ZookeeperCluster.headlessServiceName(testData.getClusterName()));
     }
 
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedKafkaServices(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         initialReconcileThenDeleteServicesThenReconcile(context,
-                KafkaCluster.serviceName(CLUSTER_NAME),
-                KafkaCluster.headlessServiceName(CLUSTER_NAME));
+                testData,
+                params,
+                KafkaCluster.serviceName(testData.getClusterName()),
+                KafkaCluster.headlessServiceName(testData.getClusterName()));
     }
 
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedZookeeperStatefulSet(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
-        String statefulSet = ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME);
-        initialReconcileThenDeleteStatefulSetsThenReconcile(context, statefulSet);
+        String statefulSet = ZookeeperCluster.zookeeperClusterName(testData.getClusterName());
+        initialReconcileThenDeleteStatefulSetsThenReconcile(context, statefulSet, testData, params);
     }
 
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedKafkaStatefulSet(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
-        String statefulSet = KafkaCluster.kafkaClusterName(CLUSTER_NAME);
-        initialReconcileThenDeleteStatefulSetsThenReconcile(context, statefulSet);
+        String statefulSet = KafkaCluster.kafkaClusterName(testData.getClusterName());
+        initialReconcileThenDeleteStatefulSetsThenReconcile(context, statefulSet, testData, params);
     }
 
-    private void initialReconcileThenDeleteStatefulSetsThenReconcile(VertxTestContext context, String statefulSet) {
+    private void initialReconcileThenDeleteStatefulSetsThenReconcile(VertxTestContext context, String statefulSet, TestData testData, Params params) {
         Checkpoint async = context.checkpoint();
 
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSet).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                 assertThat("Expected sts " + statefulSet + " should not exist",
-                        client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).get(), is(nullValue()));
+                        testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSet).get(), is(nullValue()));
 
                 LOGGER.info("Reconciling again -> update");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("Expected sts " + statefulSet + " should have been re-created",
-                        client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSet).get(), is(notNullValue()));
+                        testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSet).get(), is(notNullValue()));
                 async.flag();
             })));
     }
@@ -474,20 +501,20 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileUpdatesKafkaPersistentVolumes(Params params, VertxTestContext context) {
-        init(params);
-        assumeTrue(kafkaStorage instanceof PersistentClaimStorage, "Parameterized Test only runs for Params with Kafka Persistent storage");
+        TestData testData = init(params);
+        assumeTrue(params.kafkaStorage instanceof PersistentClaimStorage, "Parameterized Test only runs for Params with Kafka Persistent storage");
 
-        String originalStorageClass = Storage.storageClass(kafkaStorage);
+        String originalStorageClass = Storage.storageClass(params.kafkaStorage);
 
         Checkpoint async = context.checkpoint();
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertStorageClass(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalStorageClass);
+                assertStorageClass(context, KafkaCluster.kafkaClusterName(testData.getClusterName()), originalStorageClass, testData);
 
                 // Try to update the storage class
                 String changedClass = originalStorageClass + "2";
 
-                Kafka patchedPersistenceKafka = new KafkaBuilder(cluster)
+                Kafka patchedPersistenceKafka = new KafkaBuilder(testData.getKafkaCluster())
                         .editSpec()
                             .editKafka()
                                 .withNewPersistentClaimStorage()
@@ -497,26 +524,26 @@ public class KafkaAssemblyOperatorMockTest {
                             .endKafka()
                         .endSpec()
                         .build();
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(patchedPersistenceKafka);
+                kafkaAssembly(testData).patch(patchedPersistenceKafka);
 
                 LOGGER.info("Updating with changed storage class");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Check the storage class was not changed
-                assertStorageClass(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalStorageClass);
+                assertStorageClass(context, KafkaCluster.kafkaClusterName(testData.getClusterName()), originalStorageClass, testData);
                 async.flag();
             })));
     }
 
-    private Resource<Kafka> kafkaAssembly(String namespace, String name) {
-        CustomResourceDefinition crd = client.apiextensions().v1().customResourceDefinitions().withName(Kafka.CRD_NAME).get();
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd), Kafka.class, KafkaList.class)
-                .inNamespace(namespace).withName(name);
+    private Resource<Kafka> kafkaAssembly(TestData testData) {
+        CustomResourceDefinition crd = testData.getClient().apiextensions().v1().customResourceDefinitions().withName(Kafka.CRD_NAME).get();
+        return testData.getClient().customResources(CustomResourceDefinitionContext.fromCrd(crd), Kafka.class, KafkaList.class)
+                .inNamespace(testData.getNamespaceName()).withName(testData.getClusterName());
     }
 
-    private void assertStorageClass(VertxTestContext context, String statefulSetName, String expectedClass) {
-        StatefulSet statefulSet = client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+    private void assertStorageClass(VertxTestContext context, String statefulSetName, String expectedClass, TestData testData) {
+        StatefulSet statefulSet = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSetName).get();
         context.verify(() -> {
             assertThat(statefulSet, is(notNullValue()));
             // Check the storage class is initially "foo"
@@ -529,26 +556,26 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileUpdatesKafkaStorageType(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         AtomicReference<List<PersistentVolumeClaim>> originalPVCs = new AtomicReference<>();
         AtomicReference<List<Volume>> originalVolumes = new AtomicReference<>();
         AtomicReference<List<Container>> originalInitContainers = new AtomicReference<>();
 
         Checkpoint async = context.checkpoint();
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                originalPVCs.set(Optional.ofNullable(client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get())
+                originalPVCs.set(Optional.ofNullable(testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.kafkaClusterName(testData.getClusterName())).get())
                         .map(StatefulSet::getSpec)
                         .map(StatefulSetSpec::getVolumeClaimTemplates)
                         .orElse(new ArrayList<>()));
-                originalVolumes.set(Optional.ofNullable(client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get())
+                originalVolumes.set(Optional.ofNullable(testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.kafkaClusterName(testData.getClusterName())).get())
                         .map(StatefulSet::getSpec)
                         .map(StatefulSetSpec::getTemplate)
                         .map(PodTemplateSpec::getSpec)
                         .map(PodSpec::getVolumes)
                         .orElse(new ArrayList<>()));
-                originalInitContainers.set(Optional.ofNullable(client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get())
+                originalInitContainers.set(Optional.ofNullable(testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.kafkaClusterName(testData.getClusterName())).get())
                         .map(StatefulSet::getSpec)
                         .map(StatefulSetSpec::getTemplate)
                         .map(PodTemplateSpec::getSpec)
@@ -560,8 +587,8 @@ public class KafkaAssemblyOperatorMockTest {
                 // or
                 // persistent -> ephemeral
                 Kafka updatedStorageKafka = null;
-                if (kafkaStorage instanceof EphemeralStorage) {
-                    updatedStorageKafka = new KafkaBuilder(cluster)
+                if (params.kafkaStorage instanceof EphemeralStorage) {
+                    updatedStorageKafka = new KafkaBuilder(testData.getKafkaCluster())
                             .editSpec()
                                 .editKafka()
                                     .withNewPersistentClaimStorage()
@@ -570,8 +597,8 @@ public class KafkaAssemblyOperatorMockTest {
                                 .endKafka()
                             .endSpec()
                             .build();
-                } else if (kafkaStorage instanceof PersistentClaimStorage) {
-                    updatedStorageKafka = new KafkaBuilder(cluster)
+                } else if (params.kafkaStorage instanceof PersistentClaimStorage) {
+                    updatedStorageKafka = new KafkaBuilder(testData.getKafkaCluster())
                             .editSpec()
                                 .editKafka()
                                     .withNewEphemeralStorage()
@@ -582,23 +609,23 @@ public class KafkaAssemblyOperatorMockTest {
                 } else {
                     context.failNow(new Exception("If storage is not ephemeral or persistent something has gone wrong"));
                 }
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(updatedStorageKafka);
+                kafkaAssembly(testData).patch(updatedStorageKafka);
 
                 LOGGER.info("Updating with changed storage type");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Check the Volumes and PVCs were not changed
-                assertPVCs(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalPVCs.get());
-                assertVolumes(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalVolumes.get());
-                assertInitContainers(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalInitContainers.get());
+                assertPVCs(context, KafkaCluster.kafkaClusterName(testData.getClusterName()), originalPVCs.get(), testData);
+                assertVolumes(context, KafkaCluster.kafkaClusterName(testData.getClusterName()), originalVolumes.get(), testData);
+                assertInitContainers(context, KafkaCluster.kafkaClusterName(testData.getClusterName()), originalInitContainers.get(), testData);
                 async.flag();
             })));
     }
 
-    private void assertPVCs(VertxTestContext context, String statefulSetName, List<PersistentVolumeClaim> originalPVCs) {
+    private void assertPVCs(VertxTestContext context, String statefulSetName, List<PersistentVolumeClaim> originalPVCs, TestData testData) {
         context.verify(() -> {
-            StatefulSet statefulSet = client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+            StatefulSet statefulSet = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSetName).get();
             assertThat(statefulSet, is(notNullValue()));
             List<PersistentVolumeClaim> pvcs = statefulSet.getSpec().getVolumeClaimTemplates();
             assertThat(originalPVCs.size(), is(pvcs.size()));
@@ -607,9 +634,9 @@ public class KafkaAssemblyOperatorMockTest {
 
     }
 
-    private void assertVolumes(VertxTestContext context, String statefulSetName, List<Volume> originalVolumes) {
+    private void assertVolumes(VertxTestContext context, String statefulSetName, List<Volume> originalVolumes, TestData testData) {
         context.verify(() -> {
-            StatefulSet statefulSet = client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+            StatefulSet statefulSet = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSetName).get();
             assertThat(statefulSet, is(notNullValue()));
             List<Volume> volumes = statefulSet.getSpec().getTemplate().getSpec().getVolumes();
             assertThat(originalVolumes.size(), is(volumes.size()));
@@ -617,9 +644,9 @@ public class KafkaAssemblyOperatorMockTest {
         });
     }
 
-    private void assertInitContainers(VertxTestContext context, String statefulSetName, List<Container> originalInitContainers) {
+    private void assertInitContainers(VertxTestContext context, String statefulSetName, List<Container> originalInitContainers, TestData testData) {
         context.verify(() -> {
-            StatefulSet statefulSet = client.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+            StatefulSet statefulSet = testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(statefulSetName).get();
             assertThat(statefulSet, is(notNullValue()));
             List<Container> initContainers = statefulSet.getSpec().getTemplate().getSpec().getInitContainers();
             assertThat(originalInitContainers.size(), is(initContainers.size()));
@@ -632,18 +659,18 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileUpdatesKafkaWithChangedDeleteClaim(Params params, VertxTestContext context) {
-        init(params);
-        assumeTrue(kafkaStorage instanceof PersistentClaimStorage, "Kafka delete claims do not apply to non-persistent volumes");
+        TestData testData = init(params);
+        assumeTrue(params.kafkaStorage instanceof PersistentClaimStorage, "Kafka delete claims do not apply to non-persistent volumes");
 
         Map<String, String> kafkaLabels = new HashMap<>();
         kafkaLabels.put(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
-        kafkaLabels.put(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME);
-        kafkaLabels.put(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
+        kafkaLabels.put(Labels.STRIMZI_CLUSTER_LABEL, testData.getClusterName());
+        kafkaLabels.put(Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(testData.getClusterName()));
 
         Map<String, String> zkLabels = new HashMap<>();
         zkLabels.put(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
-        zkLabels.put(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME);
-        zkLabels.put(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME));
+        zkLabels.put(Labels.STRIMZI_CLUSTER_LABEL, testData.getClusterName());
+        zkLabels.put(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(testData.getClusterName()));
 
         AtomicReference<Set<String>> kafkaPvcs = new AtomicReference<>();
         AtomicReference<Set<String>> zkPvcs = new AtomicReference<>();
@@ -652,42 +679,42 @@ public class KafkaAssemblyOperatorMockTest {
 
         Checkpoint async = context.checkpoint();
 
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                kafkaPvcs.set(client.persistentVolumeClaims().inNamespace(NAMESPACE).withLabels(kafkaLabels).list().getItems()
+                kafkaPvcs.set(testData.getClient().persistentVolumeClaims().inNamespace(testData.getNamespaceName()).withLabels(kafkaLabels).list().getItems()
                         .stream()
                         .map(pvc -> pvc.getMetadata().getName())
                         .collect(Collectors.toSet()));
 
-                zkPvcs.set(client.persistentVolumeClaims().inNamespace(NAMESPACE).withLabels(zkLabels).list().getItems()
+                zkPvcs.set(testData.getClient().persistentVolumeClaims().inNamespace(testData.getNamespaceName()).withLabels(zkLabels).list().getItems()
                         .stream()
                         .map(pvc -> pvc.getMetadata().getName())
                         .collect(Collectors.toSet()));
 
-                originalKafkaDeleteClaim.set(deleteClaim(kafkaStorage));
+                originalKafkaDeleteClaim.set(deleteClaim(params.kafkaStorage));
 
                 // Try to update the storage class
-                Kafka updatedStorageKafka = new KafkaBuilder(cluster).editSpec().editKafka()
+                Kafka updatedStorageKafka = new KafkaBuilder(testData.getKafkaCluster()).editSpec().editKafka()
                         .withNewPersistentClaimStorage()
                         .withSize("123")
                         .withStorageClass("foo")
                         .withDeleteClaim(!originalKafkaDeleteClaim.get())
                         .endPersistentClaimStorage().endKafka().endSpec().build();
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(updatedStorageKafka);
+                kafkaAssembly(testData).patch(updatedStorageKafka);
                 LOGGER.info("Updating with changed delete claim");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // check that the new delete-claim annotation is on the PVCs
                 for (String pvcName: kafkaPvcs.get()) {
-                    assertThat(client.persistentVolumeClaims().inNamespace(NAMESPACE).withName(pvcName).get()
+                    assertThat(testData.getClient().persistentVolumeClaims().inNamespace(testData.getNamespaceName()).withName(pvcName).get()
                                     .getMetadata().getAnnotations(),
                             hasEntry(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM, String.valueOf(!originalKafkaDeleteClaim.get())));
                 }
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+                kafkaAssembly(testData).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                 LOGGER.info("Reconciling again -> delete");
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> async.flag()));
     }
 
@@ -695,46 +722,46 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileKafkaScaleDown(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
-        assumeTrue(kafkaReplicas > 1, "Skipping scale down test because there's only 1 broker");
+        assumeTrue(params.kafkaReplicas > 1, "Skipping scale down test because there's only 1 broker");
 
-        int scaleDownTo = kafkaReplicas - 1;
+        int scaleDownTo = params.kafkaReplicas - 1;
         // final ordinal will be deleted
-        String deletedPod = KafkaCluster.kafkaPodName(CLUSTER_NAME, scaleDownTo);
+        String deletedPod = KafkaCluster.kafkaPodName(testData.getClusterName(), scaleDownTo);
 
         AtomicInteger brokersInternalCertsCount = new AtomicInteger();
 
         Checkpoint async = context.checkpoint();
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                brokersInternalCertsCount.set(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get()
+                brokersInternalCertsCount.set(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.brokersSecretName(testData.getClusterName())).get()
                         .getData()
                         .size());
 
-                assertThat(client.pods().inNamespace(NAMESPACE).withName(deletedPod).get(), is(notNullValue()));
+                assertThat(testData.getClient().pods().inNamespace(testData.getNamespaceName()).withName(deletedPod).get(), is(notNullValue()));
 
-                Kafka scaledDownCluster = new KafkaBuilder(cluster)
+                Kafka scaledDownCluster = new KafkaBuilder(testData.getKafkaCluster())
                         .editSpec()
                             .editKafka()
                                 .withReplicas(scaleDownTo)
                             .endKafka()
                         .endSpec()
                         .build();
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(scaledDownCluster);
+                kafkaAssembly(testData).patch(scaledDownCluster);
 
                 LOGGER.info("Scaling down to {} Kafka pods", scaleDownTo);
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get().getSpec().getReplicas(),
+                assertThat(testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.kafkaClusterName(testData.getClusterName())).get().getSpec().getReplicas(),
                         is(scaleDownTo));
                 assertThat("Expected pod " + deletedPod + " to have been deleted",
-                        client.pods().inNamespace(NAMESPACE).withName(deletedPod).get(),
+                        testData.getClient().pods().inNamespace(testData.getNamespaceName()).withName(deletedPod).get(),
                         is(nullValue()));
 
                 // removing one pod, the related private and public keys, keystore and password (4 entries) should not be in the Secrets
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get()
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.brokersSecretName(testData.getClusterName())).get()
                                 .getData(),
                         aMapWithSize(brokersInternalCertsCount.get() - 4));
 
@@ -747,43 +774,43 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileKafkaScaleUp(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         AtomicInteger brokersInternalCertsCount = new AtomicInteger();
 
         Checkpoint async = context.checkpoint();
-        int scaleUpTo = kafkaReplicas + 1;
-        String newPod = KafkaCluster.kafkaPodName(CLUSTER_NAME, kafkaReplicas);
+        int scaleUpTo = params.kafkaReplicas + 1;
+        String newPod = KafkaCluster.kafkaPodName(testData.getClusterName(), params.kafkaReplicas);
 
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                brokersInternalCertsCount.set(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get()
+                brokersInternalCertsCount.set(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.brokersSecretName(testData.getClusterName())).get()
                         .getData()
                         .size());
 
-                assertThat(client.pods().inNamespace(NAMESPACE).withName(newPod).get(), is(nullValue()));
+                assertThat(testData.getClient().pods().inNamespace(testData.getNamespaceName()).withName(newPod).get(), is(nullValue()));
 
-                Kafka scaledUpKafka = new KafkaBuilder(cluster)
+                Kafka scaledUpKafka = new KafkaBuilder(testData.getKafkaCluster())
                         .editSpec()
                             .editKafka()
                                 .withReplicas(scaleUpTo)
                             .endKafka()
                         .endSpec()
                         .build();
-                kafkaAssembly(NAMESPACE, CLUSTER_NAME).patch(scaledUpKafka);
+                kafkaAssembly(testData).patch(scaledUpKafka);
 
                 LOGGER.info("Scaling up to {} Kafka pods", scaleUpTo);
             })))
-            .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
+            .compose(v -> testData.getOperator().reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName())))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get().getSpec().getReplicas(),
+                assertThat(testData.getClient().apps().statefulSets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.kafkaClusterName(testData.getClusterName())).get().getSpec().getReplicas(),
                         is(scaleUpTo));
                 assertThat("Expected pod " + newPod + " to have been created",
-                        client.pods().inNamespace(NAMESPACE).withName(newPod).get(),
+                        testData.getClient().pods().inNamespace(testData.getNamespaceName()).withName(newPod).get(),
                         is(notNullValue()));
 
                 // adding one pod, the related private and public keys, keystore and password should be added to the Secrets
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get().getData(),
+                assertThat(testData.getClient().secrets().inNamespace(testData.getNamespaceName()).withName(KafkaCluster.brokersSecretName(testData.getClusterName())).get().getData(),
                         aMapWithSize(brokersInternalCertsCount.get() + 4));
 
                 // TODO assert no rolling update
@@ -794,15 +821,15 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileResumePartialRoll(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         Checkpoint async = context.checkpoint();
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(v -> async.flag());
     }
 
     /** Test the ZK version change functions */
-    private void reconcileZkVersionChange(VertxTestContext context, String initialKafkaVersion, String changedKafkaVersion, String changedImage) {
+    private void reconcileZkVersionChange(VertxTestContext context, String initialKafkaVersion, String changedKafkaVersion, String changedImage, TestData testData, Params params) {
         // We set the versions in the initial cluster to allow downgrades / upgrades
         KafkaVersion lowerVersion = KafkaVersion.compareDottedVersions(initialKafkaVersion, changedKafkaVersion) > 0 ? VERSIONS.version(changedKafkaVersion) : VERSIONS.version(initialKafkaVersion);
 
@@ -810,11 +837,11 @@ public class KafkaAssemblyOperatorMockTest {
         config.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, lowerVersion.messageVersion());
         config.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, lowerVersion.protocolVersion());
 
-        cluster.getSpec().getKafka().setConfig(config);
-        cluster.getSpec().getKafka().setVersion(initialKafkaVersion);
+        testData.getKafkaCluster().getSpec().getKafka().setConfig(config);
+        testData.getKafkaCluster().getSpec().getKafka().setVersion(initialKafkaVersion);
 
         // We prepare updated Kafka with new version
-        Kafka updatedKafka = new KafkaBuilder(cluster)
+        Kafka updatedKafka = new KafkaBuilder(testData.getKafkaCluster())
                 .editSpec()
                     .editKafka()
                         .withVersion(changedKafkaVersion)
@@ -822,11 +849,11 @@ public class KafkaAssemblyOperatorMockTest {
                 .endSpec()
                 .build();
 
-        KafkaAssemblyOperator.ReconciliationState initialState = operator.new ReconciliationState(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
+        KafkaAssemblyOperator.ReconciliationState initialState = testData.getOperator().new ReconciliationState(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, testData.getNamespaceName(), testData.getClusterName()),
                 updatedKafka);
 
         Checkpoint async = context.checkpoint();
-        initialReconcile(context)
+        initialReconcile(context, testData, params)
             .onComplete(context.succeeding())
             .compose(v -> initialState.getKafkaClusterDescription())
             .compose(v -> initialState.prepareVersionChange())
@@ -841,24 +868,24 @@ public class KafkaAssemblyOperatorMockTest {
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileZookeeperUpgradeFromPreviousToLatest(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         String initialKafkaVersion = KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION;
         String changedKafkaVersion = KafkaVersionTestUtils.LATEST_KAFKA_VERSION;
         String changedImage = KafkaVersionTestUtils.LATEST_KAFKA_IMAGE;
 
-        reconcileZkVersionChange(context, initialKafkaVersion, changedKafkaVersion, changedImage);
+        reconcileZkVersionChange(context, initialKafkaVersion, changedKafkaVersion, changedImage, testData, params);
     }
 
     @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileZookeeperDowngradeFromLatestToPrevious(Params params, VertxTestContext context) {
-        init(params);
+        TestData testData = init(params);
 
         String initialKafkaVersion = KafkaVersionTestUtils.LATEST_KAFKA_VERSION;
         String changedKafkaVersion = KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION;
         String changedImage = KafkaVersionTestUtils.PREVIOUS_KAFKA_IMAGE;
 
-        reconcileZkVersionChange(context, initialKafkaVersion, changedKafkaVersion, changedImage);
+        reconcileZkVersionChange(context, initialKafkaVersion, changedKafkaVersion, changedImage, testData, params);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -49,6 +49,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.ParallelParametrizedTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -60,7 +61,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
@@ -338,7 +338,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Create a cluster from a Kafka */
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcile(Params params, VertxTestContext context) {
         init(params);
@@ -350,7 +350,7 @@ public class KafkaAssemblyOperatorMockTest {
             .onComplete(context.succeeding(v -> async.flag()));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesAllDeletedSecrets(Params params, VertxTestContext context) {
         init(params);
@@ -414,7 +414,7 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedZookeeperServices(Params params, VertxTestContext context) {
         init(params);
@@ -424,7 +424,7 @@ public class KafkaAssemblyOperatorMockTest {
                 ZookeeperCluster.headlessServiceName(CLUSTER_NAME));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedKafkaServices(Params params, VertxTestContext context) {
         init(params);
@@ -434,7 +434,7 @@ public class KafkaAssemblyOperatorMockTest {
                 KafkaCluster.headlessServiceName(CLUSTER_NAME));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedZookeeperStatefulSet(Params params, VertxTestContext context) {
         init(params);
@@ -443,7 +443,7 @@ public class KafkaAssemblyOperatorMockTest {
         initialReconcileThenDeleteStatefulSetsThenReconcile(context, statefulSet);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileReplacesDeletedKafkaStatefulSet(Params params, VertxTestContext context) {
         init(params);
@@ -471,7 +471,7 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileUpdatesKafkaPersistentVolumes(Params params, VertxTestContext context) {
         init(params);
@@ -526,7 +526,7 @@ public class KafkaAssemblyOperatorMockTest {
         });
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileUpdatesKafkaStorageType(Params params, VertxTestContext context) {
         init(params);
@@ -629,7 +629,7 @@ public class KafkaAssemblyOperatorMockTest {
 
 
     /** Test that we can change the deleteClaim flag, and that it's honoured */
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileUpdatesKafkaWithChangedDeleteClaim(Params params, VertxTestContext context) {
         init(params);
@@ -692,7 +692,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Create a cluster from a Kafka Cluster CM */
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileKafkaScaleDown(Params params, VertxTestContext context) {
         init(params);
@@ -744,7 +744,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Create a cluster from a Kafka Cluster CM */
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileKafkaScaleUp(Params params, VertxTestContext context) {
         init(params);
@@ -791,7 +791,7 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileResumePartialRoll(Params params, VertxTestContext context) {
         init(params);
@@ -838,7 +838,7 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileZookeeperUpgradeFromPreviousToLatest(Params params, VertxTestContext context) {
         init(params);
@@ -850,7 +850,7 @@ public class KafkaAssemblyOperatorMockTest {
         reconcileZkVersionChange(context, initialKafkaVersion, changedKafkaVersion, changedImage);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testReconcileZookeeperDowngradeFromLatestToPrevious(Params params, VertxTestContext context) {
         init(params);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -44,7 +44,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -36,6 +36,7 @@ import io.strimzi.operator.common.operator.resource.IngressV1Beta1Operator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -94,7 +95,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testCustomLabelsAndAnnotations(VertxTestContext context) {
         Map<String, String> labels = new HashMap<>(2);
         labels.put("label1", "value1");
@@ -179,7 +180,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testClusterCASecretsWithoutOwnerReference(VertxTestContext context) {
         OwnerReference ownerReference = new OwnerReferenceBuilder()
                         .withKind("Kafka")
@@ -253,7 +254,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testClientsCASecretsWithoutOwnerReference(VertxTestContext context) {
         OwnerReference ownerReference = new OwnerReferenceBuilder()
                         .withKind("Kafka")
@@ -327,7 +328,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testDeleteClusterRoleBindings(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
         ClusterRoleBindingOperator mockCrbOps = supplier.clusterRoleBindingOperator;
@@ -349,7 +350,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testSelectorLabels(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -418,7 +419,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressV1Beta1(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -509,7 +510,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testIngressV1(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorRbacScopeTest.java
@@ -25,6 +25,7 @@ import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.RoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.RoleOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -35,7 +36,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
@@ -108,7 +108,7 @@ public class KafkaAssemblyOperatorRbacScopeTest {
      * This test checks that when STRIMZI_RBAC_SCOPE feature is set to 'NAMESPACE', the cluster operator only
      * deploys and binds to Roles
      */
-    @Test
+    @ParallelTest
     public void testRolesDeployedWhenNamespaceRbacScope(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -189,7 +189,7 @@ public class KafkaAssemblyOperatorRbacScopeTest {
      * This test checks that when STRIMZI_RBAC_SCOPE feature is set to 'CLUSTER', the cluster operator
      * binds to ClusterRoles
      */
-    @Test
+    @ParallelTest
     public void testRolesDeployedWhenClusterRbacScope(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -268,7 +268,7 @@ public class KafkaAssemblyOperatorRbacScopeTest {
      * This test checks that when STRIMZI_RBAC_SCOPE feature is set to 'NAMESPACE', the cluster operator
      * binds to ClusterRoles when it can't use Roles due to cross namespace permissions
      */
-    @Test
+    @ParallelTest
     public void testRolesDeployedWhenNamespaceRbacScopeAndMultiWatchNamespace(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -86,6 +86,7 @@ import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelParametrizedTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -95,7 +96,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -333,7 +333,7 @@ public class KafkaAssemblyOperatorTest {
 
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testCreateCluster(Params params, VertxTestContext context) {
         setFields(params);
@@ -341,7 +341,7 @@ public class KafkaAssemblyOperatorTest {
                 emptyList());
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testCreateClusterWithJmxEnabled(Params params, VertxTestContext context) {
         setFields(params);
@@ -360,7 +360,7 @@ public class KafkaAssemblyOperatorTest {
                 )); //getInitialCertificates(getKafkaAssembly("foo").getMetadata().getName()));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testCreateClusterWithJmxTrans(Params params, VertxTestContext context) {
         setFields(params);
@@ -793,7 +793,7 @@ public class KafkaAssemblyOperatorTest {
         return new HashSet<>(captor.getAllValues());
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateClusterNoop(Params params, VertxTestContext context) {
         setFields(params);
@@ -801,7 +801,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateKafkaClusterChangeImage(Params params, VertxTestContext context) {
         setFields(params);
@@ -810,7 +810,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateZookeeperClusterChangeImage(Params params, VertxTestContext context) {
         setFields(params);
@@ -819,7 +819,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateKafkaClusterScaleUp(Params params, VertxTestContext context) {
         setFields(params);
@@ -828,7 +828,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateKafkaClusterScaleDown(Params params, VertxTestContext context) {
         setFields(params);
@@ -837,7 +837,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateZookeeperClusterScaleUp(Params params, VertxTestContext context) {
         setFields(params);
@@ -846,7 +846,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateZookeeperClusterScaleDown(Params params, VertxTestContext context) {
         setFields(params);
@@ -855,7 +855,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateClusterMetricsConfig(Params params, VertxTestContext context) {
         setFields(params);
@@ -866,7 +866,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateClusterAuthenticationTrue(Params params, VertxTestContext context) {
         setFields(params);
@@ -878,7 +878,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateClusterLogConfig(Params params, VertxTestContext context) {
         setFields(params);
@@ -889,7 +889,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateZkClusterMetricsConfig(Params params, VertxTestContext context) {
         setFields(params);
@@ -899,7 +899,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     public void testUpdateZkClusterLogConfig(Params params, VertxTestContext context) {
         setFields(params);
@@ -910,7 +910,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
-    private void updateCluster(VertxTestContext context, Kafka originalAssembly, Kafka updatedAssembly) {
+    private synchronized void updateCluster(VertxTestContext context, Kafka originalAssembly, Kafka updatedAssembly) {
         KafkaCluster originalKafkaCluster = KafkaCluster.fromCrd(originalAssembly, VERSIONS);
         KafkaCluster updatedKafkaCluster = KafkaCluster.fromCrd(updatedAssembly, VERSIONS);
         ZookeeperCluster originalZookeeperCluster = ZookeeperCluster.fromCrd(originalAssembly, VERSIONS);
@@ -1317,7 +1317,7 @@ public class KafkaAssemblyOperatorTest {
             })));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
     public void testReconcile(Params params, VertxTestContext context) {
@@ -1410,7 +1410,7 @@ public class KafkaAssemblyOperatorTest {
         ops.reconcileAll("test", kafkaNamespace, context.succeeding(v -> async.flag()));
     }
 
-    @ParameterizedTest
+    @ParallelParametrizedTest
     @MethodSource("data")
     @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
     public void testReconcileAllNamespaces(Params params, VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorUnsupportedFieldsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorUnsupportedFieldsTest.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -67,7 +68,7 @@ public class KafkaAssemblyOperatorUnsupportedFieldsTest {
      * This test checks that when the unsupported spec.topicOperator is not configured in the Kafka CR, no warning about
      * it will be in the status.
      */
-    @Test
+    @ParallelTest
     public void testNoTopicOperatorWarnings(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
@@ -147,7 +148,7 @@ public class KafkaAssemblyOperatorUnsupportedFieldsTest {
      * This test checks that when the unsupported spec.topicOperator is configured in the KAfka CR, a warning about it
      * will be in the status.
      */
-    @Test
+    @ParallelTest
     public void testTopicOperatorWarnings(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorUnsupportedFieldsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorUnsupportedFieldsTest.java
@@ -29,7 +29,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -45,7 +45,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -36,6 +36,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -100,7 +101,7 @@ public class KafkaBridgeAssemblyOperatorTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateCreatesCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
@@ -188,7 +189,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateWithNoDiffCausesNoChanges(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
@@ -268,7 +269,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateUpdatesCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
@@ -387,7 +388,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateThrowsWhenCreateServiceThrows(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
@@ -451,7 +452,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             .onComplete(context.failing(e -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateWithReplicasScaleUpToOne(VertxTestContext context) {
         final int scaleTo = 1;
 
@@ -505,7 +506,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateWithScaleDown(VertxTestContext context) {
         int scaleTo = 1;
 
@@ -565,7 +566,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileCallsCreateOrUpdate(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
@@ -638,7 +639,7 @@ public class KafkaBridgeAssemblyOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterStatusNotReady(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;
@@ -688,7 +689,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateBridgeZeroReplica(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockBridgeOps = supplier.kafkaBridgeOperator;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -35,7 +36,7 @@ public class KafkaConnectApiMockTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testStatusWithBackOffSucceedingImmediately(VertxTestContext context) {
         Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
         statusResults.add(Future.succeededFuture(Collections.emptyMap()));
@@ -47,7 +48,7 @@ public class KafkaConnectApiMockTest {
             .onComplete(context.succeeding(res -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testStatusWithBackOffSuccedingEventually(VertxTestContext context) {
         Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(3);
         statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
@@ -61,7 +62,7 @@ public class KafkaConnectApiMockTest {
             .onComplete(context.succeeding(res -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testStatusWithBackOffFailingRepeatedly(VertxTestContext context) {
         Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(4);
         statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
@@ -76,7 +77,7 @@ public class KafkaConnectApiMockTest {
             .onComplete(context.failing(res -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testStatusWithBackOffOtherExceptionStillFails(VertxTestContext context) {
         Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
         statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 500, null, null)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -13,7 +13,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -31,6 +31,7 @@ import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -144,7 +145,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
         return created.future();
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileCreateAndUpdate(VertxTestContext context) {
         setConnectResource(new KafkaConnectBuilder()
                 .withMetadata(new ObjectMetaBuilder()
@@ -171,7 +172,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testPauseReconcileUnpause(VertxTestContext context) {
         setConnectResource(new KafkaConnectBuilder()
                 .withMetadata(new ObjectMetaBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -57,7 +57,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -48,6 +48,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -234,7 +235,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithoutConnectorOperator(VertxTestContext context) {
         String kcName = "foo";
         String kcNamespace = "test";
@@ -243,7 +244,7 @@ public class KafkaConnectAssemblyOperatorTest {
         createKafkaConnectCluster(context, kc, false);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithConnectorOperator(VertxTestContext context) {
         String kcName = "foo";
         String kcNamespace = "test";
@@ -253,7 +254,7 @@ public class KafkaConnectAssemblyOperatorTest {
         createKafkaConnectCluster(context, kc, true);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateDoesNotUpdateWithNoDiff(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -352,7 +353,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateUpdatesCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -489,7 +490,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateFailsWhenDeploymentUpdateFails(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -551,7 +552,7 @@ public class KafkaConnectAssemblyOperatorTest {
             .onComplete(context.failing(v -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleUp(VertxTestContext context) {
         final int scaleTo = 4;
 
@@ -625,7 +626,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleDown(VertxTestContext context) {
         int scaleTo = 2;
 
@@ -701,7 +702,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -765,7 +766,7 @@ public class KafkaConnectAssemblyOperatorTest {
         })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterWithFailedScaleDownSetsStatusNotReady(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -946,7 +947,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWitDuplicateOlderConnectWithoutConnectorOperator(VertxTestContext context) {
         String kcName = "foo";
         String kcNamespace = "test";
@@ -955,7 +956,7 @@ public class KafkaConnectAssemblyOperatorTest {
         assertCreateClusterWithDuplicateOlderConnect(context, kc, false);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWitDuplicateOlderConnectWithConnectorOperator(VertxTestContext context) {
         String kcName = "foo";
         String kcNamespace = "test";
@@ -965,7 +966,7 @@ public class KafkaConnectAssemblyOperatorTest {
         assertCreateClusterWithDuplicateOlderConnect(context, kc, true);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWitDuplicateNeverConnectHasNotReadyStatus(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -1007,7 +1008,7 @@ public class KafkaConnectAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testIsOlderOrAlone()    {
         KafkaConnectS2I conflictingConnectS2I = ResourceUtils.createEmptyKafkaConnectS2I("foo", "bar");
         conflictingConnectS2I.getMetadata().setCreationTimestamp("2020-01-27T19:31:13Z");
@@ -1018,7 +1019,7 @@ public class KafkaConnectAssemblyOperatorTest {
         assertThat(AbstractConnectOperator.isOlderOrAlone("2020-01-27T19:31:14Z", conflictingConnectS2I), is(false));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateFailsWhenClusterRoleBindingRightsAreMissingButRequired(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -1069,7 +1070,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 }));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdatePassesWhenClusterRoleBindingRightsAreMissingAndNotRequired(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
@@ -1122,7 +1123,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 }));
     }
 
-    @Test
+    @ParallelTest
     public void testDeleteClusterRoleBindings(VertxTestContext context) {
         String kcName = "foo";
         String kcNamespace = "test";
@@ -1151,7 +1152,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithJmxEnabled(VertxTestContext context) {
         String kcName = "foo";
         String kcNamespace = "test";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -51,7 +51,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -43,6 +43,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -93,7 +94,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testBuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -250,7 +251,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testBuildFailureOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -371,7 +372,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testUpdateWithRebuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -537,7 +538,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testContinueWithPreviousBuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -711,7 +712,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testRestartPreviousBuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -889,7 +890,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testRestartPreviousBuildDueToFailureOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -1068,7 +1069,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateWithoutRebuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -1198,7 +1199,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateWithForcedRebuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -44,6 +44,7 @@ import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -92,7 +93,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testBuildOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -241,7 +242,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testBuildFailureOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -361,7 +362,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testUpdateWithRebuildOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -531,7 +532,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateWithoutRebuildOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -656,7 +657,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateWithForcedRebuildOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -809,7 +810,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testContinueWithPreviousBuildOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -1001,7 +1002,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testRestartPreviousBuildOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -1195,7 +1196,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testRestartPreviousBuildDueToFailureOnOpenShift(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -52,7 +52,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -55,7 +55,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectS2IAssemblyOperatorTest.java
@@ -47,6 +47,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -247,7 +248,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithoutConnectorOperator(VertxTestContext context) {
         String kcs2iName = "foo";
         String kcs2iNamespace = "test";
@@ -256,7 +257,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         createCluster(context, kcs2i, false);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithConnectorOperator(VertxTestContext context) {
         String kcs2iName = "foo";
         String kcs2iNamespace = "test";
@@ -266,7 +267,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         createCluster(context, kcs2i, true);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateDoesNotUpdateWithNoDiff(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -387,7 +388,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
     }
 
     @SuppressWarnings({"checkstyle:JavaNCSS", "checkstyle:MethodLength"})
-    @Test
+    @ParallelTest
     public void testUpdateCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -548,7 +549,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateFailsWhenDeploymentUpdateFails(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -628,7 +629,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             .onComplete(context.failing(v -> context.verify(() -> async.flag())));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleUp(VertxTestContext context) {
         int scaleTo = 4;
 
@@ -707,7 +708,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleDown(VertxTestContext context) {
         int scaleTo = 2;
 
@@ -788,7 +789,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -846,7 +847,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterStatusNotReady(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockS2IConnectOps = supplier.connectS2IOperator;
@@ -1039,7 +1040,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWitDuplicateOlderConnectWithoutConnectorOperator(VertxTestContext context) {
         String kcs2iName = "foo";
         String kcs2iNamespace = "test";
@@ -1048,7 +1049,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         createClusterWithDuplicateOlderConnect(context, kcs2i, false);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWitDuplicateOlderConnectWithConnectorOperator(VertxTestContext context) {
         String kcs2iName = "foo";
         String kcs2iNamespace = "test";
@@ -1058,7 +1059,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
         createClusterWithDuplicateOlderConnect(context, kcs2i, true);
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithSameNameAsConnectFails(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectS2IOps = supplier.connectS2IOperator;
@@ -1098,7 +1099,7 @@ public class KafkaConnectS2IAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithJmxEnabled(VertxTestContext context) {
         String kcs2iName = "foo";
         String kcs2iNamespace = "test";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -110,7 +111,7 @@ public class KafkaConnectorIT {
         }
     }
 
-    @Test
+    @ParallelTest
     public void test(VertxTestContext context) {
         KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -148,7 +149,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         return created.future();
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileUpdate(VertxTestContext context) {
         setMirrorMaker2Resource(new KafkaMirrorMaker2Builder()
                 .withMetadata(new ObjectMetaBuilder()
@@ -174,7 +175,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
             .onComplete(context.succeeding(v -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testPauseReconcile(VertxTestContext context) {
         setMirrorMaker2Resource(new KafkaMirrorMaker2Builder()
                 .withMetadata(new ObjectMetaBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -45,7 +45,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -95,7 +96,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testCreateCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -184,7 +185,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterNoDiff(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -265,7 +266,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -386,7 +387,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterWithFailingDeploymentFailure(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -446,7 +447,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             .onComplete(context.failing(v -> async.flag()));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleUp(VertxTestContext context) {
         final int scaleTo = 4;
 
@@ -505,7 +506,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleDown(VertxTestContext context) {
         int scaleTo = 2;
 
@@ -563,7 +564,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -620,7 +621,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterStatusNotReady(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -669,7 +670,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
     }
 
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithZeroReplicas(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
@@ -755,7 +756,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterWithJmxEnabled(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -35,6 +35,7 @@ import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -97,7 +98,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         vertx.close();
     }
 
-    @Test
+    @ParallelTest
     public void testCreateCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
@@ -183,7 +184,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterNoDiff(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
@@ -259,7 +260,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateCluster(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
@@ -373,7 +374,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterFailure(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
@@ -437,7 +438,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             .onComplete(context.failing(v -> context.verify(() -> async.flag())));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleUp(VertxTestContext context) {
         final int scaleTo = 4;
 
@@ -498,7 +499,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testUpdateClusterScaleDown(VertxTestContext context) {
         int scaleTo = 2;
 
@@ -559,7 +560,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
@@ -632,7 +633,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
 
     }
 
-    @Test
+    @ParallelTest
     public void testCreateClusterStatusNotReady(VertxTestContext context) throws InterruptedException {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;
@@ -689,7 +690,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @ParallelTest
     public void testCreateOrUpdateZeroReplica(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorOps = supplier.mirrorMakerOperator;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -43,7 +43,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -37,6 +37,8 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.NoStackTraceTimeoutException;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -160,7 +162,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 3. The rebalance proposal is ready on the first call
      * 4. The KafkaRebalance resource moves to the 'ProposalReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToProposalReadyRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
@@ -195,7 +197,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 5. The rebalance proposal is ready after the specified pending calls
      * 6. The KafkaRebalance resource moves to 'ProposalReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToPendingProposalToProposalReadyRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
@@ -240,7 +242,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 7. The operator stops polling the Cruise Control REST API
      * 8. The KafkaRebalance resource moves to 'Stopped' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToPendingProposalToStoppedRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
@@ -303,7 +305,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 13. The rebalance proposal is ready after the specified pending calls
      * 14. The KafkaRebalance resource moves to ProposalReady state
      */
-    @Test
+    @IsolatedTest
     public void testNewToPendingProposalToStoppedAndRefreshRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
@@ -388,7 +390,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 13. The rebalance operation is done
      * 14. The KafkaRebalance resource moves to the 'Ready' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToProposalReadyToRebalancingToReadyRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.
@@ -519,7 +521,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 3. The operator gets a "missing hard goals" error instead of a proposal
      * 4. The KafkaRebalance resource moves to the 'NotReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNewWithMissingHardGoals(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint to get error about hard goals
@@ -554,7 +556,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testUnknownPropertyInSpec(VertxTestContext context) throws IOException, URISyntaxException {
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 2);
 
@@ -604,7 +606,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 3. The rebalance proposal is ready on the first call
      * 4. The KafkaRebalance resource transitions to the 'ProposalReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToProposalReadySkipHardGoalsRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
@@ -645,7 +647,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 7. The rebalance proposal is ready on the first call
      * 8. The KafkaRebalance resource moves to the 'ProposalReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNewWithMissingHardGoalsAndRefresh(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint to get error about hard goals
@@ -725,7 +727,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 4. The KafkaRebalance resource moves to the 'PendingProposal' state
      * 5. The KafkaRebalance resource is deleted
      */
-    @Test
+    @IsolatedTest
     public void testNewToPendingProposalDeleteRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
@@ -791,7 +793,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 14. The operator stops polling the Cruise Control REST API and requests a stop execution
      * 15. The KafkaRebalance resource moves to the 'Stopped' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToProposalReadyToRebalancingToStoppedRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.
@@ -858,7 +860,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 2. The operator checks that the Kafka cluster specified in the KafkaRebalance resource (via label) doesn't exist
      * 4. The KafkaRebalance resource moves to NotReady state
      */
-    @Test
+    @IsolatedTest
     public void testNoKafkaCluster(VertxTestContext context) {
 
         KafkaRebalance kr =
@@ -886,7 +888,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * When the Kafka cluster does not match the selector labels in the cluster operator configuration, the
      * KafkaRebalance resource should be ignored and not reconciled.
      */
-    @Test
+    @IsolatedTest
     public void testKafkaClusterNotMatchingLabelSelector(VertxTestContext context) {
         KafkaRebalance kr =
                 createKafkaRebalance(CLUSTER_NAMESPACE, CLUSTER_NAME, RESOURCE_NAME, new KafkaRebalanceSpecBuilder().build());
@@ -925,7 +927,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 })));
     }
 
-    @Test
+    @IsolatedTest
     public void testRebalanceUsesUnknownProperty(VertxTestContext context) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -966,7 +968,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 2. The operator checks that the Kafka cluster specified in the KafkaRebalance resource (via label) doesn't have Cruise Control configured
      * 4. The KafkaRebalance resource moves to NotReady state
      */
-    @Test
+    @IsolatedTest
     public void testCruiseControlDisabled(VertxTestContext context) {
 
         // build a Kafka cluster without the cruiseControl definition
@@ -1006,7 +1008,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 2. The operator checks that the resource is missing the label to specify the Kafka cluster
      * 4. The KafkaRebalance resource moves to 'NotReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNoKafkaClusterInKafkaRebalanceLabel(VertxTestContext context) {
 
         KafkaRebalance kr =
@@ -1035,7 +1037,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 2. The operator requests a rebalance proposal through the Cruise Control REST API
      * 3. The operator doesn't get a response on time; the resource moves to NotReady
      */
-    @Test
+    @IsolatedTest
     public void testCruiseControlTimingOut(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received
@@ -1068,7 +1070,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 2. The operator requests a rebalance proposal through the Cruise Control REST API
      * 3. The operator doesn't get a response on time; the resource moves to 'NotReady'
      */
-    @Test
+    @IsolatedTest
     public void testCruiseControlNotReachable(VertxTestContext context) {
 
         // stop the mocked Cruise Control server to make it unreachable
@@ -1105,7 +1107,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 2. KafkaRebalance go through the `PendingProposal` to `ProposalReady` state
      * 3. KafkaRebalance status should contain optimization result and session id
      */
-    @Test
+    @IsolatedTest
     public void testRebalanceStatusInProposalReadyState(VertxTestContext context) throws IOException, URISyntaxException {
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 2);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -453,7 +453,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 11. The KafkaRebalance resource is annotated with 'strimzi.io/rebalance=refresh'
      * 12. The KafkaRebalance resource moves to the 'ProposalReady' state
      */
-    @Test
+    @IsolatedTest
     public void testNewToProposalReadyToRebalancingToReadyThenRefreshRebalance(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -38,7 +38,6 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.NoStackTraceTimeoutException;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.IsolatedTest;
-import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -49,7 +48,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.integration.ClientAndServer;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -27,6 +27,8 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.test.annotations.IsolatedTest;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -215,7 +217,7 @@ public class KafkaRebalanceStateMachineTest {
         }
     }
 
-    @Test
+    @IsolatedTest
     public void testNewToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -226,7 +228,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNewWithNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         // Test the case where the user asks for a rebalance but there is not enough data, the returned status should
@@ -239,7 +241,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNewToProposalPending(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
@@ -250,7 +252,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNewBadGoalsError(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         // Test the case where the user asks for a rebalance with custom goals which do not contain all the configured hard goals
@@ -283,7 +285,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNewBadGoalsErrorWithSkipHGCheck(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         // Test the case where the user asks for a rebalance with custom goals which do not contain all the configured hard goals
@@ -307,7 +309,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalPendingToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -318,7 +320,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalPendingToProposalReadyWithDelay(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 3);
@@ -329,7 +331,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalPendingToStopped(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 3);
@@ -340,7 +342,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyNoChange(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -351,7 +353,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyToRebalancingWithNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);
@@ -362,7 +364,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyToRebalancingWithPendingSummary(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
@@ -373,7 +375,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyToRebalancing(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -384,7 +386,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyRefreshNoChange(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -395,7 +397,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
@@ -406,7 +408,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testProposalReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);
@@ -417,7 +419,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     @Timeout(value = 30, timeUnit = TimeUnit.SECONDS)
     public void testRebalancingCompleted(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
@@ -430,7 +432,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testRebalancingPendingThenExecution(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         // This tests that the optimization proposal is added correctly if it was not ready when the rebalance(dryrun=false) was called.
@@ -445,7 +447,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testRebalancingToStopped(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, 0, 0);
@@ -458,7 +460,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testRebalancingCompletedWithError(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCUserTasksCompletedWithError(ccServer);
@@ -470,7 +472,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testStoppedRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
@@ -482,7 +484,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
 
-    @Test
+    @IsolatedTest
     public void testStoppedRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -493,7 +495,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testStoppedRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -28,7 +28,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.test.annotations.IsolatedTest;
-import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -38,7 +37,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.integration.ClientAndServer;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -504,7 +504,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
@@ -515,7 +515,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -526,7 +526,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);
@@ -537,7 +537,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
@@ -548,7 +548,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
@@ -559,7 +559,7 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testNotReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -53,7 +53,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -45,6 +45,7 @@ import io.strimzi.operator.common.operator.resource.NodeOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -132,7 +133,7 @@ public class KafkaStatusTest {
                 .build();
     }
 
-    @Test
+    @ParallelTest
     public void testStatusAfterSuccessfulReconciliationWithPreviousFailure(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
@@ -180,7 +181,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testPauseReconciliationsStatus(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         kafka.getMetadata().setAnnotations(singletonMap("strimzi.io/pause-reconciliation", Boolean.toString(true)));
@@ -217,7 +218,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testStatusAfterSuccessfulReconciliationWithPreviousSuccess(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
@@ -269,12 +270,12 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testStatusAfterFailedReconciliationWithPreviousFailure(VertxTestContext context) throws ParseException {
         testStatusAfterFailedReconciliationWithPreviousFailure(context, new RuntimeException("Something went wrong"));
     }
 
-    @Test
+    @ParallelTest
     public void testStatusAfterFailedReconciliationWithPreviousFailure_NPE(VertxTestContext context) throws ParseException {
         testStatusAfterFailedReconciliationWithPreviousFailure(context, new NullPointerException());
     }
@@ -326,7 +327,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testStatusAfterFailedReconciliationWithPreviousSuccess(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
@@ -455,7 +456,7 @@ public class KafkaStatusTest {
         return nodes;
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaListenerNodePortAddressInStatus(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder(getKafkaCrd())
                 .editOrNewSpec()
@@ -561,7 +562,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaListenerNodePortAddressInStatusWithOverrides(VertxTestContext context) throws ParseException {
         GenericKafkaListenerConfigurationBroker broker0 = new GenericKafkaListenerConfigurationBrokerBuilder()
                 .withBroker(0)
@@ -680,7 +681,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaListenerNodePortAddressWithPreferred(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder(getKafkaCrd())
                 .editOrNewSpec()
@@ -789,7 +790,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaListenerNodePortAddressSameNode(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder(getKafkaCrd())
                 .editOrNewSpec()
@@ -893,7 +894,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaListenerNodePortAddressMissingNodes(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder(getKafkaCrd())
                 .editOrNewSpec()
@@ -975,7 +976,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testInitialStatusOnNewResource() throws ParseException {
         Kafka kafka = getKafkaCrd();
         kafka.setStatus(null);
@@ -1014,7 +1015,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testInitialStatusOnOldResource() throws ParseException {
         Kafka kafka = getKafkaCrd();
 
@@ -1042,7 +1043,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testKafkaClusterIdInStatus(VertxTestContext context) throws ParseException {
         Kafka kafka = new KafkaBuilder(getKafkaCrd()).build();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -1084,7 +1085,7 @@ public class KafkaStatusTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testModelWarnings(VertxTestContext context) throws ParseException {
         Kafka kafka = getKafkaCrd();
         Kafka oldKafka = new KafkaBuilder(getKafkaCrd())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -28,6 +28,8 @@ import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.IsolatedTest;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -176,7 +178,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests regular upgrade with the message format and protocol versions configured to the same Kafka
     // version as we are upgrading from.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -209,7 +211,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests recovery from failed upgrade with the message format and protocol versions configured to the same Kafka
     // version as we are upgrading from.
-    @Test
+    @IsolatedTest
     public void testUpgradeRecoveryWithMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -280,7 +282,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests upgrade without the message format and protocol versions configured. Two rolling updates should happen => first
     // with the old message and protocol versions and another one which rolls also protocol and message versions.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithoutMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
 
@@ -316,7 +318,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests upgrade without the message format and protocol versions configured. Two rolling updates should happen => first
     // with the old message and protocol versions and another one which rolls also protocol and message versions.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithNewMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -355,7 +357,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Tests upgrade without any versions specified in the CR.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithoutAnyVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
 
@@ -391,7 +393,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests regular upgrade with the message format and protocol versions configured to much older Kafka
     // version than we are upgrading from.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithOlderMessageAndProtocolVersions(VertxTestContext context)  {
         String olderVersion = "2.0";
 
@@ -426,7 +428,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests upgrade from Kafka version not supported by the current version of the operator with message format and
     // protocol versions specified.
-    @Test
+    @IsolatedTest
     public void testUpgradeFromUnsupportedKafkaVersionWithMessageAndProtocol(VertxTestContext context)  {
         KafkaVersion unsupported = VERSIONS.version("2.1.0");
 
@@ -503,7 +505,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests upgrade from Kafka version not supported by the current version of the operator without message format and
     // protocol versions specified.
-    @Test
+    @IsolatedTest
     public void testUpgradeFromUnsupportedKafkaVersionWithoutMessageAndProtocol(VertxTestContext context)  {
         KafkaVersion unsupported = VERSIONS.version("2.1.0");
 
@@ -588,7 +590,7 @@ public class KafkaUpgradeDowngradeMockTest {
     // Tests upgrade when Kafka StatefulSet and/or Pods existing but without any of the version annotations. This
     // indicates that the Statefulset / Pods were not using the current or recent Strimzi version and since we do not
     // know the version, we should wail.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithoutAnyVersionInPodsOrStsFails(VertxTestContext context)  {
         KafkaVersion unsupported = VERSIONS.version("2.1.0");
 
@@ -653,7 +655,7 @@ public class KafkaUpgradeDowngradeMockTest {
      */
 
     // Tests regular reconciliation without any upgrades
-    @Test
+    @IsolatedTest
     public void testNoopUpgrade(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
@@ -685,7 +687,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Tesst that Kafka works fine when both Pods and StatefulSets is missing at the beginning of reconciliation
-    @Test
+    @IsolatedTest
     public void testNoopWhenStatefulSetAndPodsAreMissing(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
@@ -731,7 +733,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Test regular downgrade with message and protocol versions defined everywhere and properly rolled out to all brokers.
     // The message and protocol versions used is the same as Kafka version we downgrade to.
-    @Test
+    @IsolatedTest
     public void testDowngradeWithMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -763,7 +765,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Test partial downgrade => emulate previous downgrade failing in the middle and verify it is finished.
-    @Test
+    @IsolatedTest
     public void testDowngradeRecoveryWithMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -834,7 +836,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Test regular downgrade with message and protocol versions defined everywhere and properly rolled out to all brokers.
     // The message and protocol versions used are older than the Kafka version we downgrade to.
-    @Test
+    @IsolatedTest
     public void testDowngradeWithOlderMessageAndProtocolVersions(VertxTestContext context)  {
         String olderVersion = "2.0";
 
@@ -869,7 +871,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Test downgrade with message and protocol versions defined to newer version than we downgrade to (this fails before
     // reaching downgrade since this is invalid Kafka CR).
-    @Test
+    @IsolatedTest
     public void testDowngradeWithWrongMessageAndProtocolVersionsFails(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
@@ -898,7 +900,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Test downgrade without message and protocol versions configured and the default being used and rolled out to all brokers.
-    @Test
+    @IsolatedTest
     public void testDowngradeWithoutMessageAndProtocolVersionsFails(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
 
@@ -923,7 +925,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Test downgrade with message and protocol versions defined to correct version in the CR, but not on the broker pods.
-    @Test
+    @IsolatedTest
     public void testDowngradeWithWrongMessageAndProtocolVersionsOnPodsFails(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
@@ -952,7 +954,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Test downgrade with message and protocol versions defined to correct version in the CR, but not on the broker pods.
-    @Test
+    @IsolatedTest
     public void testDowngradeWithNoMessageAndProtocolVersionsOnPodsFails(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -29,7 +29,6 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.test.annotations.IsolatedTest;
-import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -40,7 +39,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -29,6 +29,7 @@ import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -202,7 +203,7 @@ public class PartialRollingUpdateTest {
         LOGGER.info("Started test KafkaAssemblyOperator");
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileOfPartiallyRolledKafkaCluster(VertxTestContext context) {
         kafkaSts.getSpec().getTemplate().getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
         kafkaPod0.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
@@ -228,7 +229,7 @@ public class PartialRollingUpdateTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileOfPartiallyRolledZookeeperCluster(VertxTestContext context) {
         zkSts.getSpec().getTemplate().getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
         zkPod0.getMetadata().getAnnotations().put(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
@@ -253,7 +254,7 @@ public class PartialRollingUpdateTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileOfPartiallyRolledClusterForClusterCaCertificate(VertxTestContext context) {
         clusterCaCert.getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "3");
         zkPod0.getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "3");
@@ -289,7 +290,7 @@ public class PartialRollingUpdateTest {
         });
     }
 
-    @Test
+    @ParallelTest
     public void testReconcileOfPartiallyRolledClusterForClientsCaCertificate(VertxTestContext context) {
         clientsCaCert.getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "3");
         kafkaPod0.getMetadata().getAnnotations().put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "3");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TolerationsIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TolerationsIT.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetDiff;
+import io.strimzi.test.annotations.ParallelTest;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -46,7 +47,7 @@ public class TolerationsIT {
         cluster.deleteNamespaces();
     }
 
-    @Test
+    @ParallelTest
     public void testEmptyStringValueIntoleration(VertxTestContext context) {
         Toleration t1 = new TolerationBuilder()
                 .withEffect("NoSchedule")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TolerationsIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TolerationsIT.java
@@ -20,7 +20,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -32,7 +32,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/VolumeResizingTest.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.StorageClassOperator;
+import io.strimzi.test.annotations.ParallelTest;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.AfterAll;
@@ -103,7 +104,7 @@ public class VolumeResizingTest {
                 .build();
     }
 
-    @Test
+    @ParallelTest
     public void testNoExistingVolumes()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -150,7 +151,7 @@ public class VolumeResizingTest {
                 });
     }
 
-    @Test
+    @ParallelTest
     public void testNotBoundVolumes()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -198,7 +199,7 @@ public class VolumeResizingTest {
                 });
     }
 
-    @Test
+    @ParallelTest
     public void testVolumesBoundExpandableStorageClass()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -255,7 +256,7 @@ public class VolumeResizingTest {
                 });
     }
 
-    @Test
+    @ParallelTest
     public void testVolumesBoundNonExpandableStorageClass()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -312,7 +313,7 @@ public class VolumeResizingTest {
                 });
     }
 
-    @Test
+    @ParallelTest
     public void testVolumesResizing()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -372,7 +373,7 @@ public class VolumeResizingTest {
                 });
     }
 
-    @Test
+    @ParallelTest
     public void testVolumesWaitingForRestart()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);
@@ -438,7 +439,7 @@ public class VolumeResizingTest {
                 });
     }
 
-    @Test
+    @ParallelTest
     public void testVolumesResized()  {
         Kafka kafka = getKafkaCrd();
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(kafka, VERSIONS);

--- a/cluster-operator/src/test/resources/log4j2-test.properties
+++ b/cluster-operator/src/test/resources/log4j2-test.properties
@@ -3,7 +3,7 @@ name = COConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
 
 rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -121,6 +121,11 @@
             <artifactId>spotbugs-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/src/main/java/io/strimzi/test/annotations/ParallelParametrizedTest.java
+++ b/test/src/main/java/io/strimzi/test/annotations/ParallelParametrizedTest.java
@@ -1,9 +1,11 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.test.annotations;
 
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.api.parallel.ResourceAccessMode;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import java.lang.annotation.ElementType;
@@ -20,7 +22,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(ElementType.METHOD)
 @Retention(RUNTIME)
 @Execution(ExecutionMode.CONCURRENT)
-@ResourceLock(mode = ResourceAccessMode.READ, value = "global")
 @ParameterizedTest
 public @interface ParallelParametrizedTest {
 }

--- a/test/src/main/java/io/strimzi/test/annotations/ParallelParametrizedTest.java
+++ b/test/src/main/java/io/strimzi/test/annotations/ParallelParametrizedTest.java
@@ -1,0 +1,26 @@
+package io.strimzi.test.annotations;
+
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/***
+ * Annotation for running parallel parametrized tests in strimzi test suite
+ * please be sure that you know laws of parallel execution and concurrent programming
+ * be sure that you do not use shared resources, and if you use shared resources please work with synchronization
+ */
+@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(mode = ResourceAccessMode.READ, value = "global")
+@ParameterizedTest
+public @interface ParallelParametrizedTest {
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR is a continuation of https://github.com/strimzi/strimzi-kafka-operator/pull/4858. Specifically covering all `operator/assembly` package and there is some re-work in test cases. Most of these problems are because all test cases used shared object, which causes race conditions. I have re-worked it to use the local object for each test case which is thread-safe and there is no chance that race condition will appear in this scenario.

### Checklist

- [x] Make sure all tests pass