### PR TITLE
Handle ZooKeeper close on error; add unit test and assertions

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -251,7 +251,7 @@ public class ZookeeperScaler implements AutoCloseable {
                     zkAdmin.close((int) operationTimeoutMs);
                     promise.complete();
                 } catch (Exception e) {
-                    log.debug("Failed to close the ZooKeeperAdmin", e);
+                    log.warn("Failed to close the ZooKeeperAdmin", e);
                     promise.fail(e);
                 }
             }, false, closePromise);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalerTest.java
@@ -300,6 +300,7 @@ public class ZookeeperScalerTest {
         ZooKeeperAdmin mockZooAdmin = mock(ZooKeeperAdmin.class);
         when(mockZooAdmin.getState()).thenReturn(ZooKeeper.States.CONNECTED);
         when(mockZooAdmin.getConfig(false, null)).thenThrow(KeeperException.ConnectionLossException.class);
+        when(mockZooAdmin.close(1_000)).thenThrow(InterruptedException.class);
 
         ZooKeeperAdminProvider zooKeeperAdminProvider = new ZooKeeperAdminProvider() {
             @Override


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix issue where the Zookeeper client is not closed following an unsuccessful `getConfig` or `scaleTo`, introduced with re-factoring in #4894.

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

