### PR TITLE
Prevent tests passing when they should fail, fix for #5161

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -156,8 +156,6 @@ public class CertificateRenewalTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 
-        Checkpoint async = context.checkpoint();
-
         Promise reconcileCasComplete = Promise.promise();
         op.new ReconciliationState(reconciliation, kafka).reconcileCas(dateSupplier)
             .onComplete(ar -> {
@@ -169,7 +167,6 @@ public class CertificateRenewalTest {
                 } else {
                     reconcileCasComplete.fail(ar.cause());
                 }
-                async.flag();
             });
         return reconcileCasComplete.future();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1385,6 +1385,7 @@ public class KafkaAssemblyOperatorTest {
 
         Checkpoint fooAsync = context.checkpoint();
         Checkpoint barAsync = context.checkpoint();
+        Checkpoint completeTest = context.checkpoint();
 
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 certManager,
@@ -1405,9 +1406,9 @@ public class KafkaAssemblyOperatorTest {
             }
         };
 
-        Checkpoint async = context.checkpoint();
+
         // Now try to reconcile all the Kafka clusters
-        ops.reconcileAll("test", kafkaNamespace, context.succeeding(v -> async.flag()));
+        ops.reconcileAll("test", kafkaNamespace, context.succeeding(v -> completeTest.flag()));
     }
 
     @ParameterizedTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -611,6 +611,9 @@ public class KafkaBridgeAssemblyOperatorTest {
         // Should be called twice, once for foo and once for bar
         Checkpoint asyncCreatedOrUpdated = context.checkpoint(2);
 
+        //Must create all checkpoints before flag()ing any to avoid premature test success
+        Checkpoint async = context.checkpoint();
+
         KafkaBridgeAssemblyOperator ops = new KafkaBridgeAssemblyOperator(vertx,
                 new PlatformFeaturesAvailability(true, kubernetesVersion),
                 new MockCertManager(), new PasswordGenerator(10, "a", "a"),
@@ -625,7 +628,7 @@ public class KafkaBridgeAssemblyOperatorTest {
             }
         };
 
-        Checkpoint async = context.checkpoint();
+
         Promise reconciled = Promise.promise();
         // Now try to reconcile all the Kafka Bridge clusters
         ops.reconcileAll("test", kbNamespace, v -> reconciled.complete());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -742,6 +742,8 @@ public class KafkaConnectAssemblyOperatorTest {
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
         Checkpoint asyncCreated = context.checkpoint(2);
+        //Must create all needed checkpoints before flagging anyway, to avoid premature test success
+        Checkpoint async = context.checkpoint();
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS)) {
 
@@ -754,7 +756,7 @@ public class KafkaConnectAssemblyOperatorTest {
         };
 
 
-        Checkpoint async = context.checkpoint();
+
         Promise reconciled = Promise.promise();
         // Now try to reconcile all the Kafka Connect clusters
         ops.reconcileAll("test", kcNamespace, ignored -> reconciled.complete());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -130,7 +130,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
         LOGGER.info("Reconciling initially -> create");
         Promise created = Promise.promise();
-        Checkpoint async = context.checkpoint();
+
         kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
             .onComplete(context.succeeding(ar -> context.verify(() -> {
                 if (!reconciliationPaused) {
@@ -143,7 +143,6 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                     verify(mockClient, never()).customResources(KafkaMirrorMaker2.class);
                 }
 
-                async.flag();
                 created.complete();
             })));
         return created.future();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -603,6 +603,9 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         Set<String> createdOrUpdated = new CopyOnWriteArraySet<>();
 
         Checkpoint createOrUpdateAsync = context.checkpoint(2);
+        //Must create all checkpoints used before flagging any to avoid premature test success
+        Checkpoint async = context.checkpoint();
+
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
                 supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS)) {
 
@@ -614,7 +617,6 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             }
         };
 
