### PR TITLE
[DOC] Passing proxy config from the Cluster Operator

### DIFF
--- a/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
@@ -19,3 +19,5 @@ NOTE: On OpenShift, a Kafka Connect deployment can incorporate a Source2Image fe
 * xref:assembly-config-kafka-str[Kafka Cluster configuration].
 
 include::../../modules/operators/ref-operator-cluster.adoc[leveloffset=+1]
+//Passing proxy configuration variables from Cluster Operator
+include::../../modules/operators/proc-configuring-proxy-config-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
+++ b/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
@@ -14,8 +14,8 @@ Configure the Cluster Operator deployment to specify the proxy environment varia
 The Cluster Operator accepts standard proxy configuration (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`) as environment variables.
 The proxy settings are applied to all Strimzi containers.
 
-The format for a proxy address takes the form _\http://IP-ADDRESS:PORT-NUMBER_.
-To set up a proxy with a name and password, the address takes the form _\http://USERNAME:PASSWORD@IP-ADDRESS:PORT-NUMBER_.
+The format for a proxy address is _\http://IP-ADDRESS:PORT-NUMBER_.
+To set up a proxy with a name and password, the format is _\http://USERNAME:PASSWORD@IP-ADDRESS:PORT-NUMBER_.
 
 .Prerequisites
 
@@ -53,7 +53,6 @@ spec:
 <1> Address of the proxy server.
 <2> Secure address of the proxy server.
 <3> Addresses for servers that are accessed directly as exceptions to the proxy server. The URLs are comma-separated.
-Wildcards such as _*.internal.com_ aren't accepted, but you can use a single asterisk (`*`) to match all hosts to disable the proxy.
 --
 +
 Alternatively, edit the `Deployment` directly:
@@ -63,7 +62,7 @@ Alternatively, edit the `Deployment` directly:
 kubectl edit deployment strimzi-cluster-operator
 ----
 
-. If you updated the YAML file instead of editing the `Deployment` directly, apply the changes by deploying the configuration:
+. If you updated the YAML file instead of editing the `Deployment` directly, apply the changes:
 +
 [source,shell,subs=+quotes]
 ----

--- a/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
+++ b/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-cluster-operator.adoc
+
+[id='proc-configuring-proxy-config-cluster-operator-{context}']
+= Configuring the Cluster Operator with default proxy settings
+
+[role="_abstract"]
+If you are running a Kafka cluster behind a HTTP proxy, you can still pass data in and out of the cluster.
+For example, you can run Kafka Connect with connectors that push and pull data outside the proxy.
+Or you can use a proxy to connect with an authorization server.
+Configure the Cluster Operator deployment to specify the proxy environment variables.
+
+The Cluster Operator accepts standard proxy configuration (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`) as environment variables.
+The proxy settings are applied to all Strimzi containers.
+
+The format for a proxy address takes the form _\http://IP-ADDRESS:PORT-NUMBER_.
+To set up a proxy with a name and password, the address takes the form _\http://USERNAME:PASSWORD@IP-ADDRESS:PORT-NUMBER_.
+
+.Prerequisites
+
+This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinitions`, `ClusterRoles` and `ClusterRoleBindings`.
+Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit,
+and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+
+.Procedure
+
+. To add proxy environment variables to the Cluster Operator, update its `Deployment` configuration (`install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml`).
++
+--
+.Example proxy configuration for the Cluster Operator
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  # ...
+  template:
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      containers:
+        # ...
+        env:
+        # ...
+        - name: "HTTP_PROXY"
+          value: "http://proxy.com" <1>
+        - name: "HTTPS_PROXY"
+          value: "https://proxy.com" <2>
+        - name: "NO_PROXY"
+          value: "internal.com, other.domain.com" <3>
+  # ...
+----
+<1> Address of the proxy server.
+<2> Secure address of the proxy server.
+<3> Addresses for servers that are accessed directly as exceptions to the proxy server. The URLs are comma-separated.
+Wildcards such as _*.internal.com_ aren't accepted, but you can use a single asterisk (`*`) to match all hosts to disable the proxy.
+--
++
+Alternatively, edit the `Deployment` directly:
++
+[source,shell,subs=+quotes]
+----
+kubectl edit deployment strimzi-cluster-operator
+----
+
+. If you updated the YAML file instead of editing the `Deployment` directly, apply the changes by deploying the configuration:
++
+[source,shell,subs=+quotes]
+----
+kubectl create -f install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:property-hostaliases-config-reference[Host aliases]
+* link:{BookURLDeploying}#adding-users-the-strimzi-admin-role-str[Designating Strimzi administrators^]

--- a/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
+++ b/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
@@ -7,10 +7,10 @@
 
 [role="_abstract"]
 If you are running a Kafka cluster behind a HTTP proxy, you can still pass data in and out of the cluster.
-For example, you can run Kafka Connect with connectors that push and pull data outside the proxy.
+For example, you can run Kafka Connect with connectors that push and pull data from outside the proxy.
 Or you can use a proxy to connect with an authorization server.
-Configure the Cluster Operator deployment to specify the proxy environment variables.
 
+Configure the Cluster Operator deployment to specify the proxy environment variables.
 The Cluster Operator accepts standard proxy configuration (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`) as environment variables.
 The proxy settings are applied to all Strimzi containers.
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds a new procedure to the _Using the Cluster Operator_ section of the _Using Strimzi_ guide.
_Configuring the Cluster Operator with default proxy settings_ describes the steps to add proxy configuration as environmental variables to the Cluster Operator `Deployment`.

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

