### PR TITLE
Update Vert.x to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>
-        <vertx.version>4.0.3</vertx.version>
-        <vertx-junit5.version>4.0.3</vertx-junit5.version>
+        <vertx.version>4.1.0</vertx.version>
+        <vertx-junit5.version>4.1.0</vertx-junit5.version>
         <log4j.version>2.13.3</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
@@ -136,7 +136,7 @@
         <gson.version>2.8.2</gson.version>
         <vertx.kafka.client>4.0.3</vertx.kafka.client>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-        <netty.version>4.1.60.Final</netty.version>
+        <netty.version>4.1.65.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <!-- property to skip surefire tests during failsafe execution -->


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Strimzi to Vert.x 4.1.0. It also works with newer Netty version so we can address the CVEs in Netty 4.1.60.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally