### PR TITLE
Updated Mirrormaker2 docs #3204

### DIFF
--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -34,14 +34,26 @@ spec:
   version: {DefaultKafkaVersion}
   connectCluster: "my-cluster-target"
   clusters:
-  - alias: "my-cluster-source"
-    bootstrapServers: my-cluster-source-kafka-bootstrap:9092
-  - alias: "my-cluster-target"
-    bootstrapServers: my-cluster-target-kafka-bootstrap:9092
+  - alias: "sourceCluster"
+    bootstrapServers: my-source-cluster-bootstrap:9094
+    config:
+      config.storage.replication.factor: 1
+      offset.storage.replication.factor: 1
+      status.storage.replication.factor: 1
+  - alias: "targetCluster"
+    bootstrapServers: my-target-cluster-bootstrap:9092
+    config:
+      producer.compression.type: zstd
   mirrors:
-  - sourceCluster: "my-cluster-source"
-    targetCluster: "my-cluster-target"
-    sourceConnector: {}
+  - sourceCluster: "my-source-cluster"
+    targetCluster: "my-target-cluster"
+    sourceConnector:
+      config:
+        replication.factor: 1
+        offset-syncs.topic.replication.factor: 1
+        sync.topic.acls.enabled: "false"
+        replication.policy.separator: ""
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy
 ----
 
 You can configure access control for source and target clusters using TLS or SASL authentication.

--- a/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -7,25 +7,30 @@ spec:
   replicas: 1
   connectCluster: "my-target-cluster"
   clusters:
-  - alias: "my-source-cluster"
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
-  - alias: "my-target-cluster"
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+  - alias: "sourceCluster"
+    bootstrapServers: my-source-cluster-bootstrap:9094
     config:
-      # -1 means it will use the default replication factor configured in the broker
-      config.storage.replication.factor: -1
-      offset.storage.replication.factor: -1
-      status.storage.replication.factor: -1
+      config.storage.replication.factor: 1
+      offset.storage.replication.factor: 1
+      status.storage.replication.factor: 1
+  - alias: "targetCluster"
+    bootstrapServers: my-target-cluster-bootstrap:9092
+    config:
+      producer.compression.type: zstd
+    
+  
   mirrors:
-  - sourceCluster: "my-source-cluster"
-    targetCluster: "my-target-cluster"
+  - sourceCluster: "sourceCluster"
+    targetCluster: "targetCluster"
     sourceConnector:
       config:
-        replication.factor: 1
-        offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
-        replication.policy.separator: ""
-        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy"
+        consumer.fetch.min.bytes: 262144
+        consumer.fetch.max.wait.ms: 10000
+        consumer.max.poll.records: 5000
+        # -1 means it will use the default replication factor configured in the broker
+        consumer.receive.buffer.bytes: -1
+        consumer.send.buffer.bytes: -1
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 1

--- a/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -7,30 +7,25 @@ spec:
   replicas: 1
   connectCluster: "my-target-cluster"
   clusters:
-  - alias: "sourceCluster"
-    bootstrapServers: my-source-cluster-bootstrap:9094
+  - alias: "my-source-cluster"
+    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
+  - alias: "my-target-cluster"
+    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
     config:
-      config.storage.replication.factor: 1
-      offset.storage.replication.factor: 1
-      status.storage.replication.factor: 1
-  - alias: "targetCluster"
-    bootstrapServers: my-target-cluster-bootstrap:9092
-    config:
-      producer.compression.type: zstd
-    
-  
+      # -1 means it will use the default replication factor configured in the broker
+      config.storage.replication.factor: -1
+      offset.storage.replication.factor: -1
+      status.storage.replication.factor: -1
   mirrors:
-  - sourceCluster: "sourceCluster"
-    targetCluster: "targetCluster"
+  - sourceCluster: "my-source-cluster"
+    targetCluster: "my-target-cluster"
     sourceConnector:
       config:
+        replication.factor: 1
+        offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
-        consumer.fetch.min.bytes: 262144
-        consumer.fetch.max.wait.ms: 10000
-        consumer.max.poll.records: 5000
-        # -1 means it will use the default replication factor configured in the broker
-        consumer.receive.buffer.bytes: -1
-        consumer.send.buffer.bytes: -1
+        replication.policy.separator: ""
+        replication.policy.class: "io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy"
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 1


### PR DESCRIPTION
Signed-off-by: Rupesh <punnarupeshkoushik@gmail.com>

### Updated docs don't describe how to enable compression in the target cluster

_Select the type of your PR_
- Documentation

### Description

This PR updated the Mirror maker 2 docs [clusters and mirrors] issue #3204 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

