### PR TITLE
Make certificate preparation in TLS sidecars less sensitive on new-lines

### DIFF
--- a/docker-images/kafka/stunnel-scripts/cruise_control_stunnel_config_generator.sh
+++ b/docker-images/kafka/stunnel-scripts/cruise_control_stunnel_config_generator.sh
@@ -5,7 +5,10 @@ set -e
 CC_CERTS_KEYS=/etc/tls-sidecar/cc-certs
 # Combine all the certs in the cluster CA into one file
 CA_CERTS=/tmp/cluster-ca.crt
-cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
+for cert in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
+  sed -z '$ s/\n$//' "$cert" >> "$CA_CERTS"
+  echo "" >> "$CA_CERTS"
+done
 
 echo "pid = /tmp/stunnel.pid"
 echo "foreground = yes"

--- a/docker-images/kafka/stunnel-scripts/entity_operator_stunnel_config_generator.sh
+++ b/docker-images/kafka/stunnel-scripts/entity_operator_stunnel_config_generator.sh
@@ -5,7 +5,10 @@ set -e
 EO_CERTS_KEYS=/etc/tls-sidecar/eo-certs
 # Combine all the certs in the cluster CA into one file
 CA_CERTS=/tmp/cluster-ca.crt
-cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
+for cert in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
+  sed -z '$ s/\n$//' "$cert" >> "$CA_CERTS"
+  echo "" >> "$CA_CERTS"
+done
 
 echo "pid = /tmp/stunnel.pid"
 echo "foreground = yes"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the CA secret contains multiple public keys, we have to merge them into a single file in the TLS sidecars for CC and EO. But the current way of merging them is sensitive to whether the do or do not contain a new-line at the end. When they do not have the new-line, they end up like this:

```
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```

And `stunnel` cannot read them and fails.

This PR improves the way the certificates are merged to make sure it works regardless the new line. It first removes the last new-line if there is any (to avoid double new-lines) and then adds another new-line. This way the file should always look the same.

This issue was originally raised as part of #4769.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging