### PR TITLE
Support pausing KafkaTopic reconciliations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added support for configuring cluster-operator's worker thread pool size that is used for various sync and async tasks
 * Add Kafka Quotas plugin with produce, consume, and storage quotas
 * Remove topics and groups "blacklist" pattern from KafkaMirrorMaker2 CRD
+* Support pausing reconciliation of KafkaTopic CR with annotation `strimzi.io/pause-reconciliation`
 
 ## 0.23.0
 

--- a/documentation/modules/managing/proc-pausing-reconciliation.adoc
+++ b/documentation/modules/managing/proc-pausing-reconciliation.adoc
@@ -17,8 +17,6 @@ For example, you can apply the annotation to the `KafkaConnect` resource so that
 You can also create a custom resource with the pause annotation enabled.
 The custom resource is created, but it is ignored.
 
-IMPORTANT: It is not currently possible to pause reconciliation of `KafkaTopic` resources.
-
 .Prerequisites
 
 * The Strimzi Operator that manages the custom resource is running.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -108,7 +108,7 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
         }
     }
 
-    private class PauseAnnotationChanges {
+    private static class PauseAnnotationChanges {
         private boolean resourcePausedByAnno;
         private boolean resourceUnpausedByAnno;
         private boolean isChanged;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -75,7 +75,7 @@ class TopicOperator {
     private Counter successfulReconciliationsCounter;
     private Counter lockedReconciliationsCounter;
     private AtomicInteger topicCounter;
-    private AtomicInteger pausedTopicCounter;
+    protected AtomicInteger pausedTopicCounter;
     protected Timer reconciliationsTimer;
 
     enum EventType {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -47,8 +47,10 @@ import java.util.function.Predicate;
 
 import static io.strimzi.test.TestUtils.waitFor;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorMockTest {
@@ -368,6 +370,54 @@ public class TopicOperatorMockTest {
                 .endSpec().build();
     
         testCreatedInKube(context, kt);
+    }
+
+    @Test
+    public void testReconciliationPaused(VertxTestContext context) throws InterruptedException {
+        LOGGER.info("Test started");
+
+        int retention = 100_000_000;
+        KafkaTopic kt = new KafkaTopicBuilder()
+                .withNewMetadata()
+                    .withName("my-topic")
+                    .withNamespace("myproject")
+                    .addToLabels(Labels.STRIMZI_KIND_LABEL, "topic")
+                    .addToLabels(Labels.KUBERNETES_NAME_LABEL, "topic-operator")
+                    .withAnnotations(singletonMap("strimzi.io/pause-reconciliation", "true"))
+                .endMetadata()
+                .withNewSpec()
+                    .withPartitions(1)
+                    .withReplicas(1)
+                    .addToConfig("retention.bytes", retention)
+                .endSpec()
+                .build();
+
+        testNotCreatedInKube(context, kt);
+    }
+
+    void testNotCreatedInKube(VertxTestContext context, KafkaTopic kt) throws InterruptedException {
+        String kubeName = kt.getMetadata().getName();
+        String kafkaName = kt.getSpec().getTopicName() != null ? kt.getSpec().getTopicName() : kubeName;
+        int retention = (Integer) kt.getSpec().getConfig().get("retention.bytes");
+
+        createInKube(kt);
+
+        Thread.sleep(2000);
+        LOGGER.info("Topic has not been created");
+        Topic fromKafka = getFromKafka(context, kafkaName);
+        context.verify(() -> assertThat(fromKafka, is(nullValue())));
+        // Reconcile after no changes
+        reconcile(context);
+        // Check things still the same
+        context.verify(() -> assertThat(fromKafka, is(nullValue())));
+
+        // Config change + reconcile
+        updateInKube(new KafkaTopicBuilder(kt).editSpec().addToConfig("retention.bytes", retention + 1).endSpec().build());
+        // Another reconciliation
+        reconcile(context);
+
+        // Check things still the same
+        context.verify(() -> assertThat(getFromKafka(context, kafkaName), is(nullValue())));
     }
 
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -112,6 +112,7 @@ public class TopicOperatorTest {
         Map<String, String> lbls = new HashMap<>();
         lbls.put("app", "strimzi");
         metadata.setLabels(lbls);
+        metadata.setAnnotations(new HashMap<>());
     }
 
     @AfterEach
@@ -1236,14 +1237,15 @@ public class TopicOperatorTest {
     public void testReconcileMetrics(VertxTestContext context) throws InterruptedException {
         mockKafka.setTopicsListResponse(Future.succeededFuture(emptySet()));
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
-        Future<?> reconcileFuture = topicOperator.reconcileAllTopics("periodic");
         resourceAdded(context, null, null, null);
+        Future<?> reconcileFuture = topicOperator.reconcileAllTopics("periodic");
 
         Checkpoint async = context.checkpoint();
         reconcileFuture.onComplete(context.succeeding(e -> context.verify(() -> {
             MeterRegistry registry = metrics.meterRegistry();
 
             assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resources.paused").tag("kind", "KafkaTopic").gauge().value(), is(0.0));
             assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
             assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
 
@@ -1258,6 +1260,67 @@ public class TopicOperatorTest {
 
             async.flag();
         })));
+    }
+
+    @Test
+    public void testReconcileMetricsWithPausedTopic(VertxTestContext context) throws InterruptedException {
+        mockKafka.setTopicsListResponse(Future.succeededFuture(emptySet()));
+        mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
+        metadata.getAnnotations().put("strimzi.io/pause-reconciliation", "false");
+        resourceAdded(context, null, null, null);
+        Future<?> reconcileFuture = topicOperator.reconcileAllTopics("periodic");
+
+        // workaround for the vertx junit5 integration
+        CountDownLatch latch = new CountDownLatch(2);
+        CountDownLatch splitLatch = new CountDownLatch(1);
+
+        reconcileFuture.onComplete(context.succeeding(e -> context.verify(() -> {
+            MeterRegistry registry = metrics.meterRegistry();
+
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resources.paused").tag("kind", "KafkaTopic").gauge().value(), is(0.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
+                    .tag("kind", "KafkaTopic")
+                    .tag("name", topicName.toString())
+                    .tag("resource-namespace", "default-namespace")
+                    .gauge().value(), is(1.0));
+
+            latch.countDown();
+            splitLatch.countDown();
+        })));
+
+        splitLatch.await(10_000, TimeUnit.MILLISECONDS);
+        metadata.getAnnotations().put("strimzi.io/pause-reconciliation", "true");
+
+        resourceAdded(context, null, null, null);
+        topicOperator.reconcileAllTopics("periodic").onComplete(context.succeeding(f -> context.verify(() -> {
+            MeterRegistry registry = metrics.meterRegistry();
+
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(2.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resources.paused").tag("kind", "KafkaTopic").gauge().value(), is(1.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(2.0));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(2L));
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+
+            assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
+                    .tag("kind", "KafkaTopic")
+                    .tag("name", topicName.toString())
+                    .tag("resource-namespace", "default-namespace")
+                    .gauge().value(), is(1.0));
+
+            latch.countDown();
+        })));
+
+        assertThat(latch.await(10_000, TimeUnit.MILLISECONDS), is(true));
+        context.completeNow();
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -529,7 +529,7 @@ public class TopicOperatorTest {
     @Test
     public void testReconcile_withResource_noKafka_noPrivate(VertxTestContext context) throws InterruptedException {
 
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar"), new ObjectMeta()).build();
         Topic kafkaTopic = null;
         Topic privateTopic = null;
 
@@ -570,7 +570,7 @@ public class TopicOperatorTest {
     @Test
     public void testReconcile_withResource_noKafka_withPrivate(VertxTestContext context) {
 
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar"), new ObjectMeta()).build();
         Topic kafkaTopic = null;
         Topic privateTopic = kubeTopic;
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- new feature

### Description
We had to revert https://github.com/strimzi/strimzi-kafka-operator/pull/4546 because issues with status. These issues were fixed in https://github.com/strimzi/strimzi-kafka-operator/pull/4727 so we can reopen this.

### Checklist
- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

