### PR TITLE
[systemtest] Fixes for failing tests in ListenersST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/clientproperties/AbstractKafkaClientProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/clientproperties/AbstractKafkaClientProperties.java
@@ -163,7 +163,7 @@ abstract public class AbstractKafkaClientProperties<C extends AbstractKafkaClien
                 if (!properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG).equals(CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL) &&
                     !properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG).equals("SASL_" + CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL)
                 ) {
-                    Secret clusterCaCertSecret = kubeClient(namespaceName).getSecret(caSecretName);
+                    Secret clusterCaCertSecret = kubeClient().getSecret(namespaceName, caSecretName);
                     File tsFile = File.createTempFile(AbstractKafkaClientProperties.class.getName(), ".truststore");
                     tsFile.deleteOnExit();
                     KeyStore ts = KeyStore.getInstance(TRUSTSTORE_TYPE_CONFIG);
@@ -171,7 +171,7 @@ abstract public class AbstractKafkaClientProperties<C extends AbstractKafkaClien
                     if (caSecretName.contains("custom-certificate")) {
                         ts.load(null, tsPassword.toCharArray());
                         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-                        String clusterCaCert = kubeClient(namespaceName).getSecret(caSecretName).getData().get("ca.crt");
+                        String clusterCaCert = kubeClient().getSecret(namespaceName, caSecretName).getData().get("ca.crt");
                         Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(clusterCaCert)));
                         ts.setCertificateEntry("ca.crt", cert);
                         try (FileOutputStream tsOs = new FileOutputStream(tsFile)) {
@@ -192,7 +192,7 @@ abstract public class AbstractKafkaClientProperties<C extends AbstractKafkaClien
                     && !properties.getProperty(SaslConfigs.SASL_MECHANISM).equals("OAUTHBEARER")) {
 
                     properties.setProperty(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
-                    Secret userSecret = kubeClient(namespaceName).getSecret(kafkaUsername);
+                    Secret userSecret = kubeClient().getSecret(namespaceName, kafkaUsername);
                     String password = new String(Base64.getDecoder().decode(userSecret.getData().get("password")), StandardCharsets.UTF_8);
 
                     String jaasTemplate = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
@@ -201,7 +201,7 @@ abstract public class AbstractKafkaClientProperties<C extends AbstractKafkaClien
                     properties.setProperty(SaslConfigs.SASL_JAAS_CONFIG, jaasCfg);
                 } else if (!kafkaUsername.isEmpty()) {
 
-                    Secret userSecret = kubeClient(namespaceName).getSecret(kafkaUsername);
+                    Secret userSecret = kubeClient().getSecret(namespaceName, kafkaUsername);
 
                     String clientsCaCert = userSecret.getData().get("ca.crt");
                     LOGGER.debug("Clients CA cert: {}", clientsCaCert);

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
@@ -247,11 +247,6 @@ public class KafkaClientsTemplates {
         String secretName = secretPrefix == null ? kafkaUser.getMetadata().getName() : secretPrefix + kafkaUser.getMetadata().getName();
         Secret secret = ResourceManager.kubeClient().getSecret(namespaceName, secretName);
 
-        LOGGER.warn("SecretPrefix: {}\nNamespace: {}\nSecretName: {}", secretPrefix, namespaceName, secretName);
-        LOGGER.warn("Secret: {}", secret);
-        LOGGER.warn("KafkaUser: {}", kafkaUser);
-        LOGGER.warn("Secrets in namespace: {}", ResourceManager.kubeClient().listSecrets(namespaceName));
-
         String password = new String(Base64.getDecoder().decode(secret.getData().get("password")), Charset.forName("UTF-8"));
         if (password.isEmpty()) {
             LOGGER.info("Secret {}:\n{}", kafkaUser.getMetadata().getName(), toYamlString(secret));

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
@@ -245,7 +245,12 @@ public class KafkaClientsTemplates {
 
     static String saslConfigs(String namespaceName, KafkaUser kafkaUser, String secretPrefix) {
         String secretName = secretPrefix == null ? kafkaUser.getMetadata().getName() : secretPrefix + kafkaUser.getMetadata().getName();
-        Secret secret = ResourceManager.kubeClient().namespace(namespaceName).getSecret(secretName);
+        Secret secret = ResourceManager.kubeClient().getSecret(namespaceName, secretName);
+
+        LOGGER.warn("SecretPrefix: {}\nNamespace: {}\nSecretName: {}", secretPrefix, namespaceName, secretName);
+        LOGGER.warn("Secret: {}", secret);
+        LOGGER.warn("KafkaUser: {}", kafkaUser);
+        LOGGER.warn("Secrets in namespace: {}", ResourceManager.kubeClient().listSecrets(namespaceName));
 
         String password = new String(Base64.getDecoder().decode(secret.getData().get("password")), Charset.forName("UTF-8"));
         if (password.isEmpty()) {


### PR DESCRIPTION
### Type of change

- Test fixes

### Description

This PR fixes several issues in ListenersST (and also other STs which uses our `Internal` or `External` clients) where the secrets, when we are running tests in parallel namespaces, are not correctly obtained. This also fixes issue with `RuntimeException` which is sometimes shown in the STs.

### Checklist

- [x] Make sure all tests pass

