### PR TITLE
Refactor OpenSslCertManager and Subject

### DIFF
--- a/certificate-manager/pom.xml
+++ b/certificate-manager/pom.xml
@@ -19,6 +19,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>
@@ -46,6 +50,16 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/CertManager.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public interface CertManager {
@@ -33,6 +34,14 @@ public interface CertManager {
      * @throws IOException If an input or output file could not be read/written.
      */
     void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException;
+
+    void generateRootCaCert(Subject subject, File subjectKeyFile, File subjectCertFile,
+                            ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException;
+
+    void generateIntermediateCaCert(File issuerCaKeyFile, File issuerCaCertFile,
+                                    Subject subject,
+                                    File subjectKeyFile, File subjectCertFile,
+                                    ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException;
 
     /**
      * Add the provided certificate to the truststore which is created if it doesn't exist

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -119,7 +119,7 @@ public class OpenSslCertManager implements CertManager {
                 out.append("basicConstraints = critical,CA:true,pathlen:0\n");
             }
             if (sbj != null) {
-                if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+                if (sbj.hasSubjectAltNames()) {
                     out.append("subjectAltName = @alt_names\n" +
                             "\n" +
                             "[alt_names]\n");
@@ -231,7 +231,7 @@ public class OpenSslCertManager implements CertManager {
         if (pathLength < 0) {
             throw new IllegalArgumentException("pathLength cannot be negative: " + pathLength);
         }
-        if (subject.subjectAltNames() != null && !subject.subjectAltNames().isEmpty()) {
+        if (subject.hasSubjectAltNames()) {
             throw new IllegalArgumentException("CA certificates should not have Subject Alternative Names");
         }
 
@@ -403,14 +403,12 @@ public class OpenSslCertManager implements CertManager {
                     .opt("-batch")
                     .optArg("-out", csrFile)
                     .optArg("-key", keyFile);
-            if (subject != null) {
-                if (subject.subjectAltNames() != null && subject.subjectAltNames().size() > 0) {
-                    sna = buildConfigFile(subject, true);
-                    args.optArg("-config", sna, true).optArg("-extensions", "v3_req");
-                }
-                args.optArg("-subj", subject);
-            }
 
+            if (subject.hasSubjectAltNames()) {
+                sna = buildConfigFile(subject, true);
+                args.optArg("-config", sna, true).optArg("-extensions", "v3_req");
+            }
+            args.optArg("-subj", subject);
             args.exec();
             delete(sna);
 
@@ -444,18 +442,13 @@ public class OpenSslCertManager implements CertManager {
 
         Path sna = null;
         try {
-            if (subject != null) {
-
-                if (subject.subjectAltNames() != null && subject.subjectAltNames().size() > 0) {
-
-                    // subject alt names need to be in an openssl configuration file
-                    sna = buildConfigFile(subject, false);
-                    cmd.optArg("-config", sna, true).optArg("-extensions", "v3_req");
-                }
-
-                cmd.optArg("-subj", subject);
+            if (subject.hasSubjectAltNames()) {
+                // subject alt names need to be in an openssl configuration file
+                sna = buildConfigFile(subject, false);
+                cmd.optArg("-config", sna, true).optArg("-extensions", "v3_req");
             }
 
+            cmd.optArg("-subj", subject);
             cmd.exec();
         } finally {
             delete(sna);
@@ -499,7 +492,7 @@ public class OpenSslCertManager implements CertManager {
                     .optArg("-enddate", notAfter)
                     .optArg("-config", defaultConfig, true);
 
-            if (sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
+            if (sbj.hasSubjectAltNames()) {
                 cmd.optArg("-extensions", "v3_req");
                 // subject alt names need to be in an openssl configuration file
                 sna = buildConfigFile(sbj, false);

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -24,6 +24,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -59,8 +60,15 @@ public class OpenSslCertManager implements CertManager {
 
     private static final Logger LOGGER = LogManager.getLogger(OpenSslCertManager.class);
     public static final ZoneId UTC = ZoneId.of("UTC");
+    private final Clock clock;
 
-    public OpenSslCertManager() {}
+    public OpenSslCertManager() {
+        this(Clock.systemUTC());
+    }
+
+    public OpenSslCertManager(Clock clock) {
+        this.clock = clock;
+    }
 
     void checkValidity(ZonedDateTime notBefore, ZonedDateTime notAfter) {
         Objects.requireNonNull(notBefore);
@@ -131,95 +139,91 @@ public class OpenSslCertManager implements CertManager {
 
     @Override
     public void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
-        Instant now = Instant.now();
+        Instant now = clock.instant();
         ZonedDateTime notBefore = now.atZone(UTC);
         ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
-        generateRootCaCert(keyFile, certFile, sbj, notBefore, notAfter, 0);
+        generateRootCaCert(sbj, keyFile, certFile, notBefore, notAfter, 0);
     }
 
-    public void generateRootCaCert(File keyFile, File certFile, Subject subject,
+    public void generateIntermediateCert(File keyFile, File certFile, Subject sbj, File subjectKeyFile, File subjectCertFile, int pathLen, int days) throws IOException {
+        Instant now = clock.instant();
+        ZonedDateTime notBefore = now.atZone(UTC);
+        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
+        generateIntermediateCaCert(keyFile, certFile, sbj, subjectKeyFile,
+                subjectCertFile, notBefore, notAfter, pathLen);
+    }
+
+    /**
+     * Generate a root (i.e. self-signed) CA certificate, using either a new CA key or reusing an existing subject key.
+     *
+     * @param subject The required subject, SAN etc..
+     * @param subjectKeyFile The subject key file.
+     *                       If this file is empty then a new CA key will be generated and populated by this call.
+     *                       Otherwise it is assumed to contain the existing CA key in PKCS#8 format.
+     * @param subjectCertFile The subject certificate file, populated by this call.
+     * @param notBefore The required NotBefore date of the issued certificate.
+     * @param notAfter The required NotAfter date of the issued certificate.
+     * @param pathLength The number of CA certificates below this certificate in a certificate chain.
+     *                   For example, this would be 0 if the CA certificate and key produced by this call would
+     *                   only be used to issue end entity certificates, or &gt;0 when issuing intermediate CA certificates.
+     * @throws IOException IO problems
+     */
+    public void generateRootCaCert(Subject subject, File subjectKeyFile, File subjectCertFile,
                                    ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException {
-        // Preconditions
-        Objects.requireNonNull(keyFile);
-        Objects.requireNonNull(certFile);
-        Objects.requireNonNull(subject);
-        checkValidity(notBefore, notAfter);
-        if (pathLength < 0) {
-            throw new IllegalArgumentException("pathLength cannot be negative: " + pathLength);
-        }
-        if (subject.subjectAltNames() != null && !subject.subjectAltNames().isEmpty()) {
-            throw new IllegalArgumentException("CA certificates should not have Subject Alternative Names");
-        }
-
-        // Generate a CSR for the key
-        Path tmpKey = null;
-        Path defaultConfig = null;
-        Path csrFile = null;
-        Path newCertsDir = null;
-        Path database = null;
-        Path attr = null;
-
-        try {
-            tmpKey = Files.createTempFile(null, null);
-            // Generate a key pair
-            new OpensslArgs("openssl", "genrsa")
-                    .optArg("-out", tmpKey)
-                    .opt("4096")
-                    .exec();
-
-            csrFile = Files.createTempFile(null, null);
-            new OpensslArgs("openssl", "req")
-                    .opt("-new")
-                    .optArg("-key", tmpKey)
-                    .optArg("-out", csrFile)
-                    .optArg("-subj", subject)
-                    .exec();
-
-            // Generate a self signed cert for the CA
-            database = Files.createTempFile(null, null);
-            attr = Files.createFile(new File(database.toString() + ".attr").toPath());
-            newCertsDir = Files.createTempDirectory(null);
-            defaultConfig = createDefaultConfig();
-            new OpensslArgs("openssl", "ca")
-                    .opt("-utf8").opt("-batch").opt("-notext")
-                    .opt("-selfsign")
-                    .optArg("-in", csrFile)
-                    .optArg("-out", certFile)
-                    .optArg("-keyfile", tmpKey)
-                    .optArg("-startdate", notBefore)
-                    .optArg("-enddate", notAfter)
-                    .optArg("-subj", subject)
-                    .optArg("-config", defaultConfig)
-                    .database(database, attr)
-                    .newCertsDir(newCertsDir)
-                    .basicConstraints("critical,CA:true,pathlen:" + pathLength)
-                    .keyUsage("critical,keyCertSign,cRLSign")
-                    .exec(false);
-
-            // The key will be in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
-            // Convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)
-            new OpensslArgs("openssl", "pkcs8")
-                    .opt("-topk8").opt("-nocrypt")
-                    .optArg("-in", tmpKey)
-                    .optArg("-out", keyFile)
-                    .exec();
-        } finally {
-            delete(tmpKey);
-            delete(database);
-            delete(attr);
-            delete(newCertsDir);
-            delete(csrFile);
-            delete(defaultConfig);
-        }
+        generateCaCert(null, null, subject, subjectKeyFile, subjectCertFile, notBefore, notAfter, pathLength);
     }
 
+    /**
+     * Generate an intermediate CA certificate, using either a new CA key or reusing an existing subject key.
+     *
+     * @param issuerCaKeyFile The issuing CA key.
+     * @param issuerCaCertFile The issuing CA cert.
+     * @param subject The required subject, SAN etc..
+     * @param subjectKeyFile The subject key file.
+     *                       If this file is empty then a new CA key will be generated and populated by this call.
+     *                       Otherwise it is assumed to contain the existing CA key in PKCS#8 format.
+     * @param subjectCertFile The subject certificate file, populated by this call.
+     * @param notBefore The required NotBefore date of the issued certificate.
+     * @param notAfter The required NotAfter date of the issued certificate.
+     * @param pathLength The number of CA certificates below this certificate in a certificate chain.
+     *                   For example, this would be 0 if the CA certificate and key produced by this call would
+     *                   only be used to issue end entity certificates, or &gt;0 when issuing intermediate CA certificates.
+     * @throws IOException IO problems
+     */
     public void generateIntermediateCaCert(File issuerCaKeyFile, File issuerCaCertFile,
                                            Subject subject,
                                            File subjectKeyFile, File subjectCertFile,
                                            ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException {
-        // Preconditions
         Objects.requireNonNull(issuerCaKeyFile);
         Objects.requireNonNull(issuerCaCertFile);
+        generateCaCert(issuerCaKeyFile, issuerCaCertFile, subject, subjectKeyFile, subjectCertFile, notBefore, notAfter, pathLength);
+    }
+
+    /**
+     * Generate an intermediate CA certificate, using either a new CA key or reusing an existing subject key.
+     *
+     * @param issuerCaKeyFile The issuing CA key (or null for a root CA).
+     * @param issuerCaCertFile The issuing CA cert (or null for a root CA).
+     * @param subject The required subject, SAN etc..
+     * @param subjectKeyFile The subject key file.
+     *                       If this file is empty then a new CA key will be generated and populated by this call.
+     *                       Otherwise it is assumed to contain the existing CA key in PKCS#8 format.
+     * @param subjectCertFile The subject certificate file, populated by this call.
+     * @param notBefore The required NotBefore date of the issued certificate.
+     * @param notAfter The required NotAfter date of the issued certificate.
+     * @param pathLength The number of CA certificates below this certificate in a certificate chain.
+     *                   For example, this would be 0 if the CA certificate and key produced by this call would
+     *                   only be used to issue end entity certificates, or &gt;0 when issuing intermediate CA certificates.
+     * @throws IOException IO problems
+     */
+    private void generateCaCert(File issuerCaKeyFile, File issuerCaCertFile,
+                                Subject subject,
+                                File subjectKeyFile, File subjectCertFile,
+                                ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException {
+        if (issuerCaKeyFile == null ^ issuerCaCertFile == null) {
+            throw new IllegalArgumentException();
+        }
+        // Preconditions
         Objects.requireNonNull(subject);
         Objects.requireNonNull(subjectKeyFile);
         Objects.requireNonNull(subjectCertFile);
@@ -241,11 +245,18 @@ public class OpenSslCertManager implements CertManager {
 
         try {
             tmpKey = Files.createTempFile(null, null);
-            // Generate a key pair
-            new OpensslArgs("openssl", "genrsa")
-                    .optArg("-out", tmpKey)
-                    .opt("4096")
-                    .exec();
+            boolean keyInPkcs1;
+            if (subjectKeyFile.length() == 0) {
+                // Generate a key pair
+                new OpensslArgs("openssl", "genrsa")
+                        .optArg("-out", tmpKey)
+                        .opt("4096")
+                        .exec();
+                keyInPkcs1 = true;
+            } else {
+                Files.copy(subjectKeyFile.toPath(), tmpKey, StandardCopyOption.REPLACE_EXISTING);
+                keyInPkcs1 = false;
+            }
 
             csrFile = Files.createTempFile(null, null);
             defaultConfig = buildConfigFile(subject, true);
@@ -262,29 +273,36 @@ public class OpenSslCertManager implements CertManager {
             attr = Files.createFile(new File(database.toString() + ".attr").toPath());
             newCertsDir = Files.createTempDirectory(null);
             defaultConfig = createDefaultConfig();
-            new OpensslArgs("openssl", "ca")
-                    .opt("-utf8").opt("-batch").opt("-notext")
-                    .optArg("-in", csrFile)
+            OpensslArgs opt = new OpensslArgs("openssl", "ca")
+                    .opt("-utf8").opt("-batch").opt("-notext");
+            if (issuerCaCertFile == null) {
+                opt.opt("-selfsign");
+                opt.optArg("-keyfile", tmpKey);
+            } else {
+                opt.optArg("-cert", issuerCaCertFile);
+                opt.optArg("-keyfile", issuerCaKeyFile);
+            }
+            opt.optArg("-in", csrFile)
                     .optArg("-out", subjectCertFile)
                     .optArg("-startdate", notBefore)
                     .optArg("-enddate", notAfter)
                     .optArg("-subj", subject)
                     .optArg("-config", defaultConfig)
-                    .optArg("-cert", issuerCaCertFile)
-                    .optArg("-keyfile", issuerCaKeyFile)
                     .database(database, attr)
                     .newCertsDir(newCertsDir)
                     .basicConstraints("critical,CA:true,pathlen:" + pathLength)
                     .keyUsage("critical,keyCertSign,cRLSign")
                     .exec(false);
 
-            // The key will be in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
-            // Convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)
-            new OpensslArgs("openssl", "pkcs8")
-                    .opt("-topk8").opt("-nocrypt")
-                    .optArg("-in", tmpKey)
-                    .optArg("-out", subjectKeyFile)
-                    .exec();
+            if (keyInPkcs1) {
+                // If the key is in pkcs#1 format (bracketed by BEGIN/END RSA PRIVATE KEY)
+                // convert it to pkcs#8 format (bracketed by BEGIN/END PRIVATE KEY)
+                new OpensslArgs("openssl", "pkcs8")
+                        .opt("-topk8").opt("-nocrypt")
+                        .optArg("-in", tmpKey)
+                        .optArg("-out", subjectKeyFile)
+                        .exec();
+            }
         } finally {
             delete(tmpKey);
             delete(database);
@@ -446,7 +464,7 @@ public class OpenSslCertManager implements CertManager {
 
     @Override
     public void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException {
-        Instant now = Instant.now();
+        Instant now = clock.instant();
         ZonedDateTime notBefore = now.atZone(UTC);
         ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
         generateCert(csrFile, caKey, caCert, crtFile, sbj, notBefore, notAfter);
@@ -559,7 +577,7 @@ public class OpenSslCertManager implements CertManager {
 
         public OpensslArgs optArg(String opt, Subject subject) {
             opt(opt);
-            pb.command().add(subject.toString());
+            pb.command().add(subject.opensslDn());
             return this;
         }
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -182,6 +182,10 @@ public class Subject {
         return san;
     }
 
+    public boolean hasSubjectAltNames() {
+        return !dnsNames().isEmpty() || !ipAddresses().isEmpty();
+    }
+
     /**
      * @return The DN in the format understood by {@code openssl}.
      */

--- a/certificate-manager/src/test/java/io/strimzi/certs/SubjectTests.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SubjectTests.java
@@ -4,25 +4,77 @@
  */
 package io.strimzi.certs;
 
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SubjectTests {
     @Test
-    public void testSubjectToString()   {
-        Subject sbj = new Subject();
-        sbj.setCommonName("joe");
-        assertThat(sbj.toString(), is("/CN=joe"));
+    public void testSubjectOpensslDn()   {
+        Subject.Builder subject = new Subject.Builder()
+            .withCommonName("joe");
+        assertThat(subject.build().opensslDn(), is("/CN=joe"));
 
-        sbj = new Subject();
-        sbj.setOrganizationName("MyOrg");
-        assertThat(sbj.toString(), is("/O=MyOrg"));
+        subject = new Subject.Builder()
+            .withOrganizationName("MyOrg");
+        assertThat(subject.build().opensslDn(), is("/O=MyOrg"));
 
-        sbj = new Subject();
-        sbj.setCommonName("joe");
-        sbj.setOrganizationName("MyOrg");
-        assertThat(sbj.toString(), is("/O=MyOrg/CN=joe"));
+        subject = new Subject.Builder()
+            .withCommonName("joe")
+            .withOrganizationName("MyOrg");
+        assertThat(subject.build().opensslDn(), is("/O=MyOrg/CN=joe"));
+    }
+
+    @Test
+    public void testSubjectAlternativeNames()   {
+        Subject subject = new Subject.Builder()
+                .withCommonName("joe")
+                .withOrganizationName("MyOrg")
+                .addDnsName("example.com")
+                .addDnsName("example.org")
+                .addIpAddress("123.123.123.123")
+                .addIpAddress("127.0.0.1")
+                .build();
+        assertEquals(Map.of(
+                "IP.0", "123.123.123.123",
+                "IP.1", "127.0.0.1",
+                "DNS.0", "example.org",
+                "DNS.1", "example.com"),
+                subject.subjectAltNames());
+    }
+
+    @Test
+    public void testSerialization() throws JsonProcessingException {
+        Subject subject = new Subject.Builder()
+                .withCommonName("joe")
+                .withOrganizationName("MyOrg")
+                .addDnsName("example.com")
+                .addDnsName("example.org")
+                .addIpAddress("123.123.123.123")
+                .addIpAddress("127.0.0.1")
+                .build();
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(subject);
+        assertEquals(subject, mapper.readValue(json, Subject.class));
+        assertEquals("{\"commonName\":\"joe\"," +
+                "\"organizationName\":\"MyOrg\"," +
+                "\"dnsNames\":[\"example.org\",\"example.com\"]," +
+                "\"ipAddresses\":[\"123.123.123.123\",\"127.0.0.1\"]}", json);
+    }
+
+    @Test
+    public void testDnsValidation() {
+        new Subject.Builder().addDnsName("example.com");
+        new Subject.Builder().addDnsName("*.example.com");
+        assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("foo.*.example.come"));
+        assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("54t8g#'/.l"));
+
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -59,7 +59,7 @@ public class CaRenewalTest {
         };
 
         int replicas = 3;
-        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, Subject> subjectFn = i -> new Subject.Builder().build();
         Function<Integer, String> podNameFn = i -> "pod" + i;
         boolean isMaintenanceTimeWindowsSatisfied = true;
 
@@ -134,7 +134,7 @@ public class CaRenewalTest {
                 .build();
 
         int replicas = 3;
-        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, Subject> subjectFn = i -> new Subject.Builder().build();
         Function<Integer, String> podNameFn = i -> "pod" + i;
         boolean isMaintenanceTimeWindowsSatisfied = true;
 
@@ -220,7 +220,7 @@ public class CaRenewalTest {
                 .build();
 
         int replicas = 3;
-        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, Subject> subjectFn = i -> new Subject.Builder().build();
         Function<Integer, String> podNameFn = i -> "pod" + i;
         boolean isMaintenanceTimeWindowsSatisfied = true;
 
@@ -306,7 +306,7 @@ public class CaRenewalTest {
                 .build();
 
         int replicas = 3;
-        Function<Integer, Subject> subjectFn = i -> new Subject();
+        Function<Integer, Subject> subjectFn = i -> new Subject.Builder().build();
         Function<Integer, String> podNameFn = i -> "pod" + i;
         boolean isMaintenanceTimeWindowsSatisfied = false;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -180,9 +180,9 @@ public class CertificateRenewalTest {
         File clusterCaCertFile = File.createTempFile("tls", "cluster-ca-cert");
         File clusterCaStoreFile = File.createTempFile("tls", "cluster-ca-store");
         try {
-            Subject sbj = new Subject();
-            sbj.setOrganizationName("io.strimzi");
-            sbj.setCommonName(commonName);
+            Subject sbj = new Subject.Builder()
+                .withOrganizationName("io.strimzi")
+                .withCommonName(commonName).build();
 
             certManager.generateSelfSignedCert(clusterCaKeyFile, clusterCaCertFile, sbj, ModelUtils.getCertificateValidity(certificateAuthority));
             certManager.addCertToTrustStore(clusterCaCertFile, CA_CRT, clusterCaStoreFile, clusterCaStorePassword);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -321,15 +321,15 @@ public abstract class Ca {
         File certFile = File.createTempFile("tls", "cert");
         File keyStoreFile = File.createTempFile("tls", "p12");
 
-        Subject subject = new Subject();
+        Subject.Builder subject = new Subject.Builder();
 
         if (organization != null) {
-            subject.setOrganizationName(organization);
+            subject.withOrganizationName(organization);
         }
 
-        subject.setCommonName(commonName);
+        subject.withCommonName(commonName);
 
-        CertAndKey result = generateSignedCert(subject,
+        CertAndKey result = generateSignedCert(subject.build(),
                 csrFile, keyFile, certFile, keyStoreFile);
 
         delete(reconciliation, csrFile);
@@ -592,11 +592,11 @@ public abstract class Ca {
     }
 
     private Subject nextCaSubject(int version) {
-        Subject result = new Subject();
+        Subject result = new Subject.Builder()
         // Key replacements does not work if both old and new CA certs have the same subject DN, so include the
         // key generation in the DN so the certificates appear distinct during CA key replacement.
-        result.setCommonName(commonName + " v" + version);
-        result.setOrganizationName(IO_STRIMZI);
+            .withCommonName(commonName + " v" + version)
+            .withOrganizationName(IO_STRIMZI).build();
         return result;
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
@@ -541,5 +543,15 @@ public class Util {
         }
 
         return true;
+    }
+
+    public static void delete(Path key) {
+        if (key != null) {
+            try {
+                Files.deleteIfExists(key);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/MockCertManager.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.time.ZonedDateTime;
 import java.util.Base64;
 import java.util.List;
 
@@ -203,6 +204,16 @@ public class MockCertManager implements CertManager {
     @Override
     public void renewSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
         generateSelfSignedCert(keyFile, certFile, sbj, days);
+    }
+
+    @Override
+    public void generateRootCaCert(Subject subject, File subjectKeyFile, File subjectCertFile, ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException {
+        generateSelfSignedCert(subjectKeyFile, subjectCertFile, subject, 1);
+    }
+
+    @Override
+    public void generateIntermediateCaCert(File issuerCaKeyFile, File issuerCaCertFile, Subject subject, File subjectKeyFile, File subjectCertFile, ZonedDateTime notBefore, ZonedDateTime notAfter, int pathLength) throws IOException {
+        throw new RuntimeException("Not implemented");
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This is a preparatory PR for some of the changes for the PKI rework. 

* `Subject` now uses a `Builder` to provide a simpler API.
* `Subject` now handles SAN explicitly, with `subjectAltNames` computing the numbering.
* `Subject` can be serialized as JSON (will be used).
* `OpenSslCertManager` takes a `Clock` for computations based on the current time (will be used in unit tests)
* `OpenSslCertManager` is refactored to unify the paths for cert cert generation vs. renewal and root vs. intermediate CA.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

