### PR TITLE
[systemtest] Add test check for `refresh` annotation in KafkaRebalance

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -96,10 +96,16 @@ public class CruiseControlIsolatedST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     @Tag(ACCEPTANCE)
     void testCruiseControlWithRebalanceResource(ExtensionContext extensionContext) {
-        String clusterName = "what-about-this";
+        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
         resourceManager.createResource(extensionContext, KafkaRebalanceTemplates.kafkaRebalance(clusterName).build());
+
+        KafkaRebalanceUtils.doRebalancingProcess(clusterName);
+
+        LOGGER.info("Annotating KafkaRebalance: {} with 'refresh' anno", clusterName);
+        KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.refresh);
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.ProposalReady);
 
         KafkaRebalanceUtils.doRebalancingProcess(clusterName);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -95,7 +95,7 @@ public class CruiseControlIsolatedST extends AbstractST {
 
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     @Tag(ACCEPTANCE)
-    void testCruiseControlWithRebalanceResource(ExtensionContext extensionContext) {
+    void testCruiseControlWithRebalanceResourceAndRefreshAnnotation(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
@@ -107,6 +107,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         KafkaRebalanceUtils.annotateKafkaRebalanceResource(clusterName, KafkaRebalanceAnnotation.refresh);
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.ProposalReady);
 
+        LOGGER.info("Trying rebalancing process again");
         KafkaRebalanceUtils.doRebalancingProcess(clusterName);
     }
 


### PR DESCRIPTION
### Type of change

- New test check

### Description

After #4903 we are able to use the `KafkaRebalance`, which process is already completed, again. This PR adds check for it.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass