### PR TITLE
Check for unexpected Kafka versions in CO configuration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.NoImageException;
+import io.strimzi.operator.cluster.model.UnsupportedVersionException;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
@@ -348,7 +349,7 @@ public class ClusterOperatorConfig {
             image = "Kafka Mirror Maker 2";
             envVar = STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES;
             lookup.validateKafkaMirrorMaker2Images(lookup.supportedVersionsForFeature("kafkaMirrorMaker2"));
-        } catch (NoImageException e) {
+        } catch (NoImageException | UnsupportedVersionException e) {
             throw new InvalidConfigurationException("Failed to parse default container image configuration for " + image + " from environment variable " + envVar, e);
         }
         return lookup;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -153,7 +153,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
                     .collect(Collectors.toSet());
         }
 
-        private String image(final String crImage, final String crVersion, Map<String, String> images, String envVar)
+        private String image(final String crImage, final String crVersion, Map<String, String> images)
                 throws NoImageException {
             final String image;
             if (crImage == null) {
@@ -184,9 +184,30 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          */
         public String kafkaImage(String image, String version) {
             try {
-                return image(image, version, kafkaImages, ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES);
+                return image(image, version, kafkaImages);
             } catch (NoImageException e) {
                 throw asInvalidResourceException(version, e);
+            }
+        }
+
+        /**
+         * Validates whether each supported version has configured image and whether each configured image matches
+         * supported Kafka version.
+         *
+         * @param versions The versions to validate.
+         * @param images Map with configured images
+         * @throws NoImageException If one of the versions lacks an image.
+         * @throws UnsupportedVersionException If any version with configured image is not supported
+         */
+        public void validateImages(Set<String> versions, Map<String, String> images) throws NoImageException, UnsupportedVersionException   {
+            for (String version : versions) {
+                image(null, version, images);
+            }
+
+            for (String version : images.keySet())  {
+                if (!versions.contains(version)) {
+                    throw new UnsupportedVersionException("Kafka version " + version + " has a container image configured but is not supported.");
+                }
             }
         }
 
@@ -194,11 +215,10 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          * Validate that the given versions have images present in {@link ClusterOperatorConfig#STRIMZI_KAFKA_IMAGES}.
          * @param versions The versions to validate.
          * @throws NoImageException If one of the versions lacks an image.
+         * @throws UnsupportedVersionException If any version with configured image is not supported
          */
-        public void validateKafkaImages(Iterable<String> versions) throws NoImageException {
-            for (String version : versions) {
-                image(null, version, kafkaImages, ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES);
-            }
+        public void validateKafkaImages(Set<String> versions) throws NoImageException, UnsupportedVersionException {
+            validateImages(versions, kafkaImages);
         }
 
         /**
@@ -213,8 +233,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             try {
                 return image(image,
                         version,
-                        kafkaConnectImages,
-                        ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES);
+                        kafkaConnectImages);
             } catch (NoImageException e) {
                 throw asInvalidResourceException(version, e);
             }
@@ -224,11 +243,10 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          * Validate that the given versions have images present in {@link ClusterOperatorConfig#STRIMZI_KAFKA_CONNECT_IMAGES}.
          * @param versions The versions to validate.
          * @throws NoImageException If one of the versions lacks an image.
+         * @throws UnsupportedVersionException If any version with configured image is not supported
          */
-        public void validateKafkaConnectImages(Iterable<String> versions) throws NoImageException {
-            for (String version : versions) {
-                image(null, version, kafkaConnectImages, ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES);
-            }
+        public void validateKafkaConnectImages(Set<String> versions) throws NoImageException, UnsupportedVersionException {
+            validateImages(versions, kafkaConnectImages);
         }
 
         /**
@@ -243,8 +261,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             try {
                 return image(image,
                         version,
-                        kafkaConnectS2iImages,
-                        ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES);
+                        kafkaConnectS2iImages);
             } catch (NoImageException e) {
                 throw asInvalidResourceException(version, e);
             }
@@ -254,11 +271,10 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          * Validate that the given versions have images present in {@link ClusterOperatorConfig#STRIMZI_KAFKA_CONNECT_S2I_IMAGES}.
          * @param versions The versions to validate.
          * @throws NoImageException If one of the versions lacks an image.
+         * @throws UnsupportedVersionException If any version with configured image is not supported
          */
-        public void validateKafkaConnectS2IImages(Iterable<String> versions) throws NoImageException {
-            for (String version : versions) {
-                image(null, version, kafkaConnectS2iImages, ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_S2I_IMAGES);
-            }
+        public void validateKafkaConnectS2IImages(Set<String> versions) throws NoImageException, UnsupportedVersionException {
+            validateImages(versions, kafkaConnectS2iImages);
         }
 
         /**
@@ -273,8 +289,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             try {
                 return image(image,
                         version,
-                        kafkaMirrorMakerImages,
-                        ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES);
+                        kafkaMirrorMakerImages);
             } catch (NoImageException e) {
                 throw asInvalidResourceException(version, e);
             }
@@ -290,11 +305,10 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          * Validate that the given versions have images present in {@link ClusterOperatorConfig#STRIMZI_KAFKA_MIRROR_MAKER_IMAGES}.
          * @param versions The versions to validate.
          * @throws NoImageException If one of the versions lacks an image.
+         * @throws UnsupportedVersionException If any version with configured image is not supported
          */
-        public void validateKafkaMirrorMakerImages(Iterable<String> versions) throws NoImageException {
-            for (String version : versions) {
-                image(null, version, kafkaMirrorMakerImages, ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES);
-            }
+        public void validateKafkaMirrorMakerImages(Set<String> versions) throws NoImageException, UnsupportedVersionException {
+            validateImages(versions, kafkaMirrorMakerImages);
         }
 
        /**
@@ -309,8 +323,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             try {
                 return image(image,
                         version,
-                        kafkaMirrorMaker2Images,
-                        ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES);
+                        kafkaMirrorMaker2Images);
             } catch (NoImageException e) {
                 throw asInvalidResourceException(version, e);
             }
@@ -320,11 +333,10 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
          * Validate that the given versions have images present in {@link ClusterOperatorConfig#STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES}.
          * @param versions The versions to validate.
          * @throws NoImageException If one of the versions lacks an image.
+         * @throws UnsupportedVersionException If any version with configured image is not supported
          */
-        public void validateKafkaMirrorMaker2Images(Iterable<String> versions) throws NoImageException {
-            for (String version : versions) {
-                image(null, version, kafkaMirrorMaker2Images, ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES);
-            }
+        public void validateKafkaMirrorMaker2Images(Set<String> versions) throws NoImageException, UnsupportedVersionException {
+            validateImages(versions, kafkaMirrorMaker2Images);
         }
 
         @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/UnsupportedVersionException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/UnsupportedVersionException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+/**
+ * Thrown to indicate that given Kafka version is not supported.
+ */
+public class UnsupportedVersionException extends Exception {
+    public UnsupportedVersionException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The the Cluster Operator has in the images configuration some Kafka version which is not supported, and if some user uses it, it will result in an error like this:

```
2021-05-21 21:32:46 WARN  AbstractOperator:516 - Reconciliation #14(timer) Kafka(myproject/my-cluster): Failed to reconcile
java.lang.IllegalArgumentException: argument "src" is null
	at com.fasterxml.jackson.databind.ObjectMapper._assertNotNull(ObjectMapper.java:4737) ~[com.fasterxml.jackson.core.jackson-databind-2.11.3.jar:2.11.3]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3504) ~[com.fasterxml.jackson.core.jackson-databind-2.11.3.jar:2.11.3]
	at io.strimzi.operator.cluster.model.KafkaConfiguration.readConfigModel(KafkaConfiguration.java:107) ~[io.strimzi.cluster-operator-0.24.0-SNAPSHOT.jar:0.24.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.KafkaConfiguration.validate(KafkaConfiguration.java:84) ~[io.strimzi.cluster-operator-0.24.0-SNAPSHOT.jar:0.24.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.KafkaCluster.validateConfiguration(KafkaCluster.java:634) ~[io.strimzi.cluster-operator-0.24.0-SNAPSHOT.jar:0.24.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.KafkaCluster.fromCrd(KafkaCluster.java:418) ~[io.strimzi.cluster-operator-0.24.0-SNAPSHOT.jar:0.24.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$getKafkaClusterDescription$55(KafkaAssemblyOperator.java:1461) ~[io.strimzi.cluster-operator-0.24.0-SNAPSHOT.jar:0.24.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.0.3.jar:4.0.3]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.0.3.jar:4.0.3]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[io.vertx.vertx-core-4.0.3.jar:4.0.3]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.0.3.jar:4.0.3]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.0.3.jar:4.0.3]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.0.3.jar:4.0.3]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.60.Final.jar:4.1.60.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) [io.netty.netty-common-4.1.60.Final.jar:4.1.60.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) [io.netty.netty-transport-4.1.60.Final.jar:4.1.60.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [io.netty.netty-common-4.1.60.Final.jar:4.1.60.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.60.Final.jar:4.1.60.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.60.Final.jar:4.1.60.Final]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

This is because the `ClusterOperatorConfig` currently only checks if the suppoerted versions have an image but not if all configured versions are supported. However, it still failes later with this cryptic error caused by the missing JSON config-model.

This PR adds additional validations at CO startup which catches this early and gives much nicer error:

```
Exception in thread "main" io.strimzi.operator.common.InvalidConfigurationException: Failed to parse default container image configuration for Kafka from environment variable STRIMZI_KAFKA_IMAGES
	at io.strimzi.operator.cluster.ClusterOperatorConfig.parseKafkaVersions(ClusterOperatorConfig.java:353)
	at io.strimzi.operator.cluster.ClusterOperatorConfig.fromMap(ClusterOperatorConfig.java:151)
	at io.strimzi.operator.cluster.Main.main(Main.java:61)
Caused by: io.strimzi.operator.cluster.model.UnsupportedVersionException: Kafka version 2.5.0 has a container image configured but is not supported.
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.validateImages(KafkaVersion.java:209)
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.validateKafkaImages(KafkaVersion.java:221)
	at io.strimzi.operator.cluster.ClusterOperatorConfig.parseKafkaVersions(ClusterOperatorConfig.java:335)
```

This should make these situations little bit more friendly.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally