### PR TITLE
Log the reason why dynamic configuration failed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -544,9 +544,15 @@ public class KafkaRoller {
         KafkaFuture<Void> brokerConfigFuture = alterConfigResult.values().get(Util.getBrokersConfig(podId));
         KafkaFuture<Void> brokerLoggingConfigFuture = alterConfigResult.values().get(Util.getBrokersLogging(podId));
         await(Util.kafkaFutureToVertxFuture(vertx, brokerConfigFuture), 30, TimeUnit.SECONDS,
-            error -> new ForceableProblem("Error doing dynamic update", error));
+            error -> {
+                log.error("Error doing dynamic config update", error);
+                return new ForceableProblem("Error doing dynamic update", error);
+            });
         await(Util.kafkaFutureToVertxFuture(vertx, brokerLoggingConfigFuture), 30, TimeUnit.SECONDS,
-            error -> new ForceableProblem("Error performing dynamic logging update for pod " + podId, error));
+            error -> {
+                log.error("Error performing dynamic logging update for pod {}", podId, error);
+                return new ForceableProblem("Error performing dynamic logging update for pod " + podId, error);
+            });
 
         log.info("{}: Dynamic reconfiguration for broker {} was successful.", reconciliation, podId);
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
Kafka dynamic configuration has validation on the broker side. If the rules are violated, the dynamic configuration fails and the pods are rolled. The validation error should be printed in the CO logs.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

