### PR TITLE
Upgrade operator to use Kafka 2.8.0 and EmbeddedKafkaServer

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -187,9 +187,22 @@
             <artifactId>connect-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Used by EmbeddedKafkaCluster -->
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -198,11 +211,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
-            <type>test-jar</type>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-migrationsupport</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import io.debezium.kafka.KafkaCluster;
 import org.apache.kafka.connect.cli.ConnectDistributed;
 import org.apache.kafka.connect.runtime.Connect;
 
@@ -28,8 +27,8 @@ public class ConnectCluster {
         return this;
     }
 
-    ConnectCluster usingBrokers(KafkaCluster kafkaCluster) {
-        this.brokerList = kafkaCluster.brokerList();
+    ConnectCluster usingBrokers(String bootstrapServers) {
+        this.brokerList = bootstrapServers;
         return this;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <fasterxml.jackson-databind.version>2.11.3</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.10.5</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.11.3</fasterxml.jackson-annotations.version>
-        <kafka.version>2.7.0</kafka.version>
+        <kafka.version>2.8.0</kafka.version>
         <!-- keep in-sync with dataformat-yaml -->
         <snakeyaml.version>1.26</snakeyaml.version>
         <picocli.version>4.5.2</picocli.version>
@@ -116,7 +116,6 @@
         <jayway-jsonpath.version>2.5.0</jayway-jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
         <quartz.version>2.3.2</quartz.version>
-        <debezium.version>1.5.0.Final</debezium.version>
         <jaeger.version>1.3.2</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
@@ -607,19 +606,53 @@
                 <artifactId>kafka-streams</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
+            <!-- Used by EmbeddedKafkaCluster -->
             <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-core</artifactId>
-                <version>${debezium.version}</version>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>*</artifactId>
+                        <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-core</artifactId>
-                <version>${debezium.version}</version>
-                <type>test-jar</type>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>*</artifactId>
+                        <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.12</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>*</artifactId>
+                        <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-migrationsupport</artifactId>
+                <version>${jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
@@ -1054,7 +1087,7 @@
                         <configuration>
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
-                                <ignoredUnusedDeclaredDependency>io.debezium:debezium-core</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-clients</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1088,6 +1088,7 @@
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-clients</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-streams</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -37,17 +37,6 @@
             <artifactId>zookeeper</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
-            <type>test-jar</type>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <scope>compile</scope>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -100,17 +100,31 @@
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
         </dependency>
+        <!-- Used by EmbeddedKafkaCluster -->
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
-            <type>test-jar</type>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-migrationsupport</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.operator.topic;
 
-import io.debezium.kafka.KafkaCluster;
-import io.debezium.kafka.ZookeeperServer;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.strimzi.api.kafka.Crds;
@@ -26,6 +24,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -35,8 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Field;
-import java.nio.file.Files;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -54,12 +52,11 @@ import static org.hamcrest.Matchers.nullValue;
 
 @ExtendWith(VertxExtension.class)
 public class TopicOperatorMockTest {
-
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorMockTest.class);
+    private static EmbeddedKafkaCluster cluster;
 
     private KubernetesClient kubeClient;
     private Session session;
-    private KafkaCluster kafkaCluster;
     private static Vertx vertx;
     private String deploymentId;
     private AdminClient adminClient;
@@ -71,12 +68,15 @@ public class TopicOperatorMockTest {
     // TODO this is all in common with TOIT, so factor out a common base class
 
     @BeforeAll
-    public static void before() {
+    public static void before() throws IOException {
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                         .setEnabled(true));
         vertx = Vertx.vertx(options);
+
+        cluster = new EmbeddedKafkaCluster(1);
+        cluster.start();
     }
 
     @AfterAll
@@ -95,20 +95,13 @@ public class TopicOperatorMockTest {
                         KafkaTopic.class, KafkaTopicList.class, KafkaTopic::getStatus, KafkaTopic::setStatus);
         kubeClient = mockKube.build();
 
-        kafkaCluster = new KafkaCluster();
-        kafkaCluster.addBrokers(1);
-        kafkaCluster.deleteDataPriorToStartup(true);
-        kafkaCluster.deleteDataUponShutdown(true);
-        kafkaCluster.usingDirectory(Files.createTempDirectory("operator-integration-test").toFile());
-        kafkaCluster.startup();
-
         Properties p = new Properties();
-        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.brokerList());
+        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         adminClient = AdminClient.create(p);
 
         Map<String, String> m = new HashMap();
-        m.put(io.strimzi.operator.topic.Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.brokerList());
-        m.put(io.strimzi.operator.topic.Config.ZOOKEEPER_CONNECT.key, "localhost:" + zkPort(kafkaCluster));
+        m.put(io.strimzi.operator.topic.Config.KAFKA_BOOTSTRAP_SERVERS.key, cluster.bootstrapServers());
+        m.put(io.strimzi.operator.topic.Config.ZOOKEEPER_CONNECT.key, cluster.zKConnectString());
         m.put(io.strimzi.operator.topic.Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000");
         m.put(io.strimzi.operator.topic.Config.NAMESPACE.key, "myproject");
         m.put(io.strimzi.operator.topic.Config.CLIENT_ID.key, "myproject-client-id");
@@ -168,27 +161,12 @@ public class TopicOperatorMockTest {
                 if (adminClient != null) {
                     adminClient.close();
                 }
-                if (kafkaCluster != null) {
-                    kafkaCluster.shutdown();
-                    waitFor("stop kafka cluster", 1_000, 30_000, () -> !kafkaCluster.isRunning());
-                }
+
                 latch.countDown();
             });
         }
         latch.await(30, TimeUnit.SECONDS);
         context.completeNow();
-    }
-
-    private static int zkPort(KafkaCluster cluster) {
-        // TODO Method was added in DBZ-540, so no need for reflection once
-        // dependency gets upgraded
-        try {
-            Field zkServerField = KafkaCluster.class.getDeclaredField("zkServer");
-            zkServerField.setAccessible(true);
-            return ((ZookeeperServer) zkServerField.get(cluster)).getPort();
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private void createInKube(KafkaTopic topic) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -7,21 +7,49 @@ package io.strimzi.operator.topic;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.vertx.core.Future;
 import kafka.server.KafkaConfig$;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
+    protected static EmbeddedKafkaCluster kafkaCluster;
 
-    @Override
-    protected int numKafkaBrokers() {
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        kafkaCluster = new EmbeddedKafkaCluster(numKafkaBrokers(), kafkaClusterConfig());
+        kafkaCluster.start();
+
+        setupKubeCluster();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        teardownKubeCluster();
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        setup(kafkaCluster);
+    }
+
+    @AfterEach
+    public void afterEach() throws InterruptedException, TimeoutException, ExecutionException {
+        teardown(false);
+    }
+
+    protected static int numKafkaBrokers() {
         return 1;
     }
 
-    @Override
-    protected Properties kafkaClusterConfig() {
+    protected static Properties kafkaClusterConfig() {
         Properties config = new Properties();
         config.setProperty(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "false");
         return config;

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -85,17 +85,31 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Used by EmbeddedKafkaCluster -->
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
-            <type>test-jar</type>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-migrationsupport</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When adding support for Kafka 2.8.0 as operand, the operator and other tools kept using Kafka 2.7.0. One of the reasons was that Debezium Kafka cluster used in the tests did not support 2.8.0. However, to be able to start working on ZooKeeper-less Kafka, we need to use 2.8.0 which has features such as generating cluster IDs etc. So having 2.8.0 used by the operators will make this effort much easier.

This PR upgrades all components to use Kafka 2.8.0. But also replaces the Debezium Kafka cluster which does not support Kafka 2.8.0 with the `EmbeddedKafkaCluster` which is part of Kafka itself (Kafka Streams API test JARs) and supports latest Kafka versions.

### Checklist

- [x] Make sure all tests pass