### PR TITLE
[DOC] Improve documentation about podAntiAffinity for Kafka brokers

### DIFF
--- a/documentation/assemblies/configuring/assembly-scheduling.adoc
+++ b/documentation/assemblies/configuring/assembly-scheduling.adoc
@@ -11,6 +11,8 @@ Scheduling Kafka pods in a way that avoids sharing nodes with other critical wor
 
 include::../../modules/configuring/ref-affinity.adoc[leveloffset=+1]
 
+include::../../modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc[leveloffset=+1]
+
 include::../../modules/configuring/proc-scheduling-based-on-other-pods.adoc[leveloffset=+1]
 
 include::../../modules/configuring/proc-scheduling-deployment-to-node-using-node-affinity.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
@@ -5,8 +5,8 @@
 [id='configuring-pod-anti-affinity-in-kafka-components-{context}']
 = Configuring pod anti-affinity in Kafka components
 
-To make sure your Kafka brokers deliver good and stable performance, you can use the `podAntiAffinity` to tell Kubernetes to not schedule the Kafka brokers on the same nodes as some other workloads.
-Typically, you want to avoid Kafka to run on the same worker node as other network or storage intensive applications such as databases, storage or other messaging platforms.
+Pod anti-affinity configuration helps with the stability and performance of Kafka brokers. By using `podAntiAffinity`, Kubernetes will not schedule Kafka brokers on the same nodes as other workloads. 
+Typically, you want to avoid Kafka running on the same worker node as other network or storage intensive applications such as databases, storage or other messaging platforms.
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
+++ b/documentation/modules/configuring/proc-scheduling-based-on-other-pods.adoc
@@ -5,6 +5,9 @@
 [id='configuring-pod-anti-affinity-in-kafka-components-{context}']
 = Configuring pod anti-affinity in Kafka components
 
+To make sure your Kafka brokers deliver good and stable performance, you can use the `podAntiAffinity` to tell Kubernetes to not schedule the Kafka brokers on the same nodes as some other workloads.
+Typically, you want to avoid Kafka to run on the same worker node as other network or storage intensive applications such as databases, storage or other messaging platforms.
+
 .Prerequisites
 
 * A Kubernetes cluster

--- a/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
+++ b/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// assembly-scheduling.adoc
+
+[id='configuring-pod-anti-affinity-to-schedule-each-kafka-broker-on-a-different-worker-node-{context}']
+= Configuring pod anti-affinity to schedule each Kafka broker on a different worker node
+
+When multiple Kafka brokers or multiple ZooKeeper nodes are running on the same Kubernetes worker nodes, they will all become unavailable at the same time in case of worker node issues.
+To increase the reliability, you can use `podAntiAffinity` to schedule each Kafka broker or ZooKeeper node on different Kubernetes worker node.
+
+.Prerequisites
+
+* A Kubernetes cluster
+* A running Cluster Operator
+
+.Procedure
+
+. Edit the `affinity` property in the resource specifying the cluster deployment.
+To make sure that no worker nodes are shared by Kafka brokers or by ZooKeeper nodes, use the `strimzi.io/name` label.
+The `topologyKey` should be set to `kubernetes.io/hostname` to specify that the selected pods should not be scheduled on nodes with the same hostname.
+This will still allow the same worker node to be shared by a single Kafka broker and a single ZooKeeper node.
+For example:
++
+[source,yaml,subs="+quotes,attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: strimzi.io/name
+                      operator: In
+                      values:
+                        - _CLUSTER-NAME_-kafka
+                topologyKey: "kubernetes.io/hostname"
+    # ...
+  zookeeper:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: strimzi.io/name
+                      operator: In
+                      values:
+                        - _CLUSTER-NAME_-zookeeper
+                topologyKey: "kubernetes.io/hostname"
+    # ...
+----
++
+Where `_CLUSTER-NAME_` is the name of your Kafka custom resource.
+
+. Alternatively, if you want to make sure that even no Kafka broker and ZooKeeper node share the same worker node, you can use the `strimzi.io/cluster` label.
+For example:
++
+[source,yaml,subs="+quotes,attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+spec:
+  kafka:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: strimzi.io/cluster
+                      operator: In
+                      values:
+                        - _CLUSTER-NAME_
+                topologyKey: "kubernetes.io/hostname"
+    # ...
+  zookeeper:
+    # ...
+    template:
+      pod:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: strimzi.io/cluster
+                      operator: In
+                      values:
+                        - _CLUSTER-NAME_
+                topologyKey: "kubernetes.io/hostname"
+    # ...
+----
++
+Where `_CLUSTER-NAME_` is the name of your Kafka custom resource.
+
+. Create or update the resource.
++
+This can be done using `kubectl apply`:
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_

--- a/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
+++ b/documentation/modules/configuring/proc-scheduling-brokers-on-different-worker-nodes.adoc
@@ -5,8 +5,9 @@
 [id='configuring-pod-anti-affinity-to-schedule-each-kafka-broker-on-a-different-worker-node-{context}']
 = Configuring pod anti-affinity to schedule each Kafka broker on a different worker node
 
-When multiple Kafka brokers or multiple ZooKeeper nodes are running on the same Kubernetes worker nodes, they will all become unavailable at the same time in case of worker node issues.
-To increase the reliability, you can use `podAntiAffinity` to schedule each Kafka broker or ZooKeeper node on different Kubernetes worker node.
+Many Kafka brokers or ZooKeeper nodes can run on the same Kubernetes worker node.
+If the worker node fails, they will all become unavailable at the same time. 
+To improve reliability, you can use `podAntiAffinity` configuration to schedule each Kafka broker or ZooKeeper node on a different Kubernetes worker node.
 
 .Prerequisites
 
@@ -16,8 +17,8 @@ To increase the reliability, you can use `podAntiAffinity` to schedule each Kafk
 .Procedure
 
 . Edit the `affinity` property in the resource specifying the cluster deployment.
-To make sure that no worker nodes are shared by Kafka brokers or by ZooKeeper nodes, use the `strimzi.io/name` label.
-The `topologyKey` should be set to `kubernetes.io/hostname` to specify that the selected pods should not be scheduled on nodes with the same hostname.
+To make sure that no worker nodes are shared by Kafka brokers or ZooKeeper nodes, use the `strimzi.io/name` label.
+Set the `topologyKey` to `kubernetes.io/hostname` to specify that the selected pods are not scheduled on nodes with the same hostname.
 This will still allow the same worker node to be shared by a single Kafka broker and a single ZooKeeper node.
 For example:
 +
@@ -60,7 +61,7 @@ spec:
 +
 Where `_CLUSTER-NAME_` is the name of your Kafka custom resource.
 
-. Alternatively, if you want to make sure that even no Kafka broker and ZooKeeper node share the same worker node, you can use the `strimzi.io/cluster` label.
+. If you even want to make sure that a Kafka broker and ZooKeeper node do not share the same worker node, use the `strimzi.io/cluster` label.
 For example:
 +
 [source,yaml,subs="+quotes,attributes+"]
@@ -104,6 +105,5 @@ Where `_CLUSTER-NAME_` is the name of your Kafka custom resource.
 
 . Create or update the resource.
 +
-This can be done using `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _KAFKA-CONFIG-FILE_


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

One of the common questions we receive is about using `podAntiAffinity` to configure brokers to be scheduled on different nodes. This is currently missing in our docs - we have `podAntiAffinity` example to avoid sharing node with other workloads such as databases and we have example for dedicated nodes. This Pr adds the new example to cover this common question as well.

### Checklist

- [x] Update documentation