### PR TITLE
[DOC] Update to standalone operator deployment sections

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -6,10 +6,17 @@
 [id="deploy-create-cluster_{context}"]
 = Create the Kafka cluster
 
-In order to create your Kafka cluster, you deploy the Cluster Operator to manage the Kafka cluster, then deploy the Kafka cluster.
+[role="_abstract"]
+To manage a Kafka cluster with the Cluster Operator, you deploy it as a `Kafka` resource.
+Strimzi provides example deployment files to do this.
+You can use these files to deploy the Topic Operator and User Operator at the same time.
 
-When deploying the Kafka cluster using the `Kafka` resource, you can deploy the Topic Operator and User Operator at the same time.
-Alternatively, if you are using a non-Strimzi Kafka cluster, you can deploy the Topic Operator and User Operator as standalone components.
+Alternatively, you can deploy the Topic Operator and User Operator as standalone components.
+You would do this if you are not using the Cluster Operator to manage a Kafka cluster.
+For example, when a Kafka cluster is running outside of Kubernetes.
+
+NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
+The Topic Operator and Cluster Operator watch for `KafkaTopics` and `KafkaUsers` in the single namespace of the Kafka cluster deployment.
 
 [discrete]
 == Deploying a Kafka cluster with the Topic Operator and User Operator

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -7,16 +7,16 @@
 = Create the Kafka cluster
 
 [role="_abstract"]
-To manage a Kafka cluster with the Cluster Operator, you deploy it as a `Kafka` resource.
+To be able to manage a Kafka cluster with the Cluster Operator, you must deploy it as a `Kafka` resource.
 Strimzi provides example deployment files to do this.
 You can use these files to deploy the Topic Operator and User Operator at the same time.
 
-Alternatively, you can deploy the Topic Operator and User Operator as standalone components.
-You would do this if you are not using the Cluster Operator to manage a Kafka cluster.
-For example, when a Kafka cluster is running outside of Kubernetes.
+If you haven't deployed a Kafka cluster as a `Kafka` resource, you can't use the Cluster Operator to manage it.
+This applies, for example, to a Kafka cluster running outside of Kubernetes.
+But you can deploy and use the Topic Operator and User Operator as standalone components.
 
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
-The Topic Operator and Cluster Operator watch for `KafkaTopics` and `KafkaUsers` in the single namespace of the Kafka cluster deployment.
+The Topic Operator and User Operator watch for `KafkaTopics` and `KafkaUsers` in the single namespace of the Kafka cluster deployment.
 
 [discrete]
 == Deploying a Kafka cluster with the Topic Operator and User Operator

--- a/documentation/assemblies/deploying/assembly-deploy-standalone-operators.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-standalone-operators.adoc
@@ -6,7 +6,7 @@
 = Alternative standalone deployment options for Strimzi Operators
 
 [role="_abstract"]
-As an alternative to deploying the Topic Operator and User Operator with the Cluster Operator, you can perform a standalone deployment.
+You can perform a standalone deployment of the Topic Operator and User Operator.
 Consider a standalone deployment of these operators if you are using a Kafka cluster that is not managed by the Cluster Operator.
 
 You deploy the operators to Kubernetes.

--- a/documentation/assemblies/deploying/assembly-deploy-standalone-operators.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-standalone-operators.adoc
@@ -5,10 +5,14 @@
 [id="deploy-standalone-operators_{context}"]
 = Alternative standalone deployment options for Strimzi Operators
 
-When deploying a Kafka cluster using the Cluster Operator, you can also deploy the Topic Operator and User Operator.
-Alternatively, you can perform a standalone deployment.
+[role="_abstract"]
+As an alternative to deploying the Topic Operator and User Operator with the Cluster Operator, you can perform a standalone deployment.
+Consider a standalone deployment of these operators if you are using a Kafka cluster that is not managed by the Cluster Operator.
 
-A standalone deployment means the Topic Operator and User Operator can operate with a Kafka cluster that is not managed by Strimzi.
+You deploy the operators to Kubernetes.
+Kafka can be running outside of Kubernetes.
+For example, you might be using a Kafka as a managed service.
+You adjust the deployment configuration for the standalone operator to match the address of your Kafka cluster.
 
 //Procedure for standalone deployment of Topic Operator
 include::modules/proc-deploy-topic-operator-standalone.adoc[leveloffset=+1]

