### PR TITLE
[systemtest] Fixup for LogCollector

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -14,7 +14,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
@@ -47,7 +47,7 @@ public class LogCollector implements LogCollect {
         // Get current date to create a unique folder
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
         dateTimeFormatter = dateTimeFormatter.withZone(ZoneId.of("GMT"));
-        CURRENT_DATE = dateTimeFormatter.format(LocalDate.now());
+        CURRENT_DATE = dateTimeFormatter.format(LocalDateTime.now());
     }
 
     private final KubeClient kubeClient;


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes problem with `UnsupportedTemporalTypeException: Unsupported field: HourOfDay` in LogCollector, which we hit several times in the AZP. I'm changing the `LocalDate.now()` to `LocalDateTime.now()` which will ensure that the correct time will be present.

### Checklist

- [x] Make sure all tests pass

