### PR TITLE
ST: Get secrets in AlternativeReconcileTriggersST properly

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -252,7 +252,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         StatefulSetUtils.waitTillSsHasRolled(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
         KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
 
-        Map<String, String> secretData = kubeClient(namespaceName).getSecret(KafkaResources.brokersServiceName(clusterName)).getData();
+        Map<String, String> secretData = kubeClient().getSecret(namespaceName, KafkaResources.brokersServiceName(clusterName)).getData();
 
         for (Map.Entry<String, String> item : secretData.entrySet()) {
             if (item.getKey().endsWith(".crt")) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR removes flakiness from `AlternativeReconcileTriggersST` where the secrets weren't retrieved properly in specific namespace.

### Checklist

- [x] Make sure all tests pass


