### PR TITLE
Add support for topic creation, deletion and partition creation quotas 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Update cruise control to 2.5.55
 * Support for broker load information added to the rebalance optimization proposal. Information on the load difference, before and after a rebalance is stored in a ConfigMap
 * Add support for selectively changing the verbosity of logging for individual CRs, using markers.
-* Added support for `controller_mutation_rate quota`. Creation/Deletion of topics and creation of partitions can be configured through this.
+* Added support for `controller_mutation_rate' quota. Creation/Deletion of topics and creation of partitions can be configured through this.
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Support for broker load information added to the rebalance optimization proposal. Information on the load difference, before and after a rebalance is stored in a ConfigMap
 * Add support for selectively changing the verbosity of logging for individual CRs, using markers.
 
+* Added support for `controller_mutation_rate quota`. Creation/Deletion of topics and creation of partitions can be configured through this.
 ### Changes, deprecations and removals
 
 * The fields `topicsBlacklistPattern` and `groupsBlacklistPattern` in the `KafkaMirrorMaker2` resource are deprecated and will be removed in the future.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 * Update cruise control to 2.5.55
 * Support for broker load information added to the rebalance optimization proposal. Information on the load difference, before and after a rebalance is stored in a ConfigMap
 * Add support for selectively changing the verbosity of logging for individual CRs, using markers.
-
 * Added support for `controller_mutation_rate quota`. Creation/Deletion of topics and creation of partitions can be configured through this.
+
 ### Changes, deprecations and removals
 
 * The fields `topicsBlacklistPattern` and `groupsBlacklistPattern` in the `KafkaMirrorMaker2` resource are deprecated and will be removed in the future.

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserQuotas.java
@@ -34,6 +34,17 @@ public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable 
     private Integer producerByteRate;
     private Integer consumerByteRate;
     private Integer requestPercentage;
+    private Integer controllerMutationRate;
+
+    @Description(" The quota on rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.")
+    @Minimum(0)
+    public Integer getControllerMutationRate() {
+        return controllerMutationRate;
+    }
+
+    public void setControllerMutationRate(Integer controllerMutationRate) {
+        this.controllerMutationRate = controllerMutationRate;
+    }
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserQuotas.java
@@ -34,15 +34,15 @@ public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable 
     private Integer producerByteRate;
     private Integer consumerByteRate;
     private Integer requestPercentage;
-    private Integer controllerMutationRate;
+    private Double controllerMutationRate;
 
-    @Description(" The quota on rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.")
+    @Description("A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.")
     @Minimum(0)
-    public Integer getControllerMutationRate() {
+    public Double getControllerMutationRate() {
         return controllerMutationRate;
     }
 
-    public void setControllerMutationRate(Integer controllerMutationRate) {
+    public void setControllerMutationRate(Double controllerMutationRate) {
         this.controllerMutationRate = controllerMutationRate;
     }
 

--- a/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
@@ -162,6 +162,13 @@ spec:
                   description: A quota on the maximum bytes per-second that each client
                     group can fetch from a broker before the clients in the group
                     are throttled. Defined on a per-broker basis.
+                controllerMutationRate:
+                  type: integer
+                  minimum: 0
+                  description: ' The quota on rate at which mutations are accepted
+                    for the create topics request, the create partitions request and
+                    the delete topics request. The rate is accumulated by the number
+                    of partitions created or deleted.'
                 producerByteRate:
                   type: integer
                   minimum: 0

--- a/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/044-Crd-kafkauser.yaml
@@ -163,12 +163,12 @@ spec:
                     group can fetch from a broker before the clients in the group
                     are throttled. Defined on a per-broker basis.
                 controllerMutationRate:
-                  type: integer
+                  type: number
                   minimum: 0
-                  description: ' The quota on rate at which mutations are accepted
+                  description: A quota on the rate at which mutations are accepted
                     for the create topics request, the create partitions request and
                     the delete topics request. The rate is accumulated by the number
-                    of partitions created or deleted.'
+                    of partitions created or deleted.
                 producerByteRate:
                   type: integer
                   minimum: 0

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -1037,6 +1037,11 @@ public class CrdGenerator {
             return "array";
         } else if (type.isEnum()) {
             return "string";
+        } else if (Double.class.equals(type)
+                || double.class.equals(type)
+                || float.class.equals(type)
+                || Float.class.equals(type)) {
+            return "number";
         } else {
             throw new RuntimeException(type.getName());
         }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2431,12 +2431,14 @@ include::../api/io.strimzi.api.kafka.model.KafkaUserQuotas.adoc[leveloffset=+1]
 
 [options="header"]
 |====
-|Property                  |Description
-|consumerByteRate   1.2+<.<a|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
+|Property                       |Description
+|consumerByteRate        1.2+<.<a|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
 |integer
-|producerByteRate   1.2+<.<a|A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+|controllerMutationRate  1.2+<.<a| The quota on rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
 |integer
-|requestPercentage  1.2+<.<a|A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+|producerByteRate        1.2+<.<a|A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+|integer
+|requestPercentage       1.2+<.<a|A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2434,8 +2434,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaUserQuotas.adoc[leveloffset=+1]
 |Property                       |Description
 |consumerByteRate        1.2+<.<a|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
 |integer
-|controllerMutationRate  1.2+<.<a| The quota on rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
-|integer
+|controllerMutationRate  1.2+<.<a|A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
+|xref:type-Double-{context}[`Double`]
 |producerByteRate        1.2+<.<a|A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
 |integer
 |requestPercentage       1.2+<.<a|A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -137,6 +137,10 @@ spec:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                    controllerMutationRate:
+                      type: number
+                      minimum: 0
+                      description: A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
                     producerByteRate:
                       type: integer
                       minimum: 0
@@ -317,6 +321,10 @@ spec:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                    controllerMutationRate:
+                      type: number
+                      minimum: 0
+                      description: A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
                     producerByteRate:
                       type: integer
                       minimum: 0
@@ -497,6 +505,10 @@ spec:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                    controllerMutationRate:
+                      type: number
+                      minimum: 0
+                      description: A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
                     producerByteRate:
                       type: integer
                       minimum: 0

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -157,6 +157,13 @@ spec:
                     description: A quota on the maximum bytes per-second that each
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
+                  controllerMutationRate:
+                    type: integer
+                    minimum: 0
+                    description: ' The quota on rate at which mutations are accepted
+                      for the create topics request, the create partitions request
+                      and the delete topics request. The rate is accumulated by the
+                      number of partitions created or deleted.'
                   producerByteRate:
                     type: integer
                     minimum: 0
@@ -376,6 +383,13 @@ spec:
                     description: A quota on the maximum bytes per-second that each
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
+                  controllerMutationRate:
+                    type: integer
+                    minimum: 0
+                    description: ' The quota on rate at which mutations are accepted
+                      for the create topics request, the create partitions request
+                      and the delete topics request. The rate is accumulated by the
+                      number of partitions created or deleted.'
                   producerByteRate:
                     type: integer
                     minimum: 0
@@ -595,6 +609,13 @@ spec:
                     description: A quota on the maximum bytes per-second that each
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
+                  controllerMutationRate:
+                    type: integer
+                    minimum: 0
+                    description: ' The quota on rate at which mutations are accepted
+                      for the create topics request, the create partitions request
+                      and the delete topics request. The rate is accumulated by the
+                      number of partitions created or deleted.'
                   producerByteRate:
                     type: integer
                     minimum: 0

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -158,12 +158,12 @@ spec:
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
                   controllerMutationRate:
-                    type: integer
+                    type: number
                     minimum: 0
-                    description: ' The quota on rate at which mutations are accepted
+                    description: A quota on the rate at which mutations are accepted
                       for the create topics request, the create partitions request
                       and the delete topics request. The rate is accumulated by the
-                      number of partitions created or deleted.'
+                      number of partitions created or deleted.
                   producerByteRate:
                     type: integer
                     minimum: 0
@@ -384,12 +384,12 @@ spec:
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
                   controllerMutationRate:
-                    type: integer
+                    type: number
                     minimum: 0
-                    description: ' The quota on rate at which mutations are accepted
+                    description: A quota on the rate at which mutations are accepted
                       for the create topics request, the create partitions request
                       and the delete topics request. The rate is accumulated by the
-                      number of partitions created or deleted.'
+                      number of partitions created or deleted.
                   producerByteRate:
                     type: integer
                     minimum: 0
@@ -610,12 +610,12 @@ spec:
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
                   controllerMutationRate:
-                    type: integer
+                    type: number
                     minimum: 0
-                    description: ' The quota on rate at which mutations are accepted
+                    description: A quota on the rate at which mutations are accepted
                       for the create topics request, the create partitions request
                       and the delete topics request. The rate is accumulated by the
-                      number of partitions created or deleted.'
+                      number of partitions created or deleted.
                   producerByteRate:
                     type: integer
                     minimum: 0

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -157,6 +157,13 @@ spec:
                     description: A quota on the maximum bytes per-second that each
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: A quota on the rate at which mutations are accepted
+                      for the create topics request, the create partitions request
+                      and the delete topics request. The rate is accumulated by the
+                      number of partitions created or deleted.
                   producerByteRate:
                     type: integer
                     minimum: 0
@@ -376,6 +383,13 @@ spec:
                     description: A quota on the maximum bytes per-second that each
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: A quota on the rate at which mutations are accepted
+                      for the create topics request, the create partitions request
+                      and the delete topics request. The rate is accumulated by the
+                      number of partitions created or deleted.
                   producerByteRate:
                     type: integer
                     minimum: 0
@@ -595,6 +609,13 @@ spec:
                     description: A quota on the maximum bytes per-second that each
                       client group can fetch from a broker before the clients in the
                       group are throttled. Defined on a per-broker basis.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: A quota on the rate at which mutations are accepted
+                      for the create topics request, the create partitions request
+                      and the delete topics request. The rate is accumulated by the
+                      number of partitions created or deleted.
                   producerByteRate:
                     type: integer
                     minimum: 0

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
@@ -58,13 +58,14 @@ public class KafkaUserTemplates {
         return user;
     }
 
-    public static KafkaUserBuilder userWithQuotas(KafkaUser user, Integer prodRate, Integer consRate, Integer requestPerc) {
+    public static KafkaUserBuilder userWithQuotas(KafkaUser user, Integer prodRate, Integer consRate, Integer requestPerc, Integer mutRate) {
         return new KafkaUserBuilder(user)
                 .editSpec()
                     .withNewQuotas()
                         .withConsumerByteRate(consRate)
                         .withProducerByteRate(prodRate)
                         .withRequestPercentage(requestPerc)
+                        .withControllerMutationRate(mutRate)
                     .endQuotas()
                 .endSpec();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
@@ -58,7 +58,7 @@ public class KafkaUserTemplates {
         return user;
     }
 
-    public static KafkaUserBuilder userWithQuotas(KafkaUser user, Integer prodRate, Integer consRate, Integer requestPerc, Integer mutRate) {
+    public static KafkaUserBuilder userWithQuotas(KafkaUser user, Integer prodRate, Integer consRate, Integer requestPerc, Double mutRate) {
         return new KafkaUserBuilder(user)
                 .editSpec()
                     .withNewQuotas()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -219,7 +219,7 @@ class UserST extends AbstractST {
         Integer prodRate = 1111;
         Integer consRate = 2222;
         Integer reqPerc = 42;
-        Integer mutRate = 10;
+        Double mutRate = 10d;
 
         // Create user with correct name
         resourceManager.createResource(extensionContext, KafkaUserTemplates.userWithQuotas(user, prodRate, consRate, reqPerc, mutRate)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -219,9 +219,10 @@ class UserST extends AbstractST {
         Integer prodRate = 1111;
         Integer consRate = 2222;
         Integer reqPerc = 42;
+        Integer mutRate = 10;
 
         // Create user with correct name
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.userWithQuotas(user, prodRate, consRate, reqPerc)
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.userWithQuotas(user, prodRate, consRate, reqPerc, mutRate)
             .editMetadata()
                 .withNamespace(NAMESPACE)
             .endMetadata()
@@ -235,6 +236,7 @@ class UserST extends AbstractST {
         assertThat(result.out().contains("request_percentage=" + reqPerc), is(true));
         assertThat(result.out().contains("producer_byte_rate=" + prodRate), is(true));
         assertThat(result.out().contains("consumer_byte_rate=" + consRate), is(true));
+        assertThat(result.out().contains("controller_mutation_rate=" + mutRate), is(true));
 
         // delete user
         KafkaUserResource.kafkaUserClient().inNamespace(NAMESPACE).withName(user.getMetadata().getName()).delete();
@@ -245,6 +247,7 @@ class UserST extends AbstractST {
         assertThat(resultAfterDelete.out(), not(containsString("request_percentage")));
         assertThat(resultAfterDelete.out(), not(containsString("producer_byte_rate")));
         assertThat(resultAfterDelete.out(), not(containsString("consumer_byte_rate")));
+        assertThat(resultAfterDelete.out(), not(containsString("controller_mutation_rate")));
     }
 
     @ParallelNamespaceTest

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserQuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserQuotasOperator.java
@@ -113,6 +113,7 @@ public class KafkaUserQuotasOperator {
             current.setProducerByteRate(null);
             current.setConsumerByteRate(null);
             current.setRequestPercentage(null);
+            current.setControllerMutationRate(null);
             alterUserQuotas(reconciliation, username, toClientQuotaAlterationOps(current));
         } else {
             LOGGER.warnCr(reconciliation, "Quotas for user {} already don't exist", username);
@@ -164,6 +165,9 @@ public class KafkaUserQuotasOperator {
         if (map.containsKey("request_percentage")) {
             kuq.setRequestPercentage(map.get("request_percentage").intValue());
         }
+        if (map.containsKey("controller_mutation_rate")) {
+            kuq.setControllerMutationRate(map.get("controller_mutation_rate").intValue());
+        }
         return kuq;
     }
 
@@ -181,6 +185,8 @@ public class KafkaUserQuotasOperator {
                 quotas.getConsumerByteRate() != null ? Double.valueOf(quotas.getConsumerByteRate()) : null));
         ops.add(new ClientQuotaAlteration.Op("request_percentage",
                 quotas.getRequestPercentage() != null ? Double.valueOf(quotas.getRequestPercentage()) : null));
+        ops.add(new ClientQuotaAlteration.Op("controller_mutation_rate",
+                quotas.getControllerMutationRate() != null ? Double.valueOf(quotas.getControllerMutationRate()) : null));
         return ops;
     }
 
@@ -194,6 +200,7 @@ public class KafkaUserQuotasOperator {
     private boolean quotasEquals(KafkaUserQuotas kuq1, KafkaUserQuotas kuq2) {
         return Objects.equals(kuq1.getProducerByteRate(), kuq2.getProducerByteRate()) &&
                 Objects.equals(kuq1.getConsumerByteRate(), kuq2.getConsumerByteRate()) &&
-                Objects.equals(kuq1.getRequestPercentage(), kuq2.getRequestPercentage());
+                Objects.equals(kuq1.getRequestPercentage(), kuq2.getRequestPercentage()) &&
+                Objects.equals(kuq1.getControllerMutationRate(), kuq2.getControllerMutationRate());
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserQuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserQuotasOperator.java
@@ -166,7 +166,7 @@ public class KafkaUserQuotasOperator {
             kuq.setRequestPercentage(map.get("request_percentage").intValue());
         }
         if (map.containsKey("controller_mutation_rate")) {
-            kuq.setControllerMutationRate(map.get("controller_mutation_rate").intValue());
+            kuq.setControllerMutationRate(map.get("controller_mutation_rate"));
         }
         return kuq;
     }
@@ -186,7 +186,7 @@ public class KafkaUserQuotasOperator {
         ops.add(new ClientQuotaAlteration.Op("request_percentage",
                 quotas.getRequestPercentage() != null ? Double.valueOf(quotas.getRequestPercentage()) : null));
         ops.add(new ClientQuotaAlteration.Op("controller_mutation_rate",
-                quotas.getControllerMutationRate() != null ? Double.valueOf(quotas.getControllerMutationRate()) : null));
+                quotas.getControllerMutationRate() != null ? quotas.getControllerMutationRate() : null));
         return ops;
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -113,11 +113,12 @@ public class ResourceUtils {
         return createKafkaUser(new KafkaUserScramSha512ClientAuthentication());
     }
 
-    public static KafkaUser createKafkaUserQuotas(Integer consumerByteRate, Integer producerByteRate, Integer requestPercentage) {
+    public static KafkaUser createKafkaUserQuotas(Integer consumerByteRate, Integer producerByteRate, Integer requestPercentage, Integer controllerMutationRate) {
         KafkaUserQuotas kuq = new KafkaUserQuotasBuilder()
                 .withConsumerByteRate(consumerByteRate)
                 .withProducerByteRate(producerByteRate)
                 .withRequestPercentage(requestPercentage)
+                .withControllerMutationRate(controllerMutationRate)
                 .build();
 
         return createKafkaUser(kuq);

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -113,7 +113,7 @@ public class ResourceUtils {
         return createKafkaUser(new KafkaUserScramSha512ClientAuthentication());
     }
 
-    public static KafkaUser createKafkaUserQuotas(Integer consumerByteRate, Integer producerByteRate, Integer requestPercentage, Integer controllerMutationRate) {
+    public static KafkaUser createKafkaUserQuotas(Integer consumerByteRate, Integer producerByteRate, Integer requestPercentage, Double controllerMutationRate) {
         KafkaUserQuotas kuq = new KafkaUserQuotasBuilder()
                 .withConsumerByteRate(consumerByteRate)
                 .withProducerByteRate(producerByteRate)

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class KafkaUserModelTest {
     private final KafkaUser tlsUser = ResourceUtils.createKafkaUserTls();
     private final KafkaUser scramShaUser = ResourceUtils.createKafkaUserScramSha();
-    private final KafkaUser quotasUser = ResourceUtils.createKafkaUserQuotas(1000, 2000, 42);
+    private final KafkaUser quotasUser = ResourceUtils.createKafkaUserQuotas(1000, 2000, 42, 10);
     private final Secret clientsCaCert = ResourceUtils.createClientsCaCertSecret();
     private final Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
     private final CertManager mockCertManager = new MockCertManager();
@@ -85,13 +85,13 @@ public class KafkaUserModelTest {
         assertThat(model.getQuotas().getConsumerByteRate(), is(quotas.getConsumerByteRate()));
         assertThat(model.getQuotas().getProducerByteRate(), is(quotas.getProducerByteRate()));
         assertThat(model.getQuotas().getRequestPercentage(), is(quotas.getRequestPercentage()));
+        assertThat(model.getQuotas().getControllerMutationRate(), is(quotas.getControllerMutationRate()));
     }
 
     @Test
     public void testFromCrdQuotaUserWithNullValues()   {
-        KafkaUser quotasUserWithNulls = ResourceUtils.createKafkaUserQuotas(null, 2000, null);
+        KafkaUser quotasUserWithNulls = ResourceUtils.createKafkaUserQuotas(null, 2000, null, 10);
         KafkaUserModel model = KafkaUserModel.fromCrd(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, quotasUserWithNulls, clientsCaCert, clientsCaKey, null, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
-
         assertThat(model.namespace, is(ResourceUtils.NAMESPACE));
         assertThat(model.name, is(ResourceUtils.NAME));
         assertThat(model.labels, is(Labels.fromMap(ResourceUtils.LABELS)
@@ -103,6 +103,8 @@ public class KafkaUserModelTest {
         assertThat(model.getQuotas().getConsumerByteRate(), is(nullValue()));
         assertThat(model.getQuotas().getProducerByteRate(), is(2000));
         assertThat(model.getQuotas().getRequestPercentage(), is(nullValue()));
+        assertThat(model.getQuotas().getControllerMutationRate(), is(10));
+
     }
 
     @Test

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class KafkaUserModelTest {
     private final KafkaUser tlsUser = ResourceUtils.createKafkaUserTls();
     private final KafkaUser scramShaUser = ResourceUtils.createKafkaUserScramSha();
-    private final KafkaUser quotasUser = ResourceUtils.createKafkaUserQuotas(1000, 2000, 42, 10);
+    private final KafkaUser quotasUser = ResourceUtils.createKafkaUserQuotas(1000, 2000, 42, 10d);
     private final Secret clientsCaCert = ResourceUtils.createClientsCaCertSecret();
     private final Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
     private final CertManager mockCertManager = new MockCertManager();
@@ -90,8 +90,9 @@ public class KafkaUserModelTest {
 
     @Test
     public void testFromCrdQuotaUserWithNullValues()   {
-        KafkaUser quotasUserWithNulls = ResourceUtils.createKafkaUserQuotas(null, 2000, null, 10);
+        KafkaUser quotasUserWithNulls = ResourceUtils.createKafkaUserQuotas(null, 2000, null, 10d);
         KafkaUserModel model = KafkaUserModel.fromCrd(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, quotasUserWithNulls, clientsCaCert, clientsCaKey, null, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+
         assertThat(model.namespace, is(ResourceUtils.NAMESPACE));
         assertThat(model.name, is(ResourceUtils.NAME));
         assertThat(model.labels, is(Labels.fromMap(ResourceUtils.LABELS)
@@ -103,7 +104,7 @@ public class KafkaUserModelTest {
         assertThat(model.getQuotas().getConsumerByteRate(), is(nullValue()));
         assertThat(model.getQuotas().getProducerByteRate(), is(2000));
         assertThat(model.getQuotas().getRequestPercentage(), is(nullValue()));
-        assertThat(model.getQuotas().getControllerMutationRate(), is(10));
+        assertThat(model.getQuotas().getControllerMutationRate(), is(10d));
 
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -76,7 +76,7 @@ public class KafkaUserQuotasIT {
         defaultQuotas = new KafkaUserQuotas();
         defaultQuotas.setConsumerByteRate(1000);
         defaultQuotas.setProducerByteRate(2000);
-        defaultQuotas.setControllerMutationRate(10);
+        defaultQuotas.setControllerMutationRate(10d);
     }
 
     @Test
@@ -131,7 +131,7 @@ public class KafkaUserQuotasIT {
         KafkaUserQuotas newQuotas = new KafkaUserQuotas();
         newQuotas.setConsumerByteRate(1000);
         newQuotas.setProducerByteRate(2000);
-        newQuotas.setControllerMutationRate(10);
+        newQuotas.setControllerMutationRate(10d);
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, newQuotas);
         assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
         testDescribeUserQuotas(username, newQuotas);
@@ -218,9 +218,9 @@ public class KafkaUserQuotasIT {
     public void testUpdateControllerMutationRate() throws Exception {
         String username = "changeControllerMutationRate";
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, defaultQuotas);
-        defaultQuotas.setControllerMutationRate(20);
+        defaultQuotas.setControllerMutationRate(20d);
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, defaultQuotas);
-        assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getControllerMutationRate(), is(20));
+        assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getControllerMutationRate(), is(20d));
     }
 
     @Test
@@ -229,7 +229,7 @@ public class KafkaUserQuotasIT {
         quotas.setConsumerByteRate(2000);
         quotas.setProducerByteRate(4000);
         quotas.setRequestPercentage(40);
-        quotas.setControllerMutationRate(10);
+        quotas.setControllerMutationRate(10d);
         Set<ClientQuotaAlteration.Op> ops = kuq.toClientQuotaAlterationOps(quotas);
         assertThat(ops, hasSize(4));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("consumer_byte_rate", 2000d)), is(true));
@@ -262,7 +262,7 @@ public class KafkaUserQuotasIT {
         assertThat(quotas.getConsumerByteRate(), is(2000));
         assertThat(quotas.getProducerByteRate(), is(4000));
         assertThat(quotas.getRequestPercentage(), is(40));
-        assertThat(quotas.getControllerMutationRate(), is(10));
+        assertThat(quotas.getControllerMutationRate(), is(10d));
 
         map.remove("consumer_byte_rate");
         map.remove("producer_byte_rate");
@@ -291,7 +291,7 @@ public class KafkaUserQuotasIT {
         quotas.setConsumerByteRate(2_000_000);
         quotas.setProducerByteRate(1_000_000);
         quotas.setRequestPercentage(50);
-        quotas.setControllerMutationRate(10);
+        quotas.setControllerMutationRate(10d);
 
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(false));
 
@@ -320,7 +320,7 @@ public class KafkaUserQuotasIT {
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
         initialQuotas.setRequestPercentage(50);
-        initialQuotas.setControllerMutationRate(10);
+        initialQuotas.setControllerMutationRate(10d);
 
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, initialQuotas);
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(true));
@@ -330,7 +330,7 @@ public class KafkaUserQuotasIT {
         updatedQuotas.setConsumerByteRate(4_000_000);
         updatedQuotas.setProducerByteRate(3_000_000);
         updatedQuotas.setRequestPercentage(75);
-        updatedQuotas.setControllerMutationRate(10);
+        updatedQuotas.setControllerMutationRate(10d);
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(Reconciliation.DUMMY_RECONCILIATION, username, updatedQuotas)
@@ -357,7 +357,7 @@ public class KafkaUserQuotasIT {
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
         initialQuotas.setRequestPercentage(50);
-        initialQuotas.setControllerMutationRate(10);
+        initialQuotas.setControllerMutationRate(10d);
 
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, initialQuotas);
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(true));
@@ -366,7 +366,7 @@ public class KafkaUserQuotasIT {
         KafkaUserQuotas updatedQuotas = new KafkaUserQuotas();
         updatedQuotas.setConsumerByteRate(4_000_000);
         updatedQuotas.setProducerByteRate(3_000_000);
-        updatedQuotas.setControllerMutationRate(20);
+        updatedQuotas.setControllerMutationRate(20d);
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(Reconciliation.DUMMY_RECONCILIATION, username, updatedQuotas)
@@ -394,7 +394,7 @@ public class KafkaUserQuotasIT {
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
         initialQuotas.setRequestPercentage(50);
-        initialQuotas.setControllerMutationRate(10);
+        initialQuotas.setControllerMutationRate(10d);
 
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, initialQuotas);
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(true));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserQuotasIT.java
@@ -76,6 +76,7 @@ public class KafkaUserQuotasIT {
         defaultQuotas = new KafkaUserQuotas();
         defaultQuotas.setConsumerByteRate(1000);
         defaultQuotas.setProducerByteRate(2000);
+        defaultQuotas.setControllerMutationRate(10);
     }
 
     @Test
@@ -130,6 +131,7 @@ public class KafkaUserQuotasIT {
         KafkaUserQuotas newQuotas = new KafkaUserQuotas();
         newQuotas.setConsumerByteRate(1000);
         newQuotas.setProducerByteRate(2000);
+        newQuotas.setControllerMutationRate(10);
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, newQuotas);
         assertThat(isPathExist("/config/users/" + encodeUsername(username)), is(true));
         testDescribeUserQuotas(username, newQuotas);
@@ -213,25 +215,40 @@ public class KafkaUserQuotasIT {
     }
 
     @Test
+    public void testUpdateControllerMutationRate() throws Exception {
+        String username = "changeControllerMutationRate";
+        kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, defaultQuotas);
+        defaultQuotas.setControllerMutationRate(20);
+        kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, defaultQuotas);
+        assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getControllerMutationRate(), is(20));
+    }
+
+    @Test
     public void testUserQuotasToClientQuotaAlterationOps() {
         KafkaUserQuotas quotas = new KafkaUserQuotas();
         quotas.setConsumerByteRate(2000);
         quotas.setProducerByteRate(4000);
         quotas.setRequestPercentage(40);
+        quotas.setControllerMutationRate(10);
         Set<ClientQuotaAlteration.Op> ops = kuq.toClientQuotaAlterationOps(quotas);
-        assertThat(ops, hasSize(3));
+        assertThat(ops, hasSize(4));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("consumer_byte_rate", 2000d)), is(true));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("producer_byte_rate", 4000d)), is(true));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("request_percentage", 40d)), is(true));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("controller_mutation_rate", 10d)), is(true));
 
         quotas.setConsumerByteRate(null);
         quotas.setProducerByteRate(null);
         quotas.setRequestPercentage(null);
+        quotas.setControllerMutationRate(null);
+
         ops = kuq.toClientQuotaAlterationOps(quotas);
-        assertThat(ops, hasSize(3));
+        assertThat(ops, hasSize(4));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("consumer_byte_rate", null)), is(true));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("producer_byte_rate", null)), is(true));
         assertThat(ops.contains(new ClientQuotaAlteration.Op("request_percentage", null)), is(true));
+        assertThat(ops.contains(new ClientQuotaAlteration.Op("controller_mutation_rate", null)), is(true));
+
     }
 
     @Test
@@ -240,18 +257,23 @@ public class KafkaUserQuotasIT {
         map.put("consumer_byte_rate", 2000d);
         map.put("producer_byte_rate", 4000d);
         map.put("request_percentage", 40d);
+        map.put("controller_mutation_rate", 10d);
         KafkaUserQuotas quotas = kuq.fromClientQuota(map);
         assertThat(quotas.getConsumerByteRate(), is(2000));
         assertThat(quotas.getProducerByteRate(), is(4000));
         assertThat(quotas.getRequestPercentage(), is(40));
+        assertThat(quotas.getControllerMutationRate(), is(10));
 
         map.remove("consumer_byte_rate");
         map.remove("producer_byte_rate");
         map.remove("request_percentage");
+        map.remove("controller_mutation_rate");
         quotas = kuq.fromClientQuota(map);
         assertThat(quotas.getConsumerByteRate(), is(nullValue()));
         assertThat(quotas.getProducerByteRate(), is(nullValue()));
         assertThat(quotas.getRequestPercentage(), is(nullValue()));
+        assertThat(quotas.getControllerMutationRate(), is(nullValue()));
+
     }
 
     @Test
@@ -269,6 +291,7 @@ public class KafkaUserQuotasIT {
         quotas.setConsumerByteRate(2_000_000);
         quotas.setProducerByteRate(1_000_000);
         quotas.setRequestPercentage(50);
+        quotas.setControllerMutationRate(10);
 
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(false));
 
@@ -297,6 +320,7 @@ public class KafkaUserQuotasIT {
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
         initialQuotas.setRequestPercentage(50);
+        initialQuotas.setControllerMutationRate(10);
 
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, initialQuotas);
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(true));
@@ -306,6 +330,7 @@ public class KafkaUserQuotasIT {
         updatedQuotas.setConsumerByteRate(4_000_000);
         updatedQuotas.setProducerByteRate(3_000_000);
         updatedQuotas.setRequestPercentage(75);
+        updatedQuotas.setControllerMutationRate(10);
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(Reconciliation.DUMMY_RECONCILIATION, username, updatedQuotas)
@@ -332,6 +357,7 @@ public class KafkaUserQuotasIT {
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
         initialQuotas.setRequestPercentage(50);
+        initialQuotas.setControllerMutationRate(10);
 
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, initialQuotas);
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(true));
@@ -340,6 +366,7 @@ public class KafkaUserQuotasIT {
         KafkaUserQuotas updatedQuotas = new KafkaUserQuotas();
         updatedQuotas.setConsumerByteRate(4_000_000);
         updatedQuotas.setProducerByteRate(3_000_000);
+        updatedQuotas.setControllerMutationRate(20);
 
         Checkpoint async = testContext.checkpoint();
         kuq.reconcile(Reconciliation.DUMMY_RECONCILIATION, username, updatedQuotas)
@@ -367,6 +394,7 @@ public class KafkaUserQuotasIT {
         initialQuotas.setConsumerByteRate(2_000_000);
         initialQuotas.setProducerByteRate(1_000_000);
         initialQuotas.setRequestPercentage(50);
+        initialQuotas.setControllerMutationRate(10);
 
         kuq.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, username, initialQuotas);
         assertThat(kuq.exists(Reconciliation.DUMMY_RECONCILIATION, username), is(true));
@@ -410,5 +438,6 @@ public class KafkaUserQuotasIT {
         assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getConsumerByteRate(), is(quotas.getConsumerByteRate()));
         assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getProducerByteRate(), is(quotas.getProducerByteRate()));
         assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getRequestPercentage(), is(quotas.getRequestPercentage()));
+        assertThat(kuq.describeUserQuotas(Reconciliation.DUMMY_RECONCILIATION, username).getControllerMutationRate(), is(quotas.getControllerMutationRate()));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR solves issue #4678. This PR adds support for controller_mutation_rate quota which was implemented in KIP-599. Through this quota, creation / deletion of topics and creation of partitions can be configured.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

