### PR TITLE
[systemtest] Split Kafka clusters to separate namespaces in MetricsST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -95,11 +95,18 @@ public class KafkaTemplates {
     }
 
     public static KafkaBuilder kafkaWithMetrics(String name, int kafkaReplicas, int zookeeperReplicas) {
+        return kafkaWithMetrics(name, kubeClient().getNamespace(), kafkaReplicas, zookeeperReplicas);
+    }
+
+    public static KafkaBuilder kafkaWithMetrics(String name, String namespace, int kafkaReplicas, int zookeeperReplicas) {
         Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_METRICS_CONFIG);
 
         ConfigMap metricsCm = TestUtils.configMapFromYaml(PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(kubeClient().getNamespace()).createOrReplace(metricsCm);
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespace).createOrReplace(metricsCm);
         return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
+            .editOrNewMetadata()
+                .withNamespace(namespace)
+            .endMetadata()
             .editSpec()
                 .withNewKafkaExporter()
                 .endKafkaExporter()


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fix

### Description

Currently, we have two Kafka clusters deployed in one namespace. That can cause some issues - like topic store which is connected to second Kafka cluster, so when we collect metrics for the first Kafka cluster and we want to check number of topics, the check fails, because store topic is missing.

This PR separates these two Kafka clusters to each own namespace and fixes tests which are affected by changes to first or second Kafka cluster.

### Checklist

- [x] Make sure all tests pass

