### PR TITLE
Add Kafka Quotas plugin to our Kafka images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for Kafka 2.7.1 and remove support for 2.6.0, 2.6.1, and 2.6.2
 * Support for patching of service accounts and configuring their labels and annotations. The feature is disabled by default and enabled using the new `ServiceAccountPatching` feature gate.
 * Added support for configuring cluster-operator's worker thread pool size that is used for various sync and async tasks
+* Add Kafka Quotas plugin with produce, consume, and storage quotas
 
 ## 0.23.0
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -19,12 +19,17 @@
         <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
+        <kafka-quotas-plugin.version>1.0.0-SNAPSHOT</kafka-quotas-plugin.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>kafka-quotas-plugin</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -19,17 +19,13 @@
         <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
-        <kafka-quotas-plugin.version>1.0.0-SNAPSHOT</kafka-quotas-plugin.version>
+        <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
-        </repository>
-        <repository>
-            <id>kafka-quotas-plugin</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -282,6 +278,12 @@
             <groupId>io.strimzi</groupId>
             <artifactId>mirror-maker-2-extensions</artifactId>
             <version>0.1.0</version>
+        </dependency>
+        <!-- Kafka Quotas Plugin -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-quotas-plugin</artifactId>
+            <version>${kafka-quotas-plugin.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -19,12 +19,17 @@
         <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.46</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
+        <kafka-quotas-plugin.version>1.0.0-SNAPSHOT</kafka-quotas-plugin.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>kafka-quotas-plugin</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -277,6 +282,12 @@
             <groupId>io.strimzi</groupId>
             <artifactId>mirror-maker-2-extensions</artifactId>
             <version>0.1.0</version>
+        </dependency>
+        <!-- Kafka Quotas Plugin -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-quotas-plugin</artifactId>
+            <version>${kafka-quotas-plugin.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -19,17 +19,13 @@
         <strimzi-oauth.version>0.7.2</strimzi-oauth.version>
         <cruise-control.version>2.5.46</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
-        <kafka-quotas-plugin.version>1.0.0-SNAPSHOT</kafka-quotas-plugin.version>
+        <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
-        </repository>
-        <repository>
-            <id>kafka-quotas-plugin</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This adds the Kafka Quotas Plugin to the Kafka container images via the third-party mechanism. This currently has to be manually configured in the `.spec.kafka.config` section:

```yaml
client.quota.callback.class: io.strimzi.kafka.quotas.StaticQuotaCallback
# The quota is given in bytes, and will translate to bytes/sec in total for your clients.
client.quota.callback.static.produce: 1000000 # 1MB/s
client.quota.callback.static.fetch: 1000000 # 1MB/s
# Storage quota settings in bytes. Clients will be throttled linearly between produce quota and 0 after soft limit.
client.quota.callback.static.storage.soft: 400000000000  # 400Gi
client.quota.callback.static.storage.hard: 500000000000 # 500Gi
client.quota.callback.static.storage.check-interval: 5 # 5s
```

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md