-        Checkpoint async = context.checkpoint();
         // Now try to reconcile all the Kafka MirrorMaker 2.0 clusters
         ops.reconcileAll("test", kmm2Namespace,
             context.succeeding(v -> context.verify(() -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControlTest.java
@@ -53,8 +53,8 @@ public class MockCruiseControlTest {
 
         Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(HOST, PORT, userTaskID);
 
-        Checkpoint pendingCallsCheckpoint = pendingCalls == 0 ? null : context.checkpoint();
-        Checkpoint completeTest = context.checkpoint();
+        // One interaction is always expected at the end of the test, hence the +1
+        Checkpoint expectedInteractions = context.checkpoint(pendingCalls + 1);
 
         for (int i = 1; i <= pendingCalls; i++) {
             statusFuture = statusFuture.compose(response -> {
@@ -62,7 +62,7 @@ public class MockCruiseControlTest {
                         response.getJson().getString("Status"),
                         is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                 );
-                pendingCallsCheckpoint.flag();
+                expectedInteractions.flag();
                 return client.getUserTaskStatus(HOST, PORT, userTaskID);
             });
         }
@@ -72,7 +72,7 @@ public class MockCruiseControlTest {
                     response.getJson().getString("Status"),
                     is(CruiseControlUserTaskStatus.COMPLETED.toString()))
             );
-            completeTest.flag();
+            expectedInteractions.flag();
             return Future.succeededFuture(response);
         });
     }

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -7,14 +7,14 @@ package io.strimzi.operator;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -22,7 +22,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,20 +30,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(VertxExtension.class)
 public class PlatformFeaturesAvailabilityTest {
-    protected static Vertx vertx;
 
-    @BeforeAll
-    public static void before() {
-        vertx = Vertx.vertx();
-    }
-
-    @AfterAll
-    public static void after() {
-        vertx.close();
-    }
+    private HttpServer server;
 
     @Test
-    public void testVersionDetectionOpenShift(VertxTestContext context) throws InterruptedException {
+    public void testVersionDetectionOpenShift(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
         String version = "{\n" +
                 "  \"major\": \"1\",\n" +
                 "  \"minor\": \"20\",\n" +
@@ -56,21 +47,20 @@ public class PlatformFeaturesAvailabilityTest {
                 "  \"platform\": \"linux/amd64\"\n" +
                 "}";
 
-        HttpServer mockHttp = startMockApi(context, version, Collections.EMPTY_LIST);
+        startMockApi(vertx, version, Collections.emptyList());
 
-        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + server.actualPort());
 
         Checkpoint a = context.checkpoint();
 
         PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat("Versions are not equal", pfa.getKubernetesVersion(), is(KubernetesVersion.V1_20));
-            stopMockApi(context, mockHttp);
             a.flag();
         })));
     }
 
     @Test
-    public void testVersionDetectionMinikube(VertxTestContext context) throws InterruptedException {
+    public void testVersionDetectionMinikube(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
         String version = "{\n" +
                 "  \"major\": \"1\",\n" +
                 "  \"minor\": \"20\",\n" +
@@ -83,28 +73,27 @@ public class PlatformFeaturesAvailabilityTest {
                 "  \"platform\": \"linux/amd64\"\n" +
                 "}";
 
-        HttpServer mockHttp = startMockApi(context, version, Collections.EMPTY_LIST);
+        startMockApi(vertx, version, Collections.emptyList());
 
-        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + server.actualPort());
 
         Checkpoint async = context.checkpoint();
 
         PlatformFeaturesAvailability.create(vertx, client).onComplete(context.succeeding(pfa -> context.verify(() -> {
             assertThat("Versions are not equal", pfa.getKubernetesVersion(), is(KubernetesVersion.V1_20));
-            stopMockApi(context, mockHttp);
             async.flag();
         })));
     }
 
     @Test
-    public void testApiDetectionOce(VertxTestContext context) throws InterruptedException {
+    public void testApiDetectionOce(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
         List<String> apis = new ArrayList<>();
         apis.add("/apis/route.openshift.io/v1");
         apis.add("/apis/build.openshift.io/v1");
 
-        HttpServer mockHttp = startMockApi(context, apis);
+        startMockApi(vertx, apis);
 
-        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + server.actualPort());
 
         Checkpoint async = context.checkpoint();
 
@@ -113,22 +102,21 @@ public class PlatformFeaturesAvailabilityTest {
             assertThat(pfa.hasBuilds(), is(true));
             assertThat(pfa.hasImages(), is(false));
             assertThat(pfa.hasApps(), is(false));
-            stopMockApi(context, mockHttp);
             async.flag();
         })));
     }
 
     @Test
