### PR TITLE
[DOC] update doc checker to remove contractions checks

### DIFF
--- a/.azure/scripts/check_docs.sh
+++ b/.azure/scripts/check_docs.sh
@@ -30,12 +30,6 @@ grep_check '[^[:alpha:]]etc\.[^[:alpha:]]?' "Replace 'etc.'. with ' and so on.'"
 # And/or
 grep_check '[^[:alpha:]]and/or[^[:alpha:]]' "Use either 'and' or 'or', but not 'and/or'"
 
-# Contractions
-grep_check '[^[:alpha:]](do|is|are|won|have|ca|does|did|had|has|must)n'"'"'?t[^[:alpha:]]' "Avoid 'nt contraction"
-grep_check '[^[:alpha:]]it'"'"'s[^[:alpha:]]' "Avoid it's contraction"
-grep_check '[^[:alpha:]]that'"'"'s[^[:alpha:]]' "Avoid that's contraction"
-grep_check '[^[:alpha:]]can not[^[:alpha:]]' "Use 'cannot' not 'can not'"
-
 # Asciidoc standards
 grep_check '[<][<][[:alnum:]_-]+,' "Internal links should be xref:doc_id[Section title], not <<doc_id,link text>>"
 grep_check '[[]id=(["'"'"'])[[:alnum:]_-]+(?!-[{]context[}])\1' "[id=...] should end with -{context}" "-i -P -r -n"

--- a/documentation/contributing/styleguide.adoc
+++ b/documentation/contributing/styleguide.adoc
@@ -31,7 +31,6 @@
 .Additional general guidelines
 * Stick to one file per chapter unless the content is too long,
   excluding reusable topics.
-* Don't use contractions, ;).
 * Document IDs are book-scoped, so they don't need the book title in
   them.
 * Terminate bulleted and numbered lists with periods unless the items


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Update to the _doc checker_, which removes the checks for contractions.  
The change will allow for a more conversational style in the documentation. 

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

