### PR TITLE
[systemtest] Test for logging hierarchy

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -4,12 +4,14 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
 import io.strimzi.test.TestUtils;
+import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -179,5 +181,19 @@ public class KafkaConnectorUtils {
             LOGGER.info("Connector's spec gonna be stable in {} polls", Constants.GLOBAL_STABILITY_OFFSET_COUNT - stableCounter[0]);
             return false;
         });
+    }
+
+    public static void waitForConnectorWorkerStatus(String namespaceName, String podName, String connectName, String connectorName, String state) {
+        LOGGER.info("Waiting for KafkaConnector {}'s worker will be in {} state", connectorName, state);
+        TestUtils.waitFor(String.format("Wait for KafkaConnector {}'s worker will be in {} state", connectorName, state), Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.GLOBAL_TIMEOUT,
+            () -> {
+                JsonObject connectorStatus = new JsonObject(
+                        cmdKubeClient().namespace(namespaceName).execInPod(podName,
+                        "curl", "GET",
+                        "http://" + KafkaConnectResources.serviceName(connectName) + ":8083/connectors/" + connectorName + "/status").out().trim()
+                );
+                return connectorStatus.getJsonObject("connector").getString("state").equals(state);
+            }
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #5145 the logging hierarchy is changed. Earlier, when we set logging in `KafkaConnector`, it was overridden by `root.logger` of `KafkaConnect`. 
This new test checks that even when we restart connector worker or change the `KafkaConnect` logger, the logger of connector will be kept.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
