### PR TITLE
Fix Helm install type FeatureGates variables

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/specific/HelmResource.java
@@ -126,7 +126,8 @@ public class HelmResource implements SpecificResourceType {
                 entry("logLevelOverride", Environment.STRIMZI_LOG_LEVEL),
                 entry("fullReconciliationIntervalMs", Long.toString(reconciliationInterval)),
                 entry("operationTimeoutMs", Long.toString(operationTimeout)),
-                entry("featureGates", Environment.STRIMZI_FEATURE_GATES),
+                // As FG is CSV, we need to escape commas for interpretation of helm installation string
+                entry("featureGates", Environment.STRIMZI_FEATURE_GATES.replaceAll(",", "\\\\,")),
                 entry("watchAnyNamespace", this.namespaceToWatch.equals(Constants.WATCH_ALL_NAMESPACES) ? "true" : "false"))
                 .collect(TestUtils.entriesToMap()));
 


### PR DESCRIPTION
- Bugfix

### Description
There was a problem with non-escaped comma in new variable `STRIMZI_FEATURE_GATES` while using helm as CO installation type. This fixes the issue.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

