### PR TITLE
[systemtest] Test for reconcile resource state metric in TO

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
@@ -60,6 +60,10 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
      * Method for allowing network policies for ClusterOperator
      */
     public static void allowNetworkPolicySettingsForClusterOperator(ExtensionContext extensionContext) {
+        allowNetworkPolicySettingsForClusterOperator(extensionContext, kubeClient().getNamespace());
+    }
+
+    public static void allowNetworkPolicySettingsForClusterOperator(ExtensionContext extensionContext, String namespace) {
         String clusterOperatorKind = "cluster-operator";
         LabelSelector labelSelector = new LabelSelectorBuilder()
             .addToMatchLabels(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE)
@@ -67,7 +71,7 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
 
         LOGGER.info("Apply NetworkPolicy access to {} from pods with LabelSelector {}", clusterOperatorKind, labelSelector);
 
-        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(clusterOperatorKind, labelSelector)
+        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(namespace, clusterOperatorKind, labelSelector)
             .editSpec()
                 .editFirstIngress()
                     .addNewPort()
@@ -87,6 +91,10 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
     }
 
     public static void allowNetworkPolicySettingsForEntityOperator(ExtensionContext extensionContext, String clusterName) {
+        allowNetworkPolicySettingsForEntityOperator(extensionContext, clusterName, kubeClient().getNamespace());
+    }
+
+    public static void allowNetworkPolicySettingsForEntityOperator(ExtensionContext extensionContext, String clusterName, String namespace) {
         LabelSelector labelSelector = new LabelSelectorBuilder()
                 .addToMatchLabels(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE)
                 .build();
@@ -95,7 +103,7 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
 
         LOGGER.info("Apply NetworkPolicy access to {} from pods with LabelSelector {}", eoDeploymentName, labelSelector);
 
-        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(eoDeploymentName, labelSelector)
+        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(namespace, eoDeploymentName, labelSelector)
             .editSpec()
                 .editFirstIngress()
                     .addNewPort()
@@ -121,6 +129,10 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
     }
 
     public static void allowNetworkPolicySettingsForKafkaExporter(ExtensionContext extensionContext, String clusterName) {
+        allowNetworkPolicySettingsForKafkaExporter(extensionContext, clusterName, kubeClient().getNamespace());
+    }
+
+    public static void allowNetworkPolicySettingsForKafkaExporter(ExtensionContext extensionContext, String clusterName, String namespace) {
         String kafkaExporterDeploymentName = KafkaExporterResources.deploymentName(clusterName);
         LabelSelector labelSelector = new LabelSelectorBuilder()
                 .addToMatchLabels(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE)
@@ -128,7 +140,7 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
 
         LOGGER.info("Apply NetworkPolicy access to {} from pods with LabelSelector {}", kafkaExporterDeploymentName, labelSelector);
 
-        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(kafkaExporterDeploymentName, labelSelector)
+        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(namespace, kafkaExporterDeploymentName, labelSelector)
             .editSpec()
                 .editFirstIngress()
                     .addNewPort()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/NetworkPolicyTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/NetworkPolicyTemplates.java
@@ -20,7 +20,7 @@ public class NetworkPolicyTemplates {
     private static final Logger LOGGER = LogManager.getLogger(NetworkPolicyTemplates.class);
 
     public static NetworkPolicyBuilder networkPolicyBuilder(String name) {
-        return networkPolicyBuilder(name, null)
+        return networkPolicyBuilder(kubeClient().getNamespace(), name, null)
             .withNewSpec()
                 .withNewPodSelector()
                 .endPodSelector()
@@ -28,13 +28,13 @@ public class NetworkPolicyTemplates {
             .endSpec();
     }
 
-    public static NetworkPolicyBuilder networkPolicyBuilder(String name, LabelSelector labelSelector) {
+    public static NetworkPolicyBuilder networkPolicyBuilder(String namespace, String name, LabelSelector labelSelector) {
         return new NetworkPolicyBuilder()
             .withNewApiVersion("networking.k8s.io/v1")
                 .withNewKind(Constants.NETWORK_POLICY)
                     .withNewMetadata()
                         .withName(name + "-allow")
-                        .withNamespace(kubeClient().getNamespace())
+                        .withNamespace(namespace)
                     .endMetadata()
                     .withNewSpec()
                         .addNewIngress()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/NetworkPolicyTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/NetworkPolicyTemplates.java
@@ -13,14 +13,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
-
 public class NetworkPolicyTemplates {
 
     private static final Logger LOGGER = LogManager.getLogger(NetworkPolicyTemplates.class);
 
-    public static NetworkPolicyBuilder networkPolicyBuilder(String name) {
-        return networkPolicyBuilder(kubeClient().getNamespace(), name, null)
+    public static NetworkPolicyBuilder networkPolicyBuilder(String name, String namespace) {
+        return networkPolicyBuilder(namespace, name, null)
             .withNewSpec()
                 .withNewPodSelector()
                 .endPodSelector()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -111,7 +111,7 @@ public class KafkaTopicUtils {
         LOGGER.info("Waiting for KafkaTopic change {}", topicName);
         TestUtils.waitFor("KafkaTopic change " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.GLOBAL_TIMEOUT,
             () -> KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get().getSpec().getPartitions() == partitions,
-            () -> LOGGER.info("Kafka Topic {} did not change partition", KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get())
+            () -> LOGGER.error("Kafka Topic {} did not change partition", KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get())
         );
     }
 
@@ -119,7 +119,7 @@ public class KafkaTopicUtils {
         LOGGER.info("Waiting for KafkaTopic change {}", topicName);
         TestUtils.waitFor("KafkaTopic change " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.GLOBAL_TIMEOUT,
             () -> KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get().getSpec().getReplicas() == replicas,
-            () -> LOGGER.info("Kafka Topic {} did not change replicas", KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get())
+            () -> LOGGER.error("Kafka Topic {} did not change replicas", KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get())
         );
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -115,6 +115,14 @@ public class KafkaTopicUtils {
         );
     }
 
+    public static void waitForKafkaTopicReplicasChange(String namespaceName, String topicName, int replicas) {
+        LOGGER.info("Waiting for KafkaTopic change {}", topicName);
+        TestUtils.waitFor("KafkaTopic change " + topicName, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.GLOBAL_TIMEOUT,
+            () -> KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get().getSpec().getReplicas() == replicas,
+            () -> LOGGER.info("Kafka Topic {} did not change replicas", KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get())
+        );
+    }
+
     public static void waitForKafkaTopicPartitionChange(String topicName, int partitions) {
         waitForKafkaTopicPartitionChange(kubeClient().getNamespace(), topicName, partitions);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -44,7 +44,7 @@ public class MetricsUtils {
      */
     public static String collectMetrics(String namespaceName, String scraperPodName, String metricsPodIp, int port, String metricsPath) throws InterruptedException, ExecutionException, IOException {
         List<String> executableCommand = Arrays.asList(cmdKubeClient(namespaceName).toString(), "exec", scraperPodName,
-                "-n", kubeClient().getNamespace(),
+                "-n", namespaceName,
                 "--", "curl", metricsPodIp + ":" + port + metricsPath);
 
         Exec exec = new Exec();


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #4502 we are able to get resource state metric of `KafkaTopic` from TopicOperator - this PR adds ST for it.
Every time the `KafkaTopic` resource is updating - either with correct or wrong configuration - the metric should be updated and metric for the resource should be just single - that means no new metric should be created.

The test covers this scenario:
```
correct config -> changing topic name (wrong config) -> changing topic name back (correct) and changing replicas (wrong config) -> scaling replicas to higher number (still wrong config) -> changing back to it's original state (correct config)
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

