### PR TITLE
[MO] - [system test] -> LogCollector change to support namespace logs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollect.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollect.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.logs;
+
+public interface LogCollect {
+
+    public void collectLogsFromPods();
+    public void collectEvents();
+    public void collectConfigMaps();
+    public void collectDeployments();
+    public void collectStatefulSets();
+    public void collectReplicaSets();
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollect.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollect.java
@@ -6,10 +6,10 @@ package io.strimzi.systemtest.logs;
 
 public interface LogCollect {
 
-    public void collectLogsFromPods(String namespaceName);
-    public void collectEvents(String namespaceName);
-    public void collectConfigMaps(String namespaceName);
-    public void collectDeployments(String namespaceName);
-    public void collectStatefulSets(String namespaceName);
-    public void collectReplicaSets(String namespaceName);
+    public void collectLogsFromPods();
+    public void collectEvents();
+    public void collectConfigMaps();
+    public void collectDeployments();
+    public void collectStatefulSets();
+    public void collectReplicaSets();
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollect.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollect.java
@@ -6,10 +6,10 @@ package io.strimzi.systemtest.logs;
 
 public interface LogCollect {
 
-    public void collectLogsFromPods();
-    public void collectEvents();
-    public void collectConfigMaps();
-    public void collectDeployments();
-    public void collectStatefulSets();
-    public void collectReplicaSets();
+    public void collectLogsFromPods(String namespaceName);
+    public void collectEvents(String namespaceName);
+    public void collectConfigMaps(String namespaceName);
+    public void collectDeployments(String namespaceName);
+    public void collectStatefulSets(String namespaceName);
+    public void collectReplicaSets(String namespaceName);
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -45,7 +45,7 @@ public class LogCollector implements LogCollect {
 
     static {
         // Get current date to create a unique folder
-        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss");
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         CURRENT_DATE = simpleDateFormat.format(Calendar.getInstance().getTime());
     }
@@ -68,6 +68,7 @@ public class LogCollector implements LogCollect {
 
         this.testSuite = new File(logSuiteDir);
 
+        // @BeforeAll in AbstractST always pass, and I ensure that we always deploy CO and after that some error can occur
         this.clusterOperatorPod = kubeClient.getClient().pods().inAnyNamespace().list().getItems().stream()
             .filter(pod -> pod.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
             // contract only one Cluster Operator deployment inside all namespaces

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Set;
 import java.util.TimeZone;
 
 import static io.strimzi.test.TestUtils.writeFile;
@@ -28,8 +30,6 @@ import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
  *      /time/
  *          /test-suite_time/
  *              /test-case/
- *                  /configmaps/
- *                  /events
  *                  deployment.log
  *                  configmap.log
  *                  ...
@@ -45,181 +45,142 @@ public class LogCollector implements LogCollect {
 
     static {
         // Get current date to create a unique folder
-        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
+        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         CURRENT_DATE = simpleDateFormat.format(Calendar.getInstance().getTime());
     }
 
     private final KubeClient kubeClient;
-    private final String namespace;
     private final File testSuite;
+    private final String testSuiteName;
     private final File testCase;
     private final File logDir;
-    private final File configMapDir;
-    private final File eventsDir;
-    private CoLogCollector coLogCollector;
+    private final Pod clusterOperatorPod;
+    private final String clusterOperatorNamespace;
 
-    public LogCollector(String namespaceName, String testSuite, String testCase, KubeClient kubeClient, String logDir) throws IOException {
+    public LogCollector(String testSuiteName, String testCaseName, KubeClient kubeClient, String logDir) throws IOException {
         this.kubeClient = kubeClient;
-        this.namespace = namespaceName;
+        this.testSuiteName = testSuiteName;
 
-
-        this.logDir = new File(logDir + "_" + CURRENT_DATE);
-        final String logSuiteDir = this.logDir + "/" + testSuite;
+        this.logDir = new File(logDir + "/ " + CURRENT_DATE);
+        final String logSuiteDir = this.logDir + "/" + this.testSuiteName;
 
         this.testSuite = new File(logSuiteDir);
-        this.coLogCollector = new CoLogCollector();
-        this.testCase = new File(logSuiteDir + "/" + testCase);
-        this.eventsDir = new File(this.testCase + "/events");
-        this.configMapDir = new File(this.testCase + "/configMaps");
+
+        this.clusterOperatorPod = kubeClient.getClient().pods().inAnyNamespace().list().getItems().stream()
+            .filter(pod -> pod.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+            // contract only one Cluster Operator deployment inside all namespaces
+            .findFirst()
+            .orElseThrow();
+        this.clusterOperatorNamespace = this.clusterOperatorPod.getMetadata().getNamespace();
+        this.testCase = new File(logSuiteDir + "/" + testCaseName);
 
         boolean logDirExist = this.logDir.exists() || this.logDir.mkdirs();
         boolean logTestSuiteDirExist = this.testSuite.exists() || this.testSuite.mkdirs();
         boolean logTestCaseDirExist = this.testCase.exists() || this.testCase.mkdirs();
-        boolean logEventDirExist = this.eventsDir.exists() || this.eventsDir.mkdirs();
-        boolean logConfigMapExist = this.configMapDir.exists() || this.configMapDir.mkdirs();
 
         if (!logDirExist) throw new IOException("Unable to create path");
         if (!logTestSuiteDirExist) throw new IOException("Unable to create path");
         if (!logTestCaseDirExist) throw new IOException("Unable to create path");
-        if (!logEventDirExist) throw new IOException("Unable to create path");
-        if (!logConfigMapExist) throw new IOException("Unable to create path");
     }
 
     /**
-     * CoLogCollector encapsulates different implementation of collecting logs from resource such as Deployment, ReplicaSet, ConfigMaps and so on.
+     * Core method which collects all logs from events, configs-maps, pods, deployment, statefulset, replicaset...in case test fails.
      */
-    class CoLogCollector implements LogCollect {
+    public void collect() {
+        final Set<String> namespaces = KubeClusterResource.getInstance().getMapWithSuiteNamespaces().get(this.testSuiteName);
 
-        private final Pod clusterOperatorPod;
-        private final String clusterOperatorNamespace;
-
-        public CoLogCollector() {
-            this.clusterOperatorPod = kubeClient.getClient().pods().inAnyNamespace().list().getItems().stream()
-                .filter(pod -> pod.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
-                // contract only one Cluster Operator deployment inside all namespaces
-                .findFirst()
-                .orElseThrow();
-            this.clusterOperatorNamespace = this.clusterOperatorPod.getMetadata().getNamespace();
-        }
-
-        @Override
-        public void collectLogsFromPods() {
-            // cluster operator pod logs
-            final String coPodName = this.clusterOperatorPod.getMetadata().getName();
-            this.clusterOperatorPod.getStatus().getContainerStatuses().forEach(containerStatus -> {
-                scrapeAndCreateLogs(testSuite, this.clusterOperatorNamespace, coPodName, containerStatus);
-            });
-        }
-
-        @Override
-        public void collectEvents() {
-            String events = cmdKubeClient(this.clusterOperatorNamespace).getEvents();
-            // Write events to file
-            writeFile(eventsDir + "/" + "cluster-operator-events-in-namespace" + this.clusterOperatorNamespace + ".log", events);
-        }
-
-        @Override
-        public void collectConfigMaps() {
-            kubeClient.getClient().configMaps().inNamespace(this.clusterOperatorNamespace).list().getItems().stream()
-                .filter(configMap -> configMap.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
-                .forEach(configMap -> writeFile(configMapDir + "/" + configMap.getMetadata().getName() + "-" + namespace + ".log", configMap.toString()));
-        }
-
-        @Override
-        public void collectDeployments() {
-            kubeClient.getClient().apps().deployments().inNamespace(this.clusterOperatorNamespace).list().getItems().stream()
-                .filter(deployment -> deployment.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
-                .forEach(deployment -> writeFile(testCase + "/" + deployment.getMetadata().getName() + "-" + namespace + ".log", deployment.toString()));
-        }
-        @Override
-        public void collectStatefulSets() {
-            kubeClient.getClient().apps().statefulSets().inNamespace(this.clusterOperatorNamespace).list().getItems().stream()
-                .filter(statefulSet -> statefulSet.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
-                .forEach(statefulSet -> writeFile(testCase + "/" + statefulSet.getMetadata().getName() + "-" + namespace + ".log", statefulSet.toString()));
-        }
-        @Override
-        public void collectReplicaSets() {
-            kubeClient.getClient().apps().replicaSets().inNamespace(this.clusterOperatorNamespace).list().getItems().stream()
-                .filter(replicaSet -> replicaSet.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
-                .forEach(replicaSet -> writeFile(testCase + "/" + replicaSet.getMetadata().getName() + "-" + namespace + ".log", replicaSet.toString()));
-        }
+        // collect logs for all namespace related to test suite
+        namespaces.stream().forEach(namespace -> {
+            this.collectEvents(namespace);
+            this.collectConfigMaps(namespace);
+            this.collectLogsFromPods(namespace);
+            this.collectDeployments(namespace);
+            this.collectStatefulSets(namespace);
+            this.collectReplicaSets(namespace);
+            this.collectStrimzi(namespace);
+            this.collectClusterInfo(namespace);
+        });
     }
 
     @Override
-    public void collectLogsFromPods() {
+    public void collectLogsFromPods(String namespaceName) {
         try {
-            coLogCollector.collectLogsFromPods();
-            LOGGER.info("Collecting logs for Pod(s) in namespace {}", namespace);
+            LOGGER.info("Collecting logs for Pod(s) in namespace {}", namespaceName);
 
-            kubeClient.listPods(namespace).forEach(pod -> {
-                String podName = pod.getMetadata().getName();
-                pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
-                    scrapeAndCreateLogs(testCase, namespace, podName, containerStatus);
+            // in case we are in the cluster operator namespace we wants shared logs for whole test suite
+            if (namespaceName.equals(this.clusterOperatorNamespace)) {
+                kubeClient.listPods(namespaceName).forEach(pod -> {
+                    String podName = pod.getMetadata().getName();
+                    pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
+                        scrapeAndCreateLogs(testSuite, namespaceName, podName, containerStatus);
+                    });
                 });
-            });
+            } else {
+                kubeClient.listPods(namespaceName).forEach(pod -> {
+                    String podName = pod.getMetadata().getName();
+                    pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
+                        scrapeAndCreateLogs(testCase, namespaceName, podName, containerStatus);
+                    });
+                });
+            }
         } catch (Exception allExceptions) {
             LOGGER.warn("Searching for logs in all pods failed! Some of the logs will not be stored. Exception message" + allExceptions.getMessage());
         }
     }
 
     @Override
-    public void collectEvents() {
-        coLogCollector.collectEvents();
-        LOGGER.info("Collecting events in Namespace {}", namespace);
-        String events = cmdKubeClient(namespace).getEvents();
+    public void collectEvents(String namespaceName) {
+        LOGGER.info("Collecting events in Namespace {}", namespaceName);
+        String events = cmdKubeClient(namespaceName).getEvents();
         // Write events to file
-        writeFile(eventsDir + "/" + "events-in-namespace" + namespace + ".log", events);
+        writeFile(testCase + "/" + namespaceName + "_events.log", events);
     }
 
     @Override
-    public void collectConfigMaps() {
-        coLogCollector.collectConfigMaps();
-        LOGGER.info("Collecting ConfigMaps in Namespace {}", namespace);
-        kubeClient.listConfigMaps(namespace).forEach(configMap -> {
-            writeFile(configMapDir + "/" + configMap.getMetadata().getName() + "-" + namespace + ".log", configMap.toString());
+    public void collectConfigMaps(String namespaceName) {
+        LOGGER.info("Collecting ConfigMaps in Namespace {}", namespaceName);
+        kubeClient.listConfigMaps(namespaceName).forEach(configMap -> {
+            writeFile(testCase + "/" + namespaceName + "_" + configMap.getMetadata().getName() + ".log", configMap.toString());
         });
     }
 
     @Override
-    public void collectDeployments() {
-        coLogCollector.collectDeployments();
-        LOGGER.info("Collecting Deployments in Namespace {}", namespace);
-        writeFile(testCase + "/deployments.log", cmdKubeClient(namespace).getResourcesAsYaml(Constants.DEPLOYMENT));
+    public void collectDeployments(String namespaceName) {
+        LOGGER.info("Collecting Deployments in Namespace {}", namespaceName);
+        writeFile(testCase + "/" + namespaceName + "_deployments.log", cmdKubeClient(namespaceName).getResourcesAsYaml(Constants.DEPLOYMENT));
     }
 
     @Override
-    public void collectStatefulSets() {
-        coLogCollector.collectStatefulSets();
-        LOGGER.info("Collecting StatefulSets in Namespace {}", namespace);
-        writeFile(testCase + "/statefulsets.log", cmdKubeClient(namespace).getResourcesAsYaml(Constants.STATEFUL_SET));
+    public void collectStatefulSets(String namespaceName) {
+        LOGGER.info("Collecting StatefulSets in Namespace {}", namespaceName);
+        writeFile(testCase + "/" + namespaceName + "_statefulsets.log", cmdKubeClient(namespaceName).getResourcesAsYaml(Constants.STATEFUL_SET));
     }
 
     @Override
-    public void collectReplicaSets() {
-        coLogCollector.collectReplicaSets();
-        LOGGER.info("Collecting ReplicaSet in Namespace {}", namespace);
-        writeFile(testCase + "/replicasets.log", cmdKubeClient(namespace).getResourcesAsYaml("replicaset"));
+    public void collectReplicaSets(String namespaceName) {
+        LOGGER.info("Collecting ReplicaSet in Namespace {}", namespaceName);
+        writeFile(testCase + "/" + namespaceName + "_replicasets.log", cmdKubeClient(namespaceName).getResourcesAsYaml("replicaset"));
     }
 
-    public void collectStrimzi() {
-        LOGGER.info("Collecting Strimzi in Namespace {}", namespace);
-        String crData = cmdKubeClient(namespace).exec(false, "get", "strimzi", "-o", "yaml", "-n", namespace).out();
-        writeFile(testCase + "/strimzi-custom-resources.log", crData);
+    public void collectStrimzi(String namespaceName) {
+        LOGGER.info("Collecting Strimzi in Namespace {}", namespaceName);
+        String crData = cmdKubeClient(namespaceName).exec(false, "get", "strimzi", "-o", "yaml", "-n", namespaceName).out();
+        writeFile(testCase + "/" + namespaceName + "_strimzi-custom-resources.log", crData);
     }
 
-    public void collectClusterInfo() {
+    public void collectClusterInfo(String namespaceName) {
         LOGGER.info("Collecting cluster status");
-        String nodes = cmdKubeClient(namespace).exec(false, "describe", "nodes").out();
-        writeFile(testCase + "/cluster-status.log", nodes);
+        String nodes = cmdKubeClient(namespaceName).exec(false, "describe", "nodes").out();
+        writeFile(testCase + "/" + namespaceName + "_cluster-status.log", nodes);
     }
 
     private void scrapeAndCreateLogs(File path, String namespaceName, String podName, ContainerStatus containerStatus) {
         String log = kubeClient.getPodResource(namespaceName, podName).inContainer(containerStatus.getName()).getLog();
         // Write logs from containers to files
-        writeFile(path + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
+        writeFile(path + "/" + namespaceName + "_logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
         // Describe all pods
         String describe = cmdKubeClient(namespaceName).describe("pod", podName);
-        writeFile(path + "/" + "describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);
+        writeFile(path + "/" + namespaceName + "_describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -4,56 +4,153 @@
  */
 package io.strimzi.systemtest.logs;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.test.k8s.KubeClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import static io.strimzi.test.TestUtils.writeFile;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
-public class LogCollector {
+/**
+ * LogCollector collects logs from all resources **if test case or preparation phase fails**. All can be found
+ * inside ./systemtest/target/logs directory where the structure of the logs are as follows:
+ *
+ * ./logs
+ *      /test-suite_time/
+ *          /test-case/
+ *              /configmaps/
+ *              /events
+ *              deployment.log
+ *              configmap.log
+ *              ...
+ *
+*           cluster-operator.log    // shared cluster operator logs for all tests inside one test suite
+ *      /another-test-suite_time/
+ *      ...
+ */
+public class LogCollector implements LogCollect {
     private static final Logger LOGGER = LogManager.getLogger(LogCollector.class);
 
-    private KubeClient kubeClient;
-    private String namespace;
-    private File logDir;
-    private File configMapDir;
-    private File eventsDir;
+    private static final String CURRENT_DATE;
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
-    public LogCollector(String namespaceName, KubeClient kubeClient, File logDir) {
+    static {
+        // Get current date to create a unique folder
+        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        CURRENT_DATE = simpleDateFormat.format(Calendar.getInstance().getTime());
+    }
+
+    private final KubeClient kubeClient;
+    private final String namespace;
+    private final File testSuite;
+    private final File testCase;
+    private final File logDir;
+    private final File configMapDir;
+    private final File eventsDir;
+    private CoLogCollector coLogCollector;
+
+    public LogCollector(String namespaceName, String testSuite, String testCase, KubeClient kubeClient, String logDir) throws IOException {
         this.kubeClient = kubeClient;
         this.namespace = namespaceName;
-        this.logDir = logDir;
-        this.eventsDir = new File(logDir + "/events");
-        this.configMapDir = new File(logDir + "/configMaps");
-        logDir.mkdirs();
 
-        if (!eventsDir.exists()) {
-            eventsDir.mkdirs();
+
+        this.logDir = new File(logDir + "_" + CURRENT_DATE);
+        final String logSuiteDir = this.logDir + "/" + testSuite;
+
+        this.testSuite = new File(logSuiteDir);
+        this.coLogCollector = new CoLogCollector();
+        this.testCase = new File(logSuiteDir + "/" + testCase);
+        this.eventsDir = new File(this.testCase + "/events");
+        this.configMapDir = new File(this.testCase + "/configMaps");
+
+        boolean logDirExist = this.logDir.exists() || this.logDir.mkdirs();
+        boolean logTestSuiteDirExist = this.testSuite.exists() || this.testSuite.mkdirs();
+        boolean logTestCaseDirExist = this.testCase.exists() || this.testCase.mkdirs();
+        boolean logEventDirExist = this.eventsDir.exists() || this.eventsDir.mkdirs();
+        boolean logConfigMapExist = this.configMapDir.exists() || this.configMapDir.mkdirs();
+
+        if (!logDirExist) throw new IOException("Unable to create path");
+        if (!logTestSuiteDirExist) throw new IOException("Unable to create path");
+        if (!logTestCaseDirExist) throw new IOException("Unable to create path");
+        if (!logEventDirExist) throw new IOException("Unable to create path");
+        if (!logConfigMapExist) throw new IOException("Unable to create path");
+    }
+
+    /**
+     * CoLogCollector encapsulates different implementation of collecting logs from resource such as Deployment, ReplicaSet, ConfigMaps and so on.
+     */
+    class CoLogCollector implements LogCollect {
+
+        @Override
+        public void collectLogsFromPods() {
+            final Pod coPod = kubeClient.getClient().pods().inAnyNamespace().list().getItems().stream()
+                .filter(pod -> pod.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+                // contract only one Cluster Operator deployment inside all namespaces
+                .findFirst()
+                .orElseThrow();
+
+            try {
+                // cluster operator pod logs
+                final String coPodName = coPod.getMetadata().getName();
+                coPod.getStatus().getContainerStatuses().forEach(containerStatus -> {
+                    scrapeAndCreateLogs(testSuite, coPod.getMetadata().getNamespace(), coPodName, containerStatus);
+                });
+            } catch (Exception allExceptions) {
+                LOGGER.warn("Searching for logs in all pods failed! Some of the logs will not be stored.");
+            }
         }
-        if (!configMapDir.exists()) {
-            configMapDir.mkdirs();
+
+        @Override
+        public void collectEvents() {
+            kubeClient.getClient().events().v1().events().inAnyNamespace().list().getItems().stream()
+                .filter(event -> event.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+                .forEach(event -> writeFile(eventsDir + "/" + event.getMetadata().getName() + ".log", event.toString()));
+        }
+        @Override
+        public void collectConfigMaps() {
+            kubeClient.getClient().configMaps().inAnyNamespace().list().getItems().stream()
+                .filter(configMap -> configMap.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+                .forEach(configMap -> writeFile(configMapDir + "/" + configMap.getMetadata().getName() + "-" + namespace + ".log", configMap.toString()));
+        }
+
+        @Override
+        public void collectDeployments() {
+            kubeClient.getClient().apps().deployments().inAnyNamespace().list().getItems().stream()
+                .filter(deployment -> deployment.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+                .forEach(deployment -> writeFile(testCase + "/" + deployment.getMetadata().getName() + "-" + namespace + ".log", deployment.toString()));
+        }
+        @Override
+        public void collectStatefulSets() {
+            kubeClient.getClient().apps().statefulSets().inAnyNamespace().list().getItems().stream()
+                .filter(statefulSet -> statefulSet.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+                .forEach(statefulSet -> writeFile(testCase + "/" + statefulSet.getMetadata().getName() + "-" + namespace + ".log", statefulSet.toString()));
+        }
+        @Override
+        public void collectReplicaSets() {
+            kubeClient.getClient().apps().replicaSets().inAnyNamespace().list().getItems().stream()
+                .filter(replicaSet -> replicaSet.getMetadata().getName().contains(Constants.STRIMZI_DEPLOYMENT_NAME))
+                .forEach(replicaSet -> writeFile(testCase + "/" + replicaSet.getMetadata().getName() + "-" + namespace + ".log", replicaSet.toString()));
         }
     }
 
+    @Override
     public void collectLogsFromPods() {
+        coLogCollector.collectLogsFromPods();
         LOGGER.info("Collecting logs for Pod(s) in namespace {}", namespace);
-
         try {
             kubeClient.listPods(namespace).forEach(pod -> {
                 String podName = pod.getMetadata().getName();
                 pod.getStatus().getContainerStatuses().forEach(containerStatus -> {
-                    String log = kubeClient.getPodResource(namespace, podName).inContainer(containerStatus.getName()).getLog();
-                    // Write logs from containers to files
-                    writeFile(logDir + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
-                    // Describe all pods
-                    String describe = cmdKubeClient(namespace).describe("pod", podName);
-                    writeFile(logDir + "/" + "describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);
+                    scrapeAndCreateLogs(testCase, namespace, podName, containerStatus);
                 });
             });
         } catch (Exception allExceptions) {
@@ -61,44 +158,63 @@ public class LogCollector {
         }
     }
 
+    @Override
     public void collectEvents() {
+        coLogCollector.collectEvents();
         LOGGER.info("Collecting events in Namespace {}", namespace);
         String events = cmdKubeClient(namespace).getEvents();
         // Write events to file
         writeFile(eventsDir + "/" + "events-in-namespace" + namespace + ".log", events);
     }
 
+    @Override
     public void collectConfigMaps() {
+        coLogCollector.collectConfigMaps();
         LOGGER.info("Collecting ConfigMaps in Namespace {}", namespace);
-        kubeClient.listConfigMaps().forEach(configMap -> {
+        kubeClient.listConfigMaps(namespace).forEach(configMap -> {
             writeFile(configMapDir + "/" + configMap.getMetadata().getName() + "-" + namespace + ".log", configMap.toString());
         });
     }
 
+    @Override
     public void collectDeployments() {
+        coLogCollector.collectDeployments();
         LOGGER.info("Collecting Deployments in Namespace {}", namespace);
-        writeFile(logDir + "/deployments.log", cmdKubeClient(namespace).getResourcesAsYaml(Constants.DEPLOYMENT));
+        writeFile(testCase + "/deployments.log", cmdKubeClient(namespace).getResourcesAsYaml(Constants.DEPLOYMENT));
     }
 
+    @Override
     public void collectStatefulSets() {
+        coLogCollector.collectStatefulSets();
         LOGGER.info("Collecting StatefulSets in Namespace {}", namespace);
-        writeFile(logDir + "/statefulsets.log", cmdKubeClient(namespace).getResourcesAsYaml(Constants.STATEFUL_SET));
+        writeFile(testCase + "/statefulsets.log", cmdKubeClient(namespace).getResourcesAsYaml(Constants.STATEFUL_SET));
     }
 
+    @Override
     public void collectReplicaSets() {
+        coLogCollector.collectReplicaSets();
         LOGGER.info("Collecting ReplicaSet in Namespace {}", namespace);
-        writeFile(logDir + "/replicasets.log", cmdKubeClient(namespace).getResourcesAsYaml("replicaset"));
+        writeFile(testCase + "/replicasets.log", cmdKubeClient(namespace).getResourcesAsYaml("replicaset"));
     }
 
     public void collectStrimzi() {
         LOGGER.info("Collecting Strimzi in Namespace {}", namespace);
         String crData = cmdKubeClient(namespace).exec(false, "get", "strimzi", "-o", "yaml", "-n", namespace).out();
-        writeFile(logDir + "/strimzi-custom-resources.log", crData);
+        writeFile(testCase + "/strimzi-custom-resources.log", crData);
     }
 
     public void collectClusterInfo() {
         LOGGER.info("Collecting cluster status");
         String nodes = cmdKubeClient(namespace).exec(false, "describe", "nodes").out();
-        writeFile(logDir + "/cluster-status.log", nodes);
+        writeFile(testCase + "/cluster-status.log", nodes);
+    }
+
+    private void scrapeAndCreateLogs(File path, String namespaceName, String podName, ContainerStatus containerStatus) {
+        String log = kubeClient.getPodResource(namespaceName, podName).inContainer(containerStatus.getName()).getLog();
+        // Write logs from containers to files
+        writeFile(path + "/" + "logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
+        // Describe all pods
+        String describe = cmdKubeClient(namespaceName).describe("pod", podName);
+        writeFile(path + "/" + "describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -4,9 +4,7 @@
  */
 package io.strimzi.systemtest.logs;
 
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.timemeasuring.Operation;
 import io.strimzi.test.timemeasuring.TimeMeasuringSystem;
 import org.apache.logging.log4j.LogManager;

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -16,10 +16,8 @@ import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.opentest4j.TestAbortedException;
 
-import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.TimeZone;
+import java.io.IOException;
+import java.util.Random;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -70,29 +68,20 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
         throw throwable;
     }
 
-    public synchronized static void collectLogs(ExtensionContext extensionContext, String testClass, String testMethod) {
+    public synchronized static void collectLogs(ExtensionContext extensionContext, String testClass, String testMethod) throws IOException {
         final String namespaceName;
         final LogCollector logCollector;
 
         // Stop test execution time counter in case of failures
         TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION, testClass, testMethod);
-        // Get current date to create a unique folder
-        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        final String currentDate = simpleDateFormat.format(Calendar.getInstance().getTime());
 
-        String logDir = !testMethod.isEmpty() ?
-            Environment.TEST_LOG_DIR + testClass + "." + testMethod + "_" + currentDate
-            : Environment.TEST_LOG_DIR + testClass + currentDate;
+        testMethod = testMethod.isEmpty() ? "class-context-" + new Random().nextInt(Integer.MAX_VALUE) : testMethod;
 
         if (StUtils.isParallelNamespaceTest(extensionContext)) {
             namespaceName = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
-            logDir = !testMethod.isEmpty() ?
-                Environment.TEST_LOG_DIR + testClass + "." + testMethod + "_" + namespaceName + "_" + currentDate
-                : Environment.TEST_LOG_DIR + testClass + currentDate;
-            logCollector = new LogCollector(namespaceName, kubeClient(), new File(logDir));
+            logCollector = new LogCollector(namespaceName, testClass, testMethod, kubeClient(), Environment.TEST_LOG_DIR);
         } else {
-            logCollector = new LogCollector(kubeClient().getNamespace(), kubeClient(), new File(logDir));
+            logCollector = new LogCollector(kubeClient().getNamespace(), testClass, testMethod, kubeClient(), Environment.TEST_LOG_DIR);
         }
         // collecting logs for all resources inside Kubernetes cluster
         logCollector.collectEvents();

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -76,21 +76,8 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
         TimeMeasuringSystem.getInstance().stopOperation(Operation.TEST_EXECUTION, testClass, testMethod);
 
         testMethod = testMethod.isEmpty() ? "class-context-" + new Random().nextInt(Integer.MAX_VALUE) : testMethod;
-
-        if (StUtils.isParallelNamespaceTest(extensionContext)) {
-            namespaceName = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
-            logCollector = new LogCollector(namespaceName, testClass, testMethod, kubeClient(), Environment.TEST_LOG_DIR);
-        } else {
-            logCollector = new LogCollector(kubeClient().getNamespace(), testClass, testMethod, kubeClient(), Environment.TEST_LOG_DIR);
-        }
+        logCollector = new LogCollector(testClass, testMethod, kubeClient(), Environment.TEST_LOG_DIR);
         // collecting logs for all resources inside Kubernetes cluster
-        logCollector.collectEvents();
-        logCollector.collectConfigMaps();
-        logCollector.collectLogsFromPods();
-        logCollector.collectDeployments();
-        logCollector.collectStatefulSets();
-        logCollector.collectReplicaSets();
-        logCollector.collectStrimzi();
-        logCollector.collectClusterInfo();
+        logCollector.collect();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -782,25 +782,25 @@ public abstract class AbstractST implements TestSeparator {
         testDockerImagesForKafkaCluster(clusterName, namespaceName, namespaceName, kafkaPods, zkPods, rackAwareEnabled);
     }
 
-    protected void afterEachMayOverride(ExtensionContext testContext) throws Exception {
+    protected void afterEachMayOverride(ExtensionContext extensionContext) throws Exception {
         if (!Environment.SKIP_TEARDOWN) {
-            ResourceManager.getInstance().deleteResources(testContext);
+            ResourceManager.getInstance().deleteResources(extensionContext);
 
             // if 'parallel namespace test' we are gonna delete namespace
-            if (StUtils.isParallelNamespaceTest(testContext)) {
+            if (StUtils.isParallelNamespaceTest(extensionContext)) {
 
-                final String namespaceToDelete = testContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
+                final String namespaceToDelete = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
 
-                LOGGER.info("Deleting namespace:{} for test case:{}", namespaceToDelete, testContext.getDisplayName());
-                cluster.deleteNamespace(testContext, namespaceToDelete);
+                LOGGER.info("Deleting namespace:{} for test case:{}", namespaceToDelete, extensionContext.getDisplayName());
+                cluster.deleteNamespace(extensionContext, namespaceToDelete);
             }
         }
     }
 
-    protected void afterAllMayOverride(ExtensionContext testContext) throws Exception {
+    protected void afterAllMayOverride(ExtensionContext extensionContext) throws Exception {
         if (!Environment.SKIP_TEARDOWN) {
             teardownEnvForOperator();
-            ResourceManager.getInstance().deleteResources(testContext);
+            ResourceManager.getInstance().deleteResources(extensionContext);
         }
     }
 
@@ -863,30 +863,30 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     @BeforeEach
-    void setUpTestCase(ExtensionContext testContext) {
+    void setUpTestCase(ExtensionContext extensionContext) {
         LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
         LOGGER.debug("{} - [BEFORE EACH] has been called", this.getClass().getName());
-        beforeEachMayOverride(testContext);
+        beforeEachMayOverride(extensionContext);
     }
 
     @BeforeAll
-    void setUpTestSuite(ExtensionContext testContext) {
+    void setUpTestSuite(ExtensionContext extensionContext) {
         LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
         LOGGER.debug("{} - [BEFORE ALL] has been called", this.getClass().getName());
-        beforeAllMayOverride(testContext);
+        beforeAllMayOverride(extensionContext);
     }
 
     @AfterEach
-    void tearDownTestCase(ExtensionContext testContext) throws Exception {
+    void tearDownTestCase(ExtensionContext extensionContext) throws Exception {
         LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
         LOGGER.debug("{} - [AFTER EACH] has been called", this.getClass().getName());
-        afterEachMayOverride(testContext);
+        afterEachMayOverride(extensionContext);
     }
 
     @AfterAll
-    void tearDownTestSuite(ExtensionContext testContext) throws Exception {
+    void tearDownTestSuite(ExtensionContext extensionContext) throws Exception {
         LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
         LOGGER.debug("{} - [AFTER ALL] has been called", this.getClass().getName());
-        afterAllMayOverride(testContext);
+        afterAllMayOverride(extensionContext);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -252,7 +252,7 @@ public abstract class AbstractST implements TestSeparator {
      */
     protected void prepareEnvForOperator(ExtensionContext extensionContext, String clientNamespace, List<String> namespaces, String... resources) {
         assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
-        cluster.createNamespaces(clientNamespace, namespaces);
+        cluster.createNamespaces(extensionContext, clientNamespace, namespaces);
         cluster.createCustomResources(resources);
         applyClusterOperatorInstallFiles(clientNamespace);
         NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, namespaces);
@@ -792,7 +792,7 @@ public abstract class AbstractST implements TestSeparator {
                 final String namespaceToDelete = testContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
 
                 LOGGER.info("Deleting namespace:{} for test case:{}", namespaceToDelete, testContext.getDisplayName());
-                cluster.deleteNamespace(namespaceToDelete);
+                cluster.deleteNamespace(testContext, namespaceToDelete);
             }
         }
     }
@@ -814,11 +814,11 @@ public abstract class AbstractST implements TestSeparator {
         // this is because we need to have different clusterName and kafkaClientsName in each test case without
         // synchronization it can produce `data-race`
         String testName = null;
+        String testClass = null;
 
         synchronized (lock) {
-            if (extensionContext.getTestMethod().isPresent()) {
-                testName = extensionContext.getTestMethod().get().getName();
-            }
+            if (extensionContext.getTestClass().isPresent()) testClass = extensionContext.getTestClass().get().getName();
+            if (extensionContext.getTestMethod().isPresent()) testName = extensionContext.getTestMethod().get().getName();
 
             LOGGER.info("Not first test we are gonna generate cluster name");
             String clusterName = CLUSTER_NAME_PREFIX + new Random().nextInt(Integer.MAX_VALUE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -470,7 +470,7 @@ public class MirrorMakerST extends AbstractST {
 
     @ParallelNamespaceTest
     void testWhiteList(ExtensionContext extensionContext) {
-        final String namespaceName = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
+        final String namespaceName = null;
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String kafkaClusterSourceName = clusterName + "-source";
         String kafkaClusterTargetName = clusterName + "-target";
@@ -748,7 +748,7 @@ public class MirrorMakerST extends AbstractST {
 
     @ParallelNamespaceTest
     void testConfigureDeploymentStrategy(ExtensionContext extensionContext) {
-        final String namespaceName = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
+        final String namespaceName =  null;
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String kafkaClusterSourceName = clusterName + "-source";
         String kafkaClusterTargetName = clusterName + "-target";

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -470,7 +470,7 @@ public class MirrorMakerST extends AbstractST {
 
     @ParallelNamespaceTest
     void testWhiteList(ExtensionContext extensionContext) {
-        final String namespaceName = null;
+        final String namespaceName = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String kafkaClusterSourceName = clusterName + "-source";
         String kafkaClusterTargetName = clusterName + "-target";
@@ -748,7 +748,7 @@ public class MirrorMakerST extends AbstractST {
 
     @ParallelNamespaceTest
     void testConfigureDeploymentStrategy(ExtensionContext extensionContext) {
-        final String namespaceName =  null;
+        final String namespaceName = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String kafkaClusterSourceName = clusterName + "-source";
         String kafkaClusterTargetName = clusterName + "-target";

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -320,8 +320,12 @@ public class KubeClient {
     /**
      * Gets pod
      */
+    public PodResource<Pod> getPodResource(String namespaceName, String name) {
+        return client.pods().inNamespace(namespaceName).withName(name);
+    }
+
     public PodResource<Pod> getPodResource(String name) {
-        return client.pods().inNamespace(getNamespace()).withName(name);
+        return getPodResource(kubeClient().getNamespace(), name);
     }
 
     /**

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -47,7 +47,7 @@ public class KubeClusterResource {
     private String namespace;
     private String testNamespace;
     // {test-suite-name} -> {{namespace-1}, {namespace-2},...,}
-    protected static Map<String, Set<String>> mapWithSuiteNamespaces = new HashMap<>();
+    private final static Map<String, Set<String>> MAP_WITH_SUITE_NAMESPACES = new HashMap<>();
 
     protected List<String> bindingsNamespaces = new ArrayList<>();
     private List<String> deploymentNamespaces = new ArrayList<>();
@@ -373,16 +373,16 @@ public class KubeClusterResource {
 
         if (extensionContext.getTestClass().isPresent()) testClass = extensionContext.getRequiredTestClass().getName();
 
-        if (mapWithSuiteNamespaces.containsKey(testClass)) {
-            Set<String> testSuiteNamespaces = mapWithSuiteNamespaces.get(testClass);
+        if (MAP_WITH_SUITE_NAMESPACES.containsKey(testClass)) {
+            Set<String> testSuiteNamespaces = MAP_WITH_SUITE_NAMESPACES.get(testClass);
             testSuiteNamespaces.add(namespaceName);
-            mapWithSuiteNamespaces.put(testClass, testSuiteNamespaces);
+            MAP_WITH_SUITE_NAMESPACES.put(testClass, testSuiteNamespaces);
         } else {
             // test-suite is new
-            mapWithSuiteNamespaces.put(testClass, new HashSet<>(Set.of(namespaceName)));
+            MAP_WITH_SUITE_NAMESPACES.put(testClass, new HashSet<>(Set.of(namespaceName)));
         }
 
-        LOGGER.debug("SUITE_NAMESPACE_MAP: \n{}", mapWithSuiteNamespaces);
+        LOGGER.debug("SUITE_NAMESPACE_MAP: \n{}", MAP_WITH_SUITE_NAMESPACES);
     }
 
     private synchronized void deleteNamespaceFromSet(ExtensionContext extensionContext, String namespaceName) {
@@ -391,13 +391,13 @@ public class KubeClusterResource {
         if (extensionContext.getTestClass().isPresent()) testClass = extensionContext.getRequiredTestClass().getName();
 
         // dynamically removing from the map
-        Set<String> testSuiteNamespaces = mapWithSuiteNamespaces.get(testClass);
+        Set<String> testSuiteNamespaces = MAP_WITH_SUITE_NAMESPACES.get(testClass);
         testSuiteNamespaces.remove(namespaceName);
-        mapWithSuiteNamespaces.put(testClass, testSuiteNamespaces);
-        LOGGER.debug("SUITE_NAMESPACE_MAP after deletion: \n{}", mapWithSuiteNamespaces);
+        MAP_WITH_SUITE_NAMESPACES.put(testClass, testSuiteNamespaces);
+        LOGGER.debug("SUITE_NAMESPACE_MAP after deletion: \n{}", MAP_WITH_SUITE_NAMESPACES);
     }
 
     public static Map<String, Set<String>> getMapWithSuiteNamespaces() {
-        return mapWithSuiteNamespaces;
+        return MAP_WITH_SUITE_NAMESPACES;
     }
 }


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR adding support for logging parallel namespace tests in case of failure. The format of failure test case is as follows: 

```
./logs
       /time/
           /test-suite/
               /test-case/
                   /configmaps/
                   /events
                   deployment.log
                   configmap.log
                   ... 
              cluster-operator.log    // shared cluster operator logs for all tests inside one test suite
           /another-test-suite_time/
       ...
```

### Checklist

- [x] Make sure all tests pass