### PR TITLE
Print deprecation warning for the enableECDSA field only when really set

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -55,7 +55,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private boolean accessTokenIsJwt = true;
     private List<CertSecretSource> tlsTrustedCertificates;
     private boolean disableTlsHostnameVerification = false;
-    private boolean enableECDSA = true;
+    private Boolean enableECDSA;
     private Integer maxSecondsWithoutReauthentication;
     private boolean enablePlain = false;
     private String tokenEndpointUri;
@@ -308,11 +308,11 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     @Description("Enable or disable ECDSA support by installing BouncyCastle crypto provider. " +
             "ECDSA support is always enabled. The BouncyCastle libraries are no longer packaged with Strimzi. Value is ignored.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public boolean isEnableECDSA() {
+    public Boolean getEnableECDSA() {
         return enableECDSA;
     }
 
-    public void setEnableECDSA(boolean enableECDSA) {
+    public void setEnableECDSA(Boolean enableECDSA) {
         this.enableECDSA = enableECDSA;
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `enableECDSA` field has been deprecated. But because it is a `boolean` which is set to `true` by default, it cause the operator to always print the deprecation warning whenever OAuth authentication is enabled in the broker even when the `enableECDSA` field is not used:

```
In API version kafka.strimzi.io/v1beta2 the enableECDSA property at path spec.kafka.listeners.genericKafkaListeners.auth.enableECDSA has been deprecated.
```

Similar warning is also in the Kafka CR status.

This PR changes the field type to `Boolean` and sets it to null by default. That way, if the `enableECDSA` fiels is not set, no warning is shown. Only when the field is really set in the Kafka CR to `true` or `false` the warning is printed and set in the resource status.

This should be picked for the 0.24.0 release.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally