### PR TITLE
Make (finished) KafkaRebalance in Ready state refreshable

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -504,6 +504,72 @@ public class KafkaRebalanceStateMachineTest {
 
     }
 
+    @Test
+    public void testReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+
+        MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.Ready, KafkaRebalanceState.PendingProposal,
+                KafkaRebalanceAnnotation.refresh, null, null)
+                .onComplete(result -> checkOptimizationResults(result, context, true));
+
+    }
+
+    @Test
+    public void testReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+
+        MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.Ready, KafkaRebalanceState.ProposalReady,
+                KafkaRebalanceAnnotation.refresh, null, null)
+                .onComplete(result -> checkOptimizationResults(result, context, false));
+
+    }
+
+    @Test
+    public void testReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+
+        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.Ready, KafkaRebalanceState.PendingProposal,
+                KafkaRebalanceAnnotation.refresh, null, null)
+                .onComplete(result -> checkOptimizationResults(result, context, true));
+
+    }
+
+    @Test
+    public void testNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+
+        MockCruiseControl.setupCCRebalanceResponse(ccServer, 1);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.NotReady, KafkaRebalanceState.PendingProposal,
+                KafkaRebalanceAnnotation.refresh, null, null)
+                .onComplete(result -> checkOptimizationResults(result, context, true));
+
+    }
+
+    @Test
+    public void testNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+
+        MockCruiseControl.setupCCRebalanceResponse(ccServer, 0);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.NotReady, KafkaRebalanceState.ProposalReady,
+                KafkaRebalanceAnnotation.refresh, null, null)
+                .onComplete(result -> checkOptimizationResults(result, context, false));
+
+    }
+
+    @Test
+    public void testNotReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+
+        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.NotReady, KafkaRebalanceState.PendingProposal,
+                KafkaRebalanceAnnotation.refresh, null, null)
+                .onComplete(result -> checkOptimizationResults(result, context, true));
+
+    }
+
     private static class StateMatchers extends AbstractResourceStateMatchers {
 
     }

--- a/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
+++ b/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
@@ -68,7 +68,9 @@ kubectl describe kafkarebalance _rebalance-cr-name_
 
 ** Rebalancing: The cluster rebalance operation is in progress. 
 
-** Ready: The cluster rebalancing operation completed successfully. The `KafkaRebalance` custom resource cannot be reused.
+** Ready: The cluster rebalancing operation completed successfully.
+To use the same `KafkaRebalance` custom resource to generate another optimization proposal, apply the `refresh` annotation to the custom resource.
+This moves the custom resource to the `PendingProposal` or `ProposalReady` state. You can then review the optimization proposal and approve it, if desired.
 
 ** NotReady: An error occurred--see xref:proc-fixing-problems-with-kafkarebalance-{context}[].  
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

This PR closes #3296.

Currently, when a Cruise Control rebalance completes, the `KafkaRebalance` CR will be in the `Ready` state. This state, unlike the other end states of `NotReady` and `Stopped` cannot be "refreshed". The user has to delete the `KafkaRebalance` (possibly with all their custom settings) and create a new one if they want to reuse all the same settings.

This PR allow a user to "refresh" a finished (`Ready`) `KafkaRebalance` CR which will send a new rebalance request to Cruise Control and move the CR into `ProposalPending`/`ProposalReady` ready for approval. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md