### PR TITLE
Fix shellcheck build errors due to x-prefix in comparisons

### DIFF
--- a/.azure/scripts/setup_shellcheck.sh
+++ b/.azure/scripts/setup_shellcheck.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-wget https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz -O shellcheck.tar.xz
+readonly VERSION="0.7.2"
+wget https://github.com/koalaman/shellcheck/releases/download/v$VERSION/shellcheck-v$VERSION.linux.x86_64.tar.xz -O shellcheck.tar.xz
 tar xf shellcheck.tar.xz -C /tmp --strip-components 1
 chmod +x /tmp/shellcheck
 sudo mv /tmp/shellcheck /usr/bin

--- a/docker-images/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_connect_config_generator.sh
@@ -53,16 +53,16 @@ if [ -n "$KAFKA_CONNECT_SASL_MECHANISM" ]; then
     else
         SECURITY_PROTOCOL="SASL_PLAINTEXT"
     fi
-    
-    if [ "x$KAFKA_CONNECT_SASL_MECHANISM" = "xplain" ]; then
+
+    if [ "$KAFKA_CONNECT_SASL_MECHANISM" = "plain" ]; then
         PASSWORD=$(cat "/opt/kafka/connect-password/$KAFKA_CONNECT_SASL_PASSWORD_FILE")
         SASL_MECHANISM="PLAIN"
         JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${KAFKA_CONNECT_SASL_USERNAME}\" password=\"${PASSWORD}\";"
-    elif [ "x$KAFKA_CONNECT_SASL_MECHANISM" = "xscram-sha-512" ]; then
+    elif [ "$KAFKA_CONNECT_SASL_MECHANISM" = "scram-sha-512" ]; then
         PASSWORD=$(cat "/opt/kafka/connect-password/$KAFKA_CONNECT_SASL_PASSWORD_FILE")
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_CONNECT_SASL_USERNAME}\" password=\"${PASSWORD}\";"
-    elif [ "x$KAFKA_CONNECT_SASL_MECHANISM" = "xoauth" ]; then
+    elif [ "$KAFKA_CONNECT_SASL_MECHANISM" = "oauth" ]; then
         if [ -n "$KAFKA_CONNECT_OAUTH_ACCESS_TOKEN" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_CONNECT_OAUTH_ACCESS_TOKEN\""
         fi

--- a/docker-images/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
@@ -33,15 +33,15 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" ]; then
         SECURITY_PROTOCOL="SASL_PLAINTEXT"
     fi
 
-    if [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "xplain" ]; then
+    if [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "plain" ]; then
         PASSWORD=$(cat "/opt/kafka/consumer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER")
         SASL_MECHANISM="PLAIN"
         JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER}\" password=\"${PASSWORD}\";"
-    elif [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "xscram-sha-512" ]; then
+    elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "scram-sha-512" ]; then
         PASSWORD=$(cat "/opt/kafka/consumer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER")
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER}\" password=\"${PASSWORD}\";"
-    elif [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "xoauth" ]; then
+    elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "oauth" ]; then
         if [ -n "$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_CONSUMER" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_CONSUMER\""
         fi

--- a/docker-images/kafka/scripts/kafka_mirror_maker_producer_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_mirror_maker_producer_config_generator.sh
@@ -33,15 +33,15 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" ]; then
         SECURITY_PROTOCOL="SASL_PLAINTEXT"
     fi
 
-    if [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "xplain" ]; then
+    if [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "plain" ]; then
         PASSWORD=$(cat "/opt/kafka/producer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER")
         SASL_MECHANISM="PLAIN"
         JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER}\" password=\"${PASSWORD}\";"
-    elif [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "xscram-sha-512" ]; then
+    elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "scram-sha-512" ]; then
         PASSWORD=$(cat "/opt/kafka/producer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER")
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER}\" password=\"${PASSWORD}\";"
-    elif [ "x$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "xoauth" ]; then
+    elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "oauth" ]; then
         if [ -n "$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_PRODUCER" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_PRODUCER\""
         fi


### PR DESCRIPTION
When building the project with shellcheck `0.7.2` I have a series of [SC2268](https://github.com/koalaman/shellcheck/wiki/SC2268) errors and the build fails in the final stage (after images push). With this fix the build is fine:

```
$ make MVN_ARGS='-DskipTests -DskipITs' all
# ...
./.azure/scripts/shellcheck.sh
documentation/snip-kafka-versions.sh > documentation/modules/snip-kafka-versions.adoc
documentation/version-dependent-attrs.sh > documentation/shared/version-dependent-attrs.adoc
documentation/snip-images.sh > documentation/modules/snip-images.adoc
./.azure/scripts/check_docs.sh
documentation/snip-kafka-versions.sh > documentation/modules/snip-kafka-versions.adoc
documentation/version-dependent-attrs.sh > documentation/shared/version-dependent-attrs.adoc
documentation/snip-images.sh > documentation/modules/snip-images.adoc
```
