### PR TITLE
Try to fix the Kafka binaries cache

### DIFF
--- a/.azure/templates/build_strimzi.yaml
+++ b/.azure/templates/build_strimzi.yaml
@@ -2,7 +2,7 @@
 steps:
 - task: Cache@2
   inputs:
-    key: 'mvn-m2-cache | $(System.JobName)'
+    key: '"mvn-m2-cache" | "$(System.JobName)" | **/pom.xml'
     path: "$(MVN_CACHE_FOLDER)"
   displayName: Maven cache
 - task: Cache@2

--- a/.azure/templates/build_strimzi.yaml
+++ b/.azure/templates/build_strimzi.yaml
@@ -7,7 +7,7 @@ steps:
   displayName: Maven cache
 - task: Cache@2
   inputs:
-    key: 'kafka-binaries | version-1'
+    key: '"kafka-binaries" | kafka-versions.yaml'
     path: docker-images/kafka/tmp/archives
   displayName: Kafka Binaries cache
 - task: Maven@3


### PR DESCRIPTION
The Kafka downloads from Apache take sometimes very long. That is why we are using the cache in Azure pipelines to cache the binaries. That does not seem to work anymore. This Pr tries to fix / improve the cache. The same seems to apply to the Maven cache.