### PR TITLE
Set secret type to avoid unnecessary patching

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/SecretCertProvider.java
@@ -126,6 +126,7 @@ public class SecretCertProvider {
                     .withAnnotations(annotations)
                     .withOwnerReferences(or)
                 .endMetadata()
+                .withType("Opaque")
                 .withData(data)
                 .build();
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -290,6 +290,7 @@ public class KafkaUserModel {
                     .withAnnotations(Util.mergeLabelsOrAnnotations(null, templateSecretAnnotations))
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
+                .withType("Opaque")
                 .withData(data)
                 .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The CA secrets created by the Cluster Operator currently do not have set secret type. That causes differences in the diff and unnecessary patching:

```
2021-05-18 17:55:00 DEBUG SecretOperator:111 - Secret myproject/my-cluster-clients-ca-cert already exists, patching it
2021-05-18 17:55:00 DEBUG SecretOperator:111 - Secret myproject/my-cluster-cluster-ca-cert already exists, patching it
2021-05-18 17:55:00 DEBUG ResourceDiff:33 - Ignoring Secret my-cluster-clients-ca-cert diff {"op":"remove","path":"/metadata/managedFields"}
2021-05-18 17:55:00 DEBUG ResourceDiff:33 - Ignoring Secret my-cluster-cluster-ca-cert diff {"op":"remove","path":"/metadata/managedFields"}
2021-05-18 17:55:00 DEBUG ResourceDiff:38 - Secret my-cluster-clients-ca-cert differs: {"op":"remove","path":"/type"}
2021-05-18 17:55:00 DEBUG ResourceDiff:38 - Secret my-cluster-cluster-ca-cert differs: {"op":"remove","path":"/type"}
2021-05-18 17:55:00 DEBUG ResourceDiff:39 - Current Secret my-cluster-clients-ca-cert path /type has value "Opaque"
2021-05-18 17:55:00 DEBUG ResourceDiff:39 - Current Secret my-cluster-cluster-ca-cert path /type has value "Opaque"
2021-05-18 17:55:00 DEBUG ResourceDiff:40 - Desired Secret my-cluster-cluster-ca-cert path /type has value
2021-05-18 17:55:00 DEBUG ResourceDiff:40 - Desired Secret my-cluster-clients-ca-cert path /type has value
2021-05-18 17:55:00 DEBUG SecretOperator:227 - Secret my-cluster-clients-ca-cert in namespace myproject has been patched
2021-05-18 17:55:00 DEBUG SecretOperator:227 - Secret my-cluster-cluster-ca-cert in namespace myproject has been patched
2021-05-18 17:55:00 DEBUG SecretOperator:111 - Secret myproject/my-cluster-clients-ca already exists, patching it
2021-05-18 17:55:00 DEBUG SecretOperator:111 - Secret myproject/my-cluster-cluster-ca already exists, patching it
2021-05-18 17:55:00 DEBUG ResourceDiff:33 - Ignoring Secret my-cluster-cluster-ca diff {"op":"remove","path":"/metadata/managedFields"}
2021-05-18 17:55:00 DEBUG ResourceDiff:33 - Ignoring Secret my-cluster-clients-ca diff {"op":"remove","path":"/metadata/managedFields"}
2021-05-18 17:55:00 DEBUG ResourceDiff:38 - Secret my-cluster-clients-ca differs: {"op":"remove","path":"/type"}
2021-05-18 17:55:00 DEBUG ResourceDiff:38 - Secret my-cluster-cluster-ca differs: {"op":"remove","path":"/type"}
2021-05-18 17:55:00 DEBUG ResourceDiff:39 - Current Secret my-cluster-clients-ca path /type has value "Opaque"
2021-05-18 17:55:00 DEBUG ResourceDiff:39 - Current Secret my-cluster-cluster-ca path /type has value "Opaque"
2021-05-18 17:55:00 DEBUG ResourceDiff:40 - Desired Secret my-cluster-cluster-ca path /type has value
2021-05-18 17:55:00 DEBUG ResourceDiff:40 - Desired Secret my-cluster-clients-ca path /type has value
2021-05-18 17:55:00 DEBUG SecretOperator:227 - Secret my-cluster-clients-ca in namespace myproject has been patched
2021-05-18 17:55:00 DEBUG SecretOperator:227 - Secret my-cluster-cluster-ca in namespace myproject has been patched
```

This PR sets the type to avoid the diff and save the patch calls.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally