### PR TITLE
Exclude unused grpc dependencies

### DIFF
--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -80,7 +80,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
-                    <artifactId>grpc-api</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- chores

### Description
`apicurio-registry-utils-streams` dependency fetches several `grpc` artifacts. Those are not necessary as we do not use them.
### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

