### PR TITLE
Add last Kafka Connect S2I deprecation warning to the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Changes, deprecations and removals
 
+* The deprecated `KafkaConnectS2I` custom resource will be removed after the 0.24.0 release. 
+  Please use the [migration guide](https://strimzi.io/docs/operators/latest/full/using.html#proc-migrating-kafka-connect-s2i-str) to migrate your `KafkaConnectS2I` deployments to [`KafkaConnect` Build](https://strimzi.io/docs/operators/latest/full/deploying.html#creating-new-image-using-kafka-connect-build-str) instead.
 * The fields `topicsBlacklistPattern` and `groupsBlacklistPattern` in the `KafkaMirrorMaker2` resource are deprecated and will be removed in the future.
   They are replaced by new fields `topicsExcludePattern` and `groupsExcludePattern`.
 * The field `whitelist` in the `KafkaMirrorMaker` resource is deprecated and will be removed in the future.

--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -18,7 +18,7 @@ Use the `KafkaConnectS2I` resource if you are using the {docs-okd-s2i} framework
 * The full schema of the `KafkaConnectS2I` resource is described in xref:type-KafkaConnectS2I-reference[].
 
 IMPORTANT: With the introduction of `build` configuration to the `KafkaConnect` resource, Strimzi can now automatically build a container image with the connector plugins you require for your data connections.
-As a result, support for Kafka Connect with Source-to-Image (S2I) is deprecated. To prepare for this change, you can xref:proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
+As a result, support for Kafka Connect with Source-to-Image (S2I) is deprecated and will be removed after Strimzi {ProductVersion}. To prepare for this change, you can xref:proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
 
 .Additional resources
 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-openshift-builds-image.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-openshift-builds-image.adoc
@@ -17,7 +17,7 @@ It creates a new Kafka Connect image from this directory, which can then be used
 When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the `/tmp/kafka-plugins/s2i` directory.
 
 IMPORTANT: With the introduction of `build` configuration to the `KafkaConnect` resource, Strimzi can now automatically build a container image with the connector plugins you require for your data connections.
-As a result, support for Kafka Connect with Source-to-Image (S2I) is deprecated. To prepare for this change, you can link:{BookURLUsing}#proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
+As a result, support for Kafka Connect with Source-to-Image (S2I) is deprecated and will be removed after Strimzi {ProductVersion}. To prepare for this change, you can link:{BookURLUsing}#proc-migrating-kafka-connect-s2i-{context}[migrate Kafka Connect S2I instances to Kafka Connect instances].
 
 .Procedure
 


### PR DESCRIPTION
### Type of change

- Task

### Description

`KafkaConnectS2I` resource is planned to be removed after Strimzi 0.24. This PR adds _last warning_ to the CHANGELOG.MD file. It also adds more exact removal version to the existing deprecation note in the documentation.
