### PR TITLE
Update OAuth library to 0.8.1

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -16,11 +16,18 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.8.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <cruise-control.version>2.5.55</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
+        <kafka-mirror-maker-2-extensions.version>0.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
+        <jmx-prometheus-javaagent.version>0.15.0</jmx-prometheus-javaagent.version>
+        <json-smart.version>2.4.7</json-smart.version>
+        <jsonevent-layout.version>1.7</jsonevent-layout.version>
+        <jaeger-client.version>1.3.2</jaeger-client.version>
+        <opentracing.version>0.33.0</opentracing.version>
+        <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
     </properties>
 
     <repositories>
@@ -39,7 +46,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.3</version>
+                <version>${json-smart.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>
@@ -55,19 +62,19 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>0.14.0</version>
+            <version>${jmx-prometheus-javaagent.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.logstash.log4j/jsonevent-layout -->
         <dependency>
             <groupId>net.logstash.log4j</groupId>
             <artifactId>jsonevent-layout</artifactId>
-            <version>1.7</version>
+            <version>${jsonevent-layout.version}</version>
         </dependency>
         <!-- Tracing -->
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-client</artifactId>
-            <version>1.3.2</version>
+            <version>${jaeger-client.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -82,17 +89,17 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>0.33.0</version>
+            <version>${opentracing.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
-            <version>0.33.0</version>
+            <version>${opentracing.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-kafka-client</artifactId>
-            <version>0.1.15</version>
+            <version>${opentracing-kafka.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
@@ -282,7 +289,7 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>mirror-maker-2-extensions</artifactId>
-            <version>0.1.0</version>
+            <version>${kafka-mirror-maker-2-extensions.version}</version>
         </dependency>
         <!-- Kafka Quotas Plugin -->
         <dependency>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -16,11 +16,18 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.8.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <cruise-control.version>2.5.55</cruise-control.version>
         <opa-authorizer.version>0.4.2</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
+        <kafka-mirror-maker-2-extensions.version>0.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
+        <jmx-prometheus-javaagent.version>0.15.0</jmx-prometheus-javaagent.version>
+        <json-smart.version>2.4.7</json-smart.version>
+        <jsonevent-layout.version>1.7</jsonevent-layout.version>
+        <jaeger-client.version>1.3.2</jaeger-client.version>
+        <opentracing.version>0.33.0</opentracing.version>
+        <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
     </properties>
 
     <repositories>
@@ -39,7 +46,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.3</version>
+                <version>${json-smart.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>
@@ -55,19 +62,19 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>0.15.0</version>
+            <version>${jmx-prometheus-javaagent.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.logstash.log4j/jsonevent-layout -->
         <dependency>
             <groupId>net.logstash.log4j</groupId>
             <artifactId>jsonevent-layout</artifactId>
-            <version>1.7</version>
+            <version>${jsonevent-layout.version}</version>
         </dependency>
         <!-- Tracing -->
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-client</artifactId>
-            <version>1.3.2</version>
+            <version>${jaeger-client.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -82,17 +89,17 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>0.33.0</version>
+            <version>${opentracing.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
-            <version>0.33.0</version>
+            <version>${opentracing.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-kafka-client</artifactId>
-            <version>0.1.15</version>
+            <version>${opentracing-kafka.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
@@ -282,7 +289,7 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>mirror-maker-2-extensions</artifactId>
-            <version>0.1.0</version>
+            <version>${kafka-mirror-maker-2-extensions.version}</version>
         </dependency>
         <!-- Kafka Quotas Plugin -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <jaeger.version>1.3.2</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <strimzi-oauth.version>0.8.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.0.Final</registry.version>
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the OAuth library to 0.8.1 to address CVE-2021-27568. It also changes the third party libraries `pom.xml` files to use properties to define the versions to make them easy to changes and easier to get overview of what we use than when they are spread all over the dependencies list.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally