### PR TITLE
Migrate to UBI8 base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.24.0
 
+* Use Red Hat UBI8 base image
 * Add support for Kafka 2.7.1 and remove support for 2.6.0, 2.6.1, and 2.6.2
 * Support for patching of service accounts and configuring their labels and annotations. The feature is disabled by default and enabled using the new `ServiceAccountPatching` feature gate.
 * Added support for configuring cluster-operator's worker thread pool size that is used for various sync and async tasks

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETPLATFORM
 USER root
 
 RUN microdnf update \
-    && microdnf install openssl bind-utils \
+    && microdnf install openssl bind-utils procps \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-11

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,10 +1,13 @@
-FROM centos:7
-ARG JAVA_VERSION=11
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:latest
 ARG TARGETPLATFORM
 
-RUN yum -y update \
-    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl bind-utils \
-    && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install openssl bind-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME /usr/lib/jvm/jre-11
 
 #####
 # Add Tini

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,10 +1,11 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+ARG JAVA_VERSION=11
 ARG TARGETPLATFORM
 
 USER root
 
 RUN microdnf update \
-    && microdnf install openssl bind-utils procps \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl bind-utils procps shadow-utils \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-11

--- a/docker-images/jmxtrans/Dockerfile
+++ b/docker-images/jmxtrans/Dockerfile
@@ -32,8 +32,11 @@ COPY jmxtrans_readiness_check.sh /opt/jmx/
 #####
 # Add NC
 #####
-RUN yum install -y nc
+RUN microdnf install nc \
+    && microdnf clean all
 
 VOLUME ${JSON_DIR}
 
 ENTRYPOINT [ "/docker-entrypoint.sh",  "start-without-jmx" ]
+
+USER 1001

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -6,8 +6,8 @@ ARG THIRD_PARTY_LIBS
 ARG strimzi_version
 ARG TARGETPLATFORM
 
-RUN yum -y install gettext nmap-ncat stunnel net-tools && yum clean all -y
-RUN yum -y install unzip && yum clean all -y
+RUN microdnf install gettext nmap-ncat stunnel net-tools unzip hostname findutils \
+    && microdnf clean all
 
 # Add kafka user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -6,7 +6,7 @@ ARG THIRD_PARTY_LIBS
 ARG strimzi_version
 ARG TARGETPLATFORM
 
-RUN microdnf install gettext nmap-ncat stunnel net-tools unzip hostname findutils \
+RUN microdnf install gettext nmap-ncat stunnel net-tools unzip hostname findutils tar \
     && microdnf clean all
 
 # Add kafka user with UID 1001

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -78,11 +78,11 @@ public class SystemTestCertManager {
 
     public static List<String> getCertificateChain(String certificateName) {
         return new ArrayList<>(asList(
-                "s:/O=io.strimzi/CN=" + certificateName + "\n" +
-                "   i:/O=io.strimzi/CN=cluster-ca",
+                "s:O = io.strimzi, CN = " + certificateName + "\n" +
+                "   i:O = io.strimzi, CN = cluster-ca",
                 "Server certificate\n" +
-                "subject=/O=io.strimzi/CN=" + certificateName + "\n" +
-                "issuer=/O=io.strimzi/CN=cluster-ca"
+                "subject=O = io.strimzi, CN = " + certificateName + "\n\n" +
+                "issuer=O = io.strimzi, CN = cluster-ca"
         ));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -111,8 +111,6 @@ class SecurityST extends AbstractST {
     public static final String NAMESPACE = "security-cluster-test";
     private static final Logger LOGGER = LogManager.getLogger(SecurityST.class);
     private static final String OPENSSL_RETURN_CODE = "Verify return code: 0 (ok)";
-    private static final String TLS_PROTOCOL = "Protocol  : TLSv1";
-    private static final String SSL_TIMEOUT = "Timeout   : 300 (sec)";
     static final String STRIMZI_TEST_CLUSTER_CA = "C=CZ, L=Prague, O=StrimziTest, CN=SecuritySTClusterCA";
     static final String STRIMZI_TEST_CLIENTS_CA = "C=CZ, L=Prague, O=StrimziTest, CN=SecuritySTClientsCA";
 
@@ -134,6 +132,7 @@ class SecurityST extends AbstractST {
         LOGGER.info("Check Kafka bootstrap certificate");
         String outputCertificate = SystemTestCertManager.generateOpenSslCommandByComponent(namespaceName, KafkaResources.tlsBootstrapAddress(clusterName), KafkaResources.bootstrapServiceName(clusterName),
                 KafkaResources.kafkaPodName(clusterName, 0), "kafka", false);
+        LOGGER.info("OPENSSL OUTPUT: \n\n{}\n\n", outputCertificate);
         verifyCerts(clusterName, outputCertificate, "kafka");
 
         LOGGER.info("Check zookeeper client certificate");
@@ -171,8 +170,6 @@ class SecurityST extends AbstractST {
 
         assertThat(certificate, containsString(certificateChains.get(0)));
         assertThat(certificate, containsString(certificateChains.get(1)));
-        assertThat(certificate, containsString(TLS_PROTOCOL));
-        assertThat(certificate, containsString(SSL_TIMEOUT));
         assertThat(certificate, containsString(OPENSSL_RETURN_CODE));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1763,8 +1763,8 @@ class SecurityST extends AbstractST {
 
     boolean checkMountVolumeSecret(String namespaceName, String podName, VolumeMount volumeMount, String principalDNType, String expectedPrincipal) {
         String dn = cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c",
-                "openssl x509 -in " + volumeMount.getMountPath() + "/ca.crt -noout -" + principalDNType).out().strip();
-        String certOutIssuer = dn.substring(principalDNType.length() + 3).replace("/", ",");
+                "openssl x509 -in " + volumeMount.getMountPath() + "/ca.crt -noout -nameopt RFC2253 -" + principalDNType).out().strip();
+        String certOutIssuer = dn.substring(principalDNType.length() + 1).replace("/", ",");
         return SystemTestCertManager.containsAllDN(certOutIssuer, expectedPrincipal);
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements [SP-24](https://github.com/strimzi/proposals/blob/main/023-using-ubi8-as-base-image.md) and migrates Strimzi to use Red Hat UBI8 base image.

This should close #4472.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md