### PR TITLE
Add Kafka Kubernetes Config Provider to Strimzi operand images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.24.0
 
+* Add support for [Kubernetes Configuration Provider for Apache Kafka](https://github.com/strimzi/kafka-kubernetes-config-provider)
 * Use Red Hat UBI8 base image
 * Add support for Kafka 2.7.1 and remove support for 2.6.0, 2.6.1, and 2.6.2
 * Support for patching of service accounts and configuring their labels and annotations. The feature is disabled by default and enabled using the new `ServiceAccountPatching` feature gate.

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -20,12 +20,17 @@
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
+        <kafka-kubernetes-config-provider.version>1.0.0-SNAPSHOT</kafka-kubernetes-config-provider.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -284,6 +289,26 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-quotas-plugin</artifactId>
             <version>${kafka-quotas-plugin.version}</version>
+        </dependency>
+        <!-- Kubernetes Configuration Provider for Apache Kafka -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-kubernetes-config-provider</artifactId>
+            <version>${kafka-kubernetes-config-provider.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -20,17 +20,13 @@
         <cruise-control.version>2.5.37</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
-        <kafka-kubernetes-config-provider.version>1.0.0-SNAPSHOT</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
-        </repository>
-        <repository>
-            <id>snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -20,17 +20,13 @@
         <cruise-control.version>2.5.46</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
-        <kafka-kubernetes-config-provider.version>1.0.0-SNAPSHOT</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
-        </repository>
-        <repository>
-            <id>snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -20,12 +20,17 @@
         <cruise-control.version>2.5.46</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
+        <kafka-kubernetes-config-provider.version>1.0.0-SNAPSHOT</kafka-kubernetes-config-provider.version>
     </properties>
 
     <repositories>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -284,6 +289,26 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-quotas-plugin</artifactId>
             <version>${kafka-quotas-plugin.version}</version>
+        </dependency>
+        <!-- Kubernetes Configuration Provider for Apache Kafka -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-kubernetes-config-provider</artifactId>
+            <version>${kafka-kubernetes-config-provider.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the Kubernetes Configuration Provider for Apache Kafka (see [SP27](https://github.com/strimzi/proposals/blob/main/027-kubernetes-config-provider.md)) to the Strimzi operand images so that it can be used for example in Connector configuration etc. Documentation will be done at a later point.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md