### PR TITLE
Use ZookeeperScaler#operationTimeoutMs for ZK request time out

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -242,7 +242,7 @@ public class ZookeeperScaler implements AutoCloseable {
     private void closeConnection(ZooKeeperAdmin zkAdmin) {
         if (zkAdmin != null)    {
             try {
-                zkAdmin.close();
+                zkAdmin.close((int) operationTimeoutMs);
             } catch (Exception e) {
                 log.debug("Failed to close the ZooKeeperAdmin", e);
             }
@@ -265,6 +265,7 @@ public class ZookeeperScaler implements AutoCloseable {
         clientConfig.setProperty("zookeeper.ssl.keyStore.location", keyStoreFile.getAbsolutePath());
         clientConfig.setProperty("zookeeper.ssl.keyStore.password", keyStorePassword);
         clientConfig.setProperty("zookeeper.ssl.keyStore.type", "PKCS12");
+        clientConfig.setProperty("zookeeper.request.timeout", String.valueOf(operationTimeoutMs));
 
         return clientConfig;
     }


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

Specify request timeout for the `ZooKeeper` client in `ZookeeperScaler`

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

