### PR TITLE
feature/topic-operator: Add SASL, SCRAM and Public CA connectivity options

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
@@ -44,6 +44,7 @@ public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Seria
     public static final int DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;
     public static final int DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 18;
     public static final int DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS = 6;
+    public static final String DEFAULT_SECURITY_PROTOCOL = "SSL";
 
     protected String watchedNamespace;
     protected String image;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -58,7 +58,6 @@ public class EntityTopicOperator extends AbstractModel {
     public static final String ENV_VAR_SECURITY_PROTOCOL = "STRIMZI_SECURITY_PROTOCOL";
 
     public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
-    public static final String ENV_VAR_TLS_AUTH_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
 
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY)
@@ -79,7 +78,6 @@ public class EntityTopicOperator extends AbstractModel {
     private int topicMetadataMaxAttempts;
     protected List<ContainerEnvVar> templateContainerEnvVars;
     protected SecurityContext templateContainerSecurityContext;
-    private String securityProtocol;
 
     /**
      * @param reconciliation   The reconciliation
@@ -107,7 +105,6 @@ public class EntityTopicOperator extends AbstractModel {
         this.zookeeperSessionTimeoutMs = EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS * 1_000;
         this.resourceLabels = ModelUtils.defaultResourceLabels(cluster);
         this.topicMetadataMaxAttempts = EntityTopicOperatorSpec.DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
-        this.securityProtocol = EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL;
 
         this.ancillaryConfigMapName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "entity-topic-operator-metrics-and-logging";
@@ -283,9 +280,8 @@ public class EntityTopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Integer.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Integer.toString(zookeeperSessionTimeoutMs)));
         varList.add(buildEnvVar(ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
-        varList.add(buildEnvVar(ENV_VAR_SECURITY_PROTOCOL, securityProtocol));
+        varList.add(buildEnvVar(ENV_VAR_SECURITY_PROTOCOL, EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL));
         varList.add(buildEnvVar(ENV_VAR_TLS_ENABLED, Boolean.toString(true)));
-        varList.add(buildEnvVar(ENV_VAR_TLS_AUTH_ENABLED, Boolean.toString(true)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         EntityOperator.javaOptions(varList, getJvmOptions(), javaSystemProperties);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -55,7 +55,11 @@ public class EntityTopicOperator extends AbstractModel {
     public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
+    public static final String ENV_VAR_SECURITY_PROTOCOL = "STRIMZI_SECURITY_PROTOCOL";
+
     public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
+    public static final String ENV_VAR_TLS_AUTH_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
+
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT).build();
@@ -75,6 +79,7 @@ public class EntityTopicOperator extends AbstractModel {
     private int topicMetadataMaxAttempts;
     protected List<ContainerEnvVar> templateContainerEnvVars;
     protected SecurityContext templateContainerSecurityContext;
+    private String securityProtocol;
 
     /**
      * @param reconciliation   The reconciliation
@@ -102,6 +107,7 @@ public class EntityTopicOperator extends AbstractModel {
         this.zookeeperSessionTimeoutMs = EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS * 1_000;
         this.resourceLabels = ModelUtils.defaultResourceLabels(cluster);
         this.topicMetadataMaxAttempts = EntityTopicOperatorSpec.DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
+        this.securityProtocol = EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL;
 
         this.ancillaryConfigMapName = metricAndLogConfigsName(cluster);
         this.logAndMetricsConfigVolumeName = "entity-topic-operator-metrics-and-logging";
@@ -277,7 +283,9 @@ public class EntityTopicOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS, Integer.toString(reconciliationIntervalMs)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS, Integer.toString(zookeeperSessionTimeoutMs)));
         varList.add(buildEnvVar(ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
+        varList.add(buildEnvVar(ENV_VAR_SECURITY_PROTOCOL, securityProtocol));
         varList.add(buildEnvVar(ENV_VAR_TLS_ENABLED, Boolean.toString(true)));
+        varList.add(buildEnvVar(ENV_VAR_TLS_AUTH_ENABLED, Boolean.toString(true)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         EntityOperator.javaOptions(varList, getJvmOptions(), javaSystemProperties);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -114,6 +114,8 @@ public class EntityTopicOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(toZookeeperSessionTimeout * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(toTopicMetadataMaxAttempts)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TLS_ENABLED).withValue(Boolean.toString(true)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TLS_AUTH_ENABLED).withValue(Boolean.toString(true)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_SECURITY_PROTOCOL).withValue(EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_JAVA_OPTS).withValue("-Xms128m").build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES).withValue("-Djavax.net.debug=verbose -Dsomething.else=42").build());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -113,9 +113,9 @@ public class EntityTopicOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(toReconciliationInterval * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(toZookeeperSessionTimeout * 1000)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(toTopicMetadataMaxAttempts)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_SECURITY_PROTOCOL).withValue(EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TLS_ENABLED).withValue(Boolean.toString(true)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TLS_AUTH_ENABLED).withValue(Boolean.toString(true)).build());
-        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_SECURITY_PROTOCOL).withValue(EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_JAVA_OPTS).withValue("-Xms128m").build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES).withValue("-Djavax.net.debug=verbose -Dsomething.else=42").build());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -115,7 +115,6 @@ public class EntityTopicOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(toTopicMetadataMaxAttempts)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_SECURITY_PROTOCOL).withValue(EntityTopicOperatorSpec.DEFAULT_SECURITY_PROTOCOL).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TLS_ENABLED).withValue(Boolean.toString(true)).build());
-        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TLS_AUTH_ENABLED).withValue(Boolean.toString(true)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_JAVA_OPTS).withValue("-Xms128m").build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES).withValue("-Djavax.net.debug=verbose -Dsomething.else=42").build());

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -99,24 +99,25 @@ You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
 <9> Enables TLS support for encrypted communication with the Kafka brokers.
 <10> (Optional) The Java options used by the JVM running the Topic Operator.
 <11> (Optional) The debugging (`-D`) options set for the Topic Operator.
-<12> (Optional) Skip generating trust store certificates if TLS is enabled. If this setting is enabled then the brokers have to use a public trusted certificate authority for their TLS certificates.
-The default is "false".
-<13> (Optional) Generate key store certificates for mutual TLS authentication. Setting this to false will disable client authentication with TLS to the Kafka brokers.
-The default is "true".
-<14> (Optional) Enable SASL support for client authentication when connecting to Kafka brokers.
-The default is "false".
+<12> (Optional) Skips the generation of trust store certificates if TLS is enabled through `STRIMZI_TLS_ENABLED`. If this environment variable is enabled, the brokers must use a public trusted certificate authority for their TLS certificates.
+The default is `false`.
+<13> (Optional) Generates key store certificates for mutual TLS authentication. Setting this to `false` disables client authentication with TLS to the Kafka brokers.
+The default is `true`.
+<14> (Optional) Enables SASL support for client authentication when connecting to Kafka brokers.
+The default is `false`.
 <15> (Optional) The SASL username for client authentication.
 Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
 <16> (Optional) The SASL password for client authentication.
 Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
 <17> (Optional) The SASL mechanism for client authentication.
 Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
-The value can be set to: `plain`, `scram-sha-256` and `scram-sha-512`.
+You can set the value to `plain`, `scram-sha-256`, or `scram-sha-512`.
 <18> (Optional) The security protocol used for communication with Kafka brokers.
 The default value is "PLAINTEXT".
-The value can be set to: `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT` and `SASL_SSL`.
+You can set the value to `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.
 
 . If you enabled TLS with the `STRIMZI_TLS_ENABLED` environment variable, specify the keystore and truststore used to authenticate connection to the Kafka cluster.
+. If you want to connect to Kafka brokers which are using certificates from public CAs as for example AWS MSK then you'll need to set `STRIMZI_PUBLIC_CA` to `true`.
 +
 .Example TLS configuration
 [source,shell,subs=+quotes]

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -101,8 +101,8 @@ You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
 <11> (Optional) The debugging (`-D`) options set for the Topic Operator.
 <12> (Optional) Skip generating trust store certificates if TLS is enabled. If this setting is enabled then the brokers have to use a public trusted certificate authority for their TLS certificates.
 The default is "false".
-<13> (Optional) Skip generating key store certificates for mutual TLS authentication. This will disable client authentication with TLS to the Kafka brokers.
-The default is "false".
+<13> (Optional) Generate key store certificates for mutual TLS authentication. Setting this to false will disable client authentication with TLS to the Kafka brokers.
+The default is "true".
 <14> (Optional) Enable SASL support for client authentication when connecting to Kafka brokers.
 The default is "false".
 <15> (Optional) The SASL username for client authentication.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -65,6 +65,20 @@ spec:
               value: "-Xmx=512M -Xms=256M"
             - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <11>
               value: "-Djavax.net.debug=verbose -DpropertyName=value"
+            - name: STRIMZI_PUBLIC_CA <12>
+              value: "false"
+            - name: STRIMZI_TLS_AUTH_ENABLED <13>
+              value: "false"
+            - name: STRIMZI_SASL_ENABLED <14>
+              value: "false"
+            - name: STRIMZI_SASL_USERNAME <15>
+              value: "admin"
+            - name: STRIMZI_SASL_PASSWORD <16>
+              value: "password"
+            - name: STRIMZI_SASL_MECHANISM <17>
+              value: "scram-sha-512"
+            - name: STRIMZI_SECURITY_PROTOCOL <18>
+              value: "SSL"
 ----
 <1> The Kubernetes namespace for the Topic Operator to watch for `KafkaTopic` resources. Specify the namespace of the Kafka cluster.
 <2> The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
@@ -85,6 +99,22 @@ You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
 <9> Enables TLS support for encrypted communication with the Kafka brokers.
 <10> (Optional) The Java options used by the JVM running the Topic Operator.
 <11> (Optional) The debugging (`-D`) options set for the Topic Operator.
+<12> (Optional) Skip generating trust store certificates if TLS is enabled. If this setting is enabled then the brokers have to use a public trusted certificate authority for their TLS certificates.
+The default is "false".
+<13> (Optional) Skip generating key store certificates for mutual TLS authentication. This will disable client authentication with TLS to the Kafka brokers.
+The default is "false".
+<14> (Optional) Enable SASL support for client authentication when connecting to Kafka brokers.
+The default is "false".
+<15> (Optional) The SASL username for client authentication.
+Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
+<16> (Optional) The SASL password for client authentication.
+Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
+<17> (Optional) The SASL mechanism for client authentication.
+Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
+The value can be set to: `plain`, `scram-sha-256` and `scram-sha-512`.
+<18> (Optional) The security protocol used for communication with Kafka brokers.
+The default value is "PLAINTEXT".
+The value can be set to: `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT` and `SASL_SSL`.
 
 . If you enabled TLS with the `STRIMZI_TLS_ENABLED` environment variable, specify the keystore and truststore used to authenticate connection to the Kafka cluster.
 +

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -116,8 +116,8 @@ You can set the value to `plain`, `scram-sha-256`, or `scram-sha-512`.
 The default value is "PLAINTEXT".
 You can set the value to `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.
 
+. If you want to connect to Kafka brokers that are using certificates from a public certificate authority, set `STRIMZI_PUBLIC_CA` to `true`. Set this property to `true`, for example, if you are using Kafka on Amazon Web Services (AWS).
 . If you enabled TLS with the `STRIMZI_TLS_ENABLED` environment variable, specify the keystore and truststore used to authenticate connection to the Kafka cluster.
-. If you want to connect to Kafka brokers which are using certificates from public CAs as for example AWS MSK then you'll need to set `STRIMZI_PUBLIC_CA` to `true`.
 +
 .Example TLS configuration
 [source,shell,subs=+quotes]
@@ -132,7 +132,7 @@ env:
     value: "/path/to/keystore.p12"
   - name: STRIMZI_KEYSTORE_PASSWORD <4>
     value: "__KEYSTORE-PASSWORD__"
-# ..."
+# ...
 ----
 <1> The truststore contains the public key (`ca.crt`) value of the Certificate Authority used to sign new user certificates for TLS client authentication.
 <2> The password for accessing the truststore.

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -34,7 +34,7 @@ if [ "$STRIMZI_PUBLIC_CA" != "true" ]; then
     echo "Preparing trust store certificates for internal communication is completed"
 fi
 
-if [ "$STRIMZI_TLS_AUTH_ENABLED" = "true" ]; then
+if [ "$STRIMZI_TLS_AUTH_ENABLED" != "false" ]; then
   echo "Preparing key store certificates for internal communication"
   STORE=/tmp/topic-operator/replication.keystore.p12
   rm -f "$STORE"

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -22,20 +22,26 @@ function create_keystore {
    RANDFILE=/tmp/.rnd openssl pkcs12 -export -in "$3" -inkey "$4" -name topic-operator -password pass:"$2" -out "$1"
 }
 
-echo "Preparing certificates for internal communication"
-STORE=/tmp/topic-operator/replication.truststore.p12
-rm -f "$STORE"
-for CRT in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
-  ALIAS=$(basename "$CRT" .crt)
-  echo "Adding $CRT to truststore $STORE with alias $ALIAS"
-  create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-done
+if [ "$STRIMZI_PUBLIC_CA" != "true" ]; then
+    echo "Preparing trust store certificates for internal communication"
+    STORE=/tmp/topic-operator/replication.truststore.p12
+    rm -f "$STORE"
+    for CRT in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
+      ALIAS=$(basename "$CRT" .crt)
+      echo "Adding $CRT to truststore $STORE with alias $ALIAS"
+      create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+    done
+    echo "Preparing trust store certificates for internal communication is completed"
+fi
 
-STORE=/tmp/topic-operator/replication.keystore.p12
-rm -f "$STORE"
-create_keystore "$STORE" "$CERTS_STORE_PASSWORD" \
-    /etc/tls-sidecar/eo-certs/entity-operator.crt \
-    /etc/tls-sidecar/eo-certs/entity-operator.key \
-    /etc/tls-sidecar/cluster-ca-certs/ca.crt \
-    entity-operator
-echo "Preparing certificates for internal communication is complete"
+if [ "$STRIMZI_TLS_AUTH_ENABLED" = "true" ]; then
+  echo "Preparing key store certificates for internal communication"
+  STORE=/tmp/topic-operator/replication.keystore.p12
+  rm -f "$STORE"
+  create_keystore "$STORE" "$CERTS_STORE_PASSWORD" \
+      /etc/tls-sidecar/eo-certs/entity-operator.crt \
+      /etc/tls-sidecar/eo-certs/entity-operator.key \
+      /etc/tls-sidecar/cluster-ca-certs/ca.crt \
+      entity-operator
+  echo "Preparing key store certificates for internal communication is completed"
+fi

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -15,21 +15,27 @@ if [ -n "$STRIMZI_JAVA_OPTS" ]; then
 fi
 
 if [ "$STRIMZI_TLS_ENABLED" = "true" ]; then
-    if [ -z "$STRIMZI_TRUSTSTORE_LOCATION" ] && [ -z "$STRIMZI_KEYSTORE_LOCATION" ]; then
-        # Generate temporary keystore password
-        CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
-        export CERTS_STORE_PASSWORD
+    # Generate temporary keystore password
+    CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
+    export CERTS_STORE_PASSWORD
 
-        mkdir -p /tmp/topic-operator
+    mkdir -p /tmp/topic-operator
 
-        # Import certificates into keystore and truststore
-        "${STRIMZI_HOME}/bin/tls_prepare_certificates.sh"
+    # Import certificates into keystore and truststore
+    "${STRIMZI_HOME}/bin/tls_prepare_certificates.sh"
 
-        export STRIMZI_TRUSTSTORE_LOCATION=/tmp/topic-operator/replication.truststore.p12
-        export STRIMZI_TRUSTSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
+    if [ "$STRIMZI_PUBLIC_CA" != "true" ]; then
+        if [ -z "$STRIMZI_TRUSTSTORE_LOCATION" ]; then
+            export STRIMZI_TRUSTSTORE_LOCATION=/tmp/topic-operator/replication.truststore.p12
+            export STRIMZI_TRUSTSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
+        fi
+    fi
 
-        export STRIMZI_KEYSTORE_LOCATION=/tmp/topic-operator/replication.keystore.p12
-        export STRIMZI_KEYSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
+    if [ "$STRIMZI_TLS_AUTH_ENABLED" = "true" ]; then
+        if [ -z "$STRIMZI_KEYSTORE_LOCATION" ]; then
+            export STRIMZI_KEYSTORE_LOCATION=/tmp/topic-operator/replication.keystore.p12
+            export STRIMZI_KEYSTORE_PASSWORD="$CERTS_STORE_PASSWORD"
+        fi
     fi
 fi
 

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -31,7 +31,7 @@ if [ "$STRIMZI_TLS_ENABLED" = "true" ] || [ "$STRIMZI_SECURITY_PROTOCOL" = "SSL"
         fi
     fi
 
-    if [ "$STRIMZI_TLS_AUTH_ENABLED" = "true" ]; then
+    if [ "$STRIMZI_TLS_AUTH_ENABLED" != "false" ]; then
         if [ -z "$STRIMZI_KEYSTORE_LOCATION" ]; then
             export STRIMZI_KEYSTORE_LOCATION=/tmp/topic-operator/replication.keystore.p12
             export STRIMZI_KEYSTORE_PASSWORD="$CERTS_STORE_PASSWORD"

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -14,7 +14,7 @@ if [ -n "$STRIMZI_JAVA_OPTS" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_OPTS}"
 fi
 
-if [ "$STRIMZI_TLS_ENABLED" = "true" ]; then
+if [ "$STRIMZI_TLS_ENABLED" = "true" ] || [ "$STRIMZI_SECURITY_PROTOCOL" = "SSL" ] || [ "$STRIMZI_SECURITY_PROTOCOL" = "SASL_SSL" ]; then
     # Generate temporary keystore password
     CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
     export CERTS_STORE_PASSWORD

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -112,7 +112,6 @@ public class Config {
     public static final String TC_TOPICS_PATH = "STRIMZI_TOPICS_PATH";
 
     public static final String TC_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
-    public static final String TC_TLS_AUTH_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
     public static final String TC_TLS_TRUSTSTORE_LOCATION = "STRIMZI_TRUSTSTORE_LOCATION";
     public static final String TC_TLS_TRUSTSTORE_PASSWORD = "STRIMZI_TRUSTSTORE_PASSWORD";
     public static final String TC_TLS_KEYSTORE_LOCATION = "STRIMZI_KEYSTORE_LOCATION";
@@ -177,8 +176,6 @@ public class Config {
 
     /** If the connection with Kafka has to be encrypted by TLS protocol */
     public static final Value<String> TLS_ENABLED = new Value<>(TC_TLS_ENABLED, STRING, "false");
-    /** If the connection with Kafka has to be authenticated */
-    public static final Value<String> TLS_AUTH_ENABLED = new Value<>(TC_TLS_AUTH_ENABLED, STRING, "true");
     /** The truststore with CA certificate for Kafka broker/server authentication */
     public static final Value<String> TLS_TRUSTSTORE_LOCATION = new Value<>(TC_TLS_TRUSTSTORE_LOCATION, STRING, "");
     /** The password for the truststore with CA certificate for Kafka broker/server authentication */
@@ -198,7 +195,7 @@ public class Config {
     /** The SASL password to be used for authentication */
     public static final Value<String> SASL_PASSWORD = new Value<>(TC_SASL_PASSWORD, STRING, "");
     /** The security protocol to be used */
-    public static final Value<String> SECURITY_PROTOCOL = new Value<>(TC_SECURITY_PROTOCOL, STRING, "PLAINTEXT");
+    public static final Value<String> SECURITY_PROTOCOL = new Value<>(TC_SECURITY_PROTOCOL, STRING, "");
 
     /**
      * The store topic for the Kafka Streams based TopicStore
@@ -232,7 +229,6 @@ public class Config {
         addConfigValue(configValues, TOPICS_PATH);
         addConfigValue(configValues, TLS_ENABLED);
         addConfigValue(configValues, SECURITY_PROTOCOL);
-        addConfigValue(configValues, TLS_AUTH_ENABLED);
         addConfigValue(configValues, TLS_TRUSTSTORE_LOCATION);
         addConfigValue(configValues, TLS_TRUSTSTORE_PASSWORD);
         addConfigValue(configValues, TLS_KEYSTORE_LOCATION);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -112,11 +112,19 @@ public class Config {
     public static final String TC_TOPICS_PATH = "STRIMZI_TOPICS_PATH";
 
     public static final String TC_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
+    public static final String TC_TLS_AUTH_ENABLED = "STRIMZI_TLS_AUTH_ENABLED";
     public static final String TC_TLS_TRUSTSTORE_LOCATION = "STRIMZI_TRUSTSTORE_LOCATION";
     public static final String TC_TLS_TRUSTSTORE_PASSWORD = "STRIMZI_TRUSTSTORE_PASSWORD";
     public static final String TC_TLS_KEYSTORE_LOCATION = "STRIMZI_KEYSTORE_LOCATION";
     public static final String TC_TLS_KEYSTORE_PASSWORD = "STRIMZI_KEYSTORE_PASSWORD";
     public static final String TC_TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "STRIMZI_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM";
+
+    public static final String TC_SASL_ENABLED = "STRIMZI_SASL_ENABLED";
+    public static final String TC_SASL_MECHANISM = "STRIMZI_SASL_MECHANISM";
+    public static final String TC_SASL_USERNAME = "STRIMZI_SASL_USERNAME";
+    public static final String TC_SASL_PASSWORD = "STRIMZI_SASL_PASSWORD";
+
+    public static final String TC_SECURITY_PROTOCOL = "STRIMZI_SECURITY_PROTOCOL";
 
     public static final String TC_STORE_TOPIC = "STRIMZI_STORE_TOPIC";
     public static final String TC_STORE_NAME = "STRIMZI_STORE_NAME";
@@ -169,6 +177,8 @@ public class Config {
 
     /** If the connection with Kafka has to be encrypted by TLS protocol */
     public static final Value<String> TLS_ENABLED = new Value<>(TC_TLS_ENABLED, STRING, "false");
+    /** If the connection with Kafka has to be authenticated */
+    public static final Value<String> TLS_AUTH_ENABLED = new Value<>(TC_TLS_AUTH_ENABLED, STRING, "true");
     /** The truststore with CA certificate for Kafka broker/server authentication */
     public static final Value<String> TLS_TRUSTSTORE_LOCATION = new Value<>(TC_TLS_TRUSTSTORE_LOCATION, STRING, "");
     /** The password for the truststore with CA certificate for Kafka broker/server authentication */
@@ -179,6 +189,16 @@ public class Config {
     public static final Value<String> TLS_KEYSTORE_PASSWORD = new Value<>(TC_TLS_KEYSTORE_PASSWORD, STRING, "");
     /** The endpoint identification algorithm used by clients to validate server host name. The default value is https. Clients including client connections created by the broker for inter-broker communication verify that the broker host name matches the host name in the broker’s certificate. Disable server host name verification by setting to an empty string.**/
     public static final Value<String> TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = new Value<>(TC_TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, STRING, "HTTPS");
+    /** If SASL should be used to authenticate with */
+    public static final Value<String> SASL_ENABLED = new Value<>(TC_SASL_ENABLED, STRING, "false");
+    /** The SASL mechanism to be used */
+    public static final Value<String> SASL_MECHANISM = new Value<>(TC_SASL_MECHANISM, STRING, "");
+    /** The SASL username to be used for authentication */
+    public static final Value<String> SASL_USERNAME = new Value<>(TC_SASL_USERNAME, STRING, "");
+    /** The SASL password to be used for authentication */
+    public static final Value<String> SASL_PASSWORD = new Value<>(TC_SASL_PASSWORD, STRING, "");
+    /** The security protocol to be used */
+    public static final Value<String> SECURITY_PROTOCOL = new Value<>(TC_SECURITY_PROTOCOL, STRING, "SSL");
 
     /**
      * The store topic for the Kafka Streams based TopicStore
@@ -211,10 +231,16 @@ public class Config {
         addConfigValue(configValues, TOPIC_METADATA_MAX_ATTEMPTS);
         addConfigValue(configValues, TOPICS_PATH);
         addConfigValue(configValues, TLS_ENABLED);
+        addConfigValue(configValues, SECURITY_PROTOCOL);
+        addConfigValue(configValues, TLS_AUTH_ENABLED);
         addConfigValue(configValues, TLS_TRUSTSTORE_LOCATION);
         addConfigValue(configValues, TLS_TRUSTSTORE_PASSWORD);
         addConfigValue(configValues, TLS_KEYSTORE_LOCATION);
         addConfigValue(configValues, TLS_KEYSTORE_PASSWORD);
+        addConfigValue(configValues, SASL_ENABLED);
+        addConfigValue(configValues, SASL_MECHANISM);
+        addConfigValue(configValues, SASL_USERNAME);
+        addConfigValue(configValues, SASL_PASSWORD);
         addConfigValue(configValues, TLS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM);
         addConfigValue(configValues, STORE_TOPIC);
         addConfigValue(configValues, STORE_NAME);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -198,7 +198,7 @@ public class Config {
     /** The SASL password to be used for authentication */
     public static final Value<String> SASL_PASSWORD = new Value<>(TC_SASL_PASSWORD, STRING, "");
     /** The security protocol to be used */
-    public static final Value<String> SECURITY_PROTOCOL = new Value<>(TC_SECURITY_PROTOCOL, STRING, "SSL");
+    public static final Value<String> SECURITY_PROTOCOL = new Value<>(TC_SECURITY_PROTOCOL, STRING, "PLAINTEXT");
 
     /**
      * The store topic for the Kafka Streams based TopicStore

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -185,8 +185,12 @@ public class Session extends AbstractVerticle {
                 jaasConfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
             }
 
-            kafkaClientProps.setProperty(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
-            kafkaClientProps.setProperty(SaslConfigs.SASL_MECHANISM, saslMechanism);
+            if (saslMechanism != null) {
+                kafkaClientProps.setProperty(SaslConfigs.SASL_MECHANISM, saslMechanism);
+            }
+            if (jaasConfig != null) {
+                kafkaClientProps.setProperty(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
+            }
         }
 
         this.adminClient = AdminClient.create(kafkaClientProps);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ConfigTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.topic;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Properties;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +15,15 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.strimzi.test.mockkube.MockKube;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+
+import io.strimzi.operator.common.InvalidConfigurationException;
 
 public class ConfigTest {
 
@@ -75,5 +85,138 @@ public class ConfigTest {
 
         Config c = new Config(map);
         assertThat(c.get(Config.TOPIC_METADATA_MAX_ATTEMPTS).intValue(), is(3));
+    }
+
+    @Test
+    public void testDefaultConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        Config config = new Config(map);
+        Session session = new Session(kubeClient, config);
+        Properties adminClientProps = session.adminClientProperties();
+
+        assertThat(adminClientProps.getProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("PLAINTEXT"));
+        assertNull(adminClientProps.getProperty(SaslConfigs.SASL_MECHANISM));
+        assertNull(adminClientProps.getProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG));
+    }
+
+    @Test
+    public void testTlsEnabledConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.TLS_ENABLED.key, "true");
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        Config config = new Config(map);
+        Session session = new Session(kubeClient, config);
+        Properties adminClientProps = session.adminClientProperties();
+
+        assertThat(adminClientProps.getProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG), is("HTTPS"));
+        assertThat(adminClientProps.getProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
+    }
+
+    @Test
+    public void testSecurityProtocolConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.SECURITY_PROTOCOL.key, "SSL");
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        Config config = new Config(map);
+        Session session = new Session(kubeClient, config);
+        Properties adminClientProps = session.adminClientProperties();
+
+        assertThat(adminClientProps.getProperty(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG), is("HTTPS"));
+        assertThat(adminClientProps.getProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
+    }
+
+    @Test
+    public void testInvalidSaslConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.SASL_ENABLED.key, "true");
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        Config config = new Config(map);
+        Session session = new Session(kubeClient, config);
+        assertThrows(InvalidConfigurationException.class, () -> session.adminClientProperties());
+
+        String username = "admin";
+        String password = "password";
+        map.put(Config.SASL_USERNAME.key, username);
+        map.put(Config.SASL_PASSWORD.key, password);
+        Config configWithCredentials = new Config(map);
+        Session sessionWithCredentials = new Session(kubeClient, configWithCredentials);
+        assertThrows(IllegalArgumentException.class, () -> sessionWithCredentials.adminClientProperties());
+    }
+
+    @Test
+    public void testInvalidTlsSecurityProtocolConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.SECURITY_PROTOCOL.key, "PLAINTEXT");
+        map.put(Config.TLS_ENABLED.key, "true");
+
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        Config config = new Config(map);
+        Session session = new Session(kubeClient, config);
+        assertThrows(InvalidConfigurationException.class, () -> session.adminClientProperties());
+    }
+
+    @Test
+    public void testInvalidKeystoreConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.TLS_ENABLED.key, "true");
+        map.put(Config.TLS_TRUSTSTORE_PASSWORD.key, "password");
+
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        Config config = new Config(map);
+        Session session = new Session(kubeClient, config);
+        assertThrows(InvalidConfigurationException.class, () -> session.adminClientProperties());
+    }
+
+    @Test
+    public void testScramSaslConfig() {
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.SASL_ENABLED.key, "true");
+
+        String username = "admin";
+        String password = "password";
+        map.put(Config.SASL_USERNAME.key, username);
+        map.put(Config.SASL_PASSWORD.key, password);
+        String scramJaasConfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
+        String plainJaasConfig = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
+
+        MockKube mockKube = new MockKube();
+        KubernetesClient kubeClient = mockKube.build();
+
+        map.put(Config.SASL_MECHANISM.key, "scram-sha-256");
+        Config configSHA256 = new Config(map);
+        Session sessionSHA256 = new Session(kubeClient, configSHA256);
+
+        Properties adminClientPropsSHA256 = sessionSHA256.adminClientProperties();
+        assertThat(adminClientPropsSHA256.getProperty(SaslConfigs.SASL_MECHANISM), is("SCRAM-SHA-256"));
+        assertThat(adminClientPropsSHA256.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(scramJaasConfig));
+
+        map.put(Config.SASL_MECHANISM.key, "scram-sha-512");
+        Config configSHA512 = new Config(map);
+        Session sessionSHA512 = new Session(kubeClient, configSHA512);
+
+        Properties adminClientPropsSHA512 = sessionSHA512.adminClientProperties();
+        assertThat(adminClientPropsSHA512.getProperty(SaslConfigs.SASL_MECHANISM), is("SCRAM-SHA-512"));
+        assertThat(adminClientPropsSHA512.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(scramJaasConfig));
+
+        map.put(Config.SASL_MECHANISM.key, "plain");
+        Config configPlain = new Config(map);
+        Session sessionPlain = new Session(kubeClient, configPlain);
+
+        Properties adminClientPropsPlain = sessionPlain.adminClientProperties();
+        assertThat(adminClientPropsPlain.getProperty(SaslConfigs.SASL_MECHANISM), is("PLAIN"));
+        assertThat(adminClientPropsPlain.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(plainJaasConfig));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Hello Strimzi maintainers,

I'd like to use the Strimzi Operator with an external MSK cluster, however it has a Public CA (need possibility to disable truststore), SCRAM/SASL authentication which requires security protocol change (sasl_ssl), sasl mechanism definitions and JAAS config definitions.

I'll add documentation for all the options if the approach is correct/fine. Not familiar with Java or the various Kafka connectivity/auth methods there are, looking for feedback.

The following environment variables works with MSK and a standalone Topic Operator:

```
# Flag for SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG
- name: STRIMZI_TLS_ENABLED
  value: "true"
# Disables truststore generation even if TLS enabled
- name: STRIMZI_PUBLIC_CA
  value: "true"
# Flag for auth/keystore
- name: STRIMZI_TLS_AUTH_ENABLED
  value: "false"
# SASL flag
- name: STRIMZI_SASL_ENABLED
  value: "true"
# SASL mechanism
- name: STRIMZI_SASL_MECHANISM
  value: "scram-sha-512"
# Username
- name: STRIMZI_SASL_USERNAME
  value: "admin"
# Password
- name: STRIMZI_SASL_PASSWORD
  value: "hello strimzi"
# Security protocol (default SSL)
- name: STRIMZI_SECURITY_PROTOCOL
  value: "SASL_SSL"

```

Issues: https://github.com/strimzi/strimzi-kafka-operator/issues/2761 https://github.com/strimzi/strimzi-kafka-operator/issues/4766 https://github.com/strimzi/strimzi-kafka-operator/issues/3741
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

