### PR TITLE
Fix wrongly committed Helm Chart improvement

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -169,7 +169,6 @@ the documentation for more details.
 | `readinessProbe.periodSeconds`       | Readiness probe period in seconds         | 30                                                   |
 | `imageRegistryOverride`              | Override all image registry config        | `nil`                                                |
 | `imageRepositoryOverride`            | Override all image repository config      | `nil`                                                |
-| `labelsExclusionPattern`             | Override the exclude pattern for exclude some labels             | `""`  
 | `imageTagOverride`                   | Override all image tag config             | `nil`                                                |
 | `createGlobalResources`              | Allow creation of cluster-scoped resources| `true`                                               |
 | `tolerations`                        | Add tolerations to Operator Pod           | `[]`                                                 |

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -107,10 +107,6 @@ spec:
               value: {{ .Values.kubernetesServiceDnsDomain | quote }}{{ end }}
             - name: STRIMZI_FEATURE_GATES
               value: {{ .Values.featureGates | quote }}
-            {{- if .Values.labelsExclusionPattern }}
-            - name: STRIMZI_LABELS_EXCLUSION_PATTERN
-              value: {{ .Values.labelsExclusionPattern | quote }}
-            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -144,5 +144,3 @@ imageRepositoryOverride: ""
 # Override the docker image tag used by all Strimzi images
 imageTagOverride: ""
 createGlobalResources: true
-# Override the exclude pattern for exclude some labels
-labelsExclusionPattern: ""

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -177,6 +177,7 @@ the documentation for more details.
 | `labels`                             | Add labels to Operator Pod                | `{}`                                                 |
 | `nodeSelector`                       | Add a node selector to Operator Pod       | `{}`                                                 |
 | `featureGates`                       | Feature Gates configuration               | ``                                                   |
+| `labelsExclusionPattern`             | Override the exclude pattern for exclude some labels             | `""`  
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -107,6 +107,10 @@ spec:
               value: {{ .Values.kubernetesServiceDnsDomain | quote }}{{ end }}
             - name: STRIMZI_FEATURE_GATES
               value: {{ .Values.featureGates | quote }}
+            {{- if .Values.labelsExclusionPattern }}
+            - name: STRIMZI_LABELS_EXCLUSION_PATTERN
+              value: {{ .Values.labelsExclusionPattern | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -144,3 +144,5 @@ imageRepositoryOverride: ""
 # Override the docker image tag used by all Strimzi images
 imageTagOverride: ""
 createGlobalResources: true
+# Override the exclude pattern for exclude some labels
+labelsExclusionPattern: ""


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #5083 we screwed up during the review process and committed the changes to the released Helm Chart in `helm-chart`. This PR tries to fixit. It:
* Reverts the changes in the `/helm-charts`
* Adds the same changes to `packaging/helm-charts`