### PR TITLE
Bump Jayway JsonPath version to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <scala-library.version>2.12.12</scala-library.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <mockito.version>2.28.2</mockito.version>
-        <jayway-jsonpath.version>2.5.0</jayway-jsonpath.version>
+        <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
         <slf4j.version>1.7.25</slf4j.version>
         <quartz.version>2.3.2</quartz.version>
         <jaeger.version>1.3.2</jaeger.version>


### PR DESCRIPTION
Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

_Select the type of your PR_

- Bugfix

### Description

Jayway JsonPath 2.5.0 is known to contain a CVE (https://github.com/strimzi/strimzi-kafka-oauth/pull/117)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

