### PR TITLE
Experimental ZooKeeper-less implementation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaSpec.java
@@ -55,7 +55,6 @@ public class KafkaSpec extends Spec {
     }
 
     @Description("Configuration of the ZooKeeper cluster")
-    @JsonProperty(required = true)
     public ZookeeperClusterSpec getZookeeper() {
         return zookeeper;
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -52,7 +52,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
             KubeClusterException.class,
             () -> createDeleteCustomResource("Kafka-with-missing-required-property.yaml"));
 
-        assertMissingRequiredPropertiesMessage(exception.getMessage(), "zookeeper", "kafka");
+        assertMissingRequiredPropertiesMessage(exception.getMessage(), "kafka");
     }
 
     @Test

--- a/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/040-Crd-kafka.yaml
@@ -6129,7 +6129,6 @@ spec:
                   certificates renewal). Each time window is defined by a cron expression.
             required:
             - kafka
-            - zookeeper
             description: The specification of the Kafka and ZooKeeper clusters, and
               Topic Operator.
           status:
@@ -14667,7 +14666,6 @@ spec:
                   certificates renewal). Each time window is defined by a cron expression.
             required:
             - kafka
-            - zookeeper
             description: The specification of the Kafka and ZooKeeper clusters, and
               Topic Operator.
           status:
@@ -23205,7 +23203,6 @@ spec:
                   certificates renewal). Each time window is defined by a cron expression.
             required:
             - kafka
-            - zookeeper
             description: The specification of the Kafka and ZooKeeper clusters, and
               Topic Operator.
           status:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -18,10 +18,12 @@ public class FeatureGates {
 
     private static final String CONTROL_PLANE_LISTENER = "ControlPlaneListener";
     private static final String SERVICE_ACCOUNT_PATCHING = "ServiceAccountPatching";
+    private static final String ESCAPE_THE_ZOO = "EscapeTheZoo";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate controlPlaneListener = new FeatureGate(CONTROL_PLANE_LISTENER, false);
     private final FeatureGate serviceAccountPatching = new FeatureGate(SERVICE_ACCOUNT_PATCHING, false);
+    private final FeatureGate escapeTheZoo = new FeatureGate(ESCAPE_THE_ZOO, false);
 
     /**
      * Constructs the feature gates configuration.
@@ -48,6 +50,9 @@ public class FeatureGates {
                         break;
                     case SERVICE_ACCOUNT_PATCHING:
                         setValueOnlyOnce(serviceAccountPatching, value);
+                        break;
+                    case ESCAPE_THE_ZOO:
+                        setValueOnlyOnce(escapeTheZoo, value);
                         break;
                     default:
                         throw new InvalidConfigurationException("Unknown feature gate " + featureGate + " found in the configuration");
@@ -86,12 +91,20 @@ public class FeatureGates {
     }
 
     /**
+     * @return  Returns true when the EscapeTheZoo feature gate is enabled
+     */
+    public boolean escapeTheZooEnabled() {
+        return escapeTheZoo.isEnabled();
+    }
+
+    /**
      * Returns a list of all Feature gates. Used for testing.
      *
      * @return  List of all Feature Gates
      */
     /*test*/ List<FeatureGate> allFeatureGates()  {
         return List.of(
+                escapeTheZoo,
                 controlPlaneListener,
                 serviceAccountPatching
         );
@@ -100,6 +113,7 @@ public class FeatureGates {
     @Override
     public String toString() {
         return "FeatureGates(" +
+                "escapeTheZoo=" + escapeTheZoo.isEnabled() + "," +
                 "controlPlaneListener=" + controlPlaneListener.isEnabled() + "," +
                 "ServiceAccountPatching=" + serviceAccountPatching.isEnabled() +
                 ")";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1851,8 +1851,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 log.debug("{}: Creating AdminClient for clusterId using {}", reconciliation, bootstrapHostname);
                                 kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, compositeFuture.resultAt(0), compositeFuture.resultAt(1), "cluster-operator");
                                 kafkaStatus.setClusterId(kafkaAdmin.describeCluster().clusterId().get());
-                            //} catch (KafkaException e) {
-                            //    log.warn("{}: Kafka exception getting clusterId {}", reconciliation, e.getMessage());
+                            } catch (KafkaException e) {
+                                log.warn("{}: Kafka exception getting clusterId {}", reconciliation, e.getMessage());
                             } catch (InterruptedException e) {
                                 log.warn("{}: Interrupted exception getting clusterId {}", reconciliation, e.getMessage());
                             } catch (ExecutionException e) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -394,7 +394,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     @ParallelTest
     public void testWithControlPlaneListenerActive() {
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", emptyList(), true)
+                .withListeners("my-cluster", "my-namespace", emptyList(), true, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -424,7 +424,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     @ParallelTest
     public void testWithNoListeners() {
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", emptyList(), false)
+                .withListeners("my-cluster", "my-namespace", emptyList(), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -491,7 +491,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", asList(listener1, listener2, listener3, listener4), false)
+                .withListeners("my-cluster", "my-namespace", asList(listener1, listener2, listener3, listener4), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -531,7 +531,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -569,7 +569,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -607,7 +607,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -648,7 +648,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -698,7 +698,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -737,7 +737,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -778,7 +778,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -823,7 +823,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -871,7 +871,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -910,7 +910,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
         
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -949,7 +949,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -985,7 +985,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -1024,7 +1024,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -1072,7 +1072,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -1121,7 +1121,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -1166,7 +1166,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -1219,7 +1219,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
         
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",
@@ -1270,7 +1270,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder()
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), false, false)
                 .build();
 
         assertThat(configuration, isEquivalent("listener.name.controlplane-9090.ssl.client.auth=required",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -655,7 +655,7 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> logNameCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.reconcile(anyString(), logNameCaptor.capture(), logCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
 
-        ConfigMap metricsCm = kafkaCluster.generateAncillaryConfigMap(new MetricsAndLogging(metricsCM, null), emptySet(), emptySet(), false);
+        ConfigMap metricsCm = kafkaCluster.generateAncillaryConfigMap(new MetricsAndLogging(metricsCM, null), emptySet(), emptySet(), false, false);
         when(mockCmOps.getAsync(kafkaNamespace, KafkaCluster.metricAndLogConfigsName(kafkaName))).thenReturn(Future.succeededFuture(metricsCm));
         when(mockCmOps.getAsync(kafkaNamespace, metricsCMName)).thenReturn(Future.succeededFuture(metricsCM));
         when(mockCmOps.getAsync(kafkaNamespace, differentMetricsCMName)).thenReturn(Future.succeededFuture(metricsCM));
@@ -1003,7 +1003,7 @@ public class KafkaAssemblyOperatorTest {
                 .endMetadata()
                 .withData(singletonMap("metrics-config.yml", ""))
                 .build();
-        ConfigMap metricsAndLoggingCm = originalKafkaCluster.generateAncillaryConfigMap(new MetricsAndLogging(metricsCm, null), emptySet(), emptySet(), false);
+        ConfigMap metricsAndLoggingCm = originalKafkaCluster.generateAncillaryConfigMap(new MetricsAndLogging(metricsCm, null), emptySet(), emptySet(), false, false);
         when(mockCmOps.get(clusterNamespace, KafkaCluster.metricAndLogConfigsName(clusterName))).thenReturn(metricsAndLoggingCm);
         when(mockCmOps.getAsync(clusterNamespace, KafkaCluster.metricAndLogConfigsName(clusterName))).thenReturn(Future.succeededFuture(metricsAndLoggingCm));
 

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -13,10 +13,6 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$KAFKA_HOME/custom-config/log4j.properties"
 fi
 
-rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
-KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
-export KAFKA_OPTS
-
 . ./set_kafka_jmx_options.sh "${KAFKA_JMX_ENABLED}" "${KAFKA_JMX_USERNAME}" "${KAFKA_JMX_PASSWORD}"
 
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
@@ -46,6 +42,26 @@ mkdir -p /tmp/kafka
 echo "Starting Kafka with configuration:"
 ./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
+
+# Prepare for Kraft
+if [ -n "$CLUSTER_ID" ]; then
+  KRAFT_LOG_DIR=$(grep "log\.dirs=" /tmp/strimzi.properties | sed "s/log\.dirs=*//")
+
+  if [ ! -f "$KRAFT_LOG_DIR/meta.properties" ]; then
+    echo "Formatting Kraft storage"
+    mkdir -p "$KRAFT_LOG_DIR"
+    ./bin/kafka-storage.sh format -t "$CLUSTER_ID" -c /tmp/strimzi.properties
+  else
+    echo "Kraft storage is already formatted"
+  fi
+
+  touch /var/opt/kafka/kafka-ready
+  touch /var/opt/kafka/zk-connected
+else
+  rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
+  KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
+  export KAFKA_OPTS
+fi
 
 if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
     . ./dynamic_resources.sh

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5321,7 +5321,6 @@ spec:
                   description: A list of time windows for maintenance tasks (that is, certificates renewal). Each time window is defined by a cron expression.
               required:
                 - kafka
-                - zookeeper
               description: The specification of the Kafka and ZooKeeper clusters, and Topic Operator.
             status:
               type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6273,7 +6273,6 @@ spec:
                   certificates renewal). Each time window is defined by a cron expression.
             required:
             - kafka
-            - zookeeper
             description: The specification of the Kafka and ZooKeeper clusters, and
               Topic Operator.
           status:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Prototype / experimental implementation of ZooKeeper-less Kafka. This is not intended as future _production grade_ implementation, but might help with development and testing of different sub-components to work with Kafka after ZooKeeper removal.

It is protected by a feature gate `EscapeTheZoo` => to activate, set in the `STRIMZI_FEATURE_GATES` environment variable `+EscapeTheZoo` and create the Kafka CR without the `.spec.zookeeper` section (you should also avoid `.spec.cruiseControl` and `spec.entityOperator` unless you want to develop them to work without ZooKeeper ;-)).

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

