### PR TITLE
Remove the removed topic operator Role / RoleBinding from the documentation

### DIFF
--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -51,7 +51,6 @@ repeating them for `watched-namespace-1`, `watched-namespace-2`, `watched-namesp
 [source,shell,subs="+quotes,attributes+"]
 kubectl create -f install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml -n _watched-namespace_
 kubectl create -f install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _watched-namespace_
-kubectl create -f install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n _watched-namespace_
 
 . Deploy the Cluster Operator:
 +

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -49,7 +49,6 @@ spec:
 [source,shell,subs="+quotes,attributes+"]
 kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
 kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
-kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation --clusterrole=strimzi-topic-operator --serviceaccount _my-cluster-operator-namespace_:strimzi-cluster-operator
 +
 Replace `_my-cluster-operator-namespace_` with the namespace you want to install the Cluster Operator into.
 

--- a/documentation/modules/quickstart/proc-installing-product.adoc
+++ b/documentation/modules/quickstart/proc-installing-product.adoc
@@ -78,10 +78,6 @@ kubectl create -f install/cluster-operator/020-RoleBinding-strimzi-cluster-opera
 ----
 [source, shell, subs=+quotes]
 ----
-kubectl create -f install/cluster-operator/032-RoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml -n my-kafka-project
-----
-[source, shell, subs=+quotes]
-----
 kubectl create -f install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n my-kafka-project
 ----
 --


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

We removed the dedicated Topic Operator Role / RoleBinding since the Topic Operator can now be deployed only as part of the Entity Operator which has its own Role / RoleBinding. But it looks like it remained in some parts of the docs. This PR fixes that.

This should be picked for the 0.14 release documentation.

### Checklist

- [x] Update documentation