### PR TITLE
Support configuring AdminClient in KafkaBridge by CR

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeAdminClientSpec.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.util.Map;
+
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
+    private static final long serialVersionUID = 1L;
+
+    public static final String FORBIDDEN_PREFIXES = "";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "";
+
+    @Override
+    @Description("The Kafka AdminClient configuration used for AdminClient instances created by the bridge.")
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeAdminClientSpec.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 
-    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security.";
+    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeAdminClientSpec.java
@@ -20,8 +20,8 @@ import java.util.Map;
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 
-    public static final String FORBIDDEN_PREFIXES = "";
-    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "";
+    public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security.";
+    public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override
     @Description("The Kafka AdminClient configuration used for AdminClient instances created by the bridge.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -142,7 +142,7 @@ public class KafkaBridgeSpec extends Spec {
         return adminClient;
     }
 
-    public void setConsumer(KafkaBridgeAdminClientSpec adminClient) {
+    public void setAdminClient(KafkaBridgeAdminClientSpec adminClient) {
         this.adminClient = adminClient;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "replicas", "image", "bootstrapServers", "tls", "authentication", "http", "consumer",
+        "replicas", "image", "bootstrapServers", "tls", "authentication", "http", "adminClient", "consumer",
         "producer", "resources", "jvmOptions", "logging",
         "enableMetrics", "livenessProbe", "readinessProbe", "template", "tracing"})
 @EqualsAndHashCode