-    public void testApiDetectionOpenshift(VertxTestContext context) throws InterruptedException {
+    public void testApiDetectionOpenshift(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
         List<String> apis = new ArrayList<>();
         apis.add("/apis/route.openshift.io/v1");
         apis.add("/apis/build.openshift.io/v1");
         apis.add("/apis/apps.openshift.io/v1");
         apis.add("/apis/image.openshift.io/v1");
 
-        HttpServer mockHttp = startMockApi(context, apis);
+        startMockApi(vertx, apis);
 
-        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + server.actualPort());
 
         Checkpoint async = context.checkpoint();
 
@@ -137,16 +125,15 @@ public class PlatformFeaturesAvailabilityTest {
             assertThat(pfa.hasBuilds(), is(true));
             assertThat(pfa.hasImages(), is(true));
             assertThat(pfa.hasApps(), is(true));
-            stopMockApi(context, mockHttp);
             async.flag();
         })));
     }
 
     @Test
-    public void testApiDetectionKubernetes(VertxTestContext context) throws InterruptedException {
-        HttpServer mockHttp = startMockApi(context, Collections.EMPTY_LIST);
+    public void testApiDetectionKubernetes(Vertx vertx, VertxTestContext context) throws InterruptedException, ExecutionException {
+        startMockApi(vertx, Collections.emptyList());
 
-        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + mockHttp.actualPort());
+        KubernetesClient client = new DefaultKubernetesClient("127.0.0.1:" + server.actualPort());
 
         Checkpoint async = context.checkpoint();
 
@@ -155,7 +142,6 @@ public class PlatformFeaturesAvailabilityTest {
             assertThat(pfa.hasBuilds(), is(false));
             assertThat(pfa.hasImages(), is(false));
             assertThat(pfa.hasApps(), is(false));
-            stopMockApi(context, mockHttp);
             async.flag();
         })));
     }
@@ -181,33 +167,21 @@ public class PlatformFeaturesAvailabilityTest {
         context.completeNow();
     }
 
-    public HttpServer startMockApi(VertxTestContext context, String version, List<String> apis) throws InterruptedException {
-        Checkpoint start = context.checkpoint();
+    void startMockApi(Vertx vertx, String version, List<String> apis) throws InterruptedException, ExecutionException {
 
-        HttpServer server = vertx.createHttpServer().requestHandler(request -> {
-            if (HttpMethod.GET.equals(request.method()) && apis.contains(request.uri()))   {
+        HttpServer httpServer = vertx.createHttpServer().requestHandler(request -> {
+            if (HttpMethod.GET.equals(request.method()) && apis.contains(request.uri())) {
                 request.response().setStatusCode(200).end();
             } else if (HttpMethod.GET.equals(request.method()) && "/version".equals(request.uri())) {
                 request.response().setStatusCode(200).end(version);
             } else {
                 request.response().setStatusCode(404).end();
             }
-        }).listen(0, res -> {
-            if (res.succeeded())    {
-                start.flag();
-            } else {
-                throw new RuntimeException(res.cause());
-            }
         });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-
-        return server;
+        server = httpServer.listen(0).toCompletionStage().toCompletableFuture().get();
     }
 
-    public HttpServer startMockApi(VertxTestContext context, List<String> apis) throws InterruptedException {
+    void startMockApi(Vertx vertx, List<String> apis) throws InterruptedException, ExecutionException {
         String version = "{\n" +
                 "  \"major\": \"1\",\n" +
                 "  \"minor\": \"16\",\n" +
@@ -220,22 +194,17 @@ public class PlatformFeaturesAvailabilityTest {
                 "  \"platform\": \"linux/amd64\"\n" +
                 "}";
 
-        return startMockApi(context, version, apis);
+        startMockApi(vertx, version, apis);
     }
 
-    public void stopMockApi(VertxTestContext context, HttpServer server) throws InterruptedException {
-        Checkpoint async = context.checkpoint();
-
-        server.close(res -> {
-            if (res.succeeded())    {
-                async.flag();
-            } else {
-                throw new RuntimeException("Failed to stop Mock HTTP server");
-            }
-        });
-
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
+    @AfterEach()
+    void teardown() throws ExecutionException, InterruptedException {
+        if (server == null) {
+            return;
         }
+
+        Promise<Void> serverStopped = Promise.promise();
+        server.close(x -> serverStopped.complete());
+        serverStopped.future().toCompletionStage().toCompletableFuture().get();
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -75,9 +76,6 @@ public class TopicOperatorMockTest {
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                         .setEnabled(true));
         vertx = Vertx.vertx(options);
-
-        cluster = new EmbeddedKafkaCluster(1);
-        cluster.start();
     }
 
     @AfterAll
@@ -90,7 +88,10 @@ public class TopicOperatorMockTest {
     }
 
     @BeforeEach
-    public void createMockKube(VertxTestContext context) throws Exception {
+    public void setup(VertxTestContext context) throws Exception {
+        cluster = new EmbeddedKafkaCluster(1);
+        cluster.start();
+
         MockKube mockKube = new MockKube();
         mockKube.withCustomResourceDefinition(Crds.kafkaTopic(),
                         KafkaTopic.class, KafkaTopicList.class, KafkaTopic::getStatus, KafkaTopic::setStatus);
@@ -180,7 +181,7 @@ public class TopicOperatorMockTest {
     }
 
     @Test
-    public void testCreatedWithoutTopicNameInKube(VertxTestContext context) throws InterruptedException {
+    public void testCreatedWithoutTopicNameInKube(VertxTestContext context) throws InterruptedException, ExecutionException {
         LOGGER.info("Test started");
 
         int retention = 100_000_000;
@@ -200,7 +201,7 @@ public class TopicOperatorMockTest {
         testCreatedInKube(context, kt);
     }
 
-    void testCreatedInKube(VertxTestContext context, KafkaTopic kt) throws InterruptedException {
+    void testCreatedInKube(VertxTestContext context, KafkaTopic kt) throws InterruptedException, ExecutionException {
         String kubeName = kt.getMetadata().getName();
         String kafkaName = kt.getSpec().getTopicName() != null ? kt.getSpec().getTopicName() : kubeName;
         int retention = (Integer) kt.getSpec().getConfig().get("retention.bytes");
@@ -210,13 +211,13 @@ public class TopicOperatorMockTest {
         // Check created in Kafka
         waitUntilTopicExistsInKafka(kafkaName);
         LOGGER.info("Topic has been created");
-        Topic fromKafka = getFromKafka(context, kafkaName);
+        Topic fromKafka = getFromKafka(kafkaName);
         context.verify(() -> assertThat(fromKafka.getTopicName().toString(), is(kafkaName)));
         //context.assertEquals(kubeName, fromKafka.getResourceName().toString());
         // Reconcile after no changes
         reconcile(context);
         // Check things still the same
-        context.verify(() -> assertThat(fromKafka, is(getFromKafka(context, kafkaName))));
+        context.verify(() -> assertThat(fromKafka, is(getFromKafka(kafkaName))));
 
         // Config change + reconcile
         updateInKube(new KafkaTopicBuilder(kt).editSpec().addToConfig("retention.bytes", retention + 1).endSpec().build());
@@ -225,9 +226,12 @@ public class TopicOperatorMockTest {
         reconcile(context);
 
         // Check things still the same
-        context.verify(() -> assertThat(getFromKafka(context, kafkaName), is(new Topic.Builder(fromKafka)
-                .withConfigEntry("retention.bytes", Integer.toString(retention + 1))
-                .build())));
+        context.verify(() -> {
+            assertThat(getFromKafka(kafkaName), is(new Topic.Builder(fromKafka)
+                    .withConfigEntry("retention.bytes", Integer.toString(retention + 1))
+                    .build()));
+            context.completeNow();
+        });
 
         // Reconcile after change #partitions change
         // Check things still the same
@@ -241,22 +245,9 @@ public class TopicOperatorMockTest {
         // Check things still the same
     }
 
-    Topic getFromKafka(VertxTestContext context, String topicName) throws InterruptedException {
-        AtomicReference<Topic> ref = new AtomicReference<>();
-        Checkpoint async = context.checkpoint();
+    Topic getFromKafka(String topicName) throws InterruptedException, ExecutionException {
         Future<TopicMetadata> kafkaMetadata = session.kafka.topicMetadata(Reconciliation.DUMMY_RECONCILIATION, new TopicName(topicName));
-        kafkaMetadata.map(metadata -> TopicSerialization.fromTopicMetadata(metadata)).onComplete(fromKafka -> {
-            if (fromKafka.succeeded()) {
-                ref.set(fromKafka.result());
-            } else {
-                context.failNow(fromKafka.cause());
-            }
-            async.flag();
-        });
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
-        return ref.get();
+        return kafkaMetadata.map(TopicSerialization::fromTopicMetadata).toCompletionStage().toCompletableFuture().get();
     }
 
     private Config waitUntilTopicExistsInKafka(String topicName) {
@@ -283,21 +274,16 @@ public class TopicOperatorMockTest {
     }
 
     void reconcile(VertxTestContext context) throws InterruptedException {
-        Checkpoint async = context.checkpoint();
         session.topicOperator.reconcileAllTopics("test").onComplete(ar -> {
             if (!ar.succeeded()) {
                 context.failNow(ar.cause());
             }
-            async.flag();
         });
-        if (!context.awaitCompletion(60, TimeUnit.SECONDS)) {
-            context.failNow(new Throwable("Test timeout"));
-        }
     }
 
 
     @Test
-    public void testCreatedWithSameTopicNameInKube(VertxTestContext context) throws InterruptedException {
+    public void testCreatedWithSameTopicNameInKube(VertxTestContext context) throws InterruptedException, ExecutionException {
 
         int retention = 100_000_000;
         KafkaTopic kt = new KafkaTopicBuilder()
@@ -317,7 +303,7 @@ public class TopicOperatorMockTest {
     }
 
     @Test
-    public void testCreatedWithDifferentTopicNameInKube(VertxTestContext context) throws InterruptedException {
+    public void testCreatedWithDifferentTopicNameInKube(VertxTestContext context) throws InterruptedException, ExecutionException {
         int retention = 100_000_000;
         KafkaTopic kt = new KafkaTopicBuilder()
                 .withNewMetadata()
@@ -336,7 +322,7 @@ public class TopicOperatorMockTest {
     }
 
     @Test
-    public void testCreatedWithDefaultsInKube(VertxTestContext context) throws InterruptedException {
+    public void testCreatedWithDefaultsInKube(VertxTestContext context) throws InterruptedException, ExecutionException {
         int retention = 100_000_000;
         KafkaTopic kt = new KafkaTopicBuilder()
                 .withNewMetadata()
@@ -352,7 +338,7 @@ public class TopicOperatorMockTest {
     }
 
     @Test
-    public void testReconciliationPaused(VertxTestContext context) throws InterruptedException {
+    public void testReconciliationPaused(VertxTestContext context) throws InterruptedException, ExecutionException {
         LOGGER.info("Test started");
 
         int retention = 100_000_000;
@@ -374,7 +360,7 @@ public class TopicOperatorMockTest {
         testNotCreatedInKube(context, kt);
     }
 
-    void testNotCreatedInKube(VertxTestContext context, KafkaTopic kt) throws InterruptedException {
+    void testNotCreatedInKube(VertxTestContext context, KafkaTopic kt) throws InterruptedException, ExecutionException {
         String kubeName = kt.getMetadata().getName();
         String kafkaName = kt.getSpec().getTopicName() != null ? kt.getSpec().getTopicName() : kubeName;
         int retention = (Integer) kt.getSpec().getConfig().get("retention.bytes");
@@ -383,7 +369,7 @@ public class TopicOperatorMockTest {
 
         Thread.sleep(2000);
         LOGGER.info("Topic has not been created");
-        Topic fromKafka = getFromKafka(context, kafkaName);
+        Topic fromKafka = getFromKafka(kafkaName);
         context.verify(() -> assertThat(fromKafka, is(nullValue())));
         // Reconcile after no changes
         reconcile(context);
@@ -396,7 +382,10 @@ public class TopicOperatorMockTest {
         reconcile(context);
 
         // Check things still the same
-        context.verify(() -> assertThat(getFromKafka(context, kafkaName), is(nullValue())));
+        context.verify(() -> {
+            assertThat(getFromKafka(kafkaName), is(nullValue()));
+            context.completeNow();
+        });
     }
 
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -535,9 +535,9 @@ public class TopicOperatorTest {
         Topic kafkaTopic = null;
         Topic privateTopic = null;
 
-        Checkpoint async0 = context.checkpoint();
+        Checkpoint topicResourceCreated = context.checkpoint();
         //Must create all checkpoints used before flagging any to prevent premature test success
-        Checkpoint async = context.checkpoint(1);
+        Checkpoint completeTest = context.checkpoint(1);
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null);
         //mockKafka.setTopicMetadataResponse(topicName, null, null);
@@ -548,7 +548,7 @@ public class TopicOperatorTest {
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.kubeWatch(Watcher.Action.ADDED, topicResource);
-        mockK8s.createResource(topicResource).onComplete(ar -> async0.flag());
+        mockK8s.createResource(topicResource).onComplete(ar -> topicResourceCreated.flag());
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -560,7 +560,7 @@ public class TopicOperatorTest {
             mockTopicStore.read(topicName).onComplete(readResult -> {
                 assertSucceeded(context, readResult);
                 context.verify(() -> assertThat(readResult.result(), is(kubeTopic)));
-                async.flag();
+                completeTest.flag();
                 latch.countDown();
             });
         });
@@ -579,17 +579,17 @@ public class TopicOperatorTest {
         Topic kafkaTopic = null;
         Topic privateTopic = kubeTopic;
 
-        Checkpoint async0 = context.checkpoint(2);
+        Checkpoint topicCreatedInK8sAndStored = context.checkpoint(2);
         //Must create all checkpoints used before flagging any to prevent premature test success
-        Checkpoint async = context.checkpoint();
+        Checkpoint completeTest = context.checkpoint();
 
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.kubeWatch(Watcher.Action.DELETED, topicResource);
         mockK8s.setCreateResponse(resourceName, null)
-                .createResource(topicResource).onComplete(ar -> async0.flag());
+                .createResource(topicResource).onComplete(ar -> topicCreatedInK8sAndStored.flag());
         mockK8s.setDeleteResponse(resourceName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic).onComplete(ar -> async0.flag());
+                .create(privateTopic).onComplete(ar -> topicCreatedInK8sAndStored.flag());
         mockTopicStore.setDeleteTopicResponse(topicName, null);
 
         topicOperator.reconcile(reconciliation(logContext), logContext, null, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
@@ -598,7 +598,7 @@ public class TopicOperatorTest {
             mockTopicStore.assertNotExists(context, kubeTopic.getTopicName());
             mockK8s.assertNotExists(context, kubeTopic.getResourceName());
             mockK8s.assertNoEvents(context);
-            async.flag();
+            completeTest.flag();
         });
     }
 
@@ -612,12 +612,12 @@ public class TopicOperatorTest {
         Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar"), metadata).build();
         Topic privateTopic = null;
 
-        CountDownLatch async0 = new CountDownLatch(1);
+        CountDownLatch topicCreatedInKafka = new CountDownLatch(1);
         mockTopicStore.setCreateTopicResponse(topicName, null);
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
-        async0.await();
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedInKafka.countDown());
+        topicCreatedInKafka.await();
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
         CountDownLatch async = new CountDownLatch(2);
         topicOperator.reconcile(reconciliation(logContext), logContext, null, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
@@ -676,14 +676,15 @@ public class TopicOperatorTest {
         Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic privateTopic = kafkaTopic;
 
-        CountDownLatch async0 = new CountDownLatch(2);
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
+        CountDownLatch topicCreatedInKafkaAndStored = new CountDownLatch(2);
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedInKafkaAndStored.countDown());
         mockKafka.setDeleteTopicResponse(topicName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        mockTopicStore.create(kafkaTopic).onComplete(ar -> async0.countDown());
+        mockTopicStore.create(kafkaTopic).onComplete(ar -> topicCreatedInKafkaAndStored.countDown());
         mockTopicStore.setDeleteTopicResponse(topicName, null);
-        async0.await();
+        topicCreatedInKafkaAndStored.await();
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
+
         Checkpoint async = context.checkpoint();
         topicOperator.reconcile(reconciliation(logContext), logContext, null, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
@@ -705,15 +706,15 @@ public class TopicOperatorTest {
         Topic kafkaTopic = kubeTopic;
         Topic privateTopic = null;
 
-        CountDownLatch async0 = new CountDownLatch(2);
+        CountDownLatch topicCreatedinKafkaAndK8s = new CountDownLatch(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedinKafkaAndK8s.countDown());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
-        mockK8s.createResource(topicResource).onComplete(ar -> async0.countDown());
+        mockK8s.createResource(topicResource).onComplete(ar -> topicCreatedinKafkaAndK8s.countDown());
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        async0.await();
+        topicCreatedinKafkaAndK8s.await();
 
         Checkpoint async = context.checkpoint();
         topicOperator.reconcile(reconciliation(logContext), logContext, null, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
@@ -760,15 +761,15 @@ public class TopicOperatorTest {
         Topic kafkaTopic = new Topic.Builder(topicName, 10, (short) 2, map("cleanup.policy", "bar"), metadata).build();
         Topic privateTopic = null;
 
-        CountDownLatch async0 = new CountDownLatch(2);
+        CountDownLatch topicCreatedInKafkaAndK8s = new CountDownLatch(2);
         mockKafka.setCreateTopicResponse(topicName_ -> Future.succeededFuture());
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedInKafkaAndK8s.countDown());
         mockK8s.setCreateResponse(kubeName, null);
         KafkaTopic topicResource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
-        mockK8s.createResource(topicResource).onComplete(ar -> async0.countDown());
+        mockK8s.createResource(topicResource).onComplete(ar -> topicCreatedInKafkaAndK8s.countDown());
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        async0.await();
+        topicCreatedInKafkaAndK8s.await();
 
         Checkpoint async = context.checkpoint();
         topicOperator.reconcile(reconciliation(logContext), logContext, null, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
@@ -809,18 +810,18 @@ public class TopicOperatorTest {
         Topic privateTopic = null;
         Topic mergedTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("unclean.leader.election.enable", "true", "cleanup.policy", "bar"), metadata).build();
 
-        CountDownLatch async0 = new CountDownLatch(2);
+        CountDownLatch topicCreatedInKafkaAndK8s = new CountDownLatch(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedInKafkaAndK8s.countDown());
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
-        mockK8s.createResource(topic).onComplete(ar -> async0.countDown());
+        mockK8s.createResource(topic).onComplete(ar -> topicCreatedInKafkaAndK8s.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        async0.await();
+        topicCreatedInKafkaAndK8s.await();
 
         CountDownLatch async = new CountDownLatch(2);
         topicOperator.reconcile(reconciliation(logContext), logContext, topic, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
@@ -868,17 +869,17 @@ public class TopicOperatorTest {
         Topic kafkaTopic = new Topic.Builder(topicName.toString(), 12, (short) 2, map("cleanup.policy", "baz"), metadata).build();
         Topic privateTopic = null;
 
-        CountDownLatch async0 = new CountDownLatch(2);
+        CountDownLatch topicCreatedInKafkaAndK8s = new CountDownLatch(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedInKafkaAndK8s.countDown());
 
         KafkaTopic topic = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
-        mockK8s.createResource(topic).onComplete(ar -> async0.countDown());
+        mockK8s.createResource(topic).onComplete(ar -> topicCreatedInKafkaAndK8s.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        async0.await();
+        topicCreatedInKafkaAndK8s.await();
 
         CountDownLatch async = new CountDownLatch(2);
         topicOperator.reconcile(reconciliation(logContext), logContext, topic, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
@@ -920,38 +921,38 @@ public class TopicOperatorTest {
         Topic privateTopic = new Topic.Builder(topicName, resourceName, 10, (short) 2, map("cleanup.policy", "baz"), metadata).build();
         Topic resultTopic = new Topic.Builder(topicName, resourceName, 12, (short) 2, map("cleanup.policy", "bar"), metadata).build();
 
-        CountDownLatch async0 = new CountDownLatch(3);
+        CountDownLatch topicCreatedInKafkaAndK8sAndStored = new CountDownLatch(3);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
-        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> async0.countDown());
+        mockKafka.createTopic(Reconciliation.DUMMY_RECONCILIATION, kafkaTopic).onComplete(ar -> topicCreatedInKafkaAndK8sAndStored.countDown());
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         KafkaTopic resource = TopicSerialization.toTopicResource(kubeTopic, labels);
         LogContext logContext = LogContext.periodic(topicName.toString(), topicOperator.getNamespace(), topicName.toString());
         mockK8s.setCreateResponse(topicName.asKubeName(), null);
-        mockK8s.createResource(resource).onComplete(ar -> async0.countDown());
+        mockK8s.createResource(resource).onComplete(ar -> topicCreatedInKafkaAndK8sAndStored.countDown());
         mockK8s.setModifyResponse(topicName.asKubeName(), null);
         mockTopicStore.setCreateTopicResponse(topicName, null);
-        mockTopicStore.create(privateTopic).onComplete(ar -> async0.countDown());
-        async0.await();
+        mockTopicStore.create(privateTopic).onComplete(ar -> topicCreatedInKafkaAndK8sAndStored.countDown());
+        topicCreatedInKafkaAndK8sAndStored.await();
 
-        CountDownLatch async = new CountDownLatch(3);
+        CountDownLatch topicStoreReadSuccess = new CountDownLatch(3);
         topicOperator.reconcile(reconciliation(logContext), logContext, resource, kubeTopic, kafkaTopic, privateTopic).onComplete(reconcileResult -> {
             assertSucceeded(context, reconcileResult);
             mockK8s.assertNoEvents(context);
             mockTopicStore.read(topicName).onComplete(readResult -> {
                 assertSucceeded(context, readResult);
                 context.verify(() -> assertThat(readResult.result(), is(resultTopic)));
-                async.countDown();
+                topicStoreReadSuccess.countDown();
             });
             mockK8s.getFromName(topicName.asKubeName()).onComplete(readResult -> {
                 assertSucceeded(context, readResult);
                 context.verify(() -> assertThat(TopicSerialization.fromTopicResource(readResult.result()), is(resultTopic)));
-                async.countDown();
+                topicStoreReadSuccess.countDown();
             });
             context.verify(() -> assertThat(mockKafka.getTopicState(topicName), is(resultTopic)));
-            async.countDown();
+            topicStoreReadSuccess.countDown();
             try {
-                async.await(60, TimeUnit.SECONDS);
+                topicStoreReadSuccess.await(60, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #5161 
Removes nearly all usages of checkpoints, as erroneous use can cause tests to pass when they should fail. 
Of all tests modified, only 7 failed with the checkpoints removed, and none of them failed because the code under test was incorrect, failures were mostly due to mocking issues.

Nearly all checkpoint usages weren't erroneous, but chose to replace them with calls to `VertxTestContext#completeNow` to make the completion of the context explicit, instead of relying on the implicit completion of the context when the last checkpoint is flagged. 

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards
