### PR TITLE
Pass proxy configuration into the Connect build as arguments

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
@@ -78,17 +78,18 @@ public class KafkaConnectDockerfile {
     private void proxy(PrintWriter writer) {
         if (HTTP_PROXY != null) {
             writer.println(String.format("ARG %s=%s", ENV_VAR_HTTP_PROXY.toLowerCase(Locale.ENGLISH), HTTP_PROXY));
+            writer.println();
         }
 
         if (HTTPS_PROXY != null) {
             writer.println(String.format("ARG %s=%s", ENV_VAR_HTTPS_PROXY.toLowerCase(Locale.ENGLISH), HTTPS_PROXY));
+            writer.println();
         }
 
         if (NO_PROXY != null) {
             writer.println(String.format("ARG %s=%s", ENV_VAR_NO_PROXY.toLowerCase(Locale.ENGLISH), NO_PROXY));
+            writer.println();
         }
-
-        writer.println();
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The operator accepts the proxy configuration in the form of environment variables (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`) and passes it over to the operands. However, we do not currently pass them into the Kafka Connect Build. So when user runs it behind a proxy and the build tries to download the connector plugins, it fails. This PR passes the proxy configuration into the container as build arguments (so that they do not propagate into the container when it is later used). Because `curl` doesn't like uppercase `HTTP_PROXY`, they are passed in lowercase.

This should close #4814.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging