### PR TITLE
[systemtest] Add 0.24.0 to upgrade tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -114,7 +115,15 @@ public class AbstractUpgradeST extends AbstractST {
             data.put("proceduresAfterOperatorUpgrade", procedures);
 
             // fromVersion is the mid step here, for CO upgrade we'll use this: 'prevVersion' -> 'fromVersion' -> HEAD
-            parameters.add(Arguments.of(data.getString("prevVersion"), data.getString("fromVersion"), "HEAD", data));
+
+            List<String> upgradeVersions = new ArrayList<>();
+            upgradeVersions.add(data.getString("fromVersion"));
+            upgradeVersions.add("HEAD");
+
+            if (!data.getString("prevVersion").isEmpty()) {
+                upgradeVersions.add(0, data.getString("prevVersion"));
+            }
+            parameters.add(Arguments.of(String.join("->", upgradeVersions), data));
         });
 
         return parameters.stream();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -114,16 +113,7 @@ public class AbstractUpgradeST extends AbstractST {
             procedures.put("interBrokerProtocolVersion", testKafkaVersion.protocolVersion());
             data.put("proceduresAfterOperatorUpgrade", procedures);
 
-            // fromVersion is the mid step here, for CO upgrade we'll use this: 'prevVersion' -> 'fromVersion' -> HEAD
-
-            List<String> upgradeVersions = new ArrayList<>();
-            upgradeVersions.add(data.getString("fromVersion"));
-            upgradeVersions.add("HEAD");
-
-            if (!data.getString("prevVersion").isEmpty()) {
-                upgradeVersions.add(0, data.getString("prevVersion"));
-            }
-            parameters.add(Arguments.of(String.join("->", upgradeVersions), data));
+            parameters.add(Arguments.of(data.getString("fromVersion"), "HEAD", data));
         });
 
         return parameters.stream();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -268,10 +268,11 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Setup env
         setupEnvAndUpgradeClusterOperator(extensionContext, parameters.get("midStep"), producerName, consumerName, continuousTopicName, continuousConsumerGroup, "", NAMESPACE);
 
-        // Upgrade CRDs and upgrade CO to 0.23
         logPodImages(clusterName);
-        convertCRDs(parameters.get("midStep"), NAMESPACE);
+
+        // Upgrade CRDs and upgrade CO to 0.24
         if (!testParameters.getString("prevVersion").isEmpty()) {
+            convertCRDs(parameters.get("midStep"), NAMESPACE);
             changeClusterOperator(parameters.get("midStep"), NAMESPACE);
         }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -66,14 +66,14 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
     private final String strimziReleaseWithOlderKafka = String.format("https://github.com/strimzi/strimzi-kafka-operator/releases/download/%s/strimzi-%s.zip",
             strimziReleaseWithOlderKafkaVersion, strimziReleaseWithOlderKafkaVersion);
 
-    @ParameterizedTest(name = "testUpgradeStrimziVersion->{0}->{1}->{2}")
+    @ParameterizedTest(name = "testUpgradeStrimziVersion->{0}")
     @MethodSource("loadJsonUpgradeData")
     @Tag(INTERNAL_CLIENTS_USED)
-    void testUpgradeStrimziVersion(String from, String midStep, String to, JsonObject parameters, ExtensionContext extensionContext) throws Exception {
+    void testUpgradeStrimziVersion(String upgradePath, JsonObject parameters, ExtensionContext extensionContext) throws Exception {
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getJsonObject("environmentInfo").getString("flakyEnvVariable")));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getJsonObject("environmentInfo").getString("maxK8sVersion")));
 
-        LOGGER.debug("Running upgrade test from version {} through version {} to {}", from, midStep, to);
+        LOGGER.debug("Running upgrade test - {}", upgradePath);
         performUpgrade(parameters, extensionContext);
     }
 

