### PR TITLE
Correct quartz exclusions

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -115,8 +115,16 @@
             <exclusions>
                 <!-- We just depend on the CronExpression class, not all of quartz's deps -->
                 <exclusion>
-                    <groupId>c3p0</groupId>
+                    <groupId>com.mchange</groupId>
                     <artifactId>c3p0</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.mchange</groupId>
+                    <artifactId>mchange-commons-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP-java7</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- chores

### Description
The `c3p0` exclusion uses the wrong group ID. Also, the comment says we need just `CronExpression` but there are more unused deps.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

