### PR TITLE
Remove bind-utils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
 
 ### Changes, deprecations and removals
 
-* The fields `topicsBlacklistPattern` and `groupsBlacklistPattern` in the `KafkaMirrorMaker2` resource are deprecated and will be removed in the future. 
+* The fields `topicsBlacklistPattern` and `groupsBlacklistPattern` in the `KafkaMirrorMaker2` resource are deprecated and will be removed in the future.
   They are replaced by new fields `topicsExcludePattern` and `groupsExcludePattern`.
 * The field `whitelist` in the `KafkaMirrorMaker` resource is deprecated and will be removed in the future.
-  It is replaced with a new field `include`. 
+  It is replaced with a new field `include`.
+* `bind-utils` removed from containers to improve security posture.
 
 ## 0.23.0
 

--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -3,7 +3,7 @@ export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packagin
 export JAVA_MAIN=io.strimzi.operator.cluster.Main
 
 if [ -z "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then
-  KUBERNETES_SERVICE_DNS_DOMAIN=$(nslookup kubernetes.default | grep "Name:" | sed "s/Name:\skubernetes.default.svc.//")
+  KUBERNETES_SERVICE_DNS_DOMAIN=$(getent hosts kubernetes.default | head -1 | sed "s/.*\skubernetes.default.svc.//")
   if [ -n "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then
     echo "Auto-detected KUBERNETES_SERVICE_DNS_DOMAIN: $KUBERNETES_SERVICE_DNS_DOMAIN"
     export KUBERNETES_SERVICE_DNS_DOMAIN

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 USER root
 
 RUN microdnf update \
-    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl bind-utils procps shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl procps shadow-utils \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-11


### PR DESCRIPTION
Signed-off-by: Michael McLeroy <michaelmcleroy@cloudfitsoftware.com>

### Type of change

- Enhancement / new feature

### Description

Remove dependency on bind-utils to eliminate potential security vulnerabilities with Bind in the containers.  

History: Bind-utils was [originally added](https://github.com/strimzi/strimzi-kafka-operator/issues/1926) to aid in network debugging.  Later, a [feature was added](https://github.com/strimzi/strimzi-kafka-operator/pull/4009) to autodetect the Kubernetes Services DNS suffix.

Log from strimzi-cluster-operator (Line 1 is result of code change and identical to original):
```shell
Auto-detected KUBERNETES_SERVICE_DNS_DOMAIN: cluster.local
+ export MALLOC_ARENA_MAX=2
+ MALLOC_ARENA_MAX=2
+ JAVA_OPTS=' -Dlog4j2.configurationFile=file:/opt/strimzi/custom-config/log4j2.properties -Dvertx.cacheDirBase=/tmp/vertx-cache -Djava.security.egd=file:/dev/./urandom'
++ get_gc_opts
++ '[' '' == true ']'
++ echo ''
+ JAVA_OPTS=' -Dlog4j2.configurationFile...
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

