### PR TITLE
Use the assigned namespace for secret access

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -669,7 +669,7 @@ public class KubeClient {
     }
 
     public Secret getSecret(String secretName) {
-        return getSecret(kubeClient().getNamespace(), secretName);
+        return getSecret(getNamespace(), secretName);
     }
 
     public boolean deleteSecret(String namespaceName, String secretName) {
@@ -677,7 +677,7 @@ public class KubeClient {
     }
 
     public boolean deleteSecret(String secretName) {
-        return deleteSecret(kubeClient().getNamespace(), secretName);
+        return deleteSecret(getNamespace(), secretName);
     }
 
     public List<Secret> listSecrets(String namespaceName) {


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

### Type of change
- Bugfix

### Description
`io.strimzi.test.k8s.KubeClient`'s `getSecret` and `deleteSecret` are not using the assigned namespace. As a result, for example, `kubeClient("default").getSecret("mysecret")` may not be using namespace `"default"` to lookup `"mysecret"`.

https://cloud-native.slack.com/archives/CMH3Q3SNP/p1624627249378000


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