--- a/documentation/modules/deploying/con-deploy-options-order.adoc
+++ b/documentation/modules/deploying/con-deploy-options-order.adoc
@@ -7,7 +7,7 @@
 
 The required order of deployment to a Kubernetes cluster is as follows:
 
-. Deploy the Cluster operator to manage your Kafka cluster
+. Deploy the Cluster Operator to manage your Kafka cluster
 . Deploy the Kafka cluster with the ZooKeeper cluster, and include the Topic Operator and User Operator in the deployment
 . Optionally deploy:
 ** The Topic Operator and User Operator standalone if you did not deploy them with the Kafka cluster

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -6,7 +6,7 @@
 = Deploying the standalone Topic Operator
 
 [role="_abstract"]
-This procedure shows how to deploy the Topic Operator as a standalone component to manage topics.
+This procedure shows how to deploy the Topic Operator as a standalone component for topic management.
 You can use a standalone Topic Operator with a Kafka cluster that is not managed by the Cluster Operator.
 
 A standalone deployment can operate with any Kafka cluster.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -9,15 +9,14 @@
 This procedure shows how to deploy the Topic Operator as a standalone component to manage topics.
 You can use a standalone Topic Operator with a Kafka cluster that is not managed by the Cluster Operator.
 
-A standalone deployment is more complicated than xref:deploying-the-topic-operator-using-the-cluster-operator-str[deploying the Topic Operator using the Cluster Operator].
-However, a standalone deployment is more flexible as the Topic Operator can operate with any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+A standalone deployment can operate with any Kafka cluster.
 
-A standalone deployment file is provided.
-Configure the deployment file to add the environment variables that enable the Topic Operator to connect to a Kafka cluster.
+Standalone deployment files are provided.
+Configure the `05-Deployment-strimzi-topic-operator.yaml` deployment file to add the environment variables that enable the Topic Operator to connect to a Kafka cluster.
 
 .Prerequisites
 
-* You are running a Kafka cluster for the Topic Operator to make its connection.
+* You are running a Kafka cluster for the Topic Operator to connect to.
 
 .Procedure
 
@@ -47,21 +46,21 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS <2>
-              value: my-cluster-kafka-bootstrap:9092
+              value: my-kafka-bootstrap-address:9092
             - name: STRIMZI_RESOURCE_LABELS <3>
               value: "strimzi.io/cluster=my-cluster"
             - name: STRIMZI_ZOOKEEPER_CONNECT <4>
               value: my-cluster-zookeeper-client:2181
             - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS <5>
-              value: "20000"
+              value: "18000"
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS <6>
-              value: "900000"
+              value: "120000"
             - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS <7>
               value: "6"
             - name: STRIMZI_LOG_LEVEL <8>
               value: INFO
             - name: STRIMZI_TLS_ENABLED <9>
-              value: "true"
+              value: "false"
             - name: STRIMZI_JAVA_OPTS <10>
               value: "-Xmx=512M -Xms=256M"
             - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <11>
@@ -74,9 +73,9 @@ Use a comma-separated list to specify two or three broker addresses in case a se
 <4> The host and port pair of the address to connect to the ZooKeeper cluster.
 This must be the same ZooKeeper cluster that your Kafka cluster is using.
 <5> The ZooKeeper session timeout, in milliseconds.
-The default is `20000` (20 seconds).
+The default is `18000` (18 seconds).
 <6> The interval between periodic reconciliations, in milliseconds.
-The default is `900000` (15 minutes).
+The default is `120000` (2 minutes).
 <7> The number of attempts at getting topic metadata from Kafka.
 The time between each attempt is defined as an exponential backoff.
 Consider increasing this value when topic creation takes more time due to the number of partitions or replicas.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -5,59 +5,120 @@
 [id='deploying-the-topic-operator-standalone-{context}']
 = Deploying the standalone Topic Operator
 
-This procedure shows how to deploy the Topic Operator as a standalone component.
+[role="_abstract"]
+This procedure shows how to deploy the Topic Operator as a standalone component to manage topics.
+You can use a standalone Topic Operator with a Kafka cluster that is not managed by the Cluster Operator.
 