@@ -43,6 +43,7 @@ public class KafkaBridgeSpec extends Spec {
     private KafkaClientAuthentication authentication;
     private KafkaBridgeConsumerSpec consumer;
     private KafkaBridgeProducerSpec producer;
+    private KafkaBridgeAdminClientSpec adminClient;
     private ResourceRequirements resources;
     private JvmOptions jvmOptions;
     private Logging logging;
@@ -133,6 +134,16 @@ public class KafkaBridgeSpec extends Spec {
 
     public void setBootstrapServers(String bootstrapServers) {
         this.bootstrapServers = bootstrapServers;
+    }
+
+    @Description("Kafka AdminClient related configuration.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public KafkaBridgeAdminClientSpec getAdminClient() {
+        return adminClient;
+    }
+
+    public void setConsumer(KafkaBridgeAdminClientSpec adminClient) {
+        this.adminClient = adminClient;
     }
 
     @Description("Kafka producer related configuration")

--- a/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/046-Crd-kafkabridge.yaml
@@ -256,6 +256,14 @@ spec:
                     - allowedMethods
                     description: CORS configuration for the HTTP Bridge.
                 description: The HTTP related configuration.
+              adminClient:
+                type: object
+                properties:
+                  config:
+                    type: object
+                    description: The Kafka AdminClient configuration used for AdminClient
+                      instances created by the bridge.
+                description: Kafka AdminClient related configuration.
               consumer:
                 type: object
                 properties:
@@ -1337,6 +1345,14 @@ spec:
                     - allowedMethods
                     description: CORS configuration for the HTTP Bridge.
                 description: The HTTP related configuration.
+              adminClient:
+                type: object
+                properties:
+                  config:
+                    type: object
+                    description: The Kafka AdminClient configuration used for AdminClient
+                      instances created by the bridge.
+                description: Kafka AdminClient related configuration.
               consumer:
                 type: object
                 properties:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
@@ -6,6 +6,7 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaBridgeAdminClientSpec;
+import io.strimzi.operator.common.Reconciliation;
 
 import java.util.HashMap;
 import java.util.List;
@@ -30,9 +31,10 @@ public class KafkaBridgeAdminClientConfiguration extends AbstractConfiguration {
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
      * ConfigMap / CRD.
      *
+     * @param reconciliation  The reconciliation
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
-    public KafkaBridgeAdminClientConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+    public KafkaBridgeAdminClientConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.KafkaBridgeAdminClientSpec;
+import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class for handling Kafka Bridge consumer configuration passed by the user
+ */
+public class KafkaBridgeAdminClientConfiguration extends AbstractConfiguration {
+
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
+    private static final Map<String, String> DEFAULTS;
+
+    static {
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        DEFAULTS = new HashMap<>(0);
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
+    public KafkaBridgeAdminClientConfiguration(Iterable<Map.Entry<String, Object>> jsonOptions) {
+        super(jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Class for handling Kafka Bridge consumer configuration passed by the user
+ * Class for handling Kafka Bridge Admin Client configuration passed by the user
  */
 public class KafkaBridgeAdminClientConfiguration extends AbstractConfiguration {
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
@@ -6,7 +6,6 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.KafkaBridgeAdminClientSpec;
-import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
 
 import java.util.HashMap;
 import java.util.List;
@@ -23,7 +22,7 @@ public class KafkaBridgeAdminClientConfiguration extends AbstractConfiguration {
 
     static {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
         DEFAULTS = new HashMap<>(0);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
+import io.strimzi.api.kafka.model.KafkaBridgeAdminClientSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeHttpConfig;
 import io.strimzi.api.kafka.model.KafkaBridge;
@@ -87,6 +88,7 @@ public class KafkaBridgeCluster extends AbstractModel {
     protected static final String OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/strimzi/oauth-certs/";
     protected static final String ENV_VAR_STRIMZI_TRACING = "STRIMZI_TRACING";
 
+    protected static final String ENV_VAR_KAFKA_BRIDGE_ADMIN_CLIENT_CONFIG = "KAFKA_BRIDGE_ADMIN_CLIENT_CONFIG";
     protected static final String ENV_VAR_KAFKA_BRIDGE_PRODUCER_CONFIG = "KAFKA_BRIDGE_PRODUCER_CONFIG";
     protected static final String ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG = "KAFKA_BRIDGE_CONSUMER_CONFIG";
     protected static final String ENV_VAR_KAFKA_BRIDGE_ID = "KAFKA_BRIDGE_ID";
@@ -112,6 +114,7 @@ public class KafkaBridgeCluster extends AbstractModel {
     private boolean httpEnabled = false;
     private boolean amqpEnabled = false;
     private String bootstrapServers;
+    private KafkaBridgeAdminClientSpec kafkaBridgeAdminClient;
     private KafkaBridgeConsumerSpec kafkaBridgeConsumer;
     private KafkaBridgeProducerSpec kafkaBridgeProducer;
     private List<ContainerEnvVar> templateContainerEnvVars;
@@ -160,6 +163,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         kafkaBridgeCluster.setImage(image);
         kafkaBridgeCluster.setReplicas(spec.getReplicas());
         kafkaBridgeCluster.setBootstrapServers(spec.getBootstrapServers());
+        kafkaBridgeCluster.setKafkaAdminClientConfiguration(spec.getAdminClient());
         kafkaBridgeCluster.setKafkaConsumerConfiguration(spec.getConsumer());
         kafkaBridgeCluster.setKafkaProducerConfiguration(spec.getProducer());
         if (kafkaBridge.getSpec().getLivenessProbe() != null) {
@@ -360,6 +364,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         }
 
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_BOOTSTRAP_SERVERS, bootstrapServers));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_ADMIN_CLIENT_CONFIG, kafkaBridgeAdminClient == null ? "" : new KafkaBridgeAdminClientConfiguration(kafkaBridgeAdminClient.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG, kafkaBridgeConsumer == null ? "" : new KafkaBridgeConsumerConfiguration(reconciliation, kafkaBridgeConsumer.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_PRODUCER_CONFIG, kafkaBridgeProducer == null ? "" : new KafkaBridgeProducerConfiguration(reconciliation, kafkaBridgeProducer.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_ID, cluster));
@@ -473,6 +478,14 @@ public class KafkaBridgeCluster extends AbstractModel {
      */
     protected void setHttpEnabled(boolean httpEnabled) {
         this.httpEnabled = httpEnabled;
+    }
+
+    /**
+     * Set Kafka AdminClient's configuration
+     * @param kafkaBridgeAdminClient configuration
+     */
+    protected void setKafkaAdminClientConfiguration(KafkaBridgeAdminClientSpec kafkaBridgeAdminClient) {
+        this.kafkaBridgeAdminClient = kafkaBridgeAdminClient;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -364,7 +364,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         }
 
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_BOOTSTRAP_SERVERS, bootstrapServers));
-        varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_ADMIN_CLIENT_CONFIG, kafkaBridgeAdminClient == null ? "" : new KafkaBridgeAdminClientConfiguration(kafkaBridgeAdminClient.getConfig().entrySet()).getConfiguration()));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_ADMIN_CLIENT_CONFIG, kafkaBridgeAdminClient == null ? "" : new KafkaBridgeAdminClientConfiguration(reconciliation, kafkaBridgeAdminClient.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG, kafkaBridgeConsumer == null ? "" : new KafkaBridgeConsumerConfiguration(reconciliation, kafkaBridgeConsumer.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_PRODUCER_CONFIG, kafkaBridgeProducer == null ? "" : new KafkaBridgeProducerConfiguration(reconciliation, kafkaBridgeProducer.getConfig().entrySet()).getConfiguration()));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_BRIDGE_ID, cluster));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -79,6 +79,7 @@ public class KafkaBridgeClusterTest {
     private final int healthTimeout = 5;
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
+    private final String defaultAdminclientConfiguration = "";
     private final String defaultProducerConfiguration = "";
     private final String defaultConsumerConfiguration = "";
 
@@ -121,6 +122,7 @@ public class KafkaBridgeClusterTest {
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_METRICS_ENABLED).withValue(String.valueOf(true)).build());
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(String.valueOf(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
+        expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_ADMIN_CLIENT_CONFIG).withValue(defaultAdminclientConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_CONSUMER_CONFIG).withValue(defaultConsumerConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_PRODUCER_CONFIG).withValue(defaultProducerConfiguration).build());
         expected.add(new EnvVarBuilder().withName(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_ID).withValue(cluster).build());

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2705,6 +2705,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |http              1.2+<.<a|The HTTP related configuration.
 |xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
+|adminClient       1.2+<.<a|Kafka AdminClient related configuration.
+|xref:type-KafkaBridgeAdminClientSpec-{context}[`KafkaBridgeAdminClientSpec`]
 |consumer          1.2+<.<a|Kafka consumer related configuration.
 |xref:type-KafkaBridgeConsumerSpec-{context}[`KafkaBridgeConsumerSpec`]
 |producer          1.2+<.<a|Kafka producer related configuration.
@@ -2777,6 +2779,19 @@ Used in: xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
 |string array
 |allowedMethods  1.2+<.<a|List of allowed HTTP methods.
 |string array
+|====
+
+[id='type-KafkaBridgeAdminClientSpec-{context}']
+### `KafkaBridgeAdminClientSpec` schema reference
+
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
+
+
+[options="header"]
+|====
+|Property       |Description
+|config  1.2+<.<a|The Kafka AdminClient configuration used for AdminClient instances created by the bridge.
+|map
 |====
 
 [id='type-KafkaBridgeConsumerSpec-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -224,6 +224,14 @@ spec:
                         - allowedMethods
                       description: CORS configuration for the HTTP Bridge.
                   description: The HTTP related configuration.
+                adminClient:
+                  type: object
+                  properties:
+                    config:
+                      x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                      description: The Kafka AdminClient configuration used for AdminClient instances created by the bridge.
+                  description: Kafka AdminClient related configuration.
                 consumer:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -256,6 +256,15 @@ spec:
                     - allowedMethods
                     description: CORS configuration for the HTTP Bridge.
                 description: The HTTP related configuration.
+              adminClient:
+                type: object
+                properties:
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: The Kafka AdminClient configuration used for AdminClient
+                      instances created by the bridge.
+                description: Kafka AdminClient related configuration.
               consumer:
                 type: object
                 properties:


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change

- Bugfix
- Enhancement / new feature

### Description

The KafkaBridge CRD should support configuring AminClient used by the Bridge. This is applicable after https://github.com/strimzi/strimzi-kafka-bridge/pull/524 is merged and the new Bridge version is released.
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/5070

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

