### PR TITLE
[DOC] Add note for CM creation in before/after load summaries (CC)

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -113,7 +113,7 @@ The broker load is stored in a ConfigMap (with the same name as the KafakRebalan
 Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 
-NOTE: The ConfigMap will appear once the KafkaRebalance is in `ProposalReady` state and remain even after the rebalancing process.
+NOTE: The ConfigMap appears when the KafkaRebalance resource is in the `ProposalReady` state and remains after the rebalance is complete.
 
 To extract the JSON string from the ConfigMap you could use the following command, which uses the jq command line JSON parser tool:
 

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -113,6 +113,8 @@ The broker load is stored in a ConfigMap (with the same name as the KafakRebalan
 Each metric consist of three values.
 The first is the metric value before the optimization proposal is applied, the second is the expected value of the metric after the proposal is applied, and the third is the difference between the first two values (after minus before).
 
+NOTE: The ConfigMap will appear once the KafkaRebalance is in `ProposalReady` state and remain even after the rebalancing process.
+
 To extract the JSON string from the ConfigMap you could use the following command, which uses the jq command line JSON parser tool:
 
 [source,shell,subs=+quotes]


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Documentation

### Description

As we discussed offline, it could be good to have some note in documentation about the creation of CM when we are deploying the `KafkaRebalance`, because ATM it seems that (from my POV) CM with summaries is created together with the KR. I added a note about this so it will be more clearer for all.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

