### PR TITLE
Make sure `getCruiseControlDescription` returns only after it collected / created the description

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3348,8 +3348,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         private final Future<ReconciliationState> getCruiseControlDescription() {
             CruiseControl cruiseControl = CruiseControl.fromCrd(reconciliation, kafkaAssembly, versions);
+
             if (cruiseControl != null) {
-                Util.metricsAndLogging(reconciliation, configMapOperations, kafkaAssembly.getMetadata().getNamespace(),
+                return Util.metricsAndLogging(reconciliation, configMapOperations, kafkaAssembly.getMetadata().getNamespace(),
                         cruiseControl.getLogging(), cruiseControl.getMetricsConfigInCm())
                         .compose(metricsAndLogging -> {
                             ConfigMap logAndMetricsConfigMap = cruiseControl.generateMetricsAndLogConfigMap(metricsAndLogging);
@@ -3358,12 +3359,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                             this.cruiseControlMetricsAndLogsConfigMap = logAndMetricsConfigMap;
                             this.cruiseControl = cruiseControl;
-
                             this.ccDeployment = cruiseControl.generateDeployment(pfa.isOpenshift(), annotations, imagePullPolicy, imagePullSecrets);
+
                             return Future.succeededFuture(this);
                         });
+            } else {
+                return withVoid(Future.succeededFuture());
             }
-            return withVoid(Future.succeededFuture());
         }
 
         Future<ReconciliationState> cruiseControlServiceAccount() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3346,7 +3346,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return stsGeneration == podGeneration;
         }
 
-        private final Future<ReconciliationState> getCruiseControlDescription() {
+        /*test*/ final Future<ReconciliationState> getCruiseControlDescription() {
             CruiseControl cruiseControl = CruiseControl.fromCrd(reconciliation, kafkaAssembly, versions);
 
             if (cruiseControl != null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -30,6 +31,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.IngressV1Beta1Operator;
@@ -322,6 +324,58 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
 
                     assertThat(clusterCaCertSecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
                     assertThat(clusterCaKeySecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
+
+                    async.flag();
+                })));
+    }
+
+    /*
+     * This test covers the issue described in PR #5128 / issue #5126 where the getCruiseControlDescription returns
+     * without really waiting for the actual description. the way it is tested here is that we trigger an error when
+     * querying the metrics CM needed for the description and check that the reconciliation fails because of it which
+     * means the right outcome is returned.
+     */
+    @Test
+    public void testCruiseControlDescription(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewCruiseControl()
+                        .withNewJmxPrometheusExporterMetricsConfig()
+                            .withNewValueFrom()
+                                .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-metrics-cm").withKey("my-metrics.yaml").build())
+                            .endValueFrom()
+                        .endJmxPrometheusExporterMetricsConfig()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        ConfigMapOperator cmOps = supplier.configMapOperations;
+        when(cmOps.getAsync(eq(NAMESPACE), eq("my-metrics-cm"))).thenReturn(Future.failedFuture("Failed ConfigMap getAsync call"));
+
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+                supplier, ResourceUtils.dummyClusterOperatorConfig(KafkaVersionTestUtils.getKafkaVersionLookup(), 1L));
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+
+        Checkpoint async = context.checkpoint();
+
+        op.new ReconciliationState(reconciliation, kafka).getCruiseControlDescription()
+                .onComplete(context.failing(c -> context.verify(() -> {
+                    assertThat(c.getMessage(), is("Failed ConfigMap getAsync call"));
 
                     async.flag();
                 })));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `getCruiseControlDescription` in `KafkaAssemblyOperator` is missing return statement when Cruise Control is configured and instead returns as if it was not. That causes the description to be collected asynchronously while the next methods are already running. #5126 describes how it can cause the SA or Network Policy to be deleted although Cruise Control itself is enabled. This bug probably exists for some time, but it was less visible when the metrics configuration was done inline in the Kafka CR since now with the metrics configuration in a ConfigMap, we actually query the ConfigMap which takes more time.

This PR fixes the code to return only after the description is collected / created and the network policies or service accounts should be created properly every recocniliation.

This should close #5126 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging