### PR TITLE
Update kafka exporter to 1.3.1 strimzi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Support for broker load information added to the rebalance optimization proposal. Information on the load difference, before and after a rebalance is stored in a ConfigMap
 * Add support for selectively changing the verbosity of logging for individual CRs, using markers.
 * Added support for `controller_mutation_rate' quota. Creation/Deletion of topics and creation of partitions can be configured through this.
+* Use newer version of Kafka Exporter with different bugfixes 
 
 ### Changes, deprecations and removals
 

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -27,28 +27,28 @@ COPY ./scripts/ $KAFKA_HOME
 # Add Kafka Exporter
 #####
 ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
-ENV KAFKA_EXPORTER_VERSION=1.2.0
-ENV KAFKA_EXPORTER_CHECKSUM_AMD64="7afa40365ddf0cb0a88457684bd64d565e250c7e5a4536ba7f9d37d02d2808c3b07766f94e0b1338beb296573ade29db630948c931be44bde416c0410b5d783b  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
-ENV KAFKA_EXPORTER_CHECKSUM_ARM64="1b36d0dc45b9dc20d90f88ee43b84277154d6d589c19b0674b10b4c3e48ce31e5410094deeae4426e069f9d30108bb26dcb84fab2e87e2841dadb75e58fb5916  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz"
-ENV KAFKA_EXPORTER_CHECKSUM_PPC64LE="b633951927c1671de8ee221b981433817bc103c01ff46797756a56e96bfd794210d19942917b33c5735f6f10afb83445f4a79099e8537bccc718f4358431d744  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz"
+ENV KAFKA_EXPORTER_VERSION=1.3.1-STRIMZI
+ENV KAFKA_EXPORTER_CHECKSUM_AMD64="85e37fe8a7797f53dcf1ef349b3472edc6891d8bb914d1aebb33784bfb850189d47ec989be9a8c764f4fbe991576b81545b04ddbd4ff6946a677066ec0a4619d  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
+ENV KAFKA_EXPORTER_CHECKSUM_ARM64="a594903265f3497c003d90e211480179aa8d42fb58b43456f001d3eea064d1d571e3b5bb9666c6d45382b1611433c5d616d68b742f84045be04c0c18b9df0427  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz"
+ENV KAFKA_EXPORTER_CHECKSUM_PPC64LE="8b72420d2c6aed25b6ddbae7df66be6a07e659fffa6b3f6cae1132de35c7f0a21bde0fcb3fa9234a8a79839589c18940ef01534551b57669dab09544b5af2883  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz"
 
 RUN set -ex; \
     if [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
-        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz; \
+        curl -LO https://github.com/alesj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_ARM64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \
         tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz*; \
     elif [[ ${TARGETPLATFORM} = "linux/ppc64le" ]]; then \
-        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz; \
+        curl -LO https://github.com/alesj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_PPC64LE > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \
         tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz*; \
     else \
-        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz; \
+        curl -LO https://github.com/alesj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_AMD64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \

--- a/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -31,9 +31,9 @@ kafkaserver="--kafka.server="$KAFKA_EXPORTER_KAFKA_SERVER
 
 listenaddress="--web.listen-address=:9404"
 
-tls="--tls.enabled --tls.ca-file=/etc/kafka-exporter/cluster-ca-certs/ca.crt --tls.cert-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.crt  --tls.key-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.key"
+allgroups="--legacy.partitions"
 
-sasl="--no-sasl.handshake"
+tls="--tls.enabled --tls.ca-file=/etc/kafka-exporter/cluster-ca-certs/ca.crt --tls.cert-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.crt  --tls.key-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.key"
 
 # starting Kafka Exporter with final configuration
 cat <<EOT > /tmp/run.sh
@@ -44,8 +44,8 @@ $tls \
 $kafkaserver \
 $saramaenable \
 $listenaddress \
+$allgroups \
 $loglevel \
-$sasl \
 $version
 EOT
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the Kafka Exporter to a custom version based on the upstream 1.3.1. 

This should fix several issues reported with it: closes #4561 and Closes #2480.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md