### PR TITLE
Fix infinite loop in ResourceValidator when it runs into a List<Long>

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ResourceVisitor.java
@@ -147,7 +147,9 @@ public class ResourceVisitor {
             } else if (Collection.class.isAssignableFrom(returnType)) {
                 path.add(propertyName);
                 for (Object element : (Collection<?>) propertyValue) {
-                    if (element != null && !element.getClass().isEnum()) {
+                    if (element != null
+                            && !element.getClass().isEnum()
+                            && !isScalar(element.getClass())) {
                         visit(path, element, visitor);
                     }
                 }

--- a/operator-common/src/test/resources/example.yaml
+++ b/operator-common/src/test/resources/example.yaml
@@ -27,6 +27,11 @@ spec:
     storage:
       type: ephemeral
     version: 2.8.0
+    template:
+      pod:
+        securityContext:
+          supplementalGroups:
+            - 971001234
     tlsSidecar: {}
   topicOperator: {}
   zookeeper:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This improves the handling in ResourceVisitor to not dive into `List<Long>` and similar fields when analyzing the resources since that causes a an infinite recursion and breaks the cluster operator.

This should close #5025 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging