### PR TITLE
[systemtest] Make logging of errors when resource is not created clearer

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceCondition.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.systemtest.resources;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class ResourceCondition<T extends HasMetadata> {
+    private final Predicate<T> predicate;
+    private final String conditionName;
+
+    public ResourceCondition(Predicate<T> predicate, String conditionName) {
+        this.predicate = predicate;
+        this.conditionName = conditionName;
+    }
+
+    public String getConditionName() {
+        return conditionName;
+    }
+
+    public Predicate<T> getPredicate() {
+        return predicate;
+    }
+
+    public static <T extends HasMetadata> ResourceCondition<T> readiness(ResourceType<T> type) {
+        return new ResourceCondition<>(type::waitForReadiness, "readiness");
+    }
+
+    public static <T extends HasMetadata> ResourceCondition<T> deletion() {
+        return new ResourceCondition<>(Objects::isNull, "deletion");
+    }
+}

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -133,7 +133,7 @@ public final class TestUtils {
                 result = ready.getAsBoolean();
             } catch (Exception e) {
                 exceptionMessage = e.getMessage();
-                if (++exceptionCount == 1) {
+                if (++exceptionCount == 1 && exceptionMessage != null) {
                     // Log the first exception as soon as it occurs
                     LOGGER.error("Exception waiting for {}, {}", description, exceptionMessage);
                     // log the stacktrace
@@ -148,8 +148,11 @@ public final class TestUtils {
             if (timeLeft <= 0) {
                 if (exceptionCount > 1) {
                     LOGGER.error("Exception waiting for {}, {}", description, exceptionMessage);
-                    // printing handled stacktrace
-                    LOGGER.error(stackTraceError.toString());
+
+                    if (!stackTraceError.toString().isEmpty()) {
+                        // printing handled stacktrace
+                        LOGGER.error(stackTraceError.toString());
+                    }
                 }
                 onTimeout.run();
                 WaitException waitException = new WaitException("Timeout after " + timeoutMs + " ms waiting for " + description);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fix

### Description

This PR fixes logging when the resource is not created or is currently `null` when we are waiting for readiness.

When the resource is not created and we reach the timeout, we get this kind of error:
```
2021-04-16T12:58:50.0249926Z io.strimzi.test.WaitException: Timeout after 180000 ms waiting for Resource condition:io.strimzi.systemtest.resources.ResourceManager$$Lambda$659/0x0000000840872c40@569b65b8 is fulfilled 
```
which will not tell us on which condition we are really waiting.

Because the `Predicate<T>` doesn't contain any information about method name that he "carries", I had to create this encapsulation.

After this, the log message looks clearer:
```
2021-05-05 08:32:31 [main] ERROR [TestUtils:138] Exception waiting for Resource condition: readiness is fulfilled for resource KafkaTopic:some-topic
```

Also, this PR fixes behavior when we just started with readiness wait, the resource is not created and we checking it's status. Then this line appears:
```
2021-04-16 14:28:41 [main] ERROR [TestUtils:138] Exception waiting for Wait for Kafka: my-cluster-1951300410 will have desired state: Ready, null
```


### Checklist

- [ ] Make sure all tests pass

