### PR TITLE
New SystemTest for FeatureGate: ControlPlaneListener

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -125,6 +125,11 @@ public class Environment {
     private static final String LB_FINALIZERS_ENV = "LB_FINALIZERS";
 
     /**
+     * CO Features gates variable
+     */
+    public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
+
+    /**
      * Defaults
      */
     private static final String ST_KAFKA_VERSION_DEFAULT = "2.8.0";
@@ -146,6 +151,7 @@ public class Environment {
     private static final boolean DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT = true;
     private static final ClusterOperatorInstallType CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT = ClusterOperatorInstallType.BUNDLE;
     private static final boolean LB_FINALIZERS_DEFAULT = false;
+    private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
 
     /**
      * Set values
@@ -162,6 +168,7 @@ public class Environment {
     public static final String KUBERNETES_DOMAIN = getOrDefault(KUBERNETES_DOMAIN_ENV, KUBERNETES_DOMAIN_DEFAULT);
     public static final boolean SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, Boolean::parseBoolean, false);
     public static final String STRIMZI_RBAC_SCOPE = getOrDefault(STRIMZI_RBAC_SCOPE_ENV, STRIMZI_RBAC_SCOPE_DEFAULT);
+    public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
     // variables for test-client image
     private static final String TEST_CLIENT_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/test-client:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
     public static final String TEST_CLIENT_IMAGE = getOrDefault(TEST_CLIENT_IMAGE_ENV, TEST_CLIENT_IMAGE_DEFAULT);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/HelmResource.java
@@ -115,7 +115,8 @@ public class HelmResource implements SpecificResourceType {
                 entry("resources.limits.cpu", LIMITS_CPU),
                 entry("logLevelOverride", Environment.STRIMZI_LOG_LEVEL),
                 entry("fullReconciliationIntervalMs", Long.toString(reconciliationInterval)),
-                entry("operationTimeoutMs", Long.toString(operationTimeout)))
+                entry("operationTimeoutMs", Long.toString(operationTimeout)),
+                entry("featureGates", Environment.STRIMZI_FEATURE_GATES))
                 .collect(TestUtils.entriesToMap()));
 
         Path pathToChart = new File(HELM_CHART).toPath();

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/OlmResource.java
@@ -268,7 +268,8 @@ public class OlmResource implements SpecificResourceType {
                     .replace("${OLM_INSTALL_PLAN_APPROVAL}", installationStrategy.toString())
                     .replace("${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}", Long.toString(reconciliationInterval))
                     .replace("${STRIMZI_OPERATION_TIMEOUT_MS}", Long.toString(operationTimeout))
-                    .replace("${STRIMZI_RBAC_SCOPE}", Environment.STRIMZI_RBAC_SCOPE));
+                    .replace("${STRIMZI_RBAC_SCOPE}", Environment.STRIMZI_RBAC_SCOPE)
+                    .replace("${STRIMZI_FEATURE_GATES}", Environment.STRIMZI_FEATURE_GATES));
 
 
             ResourceManager.cmdKubeClient().apply(subscriptionFile);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/OlmResource.java
@@ -67,7 +67,7 @@ public class OlmResource implements SpecificResourceType {
 
     @Override
     public void delete() {
-        this.deleteOlm(deploymentName, namespace, csvName);
+        deleteOlm(deploymentName, namespace, csvName);
     }
 
     public OlmResource() { }
@@ -97,8 +97,6 @@ public class OlmResource implements SpecificResourceType {
             createOperatorGroup(namespace);
         }
 
-        String csvName;
-
         if (fromVersion != null) {
             createAndModifySubscription(namespace, operationTimeout, reconciliationInterval, olmInstallationStrategy, fromVersion);
             // must be strimzi-cluster-operator.v0.18.0
@@ -119,7 +117,7 @@ public class OlmResource implements SpecificResourceType {
         TestUtils.waitFor("Cluster Operator deployment creation", Constants.GLOBAL_POLL_INTERVAL, CR_CREATION_TIMEOUT,
             () -> ResourceManager.kubeClient().getDeploymentNameByPrefix(Environment.OLM_OPERATOR_DEPLOYMENT_NAME) != null);
 
-        String deploymentName = ResourceManager.kubeClient().getDeploymentNameByPrefix(Environment.OLM_OPERATOR_DEPLOYMENT_NAME);
+        deploymentName = ResourceManager.kubeClient().getDeploymentNameByPrefix(Environment.OLM_OPERATOR_DEPLOYMENT_NAME);
         ResourceManager.setCoDeploymentName(deploymentName);
 
         // Wait for operator creation

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.utils.kubeUtils.controllers;
 
+import io.fabric8.kubernetes.api.model.batch.JobStatus;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.test.TestUtils;
@@ -43,11 +44,26 @@ public class JobUtils {
      * Wait for specific Job failure
      * @param jobName job name
      * @param namespace namespace
-     * @param timeout timeout after which we assume that job failed
+     * @param timeout timeout in ms after which we assume that job failed
      */
     public static void waitForJobFailure(String jobName, String namespace, long timeout) {
         LOGGER.info("Waiting for job: {} will be in error state", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeout,
             () -> !kubeClient().checkSucceededJobStatus(jobName));
+    }
+
+    /**
+     * Wait for specific Job Running active status
+     * @param jobName job name
+     * @param namespace namespace
+     * @param timeout timeout in ms after which we assume that job runs
+     */
+    public static void waitForJobRunning(String jobName, String namespace, long timeout) {
+        LOGGER.info("Waiting for job: {} will be in active state", jobName);
+        TestUtils.waitFor("job active", Constants.GLOBAL_POLL_INTERVAL, timeout,
+            () -> {
+                JobStatus jb = kubeClient().namespace(namespace).getJobStatus(jobName);
+                return jb.getActive() > 0;
+            });
     }
 }

--- a/systemtest/src/main/resources/olm/subscription.yaml
+++ b/systemtest/src/main/resources/olm/subscription.yaml
@@ -20,3 +20,5 @@ spec:
         value: "${STRIMZI_FULL_RECONCILIATION_INTERVAL_MS}"
       - name: STRIMZI_OPERATION_TIMEOUT_MS
         value: "${STRIMZI_OPERATION_TIMEOUT_MS}"
+      - name: STRIMZI_FEATURE_GATES
+        value: "${STRIMZI_FEATURE_GATES}"

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.operators;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaBasicExampleClients;
+import io.strimzi.systemtest.resources.operator.BundleResource;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.annotations.IsolatedTest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * Feature Gates should give us additional options on
+ * how to control and mature different behaviors in the operators.
+ * https://github.com/strimzi/proposals/blob/main/022-feature-gates.md
+ */
+@Tag(REGRESSION)
+public class FeatureGatesST extends AbstractST {
+
+    static final String NAMESPACE = "feature-gates-tests";
+    private static final Logger LOGGER = LogManager.getLogger(FeatureGatesST.class);
+
+    protected void deployClusterOperatorWithEnvVars(ExtensionContext extensionContext, List<EnvVar> envVars) {
+        assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
+        prepareEnvForOperator(extensionContext, NAMESPACE, Arrays.asList(NAMESPACE, NAMESPACE));
+        applyBindings(extensionContext, NAMESPACE);
+        resourceManager.createResource(extensionContext, BundleResource.clusterOperator(NAMESPACE, envVars).build());
+    }
+
+    /**
+     * Control Plane Listener
+     * https://github.com/strimzi/proposals/blob/main/025-control-plain-listener.md
+     */
+    @IsolatedTest("Feature Gates test for ControlPlainListener")
+    @Tag(INTERNAL_CLIENTS_USED)
+    public void testControlPlaneListenerFeatureGate(ExtensionContext extensionContext) throws InterruptedException {
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String producerName = "producer-test-" + new Random().nextInt(Integer.MAX_VALUE);
+        final String consumerName = "consumer-test-" + new Random().nextInt(Integer.MAX_VALUE);
+        final String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
+        int messageCount = 300;
+        List<EnvVar> testEnvVars = new ArrayList<>();
+        int kafkaReplicas = 3;
+
+        String systemEnvFG = System.getenv(Environment.STRIMZI_FEATURE_GATES_ENV);
+        if (systemEnvFG == null || !systemEnvFG.contains("ControlPlaneListener")) {
+            testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+ControlPlaneListener", null));
+        }
+        deployClusterOperatorWithEnvVars(extensionContext, testEnvVars);
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, kafkaReplicas).build());
+
+        LOGGER.info("Check for presence of ContainerPort 9090/tcp (tcp-ctrlplane) in first Kafka pod.");
+        final Pod kafkaPod = PodUtils.getPodsByPrefixInNameWithDynamicWait(NAMESPACE, clusterName + "-kafka-").get(0);
+        ContainerPort expectedControlPlaneContainerPort = new ContainerPort(9090, null, null, "tcp-ctrlplane", "TCP");
+        List<ContainerPort> kafkaPodPorts = kafkaPod.getSpec().getContainers().get(0).getPorts();
+        assertTrue(kafkaPodPorts.contains(expectedControlPlaneContainerPort));
+
+        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(NAMESPACE, kafkaStatefulSetName(clusterName));
+
+        LOGGER.info("Try to send some messages to Kafka over the next {} seconds.", messageCount);
+        KafkaTopic kafkaTopic = KafkaTopicTemplates.topic(clusterName, topicName)
+                .editSpec()
+                    .withReplicas(kafkaReplicas)
+                    .withPartitions(kafkaReplicas)
+                .endSpec()
+                .build();
+        resourceManager.createResource(extensionContext, kafkaTopic);
+
+        KafkaBasicExampleClients kafkaBasicClientJob = new KafkaBasicExampleClients.Builder()
+                .withProducerName(producerName)
+                .withConsumerName(consumerName)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+                .withTopicName(topicName)
+                .withMessageCount(messageCount)
+                .withDelayMs(500)
+                .withNamespaceName(NAMESPACE)
+                .build();
+
+        resourceManager.createResource(extensionContext, kafkaBasicClientJob.producerStrimzi().build());
+        resourceManager.createResource(extensionContext, kafkaBasicClientJob.consumerStrimzi().build());
+        JobUtils.waitForJobRunning(consumerName, NAMESPACE, Duration.ofSeconds(20).toMillis());
+
+        LOGGER.info("Delete first found Kafka broker pod.");
+        kubeClient(NAMESPACE).deletePod(NAMESPACE, kafkaPod);
+        StatefulSetUtils.waitForAllStatefulSetPodsReady(KafkaResources.kafkaStatefulSetName(clusterName), kafkaReplicas);
+
+        LOGGER.info("Force Rolling Update of Kafka via annotation.");
+        kafkaPods.keySet().forEach(podName -> {
+            kubeClient(NAMESPACE).editPod(podName).edit(pod -> new PodBuilder(pod)
+                    .editMetadata()
+                        .addToAnnotations(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true")
+                    .endMetadata()
+                    .build());
+        });
+        LOGGER.info("Wait for next reconciliation to happen.");
+        StatefulSetUtils.waitTillSsHasRolled(NAMESPACE, kafkaStatefulSetName(clusterName), kafkaReplicas, kafkaPods);
+
+        LOGGER.info("Waiting for clients to finish sending/receiving messages.");
+        ClientUtils.waitForClientSuccess(producerName, NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, NAMESPACE, MESSAGE_COUNT);
+        JobUtils.deleteJobWithWait(NAMESPACE, producerName);
+        JobUtils.deleteJobWithWait(NAMESPACE, consumerName);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Michal Tóth <mtoth@redhat.com>

### Type of change

- New test for FeatureGatesST.testControlPlaneListenerFeatureGate
- Addition of STRIMZI_FEATURE_GATES Environment variable to OLM, Helm and Bundle installation types
- Passing additionalEnvVars to ClusterOperator creation method(s)
- Small changes in OLMResource (problems with instance variables)

### Description

This is a SystemTest for first Feature Gate - ControlPlainListener
Work is related to Add and enable Control Plane listener #4888
### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

