### PR TITLE
DRAFT: Exit `KafkaRoller` schedule loop on detection of cancelled reconciliation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -801,7 +801,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         /**
          * Does manual rolling update of Kafka pods based on an annotation on the StatefulSet or on the Pods. Annotation
-         * on StatefulSet level triggers rolling update of all pods. Annotation on pods trigeres rolling update only of
+         * on StatefulSet level triggers rolling update of all pods. Annotation on pods triggers rolling update only of
          * the selected pods. If the annotation is present on both StatefulSet and one or more pods, only one rolling
          * update of all pods occurs.
          *
@@ -1750,7 +1750,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         /**
          * Get the cluster Id of the Kafka cluster
-         * 
+         *
          * @return
          */
         Future<ReconciliationState> kafkaGetClusterId() {
@@ -1784,7 +1784,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     return resultPromise.future();
                 });
         }
-        
+
         Future<ReconciliationState> kafkaInternalServicesReady()   {
             for (GenericKafkaListener listener : ListenersUtils.internalListeners(kafkaCluster.getListeners())) {
                 boolean useServiceDnsDomain = (listener.getConfiguration() != null && listener.getConfiguration().getUseServiceDnsDomain() != null)

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 USER root
 
 RUN microdnf update \
-    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl procps shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless java-${JAVA_VERSION}-openjdk-devel openssl procps shadow-utils \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-11

--- a/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
@@ -36,7 +36,7 @@ class OperatorWatcher<T extends HasMetadata> implements Watcher<T> {
             case ADDED:
             case DELETED:
             case MODIFIED:
-                Reconciliation reconciliation = new Reconciliation("watch", operator.kind(), namespace, name);
+                Reconciliation reconciliation = new Reconciliation("watch", operator.kind(), namespace, name, action);
                 log.info("{}: {} {} in namespace {} was {}", reconciliation, operator.kind(), name, namespace, action);
                 operator.reconcile(reconciliation);
                 break;

--- a/operator-common/src/main/java/io/strimzi/operator/common/Reconciliation.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Reconciliation.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.common;
 
+import io.fabric8.kubernetes.client.Watcher.Action;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -18,17 +20,24 @@ public class Reconciliation {
     private static final AtomicInteger IDS = new AtomicInteger();
 
     private final String trigger;
+    private final Action action;
     private final String kind;
     private final String namespace;
     private final String name;
     private final int id;
+    private volatile boolean cancelled;
 
-    public Reconciliation(String trigger, String kind, String namespace, String assemblyName) {
+    public Reconciliation(String trigger, String kind, String namespace, String assemblyName, Action action) {
         this.trigger = trigger;
         this.kind = kind;
         this.namespace = namespace;
         this.name = assemblyName;
         this.id = IDS.getAndIncrement();
+        this.action = action;
+    }
+
+    public Reconciliation(String trigger, String kind, String namespace, String assemblyName) {
+        this(trigger, kind, namespace, assemblyName, null);
     }
 
     public String kind() {
@@ -41,6 +50,18 @@ public class Reconciliation {
 
     public String name() {
         return name;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
     public String toString() {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Add boolean to `Reconciliation` to indicate reconcile action cancelled due to observation of DELETED action

Fixes #4869 

This is still a work-in-progress, but I would like to get feedback on whether the approach seems reasonable, etc. Note that the final version of this PR will not include changes to the `Dockerfile`, please ignore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

Signed-off-by: Michael Edgar <medgar@redhat.com>