### PR TITLE
Improve operator log messages to make them more readable

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -122,7 +122,7 @@ public class ClusterOperator extends AbstractVerticle {
                 .compose(f -> {
                     LOGGER.info("Setting up periodic reconciliation for namespace {}", namespace);
                     this.reconcileTimer = vertx.setPeriodic(this.config.getReconciliationIntervalMs(), res2 -> {
-                        LOGGER.info("Triggering periodic reconciliation for namespace {}...", namespace);
+                        LOGGER.info("Triggering periodic reconciliation for namespace {}", namespace);
                         reconcileAll("timer");
                     });
                     return startHealthServer().map((Void) null);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -153,7 +153,11 @@ public class Main {
             vertx.deployVerticle(operator,
                 res -> {
                     if (res.succeeded()) {
-                        LOGGER.info("Cluster Operator verticle started in namespace {} with label selector {}", namespace, config.getCustomResourceSelector());
+                        if (config.getCustomResourceSelector() != null) {
+                            LOGGER.info("Cluster Operator verticle started in namespace {} with label selector {}", namespace, config.getCustomResourceSelector());
+                        } else {
+                            LOGGER.info("Cluster Operator verticle started in namespace {} without label selector", namespace);
+                        }
                     } else {
                         LOGGER.error("Cluster Operator verticle in namespace {} failed to start", namespace, res.cause());
                         System.exit(1);

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperator.java
@@ -63,7 +63,7 @@ public class UserOperator extends AbstractVerticle {
 
                 LOGGER.info("Setting up periodic reconciliation for namespace {}", namespace);
                 this.reconcileTimer = vertx.setPeriodic(this.reconciliationInterval, res2 -> {
-                    LOGGER.info("Triggering periodic reconciliation for namespace {}...", namespace);
+                    LOGGER.info("Triggering periodic reconciliation for namespace {}", namespace);
                     reconcileAll("timer");
                 });
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR improves several operator log messages to make the logs more readable.
* The following messages (which appears also in User Operator) is missing a namespace and the `...` might be confusing even without the space:
  ```
  2021-06-21 12:48:35 INFO  ClusterOperator:125 - Triggering periodic reconciliation for namespace myproject...
  ```
  This PR removes the `...` part:
  ```
  2021-06-21 12:48:35 INFO  ClusterOperator:125 - Triggering periodic reconciliation for namespace myproject
  ```
* At operator startup the message always lists the label selector and when it is not set, it results into this log message with the confusing `null`
  ```
  2021-06-21 12:44:35 INFO  Main:156 - Cluster Operator verticle started in namespace * with label selector null
  ```
  This PR improves the message to list the label selector only when it is not-null. When it is null, we just say there is no label selector.