-A standalone deployment requires configuration of environment variables, and is more complicated than xref:deploying-the-topic-operator-using-the-cluster-operator-str[deploying the Topic Operator using the Cluster Operator].
-However, a standalone deployment is more flexible as the Topic Operator can operate with _any_ Kafka cluster, not necessarily one deployed by the Cluster Operator.
+A standalone deployment is more complicated than xref:deploying-the-topic-operator-using-the-cluster-operator-str[deploying the Topic Operator using the Cluster Operator].
+However, a standalone deployment is more flexible as the Topic Operator can operate with any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+
+A standalone deployment file is provided.
+Configure the deployment file to add the environment variables that enable the Topic Operator to connect to a Kafka cluster.
 
 .Prerequisites
 
-* You need an existing Kafka cluster for the Topic Operator to connect to.
+* You are running a Kafka cluster for the Topic Operator to make its connection.
 
 .Procedure
 
-. Edit the `Deployment.spec.template.spec.containers[0].env` properties in the `install/topic-operator/05-Deployment-strimzi-topic-operator.yaml` file by setting:
+. Edit the `env` properties in the `install/topic-operator/05-Deployment-strimzi-topic-operator.yaml` standalone deployment file.
 +
-.. `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` to list the bootstrap brokers in your Kafka cluster, given as a comma-separated list of `_hostname_:‍_port_` pairs.
-.. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This should be the same ZooKeeper cluster that your Kafka cluster is using.
-.. `STRIMZI_NAMESPACE` to the Kubernetes namespace in which you want the operator to watch for  `KafkaTopic` resources.
-.. `STRIMZI_RESOURCE_LABELS` to the label selector used to identify the `KafkaTopic` resources managed by the operator.
-.. `STRIMZI_FULL_RECONCILIATION_INTERVAL_MS` to specify the interval between periodic reconciliations, in milliseconds.
-.. `STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS` to specify the number of attempts at getting topic metadata from Kafka.
-The time between each attempt is defined as an exponential back-off.
-Consider increasing this value when topic creation could take more time due to the number of partitions or replicas.
-Default `6`.
-.. `STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS` to the ZooKeeper session timeout, in milliseconds.
-For example, `10000`.
-Default `20000` (20 seconds).
-.. `STRIMZI_TOPICS_PATH` to the Zookeeper node path where the Topic Operator stores its metadata.
-Default `/strimzi/topics`.
-.. `STRIMZI_TLS_ENABLED` to enable TLS support for encrypting the communication with Kafka brokers.
-Default `true`.
-.. `STRIMZI_TRUSTSTORE_LOCATION` to the path to the truststore containing certificates for enabling TLS based communication.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
-.. `STRIMZI_TRUSTSTORE_PASSWORD` to the password for accessing the truststore defined by `STRIMZI_TRUSTSTORE_LOCATION`.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
-.. `STRIMZI_KEYSTORE_LOCATION` to the path to the keystore containing private keys for enabling TLS based communication.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
-.. `STRIMZI_KEYSTORE_PASSWORD` to the password for accessing the keystore defined by `STRIMZI_KEYSTORE_LOCATION`.
-Mandatory only if TLS is enabled through `STRIMZI_TLS_ENABLED`.
-.. `STRIMZI_LOG_LEVEL` to the level for printing logging messages.
-The value can be set to: `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `TRACE`.
-Default `INFO`.
-.. `STRIMZI_JAVA_OPTS` _(optional)_ to the Java options used for the JVM running the Topic Operator. An example is `-Xmx=512M -Xms=256M`.
-.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` _(optional)_ to list the `-D` options which are set to the Topic Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
+.Example standalone Topic Operator deployment configuration
+[source,shell,subs=+quotes]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+spec:
+  # ...
+  template:
+    # ...
+    spec:
+      # ...
+      containers:
+        - name: strimzi-topic-operator
+          # ...
+          env:
+            - name: STRIMZI_NAMESPACE <1>
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS <2>
+              value: my-cluster-kafka-bootstrap:9092
+            - name: STRIMZI_RESOURCE_LABELS <3>
+              value: "strimzi.io/cluster=my-cluster"
+            - name: STRIMZI_ZOOKEEPER_CONNECT <4>
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS <5>
+              value: "20000"
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS <6>
+              value: "900000"
+            - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS <7>
+              value: "6"
+            - name: STRIMZI_LOG_LEVEL <8>
+              value: INFO
+            - name: STRIMZI_TLS_ENABLED <9>
+              value: "true"
+            - name: STRIMZI_JAVA_OPTS <10>
+              value: "-Xmx=512M -Xms=256M"
+            - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <11>
+              value: "-Djavax.net.debug=verbose -DpropertyName=value"
+----
+<1> The Kubernetes namespace for the Topic Operator to watch for `KafkaTopic` resources. Specify the namespace of the Kafka cluster.
+<2> The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
+Use a comma-separated list to specify two or three broker addresses in case a server is down.
+<3> The label selector to identify the `KafkaTopic` resources managed by the Topic Operator.
+<4> The host and port pair of the address to connect to the ZooKeeper cluster.
+This must be the same ZooKeeper cluster that your Kafka cluster is using.
+<5> The ZooKeeper session timeout, in milliseconds.
+The default is `20000` (20 seconds).
+<6> The interval between periodic reconciliations, in milliseconds.
+The default is `900000` (15 minutes).
+<7> The number of attempts at getting topic metadata from Kafka.
+The time between each attempt is defined as an exponential backoff.
+Consider increasing this value when topic creation takes more time due to the number of partitions or replicas.
+The default is `6` attempts.
+<8> The level for printing logging messages.
+You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
+<9> Enables TLS support for encrypted communication with the Kafka brokers.
+<10> (Optional) The Java options used by the JVM running the Topic Operator.
+<11> (Optional) The debugging (`-D`) options set for the Topic Operator.
 
