### PR TITLE
Fix KafkaUser conversion in api-conversion tool when transactionalId rules are used

### DIFF
--- a/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommand.java
+++ b/api-conversion/src/main/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommand.java
@@ -78,7 +78,6 @@ public class ConvertResourceCommand extends AbstractConversionCommand {
     @SuppressWarnings({"rawtypes", "unchecked"})
     protected CustomResource replace(String kind, CustomResource cr) {
         MixedOperation<CustomResource, CustomResourceList, ?> op = VERSIONED_OPERATIONS.get(kind).apply(client, TO_API_VERSION.toString());
-
         return op.inNamespace(cr.getMetadata().getNamespace()).withName(cr.getMetadata().getName()).replace(cr);
     }
 
@@ -130,6 +129,12 @@ public class ConvertResourceCommand extends AbstractConversionCommand {
         try {
             getConverter(cr.getClass()).convertTo(cr, TO_API_VERSION);
             println(cr.getKind() + " resource named " + cr.getMetadata().getName() + " in namespace " + cr.getMetadata().getNamespace() + " has been converted");
+
+            if (debug) {
+                println("Converted custom resource:");
+                println(cr);
+            }
+
             return cr;
         } catch (ApiConversionFailedException e)    {
             println("Failed to convert " + cr.getKind() + " resource named " + cr.getMetadata().getName() + " in namespace " + cr.getMetadata().getNamespace() + ": " + e.getMessage());

--- a/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommandSampleResourcesIT.java
+++ b/api-conversion/src/test/java/io/strimzi/kafka/api/conversion/cli/ConvertResourceCommandSampleResourcesIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.api.conversion.cli;
+
+import io.strimzi.kafka.api.conversion.converter.MultipartConversions;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConvertResourceCommandSampleResourcesIT {
+    private static final String NAMESPACE = "api-conversion";
+    private static final KubeClusterResource CLUSTER = KubeClusterResource.getInstance();
+
+    @BeforeEach
+    public void beforeEach()    {
+        MultipartConversions.remove();
+        CLUSTER.cluster();
+    }
+
+    @BeforeAll
+    static void setupEnvironment() {
+        CLUSTER.createNamespace(NAMESPACE);
+        CliTestUtils.setupAllCrds(CLUSTER);
+    }
+
+    @AfterAll
+    static void teardownEnvironment() {
+        CliTestUtils.deleteAllCrds(CLUSTER);
+        CLUSTER.deleteNamespaces();
+    }
+
+    @Test
+    public void convertSampleResources()    {
+        convertSampleResource("bridge-logging.yaml", 0);
+        convertSampleResource("bridge-v1alpha1.yaml", 0);
+        convertSampleResource("connect-affinity-tolerations.yaml", 0);
+        convertSampleResource("connect-logging.yaml", 0);
+        convertSampleResource("connect-metrics.yaml", 0);
+        convertSampleResource("connect-s2i-affinity-tolerations.yaml", 0);
+        convertSampleResource("connect-s2i-logging.yaml", 0);
+        convertSampleResource("connect-s2i-metrics.yaml", 0);
+        convertSampleResource("connect-s2i-v1alpha1.yaml", 0);
+        convertSampleResource("connect-s2i-v1beta1.yaml", 0);
+        convertSampleResource("connect-v1alpha1.yaml", 0);
+        convertSampleResource("connect-v1beta1.yaml", 0);
+        convertSampleResource("connector-v1alpha1.yaml", 0);
+        convertSampleResource("kafka-affinity-tolerations.yaml", 0);
+        convertSampleResource("kafka-complex.yaml", 0);
+        convertSampleResource("kafka-listeners.yaml", 0);
+        convertSampleResource("kafka-logging.yaml", 0);
+        convertSampleResource("kafka-metrics.yaml", 0);
+        convertSampleResource("kafka-tls-sidecar.yaml", 0);
+        convertSampleResource("kafka-tofull.yaml", 0);
+        convertSampleResource("kafka-tosimple.yaml", 0);
+        convertSampleResource("kafka-v1alpha1.yaml", 0);
+        convertSampleResource("kafka-v1beta1.yaml", 0);
+        convertSampleResource("kafka-v1beta2.yaml", 0);
+        convertSampleResource("mm-affinity-tolerations.yaml", 0);
+        convertSampleResource("mm-logging.yaml", 0);
+        convertSampleResource("mm-metrics.yaml", 0);
+        convertSampleResource("mm-v1alpha1.yaml", 0);
+        convertSampleResource("mm-v1beta1.yaml", 0);
+        convertSampleResource("mm2-affinity-tolerations.yaml", 0);
+        convertSampleResource("mm2-logging.yaml", 0);
+        convertSampleResource("mm2-metrics.yaml", 0);
+        convertSampleResource("mm2-v1alpha1.yaml", 0);
+        convertSampleResource("rebalance-v1alpha1.yaml", 0);
+        convertSampleResource("topic-v1alpha1.yaml", 0);
+        convertSampleResource("topic-v1beta1.yaml", 0);
+        convertSampleResource("user-v1alpha1.yaml", 0);
+        convertSampleResource("user-v1beta1.yaml", 0);
+    }
+
+    @Test
+    public void convertInvalidSampleResources()    {
+        convertSampleResource("kafka-different-policies.yaml", 1);
+        convertSampleResource("kafka-different-ranges.yaml", 1);
+        convertSampleResource("kafka-to-twice.yaml", 1);
+        convertSampleResource("kafka-to-two-tls-sidecars.yaml", 1);
+        convertSampleResource("kafka-toleration-conflict.yaml", 1);
+    }
+
+    private void convertSampleResource(String testFile, int expectedExitCode)    {
+        String testResource = getClass().getResource(testFile).getPath();
+
+        try {
+            CLUSTER.createCustomResources(testResource);
+
+            CommandLine cmd = new CommandLine(new EntryCommand());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            cmd.setOut(pw);
+            cmd.setErr(pw);
+
+            int exitCode = cmd.execute("convert-resource", "--namespace", NAMESPACE);
+            assertThat("Checking exit code for conversion of " + testFile + " is " + expectedExitCode, exitCode, is(expectedExitCode));
+        } finally {
+            CLUSTER.deleteCustomResources(testResource);
+        }
+    }
+}

--- a/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1alpha1.out
+++ b/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1alpha1.out
@@ -41,3 +41,17 @@ spec:
         name: my-topic
         patternType: literal
       operation: Describe
+    - resource:
+        type: transactionalId
+        name: schema-registry-
+        patternType: prefix
+      operation: Describe
+    - resource:
+        type: transactionalId
+        name: schema-registry-
+        patternType: prefix
+      operation: Write
+  quotas:
+    producerByteRate: 1048576
+    consumerByteRate: 2097152
+    requestPercentage: 55

--- a/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1alpha1.yaml
+++ b/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1alpha1.yaml
@@ -42,3 +42,18 @@ spec:
           name: my-topic
           patternType: literal
         operation: Describe
+      # transactionalId resources
+      - resource:
+          type: transactionalId
+          name: schema-registry-
+          patternType: prefix
+        operation: Describe
+      - resource:
+          type: transactionalId
+          name: schema-registry-
+          patternType: prefix
+        operation: Write
+  quotas:
+    producerByteRate: 1048576
+    consumerByteRate: 2097152
+    requestPercentage: 55

--- a/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1beta1.out
+++ b/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1beta1.out
@@ -41,3 +41,17 @@ spec:
         name: my-topic
         patternType: literal
       operation: Describe
+    - resource:
+        type: transactionalId
+        name: schema-registry-
+        patternType: prefix
+      operation: Describe
+    - resource:
+        type: transactionalId
+        name: schema-registry-
+        patternType: prefix
+      operation: Write
+  quotas:
+    producerByteRate: 1048576
+    consumerByteRate: 2097152
+    requestPercentage: 55

--- a/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1beta1.yaml
+++ b/api-conversion/src/test/resources/io/strimzi/kafka/api/conversion/cli/user-v1beta1.yaml
@@ -42,3 +42,18 @@ spec:
           name: my-topic
           patternType: literal
         operation: Describe
+      # transactionalId resources
+      - resource:
+          type: transactionalId
+          name: schema-registry-
+          patternType: prefix
+        operation: Describe
+      - resource:
+          type: transactionalId
+          name: schema-registry-
+          patternType: prefix
+        operation: Write
+  quotas:
+    producerByteRate: 1048576
+    consumerByteRate: 2097152
+    requestPercentage: 55

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleClusterResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleClusterResource.java
@@ -26,6 +26,7 @@ public class AclRuleClusterResource extends AclRuleResource {
     public static final String TYPE_CLUSTER = "cluster";
 
     @Description("Must be `" + TYPE_CLUSTER + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_CLUSTER;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTransactionalIdResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTransactionalIdResource.java
@@ -31,6 +31,7 @@ public class AclRuleTransactionalIdResource extends AclRuleResource {
     private String name;
 
     @Description("Must be `" + TYPE_TRANSACTIONAL_ID + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_TRANSACTIONAL_ID;

--- a/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ExternalLogging.java
@@ -31,6 +31,7 @@ public class ExternalLogging extends Logging {
     private ExternalConfigurationReference valueFrom;
 
     @Description("Must be `" + TYPE_EXTERNAL + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_EXTERNAL;

--- a/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/InlineLogging.java
@@ -29,6 +29,7 @@ public class InlineLogging extends Logging {
     private Map<String, String> loggers = null;
 
     @Description("Must be `" + TYPE_INLINE + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_INLINE;

--- a/api/src/main/java/io/strimzi/api/kafka/model/JmxPrometheusExporterMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/JmxPrometheusExporterMetrics.java
@@ -43,6 +43,7 @@ public class JmxPrometheusExporterMetrics extends MetricsConfig {
     }
 
     @Description("Must be `" + TYPE_JMX_EXPORTER + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_JMX_EXPORTER;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationCustom.java
@@ -35,6 +35,7 @@ public class KafkaAuthorizationCustom extends KafkaAuthorization {
     private List<String> superUsers;
 
     @Description("Must be `" + TYPE_CUSTOM + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_CUSTOM;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
@@ -35,6 +35,7 @@ public class KafkaAuthorizationSimple extends KafkaAuthorization {
     private List<String> superUsers;
 
     @Description("Must be `" + TYPE_SIMPLE + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_SIMPLE;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaJmxAuthenticationPassword.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaJmxAuthenticationPassword.java
@@ -24,6 +24,7 @@ public class KafkaJmxAuthenticationPassword extends KafkaJmxAuthentication {
     public static final String TYPE_PASSWORD = "password";
 
     @Description("Must be `" + TYPE_PASSWORD + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_PASSWORD;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserScramSha512ClientAuthentication.java
@@ -21,6 +21,7 @@ public class KafkaUserScramSha512ClientAuthentication extends KafkaUserAuthentic
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
 
     @Description("Must be `" + TYPE_SCRAM_SHA_512 + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_SCRAM_SHA_512;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserTlsClientAuthentication.java
@@ -22,6 +22,7 @@ public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {
     public static final String TYPE_TLS = "tls";
 
     @Description("Must be `" + TYPE_TLS + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_TLS;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationOAuth.java
@@ -42,6 +42,7 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
     private boolean accessTokenIsJwt = true;
 
     @Description("Must be `" + TYPE_OAUTH + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_OAUTH;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationPlain.java
@@ -31,6 +31,7 @@ public class KafkaClientAuthenticationPlain extends KafkaClientAuthentication {
     private PasswordSecretSource passwordSecret;
 
     @Description("Must be `" + TYPE_PLAIN + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_PLAIN;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
@@ -31,6 +31,7 @@ public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticat
     private PasswordSecretSource passwordSecret;
 
     @Description("Must be `" + TYPE_SCRAM_SHA_512 + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_SCRAM_SHA_512;

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationTls.java
@@ -30,6 +30,7 @@ public class KafkaClientAuthenticationTls extends KafkaClientAuthentication {
     private CertAndKeySecretSource certificateAndKey;
 
     @Description("Must be `" + TYPE_TLS + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_TLS;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -37,6 +37,7 @@ public class DockerOutput extends Output {
     private List<String> additionalKanikoOptions;
 
     @Description("Must be `" + TYPE_DOCKER + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_DOCKER;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
@@ -28,6 +28,7 @@ public class ImageStreamOutput extends Output {
     private String image;
 
     @Description("Must be `" + TYPE_IMAGESTREAM + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_IMAGESTREAM;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
@@ -25,6 +25,7 @@ public class TgzArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;
 
     @Description("Must be `" + TYPE_TGZ + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_TGZ;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -25,6 +25,7 @@ public class ZipArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;
 
     @Description("Must be `" + TYPE_ZIP + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_ZIP;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -61,6 +61,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private String customClaimCheck;
 
     @Description("Must be `" + TYPE_OAUTH + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_OAUTH;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationScramSha512.java
@@ -26,6 +26,7 @@ public class KafkaListenerAuthenticationScramSha512 extends KafkaListenerAuthent
     public static final String SCRAM_SHA_512 = "scram-sha-512";
 
     @Description("Must be `" + SCRAM_SHA_512 + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return SCRAM_SHA_512;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationTls.java
@@ -26,6 +26,7 @@ public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication 
     public static final String TYPE_TLS = "tls";
 
     @Description("Must be `" + TYPE_TLS + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_TLS;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalIngress.java
@@ -37,6 +37,7 @@ public class KafkaListenerExternalIngress extends KafkaListenerExternal {
     private String ingressClass;
 
     @Description("Must be `" + TYPE_INGRESS + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_INGRESS;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalLoadBalancer.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalLoadBalancer.java
@@ -38,6 +38,7 @@ public class KafkaListenerExternalLoadBalancer extends KafkaListenerExternal {
     private KafkaListenerExternalConfiguration configuration;
 
     @Description("Must be `" + TYPE_LOADBALANCER + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_LOADBALANCER;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalNodePort.java
@@ -38,6 +38,7 @@ public class KafkaListenerExternalNodePort extends KafkaListenerExternal {
     private NodePortListenerConfiguration configuration;
 
     @Description("Must be `" + TYPE_NODEPORT + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_NODEPORT;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalRoute.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerExternalRoute.java
@@ -37,6 +37,7 @@ public class KafkaListenerExternalRoute extends KafkaListenerExternal {
     private KafkaListenerExternalConfiguration configuration;
 
     @Description("Must be `" + TYPE_ROUTE + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_ROUTE;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/EphemeralStorage.java
@@ -30,6 +30,7 @@ public class EphemeralStorage extends SingleVolumeStorage {
     private String sizeLimit;
 
     @Description("Must be `" + TYPE_EPHEMERAL + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_EPHEMERAL;

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/JbodStorage.java
@@ -26,6 +26,7 @@ public class JbodStorage extends Storage {
     private List<SingleVolumeStorage> volumes;
 
     @Description("Must be `" + TYPE_JBOD + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_JBOD;

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/JaegerTracing.java
@@ -27,6 +27,7 @@ public class JaegerTracing extends Tracing {
     public static final String TYPE_JAEGER = "jaeger";
 
     @Description("Must be `" + TYPE_JAEGER + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_JAEGER;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When a `KafkaUser` resource contains ACL rules with `type: transactionalId`, for example:

```yaml
- resource:
    type: transactionalId
    name: schema-registry-
    patternType: prefix
  operation: Describe
- resource:
    type: transactionalId
    name: schema-registry-
    patternType: prefix
  operation: Write
```

the `api-conversion` tool fails with an error like this:

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PUT at: https://192.168.1.72:6443/apis/kafka.strimzi.io/v1beta2/namespaces/myproject/kafkausers/my-user. Message: KafkaUser.kafka.strimzi.io "my-user" is invalid: spec.authorization.acls.resource.type: Required value. Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=spec.authorization.acls.resource.type, message=Required value, reason=FieldValueRequired, additionalProperties={})], group=kafka.strimzi.io, kind=KafkaUser, name=my-user, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=KafkaUser.kafka.strimzi.io "my-user" is invalid: spec.authorization.acls.resource.type: Required value, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:583)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:522)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:487)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:448)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleReplace(OperationSupport.java:299)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleReplace(OperationSupport.java:280)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleReplace(BaseOperation.java:875)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.lambda$replace$0(HasMetadataOperation.java:74)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.replace(HasMetadataOperation.java:79)
	at io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.replace(HasMetadataOperation.java:28)
	at io.strimzi.kafka.api.conversion.cli.ConvertResourceCommand.replace(ConvertResourceCommand.java:82)
	at io.strimzi.kafka.api.conversion.cli.ConvertResourceCommand.convertInKube(ConvertResourceCommand.java:167)
	at io.strimzi.kafka.api.conversion.cli.ConvertResourceCommand.run(ConvertResourceCommand.java:226)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1919)
	at picocli.CommandLine.access$1200(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2159)
	at picocli.CommandLine.execute(CommandLine.java:2058)
	at io.strimzi.kafka.api.conversion.cli.EntryCommand.main(EntryCommand.java:31)
```

This is cased by the converted resource looking like this without the `type` field:

```
    - resource:
        name: "schema-registry-"
        patternType: "prefix"
      operation: "Describe"
    - resource:
        name: "schema-registry-"
        patternType: "prefix"
      operation: "Write"
```

This is caused by the `AclRuleTransactionalIdResource` class using the `@JsonInclude(JsonInclude.Include.NON_DEFAULT)` annotation which leaves out the type. To fix this, we just need to add the `@JsonInclude(JsonInclude.Include.NON_NULL)` annotation to the `type` field to make sure it is not left out. To make sure this problem does not appear anywhere else, this PR also adds it to all other `type` fields.

This PR adds also some additional tests to improve the coverage.

This should be back-ported to 0.23.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally