### PR TITLE
Vertx Kafka client update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <gson.version>2.8.2</gson.version>
-        <vertx.kafka.client>4.0.3</vertx.kafka.client>
+        <vertx.kafka.client>4.1.0</vertx.kafka.client>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <netty.version>4.1.65.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- chores

### Description
We do use Vertx in version 4.1.0. The same version can be used for vertx kafka client

### Checklist


- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