-. Deploy the Topic Operator:
+. If you enabled TLS with the `STRIMZI_TLS_ENABLED` environment variable, specify the keystore and truststore used to authenticate connection to the Kafka cluster.
++
+.Example TLS configuration
+[source,shell,subs=+quotes]
+----
+# ....
+env:
+  - name: STRIMZI_TRUSTSTORE_LOCATION <1>
+    value: "/path/to/truststore.p12"
+  - name: STRIMZI_TRUSTSTORE_PASSWORD <2>
+    value: "__TRUSTSTORE-PASSWORD__"
+  - name: STRIMZI_KEYSTORE_LOCATION <3>
+    value: "/path/to/keystore.p12"
+  - name: STRIMZI_KEYSTORE_PASSWORD <4>
+    value: "__KEYSTORE-PASSWORD__"
+# ..."
+----
+<1> The truststore contains the public key (`ca.crt`) value of the Certificate Authority used to sign new user certificates for TLS client authentication.
+<2> The password for accessing the truststore.
+<3> The keystore contains the private key (`ca.key`) of the Certificate Authority for signing new user certificates for TLS client authentication.
+<4> The password for accessing the keystore.
+
+. Deploy the Topic Operator.
 +
 [source,shell,subs=+quotes]
 kubectl create -f install/topic-operator
 
-. Verify that the Topic Operator has been deployed successfully:
+. Verify that the Topic Operator has been deployed successfully.
 +
 [source,shell,subs=+quotes]
 kubectl describe deployment strimzi-topic-operator
 +
-The Topic Operator is deployed when the `Replicas:` entry shows `1 available`.
+The Topic Operator is deployed when the `Replicas` entry shows `1 available`.
 +
-NOTE: You may experience a delay with the deployment if you have a slow connection to the Kubernetes cluster and the images have not been downloaded before.
+NOTE: You may experience a delay with the deployment if you have a slow connection to the Kubernetes cluster and the Topic Operator images have not been downloaded before.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
@@ -5,9 +5,11 @@
 [id='deploying-the-topic-operator-using-the-cluster-operator-{context}']
 = Deploying the Topic Operator using the Cluster Operator
 
+[role="_abstract"]
 This procedure describes how to deploy the Topic Operator using the Cluster Operator.
 
 You configure the `entityOperator` property of the `Kafka` resource to include the `topicOperator`.
+By default, the Topic Operator watches for `KafkaTopics` in the namespace of the Kafka cluster deployment.
 
 If you want to use the Topic Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-topic-operator-standalone-{context}[deploy the Topic Operator as a standalone component].

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -9,15 +9,14 @@
 This procedure shows how to deploy the User Operator as a standalone component to manage users.
 You can use a standalone User Operator with a Kafka cluster that is not managed by the Cluster Operator.
 
-A standalone deployment is more complicated than xref:deploying-the-user-operator-using-the-cluster-operator-str[deploying the User Operator using the Cluster Operator].
-However, a standalone deployment is more flexible as the User Operator can operate with any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+A standalone deployment can operate with any Kafka cluster.
 
-A standalone deployment file is provided.
-Configure the deployment file to add the environment variables that enable the User Operator to connect to a Kafka cluster.
+Standalone deployment files are provided.
+Edit the `05-Deployment-strimzi-user-operator.yaml` deployment file to add the environment variables that enable the User Operator to connect to a Kafka cluster.
 
 .Prerequisites
 
-* You are running a Kafka cluster for the User Operator to make its connection.
+* You are running a Kafka cluster for the User Operator to connect to.
 
 .Procedure
 
@@ -47,7 +46,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS <2>
-              value: my-cluster-kafka-bootstrap:9092
+              value: my-kafka-bootstrap-address:9092
             - name: STRIMZI_CA_CERT_NAME <3>
               value: my-cluster-clients-ca-cert
             - name: STRIMZI_CA_KEY_NAME <4>
@@ -88,7 +87,7 @@ The default is `120000` (2 minutes).
 <8> The host and port pair of the address to connect to the ZooKeeper cluster.
 This must be the same ZooKeeper cluster that your Kafka cluster is using.
 <9> The ZooKeeper session timeout, in milliseconds.
-The default is `20000` (18 seconds).
+The default is `18000` (18 seconds).
 <10> The level for printing logging messages.
 You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
 <11> Enables garbage collection (GC) logging.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -6,7 +6,7 @@
 = Deploying the standalone User Operator
 
 [role="_abstract"]
-This procedure shows how to deploy the User Operator as a standalone component to manage users.
+This procedure shows how to deploy the User Operator as a standalone component for user management.
 You can use a standalone User Operator with a Kafka cluster that is not managed by the Cluster Operator.
 
 A standalone deployment can operate with any Kafka cluster.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -5,59 +5,130 @@
 [id='deploying-the-user-operator-standalone-{context}']
 = Deploying the standalone User Operator
 
-This procedure shows how to deploy the User Operator as a standalone component.
+[role="_abstract"]
+This procedure shows how to deploy the User Operator as a standalone component to manage users.
+You can use a standalone User Operator with a Kafka cluster that is not managed by the Cluster Operator.
 
-A standalone deployment requires configuration of environment variables, and is more complicated than xref:deploying-the-user-operator-using-the-cluster-operator-str[deploying the User Operator using the Cluster Operator].
-However, a standalone deployment is more flexible as the User Operator can operate with _any_ Kafka cluster, not necessarily one deployed by the Cluster Operator.
+A standalone deployment is more complicated than xref:deploying-the-user-operator-using-the-cluster-operator-str[deploying the User Operator using the Cluster Operator].
+However, a standalone deployment is more flexible as the User Operator can operate with any Kafka cluster, not necessarily one deployed by the Cluster Operator.
+
+A standalone deployment file is provided.
+Configure the deployment file to add the environment variables that enable the User Operator to connect to a Kafka cluster.
 
 .Prerequisites
 
-* You need an existing Kafka cluster for the User Operator to connect to.
+* You are running a Kafka cluster for the User Operator to make its connection.
 
 .Procedure
 
-. Edit the following `Deployment.spec.template.spec.containers[0].env` properties in the `install/user-operator/05-Deployment-strimzi-user-operator.yaml` file by setting:
+. Edit the following `env` properties in the `install/user-operator/05-Deployment-strimzi-user-operator.yaml` standalone deployment file.
 +
