### PR TITLE
Dual Stack networking support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Allow disabling service links (environment variables describing Kubernetes services) in Pod template
 * Update Kaniko executor to 1.6.0
 * Add support for separate control plane listener (disabled by default, available via the `ControlPlaneListener` feature gate)
+* Support for Dual Stack networking
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -12,8 +12,11 @@ import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.api.kafka.model.listener.NodeAddressType;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -28,7 +31,8 @@ import static java.util.Collections.emptyMap;
  * Configures Kafka listeners
  */
 @DescriptionFile
-@JsonPropertyOrder({"brokerCertChainAndKey", "ingressClass", "preferredAddressType", "externalTrafficPolicy", "loadBalancerSourceRanges", "bootstrap", "brokers"})
+@JsonPropertyOrder({"brokerCertChainAndKey", "ingressClass", "preferredAddressType", "externalTrafficPolicy",
+        "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,
@@ -49,6 +53,8 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     private List<GenericKafkaListenerConfigurationBroker> brokers;
     private Integer maxConnections;
     private Integer maxConnectionCreationRate;
+    private IpFamilyPolicy ipFamilyPolicy;
+    private List<IpFamily> ipFamilies;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -191,6 +197,36 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
 
     public void setMaxConnectionCreationRate(Integer maxConnectionCreationRate) {
         this.maxConnectionCreationRate = maxConnectionCreationRate;
+    }
+
+    @Description("Specifies which IP Family Policy should be used by this service. " +
+            "Available options are `SingleStack` (a single IP family), " +
+            "`PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), " +
+            "and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). " +
+            "If unspecified, Kubernetes will choose the default value based on the service type. " +
+            "Available on Kubernetes 1.20 and newer.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @PresentInVersions("v1beta2+")
+    public IpFamilyPolicy getIpFamilyPolicy() {
+        return ipFamilyPolicy;
+    }
+
+    public void setIpFamilyPolicy(IpFamilyPolicy ipFamilyPolicy) {
+        this.ipFamilyPolicy = ipFamilyPolicy;
+    }
+
+    @Description("Specifies which IP Families should be used by this service. " +
+            "Available options are `IPv4` and `IPv6. " +
+            "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. " +
+            "Available on Kubernetes 1.20 and newer.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @PresentInVersions("v1beta2+")
+    public List<IpFamily> getIpFamilies() {
+        return ipFamilies;
+    }
+
+    public void setIpFamilies(List<IpFamily> ipFamilies) {
+        this.ipFamilies = ipFamilies;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -199,10 +199,11 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
         this.maxConnectionCreationRate = maxConnectionCreationRate;
     }
 
-    @Description("Specifies which IP Family Policy should be used by this service. " +
-            "Available options are `SingleStack` (a single IP family), " +
-            "`PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), " +
-            "and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). " +
+    @Description("Specifies the IP Family Policy used by the service. " +
+            "Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. " +
+            "`SingleStack` is for a single IP family. " +
+            "`PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. " +
+            "`RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. " +
             "If unspecified, Kubernetes will choose the default value based on the service type. " +
             "Available on Kubernetes 1.20 and newer.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -215,7 +216,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
         this.ipFamilyPolicy = ipFamilyPolicy;
     }
 
-    @Description("Specifies which IP Families should be used by this service. " +
+    @Description("Specifies the IP Families used by the service. " +
             "Available options are `IPv4` and `IPv6. " +
             "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. " +
             "Available on Kubernetes 1.20 and newer.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/CruiseControlTemplate.java
@@ -33,7 +33,7 @@ public class CruiseControlTemplate implements Serializable, UnknownPropertyPrese
 
     private ResourceTemplate deployment;
     private PodTemplate pod;
-    private ResourceTemplate apiService;
+    private InternalServiceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate cruiseControlContainer;
     private ContainerTemplate tlsSidecarContainer;
@@ -61,11 +61,11 @@ public class CruiseControlTemplate implements Serializable, UnknownPropertyPrese
 
     @Description("Template for Cruise Control API `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getApiService() {
+    public InternalServiceTemplate getApiService() {
         return apiService;
     }
 
-    public void setApiService(ResourceTemplate apiService) {
+    public void setApiService(InternalServiceTemplate apiService) {
         this.apiService = apiService;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Representation of a template for Strimzi external services.
- * It contains additional values applicable to load balancer or node port type services.
+ * Representation of a template for Strimzi internal services.
+ * It contains additional values applicable to internal services..
  */
 @Buildable(
         editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation of a template for Strimzi external services.
+ * It contains additional values applicable to load balancer or node port type services.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"metadata", "ipFamilyPolicy", "ipFamilies"})
+@EqualsAndHashCode
+public class InternalServiceTemplate implements Serializable, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
+
+    private MetadataTemplate metadata;
+    private IpFamilyPolicy ipFamilyPolicy;
+    private List<IpFamily> ipFamilies;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @Description("Metadata applied to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public MetadataTemplate getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(MetadataTemplate metadata) {
+        this.metadata = metadata;
+    }
+
+    @Description("Specifies which IP Family Policy should be used by this service. " +
+            "Available options are `SingleStack` (a single IP family), " +
+            "`PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), " +
+            "and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). " +
+            "If unspecified, Kubernetes will choose the default value based on the service type. " +
+            "Available on Kubernetes 1.20 and newer.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @PresentInVersions("v1beta2+")
+    public IpFamilyPolicy getIpFamilyPolicy() {
+        return ipFamilyPolicy;
+    }
+
+    public void setIpFamilyPolicy(IpFamilyPolicy ipFamilyPolicy) {
+        this.ipFamilyPolicy = ipFamilyPolicy;
+    }
+
+    @Description("Specifies which IP Families should be used by this service. " +
+            "Available options are `IPv4` and `IPv6. " +
+            "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. " +
+            "Available on Kubernetes 1.20 and newer.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @PresentInVersions("v1beta2+")
+    public List<IpFamily> getIpFamilies() {
+        return ipFamilies;
+    }
+
+    public void setIpFamilies(List<IpFamily> ipFamilies) {
+        this.ipFamilies = ipFamilies;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
@@ -47,10 +47,11 @@ public class InternalServiceTemplate implements Serializable, UnknownPropertyPre
         this.metadata = metadata;
     }
 
-    @Description("Specifies which IP Family Policy should be used by this service. " +
-            "Available options are `SingleStack` (a single IP family), " +
-            "`PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), " +
-            "and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). " +
+    @Description("Specifies the IP Family Policy used by the service. " +
+            "Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. " +
+            "`SingleStack` is for a single IP family. " +
+            "`PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. " +
+            "`RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. " +
             "If unspecified, Kubernetes will choose the default value based on the service type. " +
             "Available on Kubernetes 1.20 and newer.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -63,7 +64,7 @@ public class InternalServiceTemplate implements Serializable, UnknownPropertyPre
         this.ipFamilyPolicy = ipFamilyPolicy;
     }
 
-    @Description("Specifies which IP Families should be used by this service. " +
+    @Description("Specifies the IP Families used by the service. " +
             "Available options are `IPv4` and `IPv6. " +
             "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. " +
             "Available on Kubernetes 1.20 and newer.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/IpFamily.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/IpFamily.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum IpFamily {
+    IPV4,
+    IPV6;
+
+    @JsonCreator
+    public static IpFamily forValue(String value) {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "ipv4":
+                return IPV4;
+            case "ipv6":
+                return IPV6;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case IPV4:
+                return "IPv4";
+            case IPV6:
+                return "IPv6";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/IpFamilyPolicy.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/IpFamilyPolicy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum IpFamilyPolicy {
+    SINGLE_STACK,
+    PREFER_DUAL_STACK,
+    REQUIRE_DUAL_STACK;
+
+    @JsonCreator
+    public static IpFamilyPolicy forValue(String value) {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "singlestack":
+                return SINGLE_STACK;
+            case "preferdualstack":
+                return PREFER_DUAL_STACK;
+            case "requiredualstack":
+                return REQUIRE_DUAL_STACK;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case SINGLE_STACK:
+                return "SingleStack";
+            case PREFER_DUAL_STACK:
+                return "PreferDualStack";
+            case REQUIRE_DUAL_STACK:
+                return "RequireDualStack";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
@@ -32,7 +32,7 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;
-    private ResourceTemplate apiService;
+    private InternalServiceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate bridgeContainer;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
@@ -59,11 +59,11 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
 
     @Description("Template for Kafka Bridge API `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getApiService() {
+    public InternalServiceTemplate getApiService() {
         return apiService;
     }
 
-    public void setApiService(ResourceTemplate apiService) {
+    public void setApiService(InternalServiceTemplate apiService) {
         this.apiService = apiService;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -36,8 +36,8 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     private StatefulSetTemplate statefulset;
     private PodTemplate pod;
-    private ResourceTemplate bootstrapService;
-    private ResourceTemplate brokersService;
+    private InternalServiceTemplate bootstrapService;
+    private InternalServiceTemplate brokersService;
     private ExternalServiceTemplate externalBootstrapService;
     private ExternalServiceTemplate perPodService;
     private ResourceTemplate externalBootstrapRoute;
@@ -75,21 +75,21 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     @Description("Template for Kafka bootstrap `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getBootstrapService() {
+    public InternalServiceTemplate getBootstrapService() {
         return bootstrapService;
     }
 
-    public void setBootstrapService(ResourceTemplate bootstrapService) {
+    public void setBootstrapService(InternalServiceTemplate bootstrapService) {
         this.bootstrapService = bootstrapService;
     }
 
     @Description("Template for Kafka broker `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getBrokersService() {
+    public InternalServiceTemplate getBrokersService() {
         return brokersService;
     }
 
-    public void setBrokersService(ResourceTemplate brokersService) {
+    public void setBrokersService(InternalServiceTemplate brokersService) {
         this.brokersService = brokersService;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -33,7 +33,7 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private PodTemplate buildPod;
-    private ResourceTemplate apiService;
+    private InternalServiceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate connectContainer;
     private ContainerTemplate initContainer;
@@ -75,11 +75,11 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
 
     @Description("Template for Kafka Connect API `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getApiService() {
+    public InternalServiceTemplate getApiService() {
         return apiService;
     }
 
-    public void setApiService(ResourceTemplate apiService) {
+    public void setApiService(InternalServiceTemplate apiService) {
         this.apiService = apiService;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
@@ -32,7 +32,7 @@ public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyP
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;
-    private ResourceTemplate apiService;
+    private InternalServiceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate mirrorMaker2Container;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
@@ -59,11 +59,11 @@ public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyP
 
     @Description("Template for Kafka MirrorMaker 2.0 API `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getApiService() {
+    public InternalServiceTemplate getApiService() {
         return apiService;
     }
 
-    public void setApiService(ResourceTemplate apiService) {
+    public void setApiService(InternalServiceTemplate apiService) {
         this.apiService = apiService;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
@@ -35,8 +35,8 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
 
     private StatefulSetTemplate statefulset;
     private PodTemplate pod;
-    private ResourceTemplate clientService;
-    private ResourceTemplate nodesService;
+    private InternalServiceTemplate clientService;
+    private InternalServiceTemplate nodesService;
     private ResourceTemplate persistentVolumeClaim;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate zookeeperContainer;
@@ -65,21 +65,21 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
 
     @Description("Template for ZooKeeper client `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getClientService() {
+    public InternalServiceTemplate getClientService() {
         return clientService;
     }
 
-    public void setClientService(ResourceTemplate clientService) {
+    public void setClientService(InternalServiceTemplate clientService) {
         this.clientService = clientService;
     }
 
     @Description("Template for ZooKeeper nodes `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getNodesService() {
+    public InternalServiceTemplate getNodesService() {
         return nodesService;
     }
 
-    public void setNodesService(ResourceTemplate nodesService) {
+    public void setNodesService(InternalServiceTemplate nodesService) {
         this.nodesService = nodesService;
     }
 

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -466,15 +466,16 @@ spec:
                               - SingleStack
                               - PreferDualStack
                               - RequireDualStack
-                              description: Specifies which IP Family Policy should
-                                be used by this service. Available options are `SingleStack`
-                                (a single IP family), `PreferDualStack` (two IP families
-                                on dual-stack configured clusters or a single IP family
-                                on single-stack clusters), and `RequireDualStack`
-                                (two IP families on dual-stack configured clusters,
-                                otherwise fail). If unspecified, Kubernetes will choose
-                                the default value based on the service type. Available
-                                on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by
+                                the service. Available options are `SingleStack`,
+                                `PreferDualStack` and `RequireDualStack`. `SingleStack`
+                                is for a single IP family. `PreferDualStack` is for
+                                two IP families on dual-stack configured clusters
+                                or a single IP family on single-stack clusters. `RequireDualStack`
+                                fails unless there are two IP families on dual-stack
+                                configured clusters. If unspecified, Kubernetes will
+                                choose the default value based on the service type.
+                                Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -482,11 +483,11 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
-                              description: Specifies which IP Families should be used
-                                by this service. Available options are `IPv4` and
-                                `IPv6. If unspecified, Kubernetes will choose the
-                                default value based on the `ipFamilyPolicy` setting.
-                                Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service.
+                                Available options are `IPv4` and `IPv6. If unspecified,
+                                Kubernetes will choose the default value based on
+                                the `ipFamilyPolicy` setting. Available on Kubernetes
+                                1.20 and newer.
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
@@ -1477,15 +1478,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -1493,11 +1495,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for Kafka bootstrap `Service`.
                       brokersService:
                         type: object
@@ -1522,15 +1524,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -1538,11 +1541,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for Kafka broker `Service`.
                       externalBootstrapService:
                         type: object
@@ -2565,15 +2568,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -2581,11 +2585,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for ZooKeeper client `Service`.
                       nodesService:
                         type: object
@@ -2610,15 +2614,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -2626,11 +2631,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for ZooKeeper nodes `Service`.
                       persistentVolumeClaim:
                         type: object
@@ -4569,15 +4574,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -4585,11 +4591,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for Cruise Control API `Service`.
                       podDisruptionBudget:
                         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -460,6 +460,33 @@ spec:
                                 required:
                                 - broker
                               description: Per-broker configurations.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                              - SingleStack
+                              - PreferDualStack
+                              - RequireDualStack
+                              description: Specifies which IP Family Policy should
+                                be used by this service. Available options are `SingleStack`
+                                (a single IP family), `PreferDualStack` (two IP families
+                                on dual-stack configured clusters or a single IP family
+                                on single-stack clusters), and `RequireDualStack`
+                                (two IP families on dual-stack configured clusters,
+                                otherwise fail). If unspecified, Kubernetes will choose
+                                the default value based on the service type. Available
+                                on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                - IPv4
+                                - IPv6
+                              description: Specifies which IP Families should be used
+                                by this service. Available options are `IPv4` and
+                                `IPv6. If unspecified, Kubernetes will choose the
+                                default value based on the `ipFamilyPolicy` setting.
+                                Available on Kubernetes 1.20 and newer.
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
@@ -1444,6 +1471,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for Kafka bootstrap `Service`.
                       brokersService:
                         type: object
@@ -1462,6 +1516,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for Kafka broker `Service`.
                       externalBootstrapService:
                         type: object
@@ -2478,6 +2559,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for ZooKeeper client `Service`.
                       nodesService:
                         type: object
@@ -2496,6 +2604,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for ZooKeeper nodes `Service`.
                       persistentVolumeClaim:
                         type: object
@@ -4428,6 +4563,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for Cruise Control API `Service`.
                       podDisruptionBudget:
                         type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
@@ -832,14 +832,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -847,11 +848,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
@@ -826,6 +826,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
@@ -834,6 +834,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
@@ -840,14 +840,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -855,11 +856,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
@@ -847,14 +847,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -862,11 +863,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Bridge API `Service`.
                   bridgeContainer:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
@@ -841,6 +841,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Bridge API `Service`.
                   bridgeContainer:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
@@ -939,6 +939,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
@@ -945,14 +945,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -960,11 +961,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -295,15 +295,11 @@ public class CruiseControl extends AbstractModel {
             CruiseControlTemplate template = spec.getTemplate();
 
             ModelUtils.parsePodTemplate(cruiseControl, template.getPod());
+            ModelUtils.parseInternalServiceTemplate(cruiseControl, template.getApiService());
 
             if (template.getDeployment() != null && template.getDeployment().getMetadata() != null) {
                 cruiseControl.templateDeploymentLabels = template.getDeployment().getMetadata().getLabels();
                 cruiseControl.templateDeploymentAnnotations = template.getDeployment().getMetadata().getAnnotations();
-            }
-
-            if (template.getApiService() != null && template.getApiService().getMetadata() != null) {
-                cruiseControl.templateServiceLabels = template.getApiService().getMetadata().getLabels();
-                cruiseControl.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
             }
 
             if (template.getCruiseControlContainer() != null && template.getCruiseControlContainer().getEnv() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -180,6 +180,7 @@ public class KafkaBridgeCluster extends AbstractModel {
 
             ModelUtils.parseDeploymentTemplate(kafkaBridgeCluster, template.getDeployment());
             ModelUtils.parsePodTemplate(kafkaBridgeCluster, template.getPod());
+            ModelUtils.parseInternalServiceTemplate(kafkaBridgeCluster, template.getApiService());
 
             if (template.getApiService() != null && template.getApiService().getMetadata() != null)  {
                 kafkaBridgeCluster.templateServiceLabels = template.getApiService().getMetadata().getLabels();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -791,7 +791,8 @@ public class KafkaCluster extends AbstractModel {
                     getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templateExternalBootstrapServiceLabels, ListenersUtils.bootstrapLabels(listener))),
                     getSelectorLabels(),
                     Util.mergeLabelsOrAnnotations(ListenersUtils.bootstrapAnnotations(listener), templateExternalBootstrapServiceAnnotations),
-                    ListenersUtils.ipFamilyPolicy(listener), ListenersUtils.ipFamilies(listener)
+                    ListenersUtils.ipFamilyPolicy(listener),
+                    ListenersUtils.ipFamilies(listener)
             );
 
             if (KafkaListenerType.LOADBALANCER == listener.getType()) {
@@ -858,7 +859,8 @@ public class KafkaCluster extends AbstractModel {
                     getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodServiceLabels, ListenersUtils.brokerLabels(listener, pod))),
                     selector,
                     Util.mergeLabelsOrAnnotations(ListenersUtils.brokerAnnotations(listener, pod), templatePerPodServiceAnnotations),
-                    ListenersUtils.ipFamilyPolicy(listener), ListenersUtils.ipFamilies(listener)
+                    ListenersUtils.ipFamilyPolicy(listener),
+                    ListenersUtils.ipFamilies(listener)
             );
 
             if (KafkaListenerType.LOADBALANCER == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -497,16 +497,8 @@ public class KafkaCluster extends AbstractModel {
             }
 
             ModelUtils.parsePodTemplate(result, template.getPod());
-
-            if (template.getBootstrapService() != null && template.getBootstrapService().getMetadata() != null) {
-                result.templateServiceLabels = template.getBootstrapService().getMetadata().getLabels();
-                result.templateServiceAnnotations = template.getBootstrapService().getMetadata().getAnnotations();
-            }
-
-            if (template.getBrokersService() != null && template.getBrokersService().getMetadata() != null) {
-                result.templateHeadlessServiceLabels = template.getBrokersService().getMetadata().getLabels();
-                result.templateHeadlessServiceAnnotations = template.getBrokersService().getMetadata().getAnnotations();
-            }
+            ModelUtils.parseInternalServiceTemplate(result, template.getBootstrapService());
+            ModelUtils.parseInternalHeadlessServiceTemplate(result, template.getBrokersService());
 
             if (template.getExternalBootstrapService() != null) {
                 if (template.getExternalBootstrapService().getMetadata() != null) {
@@ -798,7 +790,8 @@ public class KafkaCluster extends AbstractModel {
                     ports,
                     getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templateExternalBootstrapServiceLabels, ListenersUtils.bootstrapLabels(listener))),
                     getSelectorLabels(),
-                    Util.mergeLabelsOrAnnotations(ListenersUtils.bootstrapAnnotations(listener), templateExternalBootstrapServiceAnnotations)
+                    Util.mergeLabelsOrAnnotations(ListenersUtils.bootstrapAnnotations(listener), templateExternalBootstrapServiceAnnotations),
+                    ListenersUtils.ipFamilyPolicy(listener), ListenersUtils.ipFamilies(listener)
             );
 
             if (KafkaListenerType.LOADBALANCER == listener.getType()) {
@@ -864,7 +857,8 @@ public class KafkaCluster extends AbstractModel {
                     ports,
                     getLabelsWithStrimziName(name, Util.mergeLabelsOrAnnotations(templatePerPodServiceLabels, ListenersUtils.brokerLabels(listener, pod))),
                     selector,
-                    Util.mergeLabelsOrAnnotations(ListenersUtils.brokerAnnotations(listener, pod), templatePerPodServiceAnnotations)
+                    Util.mergeLabelsOrAnnotations(ListenersUtils.brokerAnnotations(listener, pod), templatePerPodServiceAnnotations),
+                    ListenersUtils.ipFamilyPolicy(listener), ListenersUtils.ipFamilies(listener)
             );
 
             if (KafkaListenerType.LOADBALANCER == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -254,11 +254,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
             ModelUtils.parseDeploymentTemplate(kafkaConnect, template.getDeployment());
             ModelUtils.parsePodTemplate(kafkaConnect, template.getPod());
-
-            if (template.getApiService() != null && template.getApiService().getMetadata() != null)  {
-                kafkaConnect.templateServiceLabels = template.getApiService().getMetadata().getLabels();
-                kafkaConnect.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
-            }
+            ModelUtils.parseInternalServiceTemplate(kafkaConnect, template.getApiService());
 
             if (template.getClusterRoleBinding() != null && template.getClusterRoleBinding().getMetadata() != null) {
                 kafkaConnect.templateClusterRoleBindingLabels = template.getClusterRoleBinding().getMetadata().getLabels();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -10,6 +10,8 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 
 import java.util.Collections;
 import java.util.List;
@@ -562,6 +564,34 @@ public class ListenersUtils {
     public static ExternalTrafficPolicy externalTrafficPolicy(GenericKafkaListener listener)    {
         if (listener.getConfiguration() != null) {
             return listener.getConfiguration().getExternalTrafficPolicy();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Finds IP family policy
+     *
+     * @param listener  Listener for which the IP family policy should be found
+     * @return          IP family policy or null if not specified
+     */
+    public static IpFamilyPolicy ipFamilyPolicy(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null) {
+            return listener.getConfiguration().getIpFamilyPolicy();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Finds IP families
+     *
+     * @param listener  Listener for which the IP families should be found
+     * @return          IP families or null if not specified
+     */
+    public static List<IpFamily> ipFamilies(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null) {
+            return listener.getConfiguration().getIpFamilies();
         } else {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -72,6 +72,8 @@ public class ListenersValidator {
 
             if (listener.getConfiguration() != null)    {
                 validateServiceDnsDomain(errors, listener);
+                validateIpFamilyPolicy(errors, listener);
+                validateIpFamilies(errors, listener);
                 validateIngressClass(errors, listener);
                 validateExternalTrafficPolicy(errors, listener);
                 validateLoadBalancerSourceRanges(errors, listener);
@@ -190,6 +192,32 @@ public class ListenersValidator {
         if (KafkaListenerType.INTERNAL != listener.getType()
                 && listener.getConfiguration().getUseServiceDnsDomain() != null)    {
             errors.add("listener " + listener.getName() + " cannot configure useServiceDnsDomain because it is not internal listener");
+        }
+    }
+
+    /**
+     * Validates that ipFamilyPolicy is used only with external listeners
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validateIpFamilyPolicy(Set<String> errors, GenericKafkaListener listener) {
+        if (KafkaListenerType.INTERNAL == listener.getType()
+                && listener.getConfiguration().getIpFamilyPolicy() != null)    {
+            errors.add("listener " + listener.getName() + " cannot configure ipFamilyPolicy because it is not internal listener");
+        }
+    }
+
+    /**
+     * Validates that ipFamilies is used only with external listeners
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validateIpFamilies(Set<String> errors, GenericKafkaListener listener) {
+        if (KafkaListenerType.INTERNAL == listener.getType()
+                && listener.getConfiguration().getIpFamilies() != null)    {
+            errors.add("listener " + listener.getName() + " cannot configure ipFamilies because it is not internal listener");
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -30,6 +30,7 @@ import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.template.DeploymentTemplate;
+import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.certs.CertAndKey;
@@ -259,6 +260,42 @@ public class ModelUtils {
             model.templatePodHostAliases = pod.getHostAliases();
             model.templatePodTopologySpreadConstraints = pod.getTopologySpreadConstraints();
             model.templatePodEnableServiceLinks = pod.getEnableServiceLinks();
+        }
+    }
+
+    /**
+     * Parses the values from the InternalServiceTemplate in CRD model into the component model
+     *
+     * @param model AbstractModel class where the values from the PodTemplate should be set
+     * @param service InternalServiceTemplate with the values form the CRD
+     */
+    public static void parseInternalServiceTemplate(AbstractModel model, InternalServiceTemplate service)   {
+        if (service != null)  {
+            if (service.getMetadata() != null) {
+                model.templateServiceLabels = service.getMetadata().getLabels();
+                model.templateServiceAnnotations = service.getMetadata().getAnnotations();
+            }
+
+            model.templateServiceIpFamilyPolicy = service.getIpFamilyPolicy();
+            model.templateServiceIpFamilies = service.getIpFamilies();
+        }
+    }
+
+    /**
+     * Parses the values from the InternalServiceTemplate of a headless service in CRD model into the component model
+     *
+     * @param model AbstractModel class where the values from the PodTemplate should be set
+     * @param service InternalServiceTemplate with the values form the CRD
+     */
+    public static void parseInternalHeadlessServiceTemplate(AbstractModel model, InternalServiceTemplate service)   {
+        if (service != null)  {
+            if (service.getMetadata() != null) {
+                model.templateHeadlessServiceLabels = service.getMetadata().getLabels();
+                model.templateHeadlessServiceAnnotations = service.getMetadata().getAnnotations();
+            }
+
+            model.templateHeadlessServiceIpFamilyPolicy = service.getIpFamilyPolicy();
+            model.templateHeadlessServiceIpFamilies = service.getIpFamilies();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -289,16 +289,8 @@ public class ZookeeperCluster extends AbstractModel {
             }
 
             ModelUtils.parsePodTemplate(zk, template.getPod());
-
-            if (template.getClientService() != null && template.getClientService().getMetadata() != null)  {
-                zk.templateServiceLabels = template.getClientService().getMetadata().getLabels();
-                zk.templateServiceAnnotations = template.getClientService().getMetadata().getAnnotations();
-            }
-
-            if (template.getNodesService() != null && template.getNodesService().getMetadata() != null)  {
-                zk.templateHeadlessServiceLabels = template.getNodesService().getMetadata().getLabels();
-                zk.templateHeadlessServiceAnnotations = template.getNodesService().getMetadata().getAnnotations();
-            }
+            ModelUtils.parseInternalServiceTemplate(zk, template.getClientService());
+            ModelUtils.parseInternalHeadlessServiceTemplate(zk, template.getNodesService());
 
             if (template.getPersistentVolumeClaim() != null && template.getPersistentVolumeClaim().getMetadata() != null) {
                 zk.templatePersistentVolumeClaimLabels = Util.mergeLabelsOrAnnotations(template.getPersistentVolumeClaim().getMetadata().getLabels(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -46,6 +46,8 @@ import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
@@ -71,6 +73,7 @@ import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_B
 import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_BROKER_DISK_MIB_CAPACITY;
 import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_BROKER_INBOUND_NETWORK_KIB_PER_SECOND_CAPACITY;
 import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_BROKER_OUTBOUND_NETWORK_KIB_PER_SECOND_CAPACITY;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -80,6 +83,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasItems;
@@ -455,6 +459,8 @@ public class CruiseControlTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(CruiseControl.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(CruiseControl.REST_API_PORT)));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
 
         TestUtils.checkOwnerReference(cc.createOwnerReference(), svc);
     }
@@ -537,6 +543,8 @@ public class CruiseControlTest {
                                     .withLabels(svcLabels)
                                     .withAnnotations(svcAnots)
                                 .endMetadata()
+                                .withIpFamilyPolicy(IpFamilyPolicy.PREFER_DUAL_STACK)
+                                .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                             .endApiService()
                         .endTemplate()
                     .endCruiseControl()
@@ -566,6 +574,8 @@ public class CruiseControlTest {
         Service svc = cc.generateService();
         assertThat(svc.getMetadata().getLabels(), is(svcLabels));
         assertThat(svc.getMetadata().getAnnotations(),  is(svcAnots));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), contains("IPv6", "IPv4"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -55,6 +55,8 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSourceBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.template.DeploymentStrategy;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -74,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -82,6 +85,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -229,6 +233,8 @@ public class KafkaConnectS2IClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaConnectCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getMetadata().getAnnotations().size(), is(0));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
 
         checkOwnerReference(kc.createOwnerReference(), svc);
     }
@@ -576,6 +582,8 @@ public class KafkaConnectS2IClusterTest {
                                 .withLabels(svcLabels)
                                 .withAnnotations(svcAnots)
                             .endMetadata()
+                            .withIpFamilyPolicy(IpFamilyPolicy.PREFER_DUAL_STACK)
+                            .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                         .endApiService()
                         .withNewPodDisruptionBudget()
                             .withNewMetadata()
@@ -614,6 +622,8 @@ public class KafkaConnectS2IClusterTest {
         Service svc = kc.generateService();
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(svcLabels.entrySet()), is(true));
         assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(svcAnots.entrySet()), is(true));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), contains("IPv6", "IPv4"));
 
         // Check PodDisruptionBudget
         PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -10,6 +10,8 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBrokerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 
@@ -22,6 +24,7 @@ import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -144,6 +147,8 @@ public class ListenersUtilsTest {
             .withTls(true)
             .withNewConfiguration()
                 .withExternalTrafficPolicy(ExternalTrafficPolicy.CLUSTER)
+                .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                 .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-np-1", "my-np-2"))
@@ -191,6 +196,8 @@ public class ListenersUtilsTest {
             .withTls(true)
             .withNewConfiguration()
                 .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                 .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                 .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
                 .withNewBootstrap()
@@ -592,6 +599,32 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.externalTrafficPolicy(newNodePort), is(nullValue()));
         assertThat(ListenersUtils.externalTrafficPolicy(newNodePort2), is(ExternalTrafficPolicy.CLUSTER));
         assertThat(ListenersUtils.externalTrafficPolicy(newNodePort3), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testIpFamilyPolicy() {
+        assertThat(ListenersUtils.ipFamilyPolicy(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilyPolicy(oldExternal), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilyPolicy(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilyPolicy(newLoadBalancer2), is(IpFamilyPolicy.REQUIRE_DUAL_STACK));
+        assertThat(ListenersUtils.ipFamilyPolicy(oldPlain), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilyPolicy(newTls), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilyPolicy(newNodePort), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilyPolicy(newNodePort2), is(IpFamilyPolicy.REQUIRE_DUAL_STACK));
+        assertThat(ListenersUtils.ipFamilyPolicy(newNodePort3), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testIpFamilies() {
+        assertThat(ListenersUtils.ipFamilies(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilies(oldExternal), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilies(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilies(newLoadBalancer2), contains(IpFamily.IPV6, IpFamily.IPV4));
+        assertThat(ListenersUtils.ipFamilies(oldPlain), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilies(newTls), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilies(newNodePort), is(nullValue()));
+        assertThat(ListenersUtils.ipFamilies(newNodePort2), contains(IpFamily.IPV6, IpFamily.IPV4));
+        assertThat(ListenersUtils.ipFamilies(newNodePort3), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -19,6 +19,8 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerCon
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.listener.arraylistener.ListenersConvertor;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 
@@ -237,6 +239,8 @@ public class ListenersValidatorTest {
                     .withIngressClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                    .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                    .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
@@ -288,7 +292,9 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
-                "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, or Ingress based listener"
+                "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
+                "listener " + name + " cannot configure ipFamilyPolicy because it is not internal listener",
+                "listener " + name + " cannot configure ipFamilies because it is not internal listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -306,6 +312,8 @@ public class ListenersValidatorTest {
                     .withIngressClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                    .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                    .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
@@ -364,6 +372,8 @@ public class ListenersValidatorTest {
                     .withIngressClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                    .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                    .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
@@ -444,6 +454,8 @@ public class ListenersValidatorTest {
                     .withIngressClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                    .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                    .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
@@ -542,6 +554,8 @@ public class ListenersValidatorTest {
                     .withIngressClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
+                    .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
+                    .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -846,6 +846,7 @@ public class CrdGenerator {
         return schema;
     }
 
+    @SuppressWarnings("unchecked")
     private ObjectNode buildArraySchema(ApiVersion crApiVersion, Property property, PropertyType propertyType, boolean description) {
         int arrayDimension = propertyType.arrayDimension();
         ObjectNode result = nf.objectNode();
@@ -869,6 +870,15 @@ public class CrdGenerator {
         } else if (Map.class.equals(elementType)) {
             preserveUnknownFields(itemResult);
             itemResult.put("type", "object");
+        } else if (elementType.isEnum()) {
+            itemResult.put("type", "string");
+
+            try {
+                Method valuesMethod = elementType.getMethod("values");
+                itemResult.set("enum", enumCaseArray((Enum[]) valuesMethod.invoke(null)));
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
         } else  {
             buildObjectSchema(crApiVersion, itemResult, elementType, true, description);
         }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -110,6 +110,10 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
 
     public List<? extends List<? extends U>> listOfWildcardTypeVar4;
 
+    public List<CustomisedEnum> listOfCustomizedEnum;
+
+    public List<NormalEnum> listOfNormalEnum;
+
     public List<Map<String, Object>> listOfMaps;
 
     private String either;

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -39,12 +39,16 @@
 |xref:type-Number-{context}[`Number`] array
 |listOfBoundTypeVar2     1.2+<.<a|
 |xref:type-Number-{context}[`Number`] array
+|listOfCustomizedEnum    1.2+<.<a|
+|string (one or more of [one, two]) array
 |listOfInts              1.2+<.<a|
 |integer array
 |listOfInts2             1.2+<.<a|
 |integer array of dimension 2
 |listOfMaps              1.2+<.<a|
 |map array
+|listOfNormalEnum        1.2+<.<a|
+|string (one or more of [BAR, FOO]) array
 |listOfObjects           1.2+<.<a|
 |xref:type-ObjectProperty-{context}[`ObjectProperty`] array
 |listOfPolymorphic       1.2+<.<a|

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -314,6 +314,13 @@ spec:
           items:
             type: "object"
             properties: {}
+        listOfCustomizedEnum:
+          type: "array"
+          items:
+            type: "string"
+            enum:
+            - "one"
+            - "two"
         listOfInts:
           type: "array"
           items:
@@ -328,6 +335,13 @@ spec:
           type: "array"
           items:
             type: "object"
+        listOfNormalEnum:
+          type: "array"
+          items:
+            type: "string"
+            enum:
+            - "FOO"
+            - "BAR"
         listOfObjects:
           type: "array"
           items:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -320,6 +320,13 @@ spec:
           items:
             type: "object"
             properties: {}
+        listOfCustomizedEnum:
+          type: "array"
+          items:
+            type: "string"
+            enum:
+            - "one"
+            - "two"
         listOfInts:
           type: "array"
           items:
@@ -334,6 +341,13 @@ spec:
           type: "array"
           items:
             type: "object"
+        listOfNormalEnum:
+          type: "array"
+          items:
+            type: "string"
+            enum:
+            - "FOO"
+            - "BAR"
         listOfObjects:
           type: "array"
           items:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -312,6 +312,13 @@ spec:
           items:
             type: "object"
             properties: {}
+        listOfCustomizedEnum:
+          type: "array"
+          items:
+            type: "string"
+            enum:
+            - "one"
+            - "two"
         listOfInts:
           type: "array"
           items:
@@ -326,6 +333,13 @@ spec:
           type: "array"
           items:
             type: "object"
+        listOfNormalEnum:
+          type: "array"
+          items:
+            type: "string"
+            enum:
+            - "FOO"
+            - "BAR"
         listOfObjects:
           type: "array"
           items:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -289,9 +289,9 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-GenericKafkaListenerConfigurationBootstrap-{context}[`GenericKafkaListenerConfigurationBootstrap`]
 |brokers                       1.2+<.<a|Per-broker configurations.
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
-|ipFamilyPolicy                1.2+<.<a|Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+|ipFamilyPolicy                1.2+<.<a|Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
 |string (one of [RequireDualStack, SingleStack, PreferDualStack])
-|ipFamilies                    1.2+<.<a|Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+|ipFamilies                    1.2+<.<a|Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
 |string (one or more of [IPv6, IPv4]) array
 |class                         1.2+<.<a|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
 |string
@@ -909,9 +909,9 @@ Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xre
 |Property               |Description
 |metadata        1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|ipFamilyPolicy  1.2+<.<a|Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+|ipFamilyPolicy  1.2+<.<a|Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
 |string (one of [RequireDualStack, SingleStack, PreferDualStack])
-|ipFamilies      1.2+<.<a|Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+|ipFamilies      1.2+<.<a|Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
 |string (one or more of [IPv6, IPv4]) array
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -289,6 +289,10 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-GenericKafkaListenerConfigurationBootstrap-{context}[`GenericKafkaListenerConfigurationBootstrap`]
 |brokers                       1.2+<.<a|Per-broker configurations.
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
+|ipFamilyPolicy                1.2+<.<a|Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+|string (one of [RequireDualStack, SingleStack, PreferDualStack])
+|ipFamilies                    1.2+<.<a|Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+|string (one or more of [IPv6, IPv4]) array
 |class                         1.2+<.<a|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
 |string
 |finalizers                    1.2+<.<a|A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
@@ -776,9 +780,9 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |pod                       1.2+<.<a|Template for Kafka `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |bootstrapService          1.2+<.<a|Template for Kafka bootstrap `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |brokersService            1.2+<.<a|Template for Kafka broker `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |externalBootstrapService  1.2+<.<a|Template for Kafka external bootstrap `Service`.
 |xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`]
 |perPodService             1.2+<.<a|Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
@@ -823,7 +827,7 @@ Used in: xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:
 [id='type-MetadataTemplate-{context}']
 ### `MetadataTemplate` schema reference
 
-Used in: xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`], xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`], xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
+Used in: xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`], xref:type-ExternalServiceTemplate-{context}[`ExternalServiceTemplate`], xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`], xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`], xref:type-PodTemplate-{context}[`PodTemplate`], xref:type-ResourceTemplate-{context}[`ResourceTemplate`], xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
 
 xref:type-MetadataTemplate-schema-{context}[Full list of `MetadataTemplate` schema properties]
 
@@ -894,17 +898,21 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
 |====
 
-[id='type-ResourceTemplate-{context}']
-### `ResourceTemplate` schema reference
+[id='type-InternalServiceTemplate-{context}']
+### `InternalServiceTemplate` schema reference
 
-Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
+Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
 
 
 [options="header"]
 |====
-|Property         |Description
-|metadata  1.2+<.<a|Metadata applied to the resource.
+|Property               |Description
+|metadata        1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|ipFamilyPolicy  1.2+<.<a|Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+|string (one of [RequireDualStack, SingleStack, PreferDualStack])
+|ipFamilies      1.2+<.<a|Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+|string (one or more of [IPv6, IPv4]) array
 |====
 
 [id='type-ExternalServiceTemplate-{context}']
@@ -918,6 +926,19 @@ include::../api/io.strimzi.api.kafka.model.template.ExternalServiceTemplate.adoc
 
 [id='type-ExternalServiceTemplate-schema-{context}']
 ==== `ExternalServiceTemplate` schema properties
+
+
+[options="header"]
+|====
+|Property         |Description
+|metadata  1.2+<.<a|Metadata applied to the resource.
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|====
+
+[id='type-ResourceTemplate-{context}']
+### `ResourceTemplate` schema reference
+
+Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaUserTemplate-{context}[`KafkaUserTemplate`], xref:type-ZookeeperClusterTemplate-{context}[`ZookeeperClusterTemplate`]
 
 
 [options="header"]
@@ -1044,9 +1065,9 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |pod                    1.2+<.<a|Template for ZooKeeper `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |clientService          1.2+<.<a|Template for ZooKeeper client `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |nodesService           1.2+<.<a|Template for ZooKeeper nodes `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |persistentVolumeClaim  1.2+<.<a|Template for all ZooKeeper `PersistentVolumeClaims`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |podDisruptionBudget    1.2+<.<a|Template for ZooKeeper `PodDisruptionBudget`.
@@ -1278,7 +1299,7 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 |pod                     1.2+<.<a|Template for Cruise Control `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService              1.2+<.<a|Template for Cruise Control API `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |podDisruptionBudget     1.2+<.<a|Template for Cruise Control `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |cruiseControlContainer  1.2+<.<a|Template for the Cruise Control container.
@@ -1767,7 +1788,7 @@ Used in: xref:type-KafkaConnectS2ISpec-{context}[`KafkaConnectS2ISpec`], xref:ty
 |pod                  1.2+<.<a|Template for Kafka Connect `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<a|Template for Kafka Connect API `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |buildConfig          1.2+<.<a|Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |buildContainer       1.2+<.<a|Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
@@ -2790,7 +2811,7 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 |pod                  1.2+<.<a|Template for Kafka Bridge `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<a|Template for Kafka Bridge API `Service`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |bridgeContainer      1.2+<.<a|Template for the Kafka Bridge container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |podDisruptionBudget  1.2+<.<a|Template for Kafka Bridge `PodDisruptionBudget`.

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
@@ -147,7 +147,7 @@ public class ResourceVisitor {
             } else if (Collection.class.isAssignableFrom(returnType)) {
                 path.add(propertyName);
                 for (Object element : (Collection<?>) propertyValue) {
-                    if (element != null) {
+                    if (element != null && !element.getClass().isEnum()) {
                         visit(path, element, visitor);
                     }
                 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -195,7 +196,7 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     }
 
     @Test
-    public void testIpFamilyPatching()  {
+    public void testDualStackNetworkingPatching()  {
         KubernetesClient client = mock(KubernetesClient.class);
 
         Service current = new ServiceBuilder()
@@ -217,6 +218,7 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
                                     .withTargetPort(new IntOrString(5678))
                                     .build()
                     )
+                    .withIpFamilyPolicy("SingleStack")
                     .withIpFamilies("IPv6")
                 .endSpec()
                 .build();
@@ -240,36 +242,73 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
                                     .withTargetPort(new IntOrString(5678))
                                     .build()
                     )
-                    .withIpFamilies("IPv6")
+                    .withIpFamilyPolicy("PreferDualStack")
+                    .withIpFamilies("IPv4", "IPv6")
                 .endSpec()
                 .build();
 
         Service desired = new ServiceBuilder()
                 .withNewMetadata()
-                .withNamespace(NAMESPACE)
-                .withName(RESOURCE_NAME)
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
                 .endMetadata()
                 .withNewSpec()
-                .withType("NodePort")
-                .withPorts(
-                        new ServicePortBuilder()
-                                .withName("port2")
-                                .withPort(5678)
-                                .withTargetPort(new IntOrString(5678))
-                                .build(),
-                        new ServicePortBuilder()
-                                .withName("port1")
-                                .withPort(1234)
-                                .withTargetPort(new IntOrString(1234))
-                                .build()
-                )
+                    .withType("NodePort")
+                    .withPorts(
+                            new ServicePortBuilder()
+                                    .withName("port2")
+                                    .withPort(5678)
+                                    .withTargetPort(new IntOrString(5678))
+                                    .build(),
+                            new ServicePortBuilder()
+                                    .withName("port1")
+                                    .withPort(1234)
+                                    .withTargetPort(new IntOrString(1234))
+                                    .build()
+                    )
+                .endSpec()
+                .build();
+
+        Service desired2 = new ServiceBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("NodePort")
+                    .withPorts(
+                            new ServicePortBuilder()
+                                    .withName("port2")
+                                    .withPort(5678)
+                                    .withTargetPort(new IntOrString(5678))
+                                    .build(),
+                            new ServicePortBuilder()
+                                    .withName("port1")
+                                    .withPort(1234)
+                                    .withTargetPort(new IntOrString(1234))
+                                    .build()
+                    )
+                    .withIpFamilyPolicy("RequireDualStack")
+                    .withIpFamilies("IPv4", "IPv6")
                 .endSpec()
                 .build();
 
         ServiceOperator op = new ServiceOperator(vertx, client);
-        op.patchDualStackNetworking(current, desired);
 
+        op.patchDualStackNetworking(current, desired);
+        assertThat(current.getSpec().getIpFamilyPolicy(), is(desired.getSpec().getIpFamilyPolicy()));
         assertThat(current.getSpec().getIpFamilies(), is(desired.getSpec().getIpFamilies()));
+
+        op.patchDualStackNetworking(current2, desired);
+        assertThat(current2.getSpec().getIpFamilyPolicy(), is(not(desired.getSpec().getIpFamilyPolicy())));
         assertThat(current2.getSpec().getIpFamilies(), is(desired.getSpec().getIpFamilies()));
+
+        op.patchDualStackNetworking(current, desired2);
+        assertThat(current.getSpec().getIpFamilyPolicy(), is(not(desired2.getSpec().getIpFamilyPolicy())));
+        assertThat(current.getSpec().getIpFamilies(), is(desired2.getSpec().getIpFamilies()));
+
+        op.patchDualStackNetworking(current2, desired2);
+        assertThat(current2.getSpec().getIpFamilyPolicy(), is(not(desired2.getSpec().getIpFamilyPolicy())));
+        assertThat(current2.getSpec().getIpFamilies(), is(desired2.getSpec().getIpFamilies()));
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -267,7 +267,7 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
                 .build();
 
         ServiceOperator op = new ServiceOperator(vertx, client);
-        op.patchIpFamily(current, desired);
+        op.patchDualStackNetworking(current, desired);
 
         assertThat(current.getSpec().getIpFamilies(), is(desired.getSpec().getIpFamilies()));
         assertThat(current2.getSpec().getIpFamilies(), is(desired.getSpec().getIpFamilies()));

--- a/operator-common/src/test/resources/example2.yaml
+++ b/operator-common/src/test/resources/example2.yaml
@@ -32,6 +32,11 @@ spec:
     storage:
       type: ephemeral
     version: 2.8.0
+    template:
+      bootstrapService:
+        ipFamilies:
+          - IPv4
+          - IPv6
     tlsSidecar: {}
   topicOperator: {}
   zookeeper:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -299,7 +299,7 @@ spec:
                                   - SingleStack
                                   - PreferDualStack
                                   - RequireDualStack
-                                description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                                description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                               ipFamilies:
                                 type: array
                                 items:
@@ -307,7 +307,7 @@ spec:
                                   enum:
                                     - IPv4
                                     - IPv6
-                                description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                                description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                               class:
                                 type: string
                                 description: Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
@@ -1153,7 +1153,7 @@ spec:
                                 - SingleStack
                                 - PreferDualStack
                                 - RequireDualStack
-                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -1161,7 +1161,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for Kafka bootstrap `Service`.
                         brokersService:
                           type: object
@@ -1184,7 +1184,7 @@ spec:
                                 - SingleStack
                                 - PreferDualStack
                                 - RequireDualStack
-                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -1192,7 +1192,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for Kafka broker `Service`.
                         externalBootstrapService:
                           type: object
@@ -2121,7 +2121,7 @@ spec:
                                 - SingleStack
                                 - PreferDualStack
                                 - RequireDualStack
-                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -2129,7 +2129,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for ZooKeeper client `Service`.
                         nodesService:
                           type: object
@@ -2152,7 +2152,7 @@ spec:
                                 - SingleStack
                                 - PreferDualStack
                                 - RequireDualStack
-                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -2160,7 +2160,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for ZooKeeper nodes `Service`.
                         persistentVolumeClaim:
                           type: object
@@ -3913,7 +3913,7 @@ spec:
                                 - SingleStack
                                 - PreferDualStack
                                 - RequireDualStack
-                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -3921,7 +3921,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for Cruise Control API `Service`.
                         podDisruptionBudget:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -293,6 +293,21 @@ spec:
                                   required:
                                     - broker
                                 description: Per-broker configurations.
+                              ipFamilyPolicy:
+                                type: string
+                                enum:
+                                  - SingleStack
+                                  - PreferDualStack
+                                  - RequireDualStack
+                                description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                              ipFamilies:
+                                type: array
+                                items:
+                                  type: string
+                                  enum:
+                                    - IPv4
+                                    - IPv6
+                                description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                               class:
                                 type: string
                                 description: Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
@@ -1132,6 +1147,21 @@ spec:
                                   type: object
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                                - SingleStack
+                                - PreferDualStack
+                                - RequireDualStack
+                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - IPv4
+                                  - IPv6
+                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for Kafka bootstrap `Service`.
                         brokersService:
                           type: object
@@ -1148,6 +1178,21 @@ spec:
                                   type: object
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                                - SingleStack
+                                - PreferDualStack
+                                - RequireDualStack
+                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - IPv4
+                                  - IPv6
+                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for Kafka broker `Service`.
                         externalBootstrapService:
                           type: object
@@ -2070,6 +2115,21 @@ spec:
                                   type: object
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                                - SingleStack
+                                - PreferDualStack
+                                - RequireDualStack
+                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - IPv4
+                                  - IPv6
+                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for ZooKeeper client `Service`.
                         nodesService:
                           type: object
@@ -2086,6 +2146,21 @@ spec:
                                   type: object
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                                - SingleStack
+                                - PreferDualStack
+                                - RequireDualStack
+                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - IPv4
+                                  - IPv6
+                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for ZooKeeper nodes `Service`.
                         persistentVolumeClaim:
                           type: object
@@ -3832,6 +3907,21 @@ spec:
                                   type: object
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                                - SingleStack
+                                - PreferDualStack
+                                - RequireDualStack
+                              description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - IPv4
+                                  - IPv6
+                              description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                           description: Template for Cruise Control API `Service`.
                         podDisruptionBudget:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -748,6 +748,21 @@ spec:
                               type: object
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
+                        ipFamilyPolicy:
+                          type: string
+                          enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                        ipFamilies:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - IPv4
+                              - IPv6
+                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Connect API `Service`.
                     buildConfig:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -754,7 +754,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                         ipFamilies:
                           type: array
                           items:
@@ -762,7 +762,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Connect API `Service`.
                     buildConfig:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -764,7 +764,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                         ipFamilies:
                           type: array
                           items:
@@ -772,7 +772,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Connect API `Service`.
                     buildConfig:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -758,6 +758,21 @@ spec:
                               type: object
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
+                        ipFamilyPolicy:
+                          type: string
+                          enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                        ipFamilies:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - IPv4
+                              - IPv6
+                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Connect API `Service`.
                     buildConfig:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -765,6 +765,21 @@ spec:
                               type: object
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
+                        ipFamilyPolicy:
+                          type: string
+                          enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                        ipFamilies:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - IPv4
+                              - IPv6
+                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Bridge API `Service`.
                     bridgeContainer:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -771,7 +771,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                         ipFamilies:
                           type: array
                           items:
@@ -779,7 +779,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Bridge API `Service`.
                     bridgeContainer:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -842,7 +842,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
                         ipFamilies:
                           type: array
                           items:
@@ -850,7 +850,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
+                          description: Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Connect API `Service`.
                     buildConfig:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -836,6 +836,21 @@ spec:
                               type: object
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
+                        ipFamilyPolicy:
+                          type: string
+                          enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                          description: Specifies which IP Family Policy should be used by this service. Available options are `SingleStack` (a single IP family), `PreferDualStack` (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), and `RequireDualStack` (two IP families on dual-stack configured clusters, otherwise fail). If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.
+                        ipFamilies:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - IPv4
+                              - IPv6
+                          description: Specifies which IP Families should be used by this service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.
                       description: Template for Kafka Connect API `Service`.
                     buildConfig:
                       type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -464,6 +464,33 @@ spec:
                                 required:
                                 - broker
                               description: Per-broker configurations.
+                            ipFamilyPolicy:
+                              type: string
+                              enum:
+                              - SingleStack
+                              - PreferDualStack
+                              - RequireDualStack
+                              description: Specifies which IP Family Policy should
+                                be used by this service. Available options are `SingleStack`
+                                (a single IP family), `PreferDualStack` (two IP families
+                                on dual-stack configured clusters or a single IP family
+                                on single-stack clusters), and `RequireDualStack`
+                                (two IP families on dual-stack configured clusters,
+                                otherwise fail). If unspecified, Kubernetes will choose
+                                the default value based on the service type. Available
+                                on Kubernetes 1.20 and newer.
+                            ipFamilies:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                - IPv4
+                                - IPv6
+                              description: Specifies which IP Families should be used
+                                by this service. Available options are `IPv4` and
+                                `IPv6. If unspecified, Kubernetes will choose the
+                                default value based on the `ipFamilyPolicy` setting.
+                                Available on Kubernetes 1.20 and newer.
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
@@ -1468,6 +1495,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for Kafka bootstrap `Service`.
                       brokersService:
                         type: object
@@ -1488,6 +1542,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for Kafka broker `Service`.
                       externalBootstrapService:
                         type: object
@@ -2541,6 +2622,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for ZooKeeper client `Service`.
                       nodesService:
                         type: object
@@ -2561,6 +2669,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for ZooKeeper nodes `Service`.
                       persistentVolumeClaim:
                         type: object
@@ -4533,6 +4668,33 @@ spec:
                                   Can be applied to different resources such as `StatefulSets`,
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
+                          ipFamilyPolicy:
+                            type: string
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            description: Specifies which IP Family Policy should be
+                              used by this service. Available options are `SingleStack`
+                              (a single IP family), `PreferDualStack` (two IP families
+                              on dual-stack configured clusters or a single IP family
+                              on single-stack clusters), and `RequireDualStack` (two
+                              IP families on dual-stack configured clusters, otherwise
+                              fail). If unspecified, Kubernetes will choose the default
+                              value based on the service type. Available on Kubernetes
+                              1.20 and newer.
+                          ipFamilies:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                              - IPv4
+                              - IPv6
+                            description: Specifies which IP Families should be used
+                              by this service. Available options are `IPv4` and `IPv6.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the `ipFamilyPolicy` setting. Available on
+                              Kubernetes 1.20 and newer.
                         description: Template for Cruise Control API `Service`.
                       podDisruptionBudget:
                         type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -470,15 +470,16 @@ spec:
                               - SingleStack
                               - PreferDualStack
                               - RequireDualStack
-                              description: Specifies which IP Family Policy should
-                                be used by this service. Available options are `SingleStack`
-                                (a single IP family), `PreferDualStack` (two IP families
-                                on dual-stack configured clusters or a single IP family
-                                on single-stack clusters), and `RequireDualStack`
-                                (two IP families on dual-stack configured clusters,
-                                otherwise fail). If unspecified, Kubernetes will choose
-                                the default value based on the service type. Available
-                                on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Family Policy used by
+                                the service. Available options are `SingleStack`,
+                                `PreferDualStack` and `RequireDualStack`. `SingleStack`
+                                is for a single IP family. `PreferDualStack` is for
+                                two IP families on dual-stack configured clusters
+                                or a single IP family on single-stack clusters. `RequireDualStack`
+                                fails unless there are two IP families on dual-stack
+                                configured clusters. If unspecified, Kubernetes will
+                                choose the default value based on the service type.
+                                Available on Kubernetes 1.20 and newer.
                             ipFamilies:
                               type: array
                               items:
@@ -486,11 +487,11 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
-                              description: Specifies which IP Families should be used
-                                by this service. Available options are `IPv4` and
-                                `IPv6. If unspecified, Kubernetes will choose the
-                                default value based on the `ipFamilyPolicy` setting.
-                                Available on Kubernetes 1.20 and newer.
+                              description: Specifies the IP Families used by the service.
+                                Available options are `IPv4` and `IPv6. If unspecified,
+                                Kubernetes will choose the default value based on
+                                the `ipFamilyPolicy` setting. Available on Kubernetes
+                                1.20 and newer.
                             class:
                               type: string
                               description: Configures the `Ingress` class that defines
@@ -1501,15 +1502,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -1517,11 +1519,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for Kafka bootstrap `Service`.
                       brokersService:
                         type: object
@@ -1548,15 +1550,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -1564,11 +1567,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for Kafka broker `Service`.
                       externalBootstrapService:
                         type: object
@@ -2628,15 +2631,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -2644,11 +2648,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for ZooKeeper client `Service`.
                       nodesService:
                         type: object
@@ -2675,15 +2679,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -2691,11 +2696,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for ZooKeeper nodes `Service`.
                       persistentVolumeClaim:
                         type: object
@@ -4674,15 +4679,16 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
-                            description: Specifies which IP Family Policy should be
-                              used by this service. Available options are `SingleStack`
-                              (a single IP family), `PreferDualStack` (two IP families
+                            description: Specifies the IP Family Policy used by the
+                              service. Available options are `SingleStack`, `PreferDualStack`
+                              and `RequireDualStack`. `SingleStack` is for a single
+                              IP family. `PreferDualStack` is for two IP families
                               on dual-stack configured clusters or a single IP family
-                              on single-stack clusters), and `RequireDualStack` (two
-                              IP families on dual-stack configured clusters, otherwise
-                              fail). If unspecified, Kubernetes will choose the default
-                              value based on the service type. Available on Kubernetes
-                              1.20 and newer.
+                              on single-stack clusters. `RequireDualStack` fails unless
+                              there are two IP families on dual-stack configured clusters.
+                              If unspecified, Kubernetes will choose the default value
+                              based on the service type. Available on Kubernetes 1.20
+                              and newer.
                           ipFamilies:
                             type: array
                             items:
@@ -4690,11 +4696,11 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: Specifies which IP Families should be used
-                              by this service. Available options are `IPv4` and `IPv6.
-                              If unspecified, Kubernetes will choose the default value
-                              based on the `ipFamilyPolicy` setting. Available on
-                              Kubernetes 1.20 and newer.
+                            description: Specifies the IP Families used by the service.
+                              Available options are `IPv4` and `IPv6. If unspecified,
+                              Kubernetes will choose the default value based on the
+                              `ipFamilyPolicy` setting. Available on Kubernetes 1.20
+                              and newer.
                         description: Template for Cruise Control API `Service`.
                       podDisruptionBudget:
                         type: object

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -842,6 +842,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -848,14 +848,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -863,11 +864,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -852,6 +852,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -858,14 +858,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -873,11 +874,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -858,6 +858,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Bridge API `Service`.
                   bridgeContainer:
                     type: object

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -864,14 +864,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -879,11 +880,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Bridge API `Service`.
                   bridgeContainer:
                     type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -958,6 +958,32 @@ spec:
                               Can be applied to different resources such as `StatefulSets`,
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: Specifies which IP Family Policy should be used
+                          by this service. Available options are `SingleStack` (a
+                          single IP family), `PreferDualStack` (two IP families on
+                          dual-stack configured clusters or a single IP family on
+                          single-stack clusters), and `RequireDualStack` (two IP families
+                          on dual-stack configured clusters, otherwise fail). If unspecified,
+                          Kubernetes will choose the default value based on the service
+                          type. Available on Kubernetes 1.20 and newer.
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: Specifies which IP Families should be used by
+                          this service. Available options are `IPv4` and `IPv6. If
+                          unspecified, Kubernetes will choose the default value based
+                          on the `ipFamilyPolicy` setting. Available on Kubernetes
+                          1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -964,14 +964,15 @@ spec:
                         - SingleStack
                         - PreferDualStack
                         - RequireDualStack
-                        description: Specifies which IP Family Policy should be used
-                          by this service. Available options are `SingleStack` (a
-                          single IP family), `PreferDualStack` (two IP families on
-                          dual-stack configured clusters or a single IP family on
-                          single-stack clusters), and `RequireDualStack` (two IP families
-                          on dual-stack configured clusters, otherwise fail). If unspecified,
-                          Kubernetes will choose the default value based on the service
-                          type. Available on Kubernetes 1.20 and newer.
+                        description: Specifies the IP Family Policy used by the service.
+                          Available options are `SingleStack`, `PreferDualStack` and
+                          `RequireDualStack`. `SingleStack` is for a single IP family.
+                          `PreferDualStack` is for two IP families on dual-stack configured
+                          clusters or a single IP family on single-stack clusters.
+                          `RequireDualStack` fails unless there are two IP families
+                          on dual-stack configured clusters. If unspecified, Kubernetes
+                          will choose the default value based on the service type.
+                          Available on Kubernetes 1.20 and newer.
                       ipFamilies:
                         type: array
                         items:
@@ -979,11 +980,10 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: Specifies which IP Families should be used by
-                          this service. Available options are `IPv4` and `IPv6. If
-                          unspecified, Kubernetes will choose the default value based
-                          on the `ipFamilyPolicy` setting. Available on Kubernetes
-                          1.20 and newer.
+                        description: Specifies the IP Families used by the service.
+                          Available options are `IPv4` and `IPv6. If unspecified,
+                          Kubernetes will choose the default value based on the `ipFamilyPolicy`
+                          setting. Available on Kubernetes 1.20 and newer.
                     description: Template for Kafka Connect API `Service`.
                   buildConfig:
                     type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds better support for dual stack networking (IPv4+IPv6). It lets users to choose the preferred policy and the preferred stack. This has to be done on two places:
* All internal Kafka listeners (both `type: internal` but also replication and control plane listeners share the `...-kafka-bootstrap` and `...-kafka-brokers` services), as well as Zookeeper, Connect, CruiseControl etc., have this configuration in the `template` section.
* External Kafka listener have their own services on a per listener basis and have this configuration in the `listeners` section to allow different configuration for each listener.

This PR also adds support for Enum based Lists to our CRDs and updates the `ServiceOperator` to handle the dual stack networking defaults in case user doesn't configure anything (since in that case, Kubernetes will pick some defaults on their own).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md