### PR TITLE
[DOC] Procedure to load external configuration values

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -37,7 +37,7 @@ public class ExternalConfiguration implements Serializable, UnknownPropertyPrese
     private List<ExternalConfigurationVolumeSource> volumes;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.")
+    @Description("Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as environment variables.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public List<ExternalConfigurationEnv> getEnv() {
         return env;
@@ -47,7 +47,7 @@ public class ExternalConfiguration implements Serializable, UnknownPropertyPrese
         this.env = env;
     }
 
-    @Description("Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.")
+    @Description("Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as volumes.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public List<ExternalConfigurationVolumeSource> getVolumes() {
         return volumes;

--- a/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/041-Crd-kafkaconnect.yaml
@@ -1602,8 +1602,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -1659,8 +1659,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:
@@ -3656,8 +3656,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -3713,8 +3713,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:
@@ -5710,8 +5710,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -5767,8 +5767,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/042-Crd-kafkaconnects2i.yaml
@@ -1610,8 +1610,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -1667,8 +1667,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:
@@ -3681,8 +3681,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -3738,8 +3738,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:
@@ -5752,8 +5752,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -5809,8 +5809,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/048-Crd-kafkamirrormaker2.yaml
@@ -1724,8 +1724,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -1781,8 +1781,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               metricsConfig:
@@ -3783,8 +3783,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -3840,8 +3840,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               metricsConfig:

--- a/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
@@ -35,3 +35,6 @@ include::assembly-customizing-kubernetes-resources.adoc[leveloffset=+1]
 include::assembly-scheduling.adoc[leveloffset=+1]
 
 include::assembly-external-logging.adoc[leveloffset=+1]
+
+//Procedure to load configuration from external sources for all Kafka components
+include::../../modules/configuring/proc-loading-config-with-provider.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1852,9 +1852,9 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 [options="header"]
 |====
 |Property        |Description
-|env      1.2+<.<a|Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
+|env      1.2+<.<a|Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as environment variables.
 |xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`] array
-|volumes  1.2+<.<a|Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+|volumes  1.2+<.<a|Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as volumes.
 |xref:type-ExternalConfigurationVolumeSource-{context}[`ExternalConfigurationVolumeSource`] array
 |====
 

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -170,6 +170,7 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <9> (Required) Configuration of the container registry where new images are pushed.
 <10> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
 <11> xref:type-ExternalConfiguration-reference[External configuration for Kafka connectors] using environment variables, as shown here, or volumes.
+You can also use the _Kubernetes Configuration Provider_ to xref:proc-loading-config-with-provider-str[load configuration values from external sources].
 <12> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
 <13> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <14> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -233,6 +233,7 @@ You can use comma-separated lists.
 <43> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
 <44> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
 <45> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
+You can also use the _Kubernetes Configuration Provider_ to xref:proc-loading-config-with-provider-str[load configuration values from external sources].
 
 . Create or update the resource:
 +

--- a/documentation/modules/configuring/proc-loading-config-with-provider.adoc
+++ b/documentation/modules/configuring/proc-loading-config-with-provider.adoc
@@ -1,0 +1,152 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka-connect.adoc
+
+[id='proc-loading-config-with-provider-{context}']
+= Loading configuration values from external sources
+
+[role="_abstract"]
+Use the _Kubernetes Configuration Provider_ plugin to load configuration data from external sources.
+Load data from Kubernetes Secrets or ConfigMaps.
+
+Suppose you have a Secret that's managed outside the Kafka namespace, or outside the Kafka cluster.
+The provider allows you to reference the values of the Secret in your configuration without extracting the files.
+You just need to tell the provider what Secret to use and provide access rights.
+The provider loads the data without needing to restart the Kafka component.
+
+The provider operates independently of Strimzi.
+You can use it to load configuration data for all Kafka components, including producers and consumers.
+Use it, for example, to provide the credentials for Kafka Connect connector configuration.
+
+In this procedure, an external ConfigMap provides configuration properties for a connector.
+
+NOTE: As an alternative to using the Kubernetes Configuration Provider, you can mount ConfigMaps or Secrets into a Kafka Connect pod as environment variables or volumes.
+You do this by adding configuration using the  xref:type-ExternalConfiguration-reference[`externalConfiguration` property] in `KafkaConnect.spec`.
+
+.Prerequisites
+
+* A Kubernetes cluster is available.
+* A Kafka cluster is running.
+* The Cluster Operator is running.
+
+.Procedure
+
+. Create a ConfigMap or Secret that contains the configuration properties.
++
+In this example, a ConfigMap named `my-connector-configuration` contains connector properties:
++
+.Example ConfigMap with connector properties
+[source,yaml,subs=attributes+]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-connector-configuration
+data:
+  option1: value1
+  option2: value2
+----
+
+. Specify the Kubernetes Configuration Provider in the Kafka Connect configuration.
++
+The specification shown here can support loading values from Secrets and ConfigMaps.
++
+.Example external volumes set to values from a ConfigMap
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  # ...
+  config:
+    # ...
+    config.providers: secrets,configmaps <1>
+    config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider <2>
+    config.providers.configmaps.class: io.strimzi.kafka.KubernetesConfigMapConfigProvider <3>
+  # ...
+----
+<1> The alias for the configuration provider is used to define other configuration parameters.
+The provider parameters use the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
+<2> `KubernetesSecretConfigProvider` provides values from Secrets.
+<3> `KubernetesConfigMapConfigProvider` provides values from ConfigMaps.
+
+. Create or update the resource to enable the provider.
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONNECT-CONFIG-FILE_
+
+. Create a role that permits access to the values in the external ConfigMap.
++
+.Example role to access values from a ConfigMap
+[source,yaml,subs="attributes+"]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: connector-configuration-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["my-connector-configuration"]
+  verbs: ["get"]
+# ...
+----
++
+The rule gives the role permission to access the `my-connector-configuration` ConfigMap.
+
+. Create a role binding to permit access to the namespace that contains the ConfigMap.
++
+.Example role binding to access the namespace that contains the ConfigMap
+[source,yaml,subs="attributes+"]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: connector-configuration-role-binding
+subjects:
+- kind: ServiceAccount
+  name: my-connect-connect
+  namespace: my-project
+roleRef:
+  kind: Role
+  name: connector-configuration-role
+  apiGroup: rbac.authorization.k8s.io
+# ...
+----
++
+The role binding gives the role permission to access the `my-project` namespace.
++
+The service account must be the same one used by the Kafka Connect deployment.
+The service account name format is __CLUSTER_NAME__-connect, where __CLUSTER_NAME__ is the name of the `KafkaConnect` custom resource.
+
+. Reference the ConfigMap in the connector configuration.
++
+.Example connector configuration referencing the ConfigMap
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  name: my-connector
+  labels:
+    strimzi.io/cluster: my-connect
+spec:
+  # ...
+  config:
+    option: ${configmaps:my-project/my-connector-configuration:option1}
+    # ...
+# ...
+----
++
+Placeholders for the property values in the ConfigMap are referenced in the connector configuration.
+The placeholder structure is `configmaps:__PATH-AND-FILE-NAME__:__PROPERTY__`.
+`KubernetesConfigMapConfigProvider` reads and extracts the _option1_ property value from the external ConfigMap.
+
+
+[role="_additional-resources"]
+.Additional resources
+* xref:type-ExternalConfiguration-reference[External configuration for Kafka Connect connectors]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1466,7 +1466,7 @@ spec:
                         required:
                           - name
                           - valueFrom
-                      description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
+                      description: Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as environment variables.
                     volumes:
                       type: array
                       items:
@@ -1519,7 +1519,7 @@ spec:
                             description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                         required:
                           - name
-                      description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+                      description: Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as volumes.
                   description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
                 build:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-kafkaconnects2i.yaml
@@ -1476,7 +1476,7 @@ spec:
                         required:
                           - name
                           - valueFrom
-                      description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
+                      description: Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as environment variables.
                     volumes:
                       type: array
                       items:
@@ -1529,7 +1529,7 @@ spec:
                             description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                         required:
                           - name
-                      description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+                      description: Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as volumes.
                   description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
                 build:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1560,7 +1560,7 @@ spec:
                         required:
                           - name
                           - valueFrom
-                      description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as environment variables.
+                      description: Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as environment variables.
                     volumes:
                       type: array
                       items:
@@ -1613,7 +1613,7 @@ spec:
                             description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
                         required:
                           - name
-                      description: Allows to pass data from Secret or ConfigMap to the Kafka Connect pods as volumes.
+                      description: Allows data to pass from a Secret or ConfigMap to the Kafka Connect pods as volumes.
                   description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
                 metricsConfig:
                   type: object

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1635,8 +1635,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -1692,8 +1692,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:

--- a/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
+++ b/packaging/install/cluster-operator/042-Crd-kafkaconnects2i.yaml
@@ -1645,8 +1645,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -1702,8 +1702,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               build:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1760,8 +1760,8 @@ spec:
                       required:
                       - name
                       - valueFrom
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as environment variables.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as environment variables.
                   volumes:
                     type: array
                     items:
@@ -1817,8 +1817,8 @@ spec:
                             Secret or ConfigMap has to be specified.
                       required:
                       - name
-                    description: Allows to pass data from Secret or ConfigMap to the
-                      Kafka Connect pods as volumes.
+                    description: Allows data to pass from a Secret or ConfigMap to
+                      the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
               metricsConfig:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Adds a new procedure to the _Configuring a Strimzi deployment_ section in the _Using Strimzi_ guide.
_Loading configuration values from external sources_ describes how to use the Kubernetes Configuration Provider to load external configuration values.
There are also links to the procedure from the Kafka Connect and MirrorMaker configuration sections.

Plus: minor change to a property description in the schema reference. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