-.. `STRIMZI_KAFKA_BOOTSTRAP_SERVERS` to list the Kafka brokers, given as a comma-separated list of `_hostname_:‍_port_` pairs.
-.. `STRIMZI_ZOOKEEPER_CONNECT` to list the ZooKeeper nodes, given as a comma-separated list of `_hostname_:‍_port_` pairs. This must be the same ZooKeeper cluster that your Kafka cluster is using. Connecting to ZooKeeper nodes with TLS encryption is not supported.
-.. `STRIMZI_NAMESPACE` to the Kubernetes namespace in which you want the operator to watch for `KafkaUser` resources.
-.. `STRIMZI_LABELS` to the label selector used to identify the `KafkaUser` resources managed by the operator.
-.. `STRIMZI_FULL_RECONCILIATION_INTERVAL_MS` to specify the interval between periodic reconciliations, in milliseconds.
-.. `STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS` to the ZooKeeper session timeout, in milliseconds.
-For example, `10000`.
-Default `20000` (20 seconds).
-.. `STRIMZI_CA_CERT_NAME` to point to a Kubernetes `Secret` that contains the public key of the Certificate Authority for signing new user certificates for TLS client authentication.
-The `Secret` must contain the public key of the Certificate Authority under the key `ca.crt`.
-.. `STRIMZI_CA_KEY_NAME` to point to a Kubernetes `Secret` that contains the private key of the Certificate Authority for signing new user certificates for TLS client authentication.
-The `Secret` must contain the private key of the Certificate Authority under the key `ca.key`.
-.. `STRIMZI_CLUSTER_CA_CERT_SECRET_NAME` to point to a Kubernetes `Secret` containing the public key of the Certificate Authority used for signing Kafka brokers certificates for enabling TLS-based communication.
-The `Secret` must contain the public key of the Certificate Authority under the key `ca.crt`.
-This environment variable is optional and should be set only if the communication with the Kafka cluster is TLS based.
-.. `STRIMZI_EO_KEY_SECRET_NAME` to point to a Kubernetes `Secret` containing the private key and related certificate for TLS client authentication against the Kafka cluster.
-The `Secret` must contain the keystore with the private key and certificate under the key `entity-operator.p12`, and the related password under the key `entity-operator.password`.
-This environment variable is optional and should be set only if TLS client authentication is needed when the communication with the Kafka cluster is TLS based.
-.. `STRIMZI_CA_VALIDITY` the validity period for the Certificate Authority.
-Default is `365` days.
-.. `STRIMZI_CA_RENEWAL` the renewal period for the Certificate Authority.
-.. `STRIMZI_LOG_LEVEL` to the level for printing logging messages.
-The value can be set to: `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `TRACE`.
-Default `INFO`.
-.. `STRIMZI_GC_LOG_ENABLED` to enable garbage collection (GC) logging.
-Default `true`.
-Default is `30` days to initiate certificate renewal before the old certificates expire.
-.. `STRIMZI_JAVA_OPTS` _(optional)_ to the Java options used for the JVM running User Operator. An example is `-Xmx=512M -Xms=256M`.
-.. `STRIMZI_JAVA_SYSTEM_PROPERTIES` _(optional)_ to list the `-D` options which are set to the User Operator. An example is `-Djavax.net.debug=verbose -DpropertyName=value`.
+.Example standalone User Operator deployment configuration
+[source,shell,subs=+quotes]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-user-operator
+  labels:
+    app: strimzi
+spec:
+  # ...
+  template:
+    # ...
+    spec:
+      # ...
+      containers:
+        - name: strimzi-user-operator
+          # ...
+          env:
+            - name: STRIMZI_NAMESPACE <1>
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS <2>
+              value: my-cluster-kafka-bootstrap:9092
+            - name: STRIMZI_CA_CERT_NAME <3>
+              value: my-cluster-clients-ca-cert
+            - name: STRIMZI_CA_KEY_NAME <4>
+              value: my-cluster-clients-ca
+            - name: STRIMZI_ZOOKEEPER_CONNECT <5>
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_LABELS <6>
+              value: "strimzi.io/cluster=my-cluster"
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS <7>
+              value: "120000"
+            - name: STRIMZI_ZOOKEEPER_CONNECT <8>
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS <9>
+              value: "18000"
+            - name: STRIMZI_LOG_LEVEL <10>
+              value: INFO
+            - name: STRIMZI_GC_LOG_ENABLED <11>
+              value: "true"
+            - name: STRIMZI_CA_VALIDITY <12>
+              value: "365"
+            - name: STRIMZI_CA_RENEWAL <13>
+              value: "30"
+            - name: STRIMZI_JAVA_OPTS <14>
+              value: "-Xmx=512M -Xms=256M"
+            - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <15>
+              value: "-Djavax.net.debug=verbose -DpropertyName=value"
+----
+<1> The Kubernetes namespace for the User Operator to watch for `KafkaUser` resources. Only one namespace can be specified.
+<2>  The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
+Use a comma-separated list to specify two or three broker addresses in case a server is down.
+<3> The Kubernetes `Secret` that contains the public key (`ca.crt`) value of the Certificate Authority that signs new user certificates for TLS client authentication.
+<4> The Kubernetes `Secret` that contains the private key (`ca.key`) value of the Certificate Authority that signs new user certificates for TLS client authentication.
+<5> The host and port pair of the address to connect to the ZooKeeper cluster.
+This must be the same ZooKeeper cluster that your Kafka cluster is using.
+<6> The label selector used to identify the `KafkaUser` resources managed by the User Operator.
+<7> The interval between periodic reconciliations, in milliseconds.
+The default is `120000` (2 minutes).
+<8> The host and port pair of the address to connect to the ZooKeeper cluster.
+This must be the same ZooKeeper cluster that your Kafka cluster is using.
+<9> The ZooKeeper session timeout, in milliseconds.
+The default is `20000` (18 seconds).
+<10> The level for printing logging messages.
+You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
+<11> Enables garbage collection (GC) logging.
+The default is `true`.
+<12> The validity period for the Certificate Authority.
+The default is `365` days.
+<13> The renewal period for the Certificate Authority. The renewal period is measured backwards from the expiry date of the current certificate.
+The default is `30` days to initiate certificate renewal before the old certificates expire.
+<14> (Optional) The Java options used by the JVM running the User Operator
+<15> (Optional) The debugging (`-D`) options set for the User Operator
 
-. Deploy the User Operator:
+
+. If you are using TLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.
+Otherwise, go to the next step.
++
+.Example TLS configuration
+[source,shell,subs=+quotes]
+----
+# ....
+env:
+  - name: STRIMZI_CLUSTER_CA_CERT_SECRET_NAME <1>
+    value: my-cluster-cluster-cert
+  - name: STRIMZI_EO_KEY_SECRET_NAME <2>
+    value: my-cluster-cluster-ca
+# ..."
+----
+<1> The Kubernetes `Secret` that contains the public key (`ca.crt`) value of the Certificate Authority that signs Kafka broker certificates for TLS client authentication.
+<2> The Kubernetes `Secret` that contains the keystore (`entity-operator_.p12`) with the private key and certificate for TLS authentication against the Kafka cluster.
+The `Secret` must also contain the password (`entity-operator_.password`) for accessing the keystore.
+
+. Deploy the User Operator.
 +
 [source,shell,subs=+quotes]
 kubectl create -f install/user-operator
 
-. Verify that the User Operator has been deployed successfully:
+. Verify that the User Operator has been deployed successfully.
 +
 [source,shell,subs=+quotes]
 kubectl describe deployment strimzi-user-operator
 +
-The User Operator is deployed when the `Replicas:` entry shows `1 available`.
+The User Operator is deployed when the `Replicas` entry shows `1 available`.
 +
-NOTE: You may experience a delay with the deployment if you have a slow connection to the Kubernetes cluster and the images have not been downloaded before.
+NOTE: You might experience a delay with the deployment if you have a slow connection to the Kubernetes cluster and the User Operator images have not been downloaded before.

--- a/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
@@ -5,9 +5,11 @@
 [id='deploying-the-user-operator-using-the-cluster-operator-{context}']
 = Deploying the User Operator using the Cluster Operator
 
+[role="_abstract"]
 This procedure describes how to deploy the User Operator using the Cluster Operator.
 
 You configure the `entityOperator` property of the `Kafka` resource to include the `userOperator`.
+By default, the User Operator watches for `KafkaUsers` in the namespace of the Kafka cluster deployment.
 
 If you want to use the User Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-user-operator-standalone-{context}[deploy the User Operator as a standalone component].


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates the _Alternative standalone deployment options for Strimzi Operators_ section in the _Deploying Strimzi_ guide
The standalone deployment procedures now show example configuration.
Section provides more context on when standalone deployment is useful

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