--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -1,19 +1,19 @@
 [
   {
     "fromVersion":"HEAD",
-    "toVersion":"0.23.0",
+    "toVersion":"0.24.0",
     "fromExamples":"HEAD",
-    "toExamples":"strimzi-0.23.0",
+    "toExamples":"strimzi-0.24.0",
     "urlFrom":"HEAD",
-    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.23.0/strimzi-0.23.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
     "generateTopics": true,
     "additionalTopics": 2,
-    "oldestKafka": "2.6.0",
+    "oldestKafka": "2.7.0",
     "imagesAfterOperatorDowngrade": {
-      "zookeeper": "strimzi/kafka:0.23.0-kafka-2.8.0",
-      "kafka": "strimzi/kafka:0.23.0-kafka-2.8.0",
-      "topicOperator": "strimzi/operator:0.23.0",
-      "userOperator": "strimzi/operator:0.23.0"
+      "zookeeper": "strimzi/kafka:0.24.0-kafka-2.8.0",
+      "kafka": "strimzi/kafka:0.24.0-kafka-2.8.0",
+      "topicOperator": "strimzi/operator:0.24.0",
+      "userOperator": "strimzi/operator:0.24.0"
     },
     "deployKafkaVersion": "2.8.0",
     "client": {

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -1,11 +1,9 @@
 [
   {
-    "fromVersion":"0.24.0",
-    "fromExamples":"strimzi-0.24.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
-    "prevVersion": "0.22.1",
-    "prevVersionExamples": "strimzi-0.22.1",
-    "urlPrevVersion": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.1/strimzi-0.22.1.zip",
+    "fromVersion":"0.22.1",
+    "fromExamples":"strimzi-0.22.1",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.1/strimzi-0.22.1.zip",
+    "convertCRDs": true,
     "conversionTool": {
       "urlToConversionTool": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.0/api-conversion-0.22.0.zip",
       "toConversionTool": "api-conversion-0.22.0"
@@ -36,12 +34,44 @@
     }
   },
   {
+    "fromVersion":"0.23.0",
+    "fromExamples":"strimzi-0.23.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.23.0/strimzi-0.23.0.zip",
+    "convertCRDs": false,
+    "conversionTool": {
+      "urlToConversionTool": "",
+      "toConversionTool": ""
+    },
+    "generateTopics": true,
+    "additionalTopics": 2,
+    "oldestKafka": "2.6.0",
+    "imagesBeforeKafkaUpgrade": {
+      "zookeeper": "strimzi/kafka:latest-kafka-2.7.0",
+      "kafka": "strimzi/kafka:latest-kafka-2.7.0",
+      "topicOperator": "strimzi/operator:latest",
+      "userOperator": "strimzi/operator:latest"
+    },
+    "imagesAfterKafkaUpgrade": {
+      "zookeeper": "strimzi/kafka:latest-kafka-2.8.0",
+      "kafka": "strimzi/kafka:latest-kafka-2.8.0",
+      "topicOperator": "strimzi/operator:latest",
+      "userOperator": "strimzi/operator:latest"
+    },
+    "client": {
+      "continuousClientsMessages": 500
+    },
+    "environmentInfo": {
+      "maxK8sVersion": "latest",
+      "status": "stable",
+      "flakyEnvVariable": "none",
+      "reason" : "Test is working on all environment used by QE."
+    }
+  },
+  {
     "fromVersion":"0.24.0",
     "fromExamples":"strimzi-0.24.0",
     "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
-    "prevVersion": "",
-    "prevVersionExamples": "",
-    "urlPrevVersion": "",
+    "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",
       "toConversionTool": ""

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -1,8 +1,8 @@
 [
   {
-    "fromVersion":"0.23.0",
-    "fromExamples":"strimzi-0.23.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.23.0/strimzi-0.23.0.zip",
+    "fromVersion":"0.24.0",
+    "fromExamples":"strimzi-0.24.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
     "prevVersion": "0.22.1",
     "prevVersionExamples": "strimzi-0.22.1",
     "urlPrevVersion": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.1/strimzi-0.22.1.zip",
@@ -13,6 +13,42 @@
     "generateTopics": true,
     "additionalTopics": 2,
     "oldestKafka": "2.6.0",
+    "imagesBeforeKafkaUpgrade": {
+      "zookeeper": "strimzi/kafka:latest-kafka-2.7.0",
+      "kafka": "strimzi/kafka:latest-kafka-2.7.0",
+      "topicOperator": "strimzi/operator:latest",
+      "userOperator": "strimzi/operator:latest"
+    },
+    "imagesAfterKafkaUpgrade": {
+      "zookeeper": "strimzi/kafka:latest-kafka-2.8.0",
+      "kafka": "strimzi/kafka:latest-kafka-2.8.0",
+      "topicOperator": "strimzi/operator:latest",
+      "userOperator": "strimzi/operator:latest"
+    },
+    "client": {
+      "continuousClientsMessages": 500
+    },
+    "environmentInfo": {
+      "maxK8sVersion": "latest",
+      "status": "stable",
+      "flakyEnvVariable": "none",
+      "reason" : "Test is working on all environment used by QE."
+    }
+  },
+  {
+    "fromVersion":"0.24.0",
+    "fromExamples":"strimzi-0.24.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
+    "prevVersion": "",
+    "prevVersionExamples": "",
+    "urlPrevVersion": "",
+    "conversionTool": {
+      "urlToConversionTool": "",
+      "toConversionTool": ""
+    },
+    "generateTopics": true,
+    "additionalTopics": 2,
+    "oldestKafka": "2.7.0",
     "imagesBeforeKafkaUpgrade": {
       "zookeeper": "strimzi/kafka:latest-kafka-2.7.0",
       "kafka": "strimzi/kafka:latest-kafka-2.7.0",


### PR DESCRIPTION
### Type of change

- New check

### Description

This PR adds `0.24.0` version to our upgrade tests and adding one more upgrade stage:
```
0.22.1 >  HEAD
0.23.0 > HEAD
0.24.0 > HEAD
```
Also this PR fixes naming of the parametrized test which was broken by adding additional stage.

### Checklist

- [ ] Make sure all tests pass

