### PR TITLE
Fix vertx HttpClient client closed errors in connect client

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -290,7 +290,9 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         request.result().send(response -> {
                             if (response.succeeded()) {
                                 if (response.result().statusCode() == 202) {
-                                    result.complete();
+                                    response.result().bodyHandler(body -> {
+                                        result.complete();
+                                    });
                                 } else {
                                     result.fail("Unexpected status code " + response.result().statusCode()
                                             + " for GET request to " + host + ":" + port + path);
@@ -390,11 +392,11 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                     .write(buffer.toString());
                             request.result().send(response -> {
                                 if (response.succeeded()) {
-                                    response.result().bodyHandler(body -> {
-                                    });
                                     if (response.result().statusCode() == 200) {
-                                        log.debug("Logger {} updated to level {}", logger, level);
-                                        result.complete();
+                                        response.result().bodyHandler(body -> {
+                                            log.debug("Logger {} updated to level {}", logger, level);
+                                            result.complete();
+                                        });
                                     } else {
                                         log.debug("Logger {} did not update to level {} (http code {})", logger, level, response.result().statusCode());
                                         result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
@@ -548,7 +550,9 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                     request.result().send(response -> {
                         if (response.succeeded()) {
                             if (response.result().statusCode() == 204) {
-                                result.complete();
+                                response.result().bodyHandler(body -> {
+                                    result.complete();
+                                });
                             } else {
                                 result.fail("Unexpected status code " + response.result().statusCode()
                                         + " for POST request to " + host + ":" + port + path);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR address #4813 and fixes `HttpClientRequestImpl: - io.vertx.core.VertxException: Connection was closed` issues in the `KafkaConnectApiImpl` class.

For reasons I do not yet understand, in order to avoid these errors you must use a bodyhandler on the `HttpClientResponse` *and* complete the result promise within that handler to avoid these errors.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging