### PR TITLE
[systemtest] Connect Builder - test for other type with and without file name

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -12,12 +12,14 @@ import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
+import io.strimzi.api.kafka.model.connect.build.OtherArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.Plugin;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.connect.build.TgzArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.ZipArtifactBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
@@ -43,8 +45,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import static io.strimzi.systemtest.Constants.CONNECT;
@@ -56,7 +60,9 @@ import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(REGRESSION)
@@ -73,6 +79,7 @@ class ConnectBuilderST extends AbstractST {
 
     private static final String ECHO_SINK_JAR_URL = "https://github.com/scholzj/echo-sink/releases/download/1.1.0/echo-sink-1.1.0.jar";
     private static final String ECHO_SINK_JAR_CHECKSUM = "b7da48d5ecd1e4199886d169ced1bf702ffbdfd704d69e0da97e78ff63c1bcece2f59c2c6c751f9c20be73472b8cb6a31b6fd4f75558c1cb9d96daa9e9e603d2";
+    private static final String ECHO_SINK_FILE_NAME = "echo-sink-test.jar";
 
     private static final String ECHO_SINK_JAR_WRONG_CHECKSUM = "f1f167902325062efc8c755647bc1b782b2b067a87a6e507ff7a3f6205803220";
 
@@ -85,18 +92,20 @@ class ConnectBuilderST extends AbstractST {
     private static final String CAMEL_CONNECTOR_ZIP_URL = "https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.zip";
     private static final String CAMEL_CONNECTOR_ZIP_CHECKSUM = "bc15135b8ef7faccd073508da0510c023c0f6fa3ec7e48c98ad880dd112b53bf106ad0a47bcb353eed3ec03bb3d273da7de356f3f7f1766a13a234a6bc28d602";
 
-    private String imageName = "";
+    private static final String PLUGIN_WITH_OTHER_TYPE_NAME = "plugin-with-other-type";
+
+    private String outputRegistry = "";
 
     private static final Plugin PLUGIN_WITH_TAR_AND_JAR = new PluginBuilder()
         .withName("connector-with-tar-and-jar")
         .withArtifacts(
             new JarArtifactBuilder()
-                .withNewUrl(ECHO_SINK_JAR_URL)
-                .withNewSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                .withUrl(ECHO_SINK_JAR_URL)
+                .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
                 .build(),
             new TgzArtifactBuilder()
-                .withNewUrl(ECHO_SINK_TGZ_URL)
-                .withNewSha512sum(ECHO_SINK_TGZ_CHECKSUM)
+                .withUrl(ECHO_SINK_TGZ_URL)
+                .withSha512sum(ECHO_SINK_TGZ_CHECKSUM)
                 .build())
         .build();
 
@@ -104,21 +113,33 @@ class ConnectBuilderST extends AbstractST {
         .withName("connector-from-zip")
         .withArtifacts(
             new ZipArtifactBuilder()
-                .withNewUrl(CAMEL_CONNECTOR_ZIP_URL)
-                .withNewSha512sum(CAMEL_CONNECTOR_ZIP_CHECKSUM)
+                .withUrl(CAMEL_CONNECTOR_ZIP_URL)
+                .withSha512sum(CAMEL_CONNECTOR_ZIP_CHECKSUM)
                 .build())
+        .build();
+
+    private static final Plugin PLUGIN_WITH_OTHER_TYPE = new PluginBuilder()
+        .withName(PLUGIN_WITH_OTHER_TYPE_NAME)
+        .withArtifacts(
+            new OtherArtifactBuilder()
+                .withUrl(ECHO_SINK_JAR_URL)
+                .withFileName(ECHO_SINK_FILE_NAME)
+                .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                .build()
+        )
         .build();
 
     @ParallelTest
     void testBuildFailsWithWrongChecksumOfArtifact(ExtensionContext extensionContext) {
         String connectClusterName = mapWithClusterNames.get(extensionContext.getDisplayName()) + "-connect";
         String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final String imageName = getImageNameForTestCase(extensionContext);
 
         Plugin pluginWithWrongChecksum = new PluginBuilder()
             .withName("connector-with-wrong-checksum")
             .withArtifacts(new JarArtifactBuilder()
-                .withNewUrl(ECHO_SINK_JAR_URL)
-                .withNewSha512sum(ECHO_SINK_JAR_WRONG_CHECKSUM)
+                .withUrl(ECHO_SINK_JAR_URL)
+                .withSha512sum(ECHO_SINK_JAR_WRONG_CHECKSUM)
                 .build())
             .build();
 
@@ -133,7 +154,7 @@ class ConnectBuilderST extends AbstractST {
                 .withNewBuild()
                     .withPlugins(pluginWithWrongChecksum)
                     .withNewDockerOutput()
-                        .withNewImage(imageName)
+                        .withImage(imageName)
                     .endDockerOutput()
                 .endBuild()
             .endSpec()
@@ -158,8 +179,8 @@ class ConnectBuilderST extends AbstractST {
             Plugin pluginWithRightChecksum = new PluginBuilder()
                 .withName("connector-with-right-checksum")
                 .withArtifacts(new JarArtifactBuilder()
-                    .withNewUrl(ECHO_SINK_JAR_URL)
-                    .withNewSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                    .withUrl(ECHO_SINK_JAR_URL)
+                    .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
                     .build())
                 .build();
 
@@ -185,6 +206,7 @@ class ConnectBuilderST extends AbstractST {
         String connectClusterName = mapWithClusterNames.get(extensionContext.getDisplayName()) + "-connect";
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
         String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final String imageName = getImageNameForTestCase(extensionContext);
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(SHARED_KAFKA_CLUSTER_NAME, topicName).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(extensionContext, connectClusterName, SHARED_KAFKA_CLUSTER_NAME, 1, false)
@@ -199,7 +221,7 @@ class ConnectBuilderST extends AbstractST {
                 .withNewBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR, PLUGIN_WITH_ZIP)
                     .withNewDockerOutput()
-                        .withNewImage(imageName)
+                        .withImage(imageName)
                     .endDockerOutput()
                 .endBuild()
                 .withNewInlineLogging()
@@ -266,7 +288,7 @@ class ConnectBuilderST extends AbstractST {
                 .withNewBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR)
                     .withNewImageStreamOutput()
-                        .withNewImage(imageStreamName + ":latest")
+                        .withImage(imageStreamName + ":latest")
                     .endImageStreamOutput()
                 .endBuild()
             .endSpec()
@@ -290,13 +312,14 @@ class ConnectBuilderST extends AbstractST {
         String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
         String echoConnector = "echo-sink-connector";
         String camelConnector = "camel-http-connector";
+        final String imageName = getImageNameForTestCase(extensionContext);
 
         Plugin secondPlugin =  new PluginBuilder()
             .withName("camel-connector")
             .withArtifacts(
                 new TgzArtifactBuilder()
-                    .withNewUrl(CAMEL_CONNECTOR_TGZ_URL)
-                    .withNewSha512sum(CAMEL_CONNECTOR_TGZ_CHECKSUM)
+                    .withUrl(CAMEL_CONNECTOR_TGZ_URL)
+                    .withSha512sum(CAMEL_CONNECTOR_TGZ_CHECKSUM)
                     .build())
             .build();
 
@@ -318,7 +341,7 @@ class ConnectBuilderST extends AbstractST {
                 .withNewBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR)
                     .withNewDockerOutput()
-                        .withNewImage(imageName)
+                        .withImage(imageName)
                     .endDockerOutput()
                 .endBuild()
                 .withNewInlineLogging()
@@ -376,6 +399,76 @@ class ConnectBuilderST extends AbstractST {
         assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(CAMEL_CONNECTOR_CLASS_NAME)));
     }
 
+    @ParallelTest
+    void testBuildOtherPluginTypeWithAndWithoutFileName(ExtensionContext extensionContext) {
+        final String connectClusterName = mapWithClusterNames.get(extensionContext.getDisplayName()) + "-connect";
+        String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final String imageName = getImageNameForTestCase(extensionContext);
+
+        String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(SHARED_KAFKA_CLUSTER_NAME, topicName).build());
+        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
+
+        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(extensionContext, connectClusterName, SHARED_KAFKA_CLUSTER_NAME, 1, false)
+            .editMetadata()
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+            .endMetadata()
+            .editOrNewSpec()
+                .addToConfig("key.converter.schemas.enable", false)
+                .addToConfig("value.converter.schemas.enable", false)
+                .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                    .withNewBuild()
+                        .withPlugins(PLUGIN_WITH_OTHER_TYPE)
+                        .withNewDockerOutput()
+                            .withImage(imageName)
+                        .endDockerOutput()
+                .endBuild()
+            .endSpec()
+            .build());
+
+        String deploymentName = KafkaConnectResources.deploymentName(connectClusterName);
+        Map<String, String> connectSnapshot = DeploymentUtils.depSnapshot(deploymentName);
+        String connectPodName = kubeClient().listPods(connectClusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+
+        LOGGER.info("Checking that plugin has correct file name: {}", ECHO_SINK_FILE_NAME);
+        assertEquals(getPluginFileNameFromConnectPod(connectPodName), ECHO_SINK_FILE_NAME);
+
+        final Plugin pluginWithoutFileName = new PluginBuilder()
+            .withName(PLUGIN_WITH_OTHER_TYPE_NAME)
+            .withArtifacts(
+                new OtherArtifactBuilder()
+                    .withUrl(ECHO_SINK_JAR_URL)
+                    .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                    .build()
+            )
+            .build();
+
+        LOGGER.info("Removing file name from the plugin, hash should be used");
+        KafkaConnectResource.replaceKafkaConnectResource(connectClusterName, connect -> {
+            connect.getSpec().getBuild().setPlugins(Collections.singletonList(pluginWithoutFileName));
+        });
+
+        DeploymentUtils.waitTillDepHasRolled(deploymentName, 1, connectSnapshot);
+
+        LOGGER.info("Checking that plugin has different name than before");
+        connectPodName = kubeClient().listPods(connectClusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+        String fileName = getPluginFileNameFromConnectPod(connectPodName);
+        assertNotEquals(fileName, ECHO_SINK_FILE_NAME);
+        assertEquals(fileName, Util.sha1Prefix(ECHO_SINK_JAR_URL));
+    }
+
+    private String getPluginFileNameFromConnectPod(String connectPodName) {
+        return cmdKubeClient().execInPod(connectPodName,
+            "/bin/bash", "-c", "ls plugins/plugin-with-other-type/*").out().trim();
+    }
+
+    private String getImageNameForTestCase(ExtensionContext extensionContext) {
+        int randomNum = new Random().nextInt(Integer.MAX_VALUE);
+        return outputRegistry + "/connect-build-" + randomNum + ":latest";
+    }
+
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         install = new SetupClusterOperator.SetupClusterOperatorBuilder()
@@ -385,16 +478,12 @@ class ConnectBuilderST extends AbstractST {
             .createInstallation()
             .runInstallation();
 
-        String outputRegistry = "";
-
         if (cluster.isNotKubernetes()) {
-            outputRegistry = "image-registry.openshift-image-registry.svc:5000/";
-            imageName = outputRegistry + NAMESPACE + "/connect-build:latest";
+            outputRegistry = "image-registry.openshift-image-registry.svc:5000/" + NAMESPACE;
         } else {
             LOGGER.warn("For running these tests on K8s you have to have internal registry deployed using `minikube start --insecure-registry '10.0.0.0/24'` and `minikube addons enable registry`");
             Service service = kubeClient("kube-system").getService("registry");
             outputRegistry = service.getSpec().getClusterIP() + ":" + service.getSpec().getPorts().stream().filter(servicePort -> servicePort.getName().equals("http")).findFirst().get().getPort();
-            imageName = outputRegistry + "/connect-build:latest";
         }
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(SHARED_KAFKA_CLUSTER_NAME, 3).build());
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test
- Fixup

### Description

This PR adds test for fix of issue with file names - fixed in #5121. Earlier, when we used plugin with URL that is not valid for a file name (for example `https://some-url.tld/downaload?artifact=12334&path=some/random/path&someOther=option` - the "suffix" was used for the file name = `path&someOther=option`) exception appeared. Now, the URL hash is used for the file name, if we don't specify it differently inside the `Other` type artifact.

I noticed that we are overriding images pushed into local registries - because of test parallelism. I added simple fix for it, random number is generated for each image.

Also I changed the fields which were "deprecated" to the correct one.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

