### PR TITLE
Fix resource count metric when multiple ns are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * User Operator now uses Kafka Admin API to manage SCRAM-SHA-512 credentials.
   All operations done by the User Operator now use Kafka Admin API and connect directly to Kafka instead of ZooKeeper.
   As a result, the environment variables `STRIMZI_ZOOKEEPER_CONNECT` and `STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS` were removed from the User Operator configuration.
- * Annotate Cluster Operator resource metrics by a namespace label
+* Annotate Cluster Operator resource metrics with a namespace label
 
 ## 0.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 * Add support for `tls-external` authentication to User Operator to allow management of ACLs and Quotas for TLS users with user certificates generated externally (#5249) 
 * Support for disabling the automatic generation of network policies by the Cluster Operator. Set the Cluster Operator's `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` to disable network policies. (#5258)
 * Update User Operator to use Admin API for managing SCRAM-SHA-512 users 
-* Annotate Cluster Operator resource metrics by a namespace label
 
 ### Changes, deprecations and removals
 
@@ -20,6 +19,7 @@
 * User Operator now uses Kafka Admin API to manage SCRAM-SHA-512 credentials.
   All operations done by the User Operator now use Kafka Admin API and connect directly to Kafka instead of ZooKeeper.
   As a result, the environment variables `STRIMZI_ZOOKEEPER_CONNECT` and `STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS` were removed from the User Operator configuration.
+ * Annotate Cluster Operator resource metrics by a namespace label
 
 ## 0.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add support for `tls-external` authentication to User Operator to allow management of ACLs and Quotas for TLS users with user certificates generated externally (#5249) 
 * Support for disabling the automatic generation of network policies by the Cluster Operator. Set the Cluster Operator's `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` to disable network policies. (#5258)
 * Update User Operator to use Admin API for managing SCRAM-SHA-512 users 
+* Annotate Cluster Operator resource metrics by a namespace label
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -318,9 +318,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             LOGGER.debugCr(reconciliation, "Setting list of connector plugins in Kafka Connect status");
             connectStatus.setConnectorPlugins(connectorPlugins);
 
-            if (getConnectorsResourceCounter(namespace) != null)  {
-                getConnectorsResourceCounter(namespace).set(desiredConnectors.size());
-            }
+            getConnectorsResourceCounter(namespace).set(desiredConnectors.size());
 
             Set<String> deleteConnectorNames = new HashSet<>(runningConnectorNames);
             deleteConnectorNames.removeAll(desiredConnectors.stream().map(c -> c.getMetadata().getName()).collect(Collectors.toSet()));
@@ -829,31 +827,31 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     public Counter getConnectorsReconciliationsCounter(String namespace) {
-        return Operator.getCounter(namespace, kind(), metrics, null, connectorsReconciliationsCounterMap,
+        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsReconciliationsCounterMap,
                 METRICS_PREFIX + "reconciliations",
                 "Number of reconciliations done by the operator for individual resources");
     }
 
     public Counter getConnectorsFailedReconciliationsCounter(String namespace) {
-        return Operator.getCounter(namespace, kind(), metrics, null, connectorsFailedReconciliationsCounterMap,
+        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsFailedReconciliationsCounterMap,
                 METRICS_PREFIX + "reconciliations.failed",
                 "Number of reconciliations done by the operator for individual resources which failed");
     }
 
     public Counter getConnectorsSuccessfulReconciliationsCounter(String namespace) {
-        return Operator.getCounter(namespace, kind(), metrics, null, connectorsSuccessfulReconciliationsCounterMap,
+        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsSuccessfulReconciliationsCounterMap,
                 METRICS_PREFIX + "reconciliations.successful",
                 "Number of reconciliations done by the operator for individual resources which were successful");
     }
 
     public AtomicInteger getConnectorsResourceCounter(String namespace) {
-        return Operator.getGauge(namespace, kind(), metrics, null, connectorsResourceCounterMap,
+        return Operator.getGauge(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsResourceCounterMap,
                 METRICS_PREFIX + "resources",
                 "Number of custom resources the operator sees");
     }
 
     public Timer getConnectorsReconciliationsTimer(String namespace) {
-        return Operator.getTimer(namespace, kind(), metrics, null, connectorsReconciliationsTimerMap,
+        return Operator.getTimer(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsReconciliationsTimerMap,
                 METRICS_PREFIX + "reconciliations.duration",
                 "The time the reconciliation takes to complete");
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -112,11 +112,11 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     protected final ServiceAccountOperator serviceAccountOperations;
     private final int port;
 
-    private Map<String, Counter> connectorsReconciliationsCounterMap;
-    private Map<String, Counter> connectorsFailedReconciliationsCounterMap;
-    private Map<String, Counter> connectorsSuccessfulReconciliationsCounterMap;
-    private Map<String, AtomicInteger> connectorsResourceCounterMap;
-    private Map<String, Timer> connectorsReconciliationsTimerMap;
+    private Map<String, Counter> connectorsReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private Map<String, Counter> connectorsFailedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private Map<String, Counter> connectorsSuccessfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private Map<String, AtomicInteger> connectorsResourceCounterMap = new ConcurrentHashMap<>(1);
+    private Map<String, Timer> connectorsReconciliationsTimerMap = new ConcurrentHashMap<>(1);
 
     public AbstractConnectOperator(Vertx vertx, PlatformFeaturesAvailability pfa, String kind,
                                    CrdOperator<C, T, L> resourceOperator,
@@ -139,13 +139,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         this.operatorNamespaceLabels = config.getOperatorNamespaceLabels();
         this.pfa = pfa;
         this.port = port;
-
-        connectorsReconciliationsCounterMap = new ConcurrentHashMap<>();
-        connectorsFailedReconciliationsCounterMap = new ConcurrentHashMap<>();
-        connectorsSuccessfulReconciliationsCounterMap = new ConcurrentHashMap<>();
-        connectorsResourceCounterMap = new ConcurrentHashMap<>();
-        connectorsReconciliationsTimerMap = new ConcurrentHashMap<>();
-
     }
 
     @Override
@@ -318,7 +311,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             LOGGER.debugCr(reconciliation, "Setting list of connector plugins in Kafka Connect status");
             connectStatus.setConnectorPlugins(connectorPlugins);
 
-            getConnectorsResourceCounter(namespace).set(desiredConnectors.size());
+            connectorsResourceCounter(namespace).set(desiredConnectors.size());
 
             Set<String> deleteConnectorNames = new HashSet<>(runningConnectorNames);
             deleteConnectorNames.removeAll(desiredConnectors.stream().map(c -> c.getMetadata().getName()).collect(Collectors.toSet()));
@@ -359,15 +352,15 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                              boolean useResources, String connectorName, KafkaConnector connector) {
         Promise<Void> reconciliationResult = Promise.promise();
 
-        getConnectorsReconciliationsCounter(reconciliation.namespace()).increment();
+        connectorsReconciliationsCounter(reconciliation.namespace()).increment();
         Timer.Sample connectorsReconciliationsTimerSample = Timer.start(metrics.meterRegistry());
 
         if (connector != null && Annotations.isReconciliationPausedWithAnnotation(connector)) {
 
             return maybeUpdateConnectorStatus(reconciliation, connector, null, null).compose(
                 i -> {
-                    connectorsReconciliationsTimerSample.stop(getConnectorsReconciliationsTimer(reconciliation.namespace()));
-                    getConnectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
+                    connectorsReconciliationsTimerSample.stop(connectorsReconciliationsTimer(reconciliation.namespace()));
+                    connectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
                     return Future.succeededFuture();
                 }
             );
@@ -375,13 +368,13 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
         reconcileConnector(reconciliation, host, apiClient, useResources, connectorName, connector)
                 .onComplete(result -> {
-                    connectorsReconciliationsTimerSample.stop(getConnectorsReconciliationsTimer(reconciliation.namespace()));
+                    connectorsReconciliationsTimerSample.stop(connectorsReconciliationsTimer(reconciliation.namespace()));
 
                     if (result.succeeded())    {
-                        getConnectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
+                        connectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
                         reconciliationResult.complete();
                     } else {
-                        getConnectorsFailedReconciliationsCounter(reconciliation.namespace()).increment();
+                        connectorsFailedReconciliationsCounter(reconciliation.namespace()).increment();
                         reconciliationResult.fail(result.cause());
                     }
                 });
@@ -826,33 +819,30 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         return secretOperations.reconcile(reconciliation, namespace, KafkaConnectCluster.jmxSecretName(name), null);
     }
 
-    public Counter getConnectorsReconciliationsCounter(String namespace) {
-        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsReconciliationsCounterMap,
-                METRICS_PREFIX + "reconciliations",
+    public Counter connectorsReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations", metrics, null, connectorsReconciliationsCounterMap,
                 "Number of reconciliations done by the operator for individual resources");
     }
 
-    public Counter getConnectorsFailedReconciliationsCounter(String namespace) {
-        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsFailedReconciliationsCounterMap,
-                METRICS_PREFIX + "reconciliations.failed",
+    public Counter connectorsFailedReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.failed", metrics, null, connectorsFailedReconciliationsCounterMap,
                 "Number of reconciliations done by the operator for individual resources which failed");
     }
 
-    public Counter getConnectorsSuccessfulReconciliationsCounter(String namespace) {
-        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsSuccessfulReconciliationsCounterMap,
-                METRICS_PREFIX + "reconciliations.successful",
+    public Counter connectorsSuccessfulReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.successful", metrics, null, connectorsSuccessfulReconciliationsCounterMap,
                 "Number of reconciliations done by the operator for individual resources which were successful");
     }
 
-    public AtomicInteger getConnectorsResourceCounter(String namespace) {
-        return Operator.getGauge(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsResourceCounterMap,
-                METRICS_PREFIX + "resources",
+    public AtomicInteger connectorsResourceCounter(String namespace) {
+        return Operator.getGauge(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "resources",
+                metrics, null, connectorsResourceCounterMap,
                 "Number of custom resources the operator sees");
     }
 
-    public Timer getConnectorsReconciliationsTimer(String namespace) {
-        return Operator.getTimer(namespace, KafkaConnector.RESOURCE_KIND, metrics, null, connectorsReconciliationsTimerMap,
-                METRICS_PREFIX + "reconciliations.duration",
+    public Timer connectorsReconciliationsTimer(String namespace) {
+        return Operator.getTimer(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.duration",
+                metrics, null, connectorsReconciliationsTimerMap,
                 "The time the reconciliation takes to complete");
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -527,6 +527,7 @@ public class ConnectorMockTest {
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName(connectorName)
+                    .withNamespace(NAMESPACE)
                     .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
                 .endMetadata()
                 .withNewSpec().endSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -179,7 +179,6 @@ public class KafkaConnectorIT {
 
                 assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(2.0));
                 assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(2.0));
-                assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(0.0));
 
                 assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", KafkaConnector.RESOURCE_KIND).timer().count(), CoreMatchers.is(2L));
                 assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", KafkaConnector.RESOURCE_KIND).timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -84,15 +84,17 @@ public abstract class AbstractOperator<
     private final Optional<LabelSelector> selector;
 
     protected final MetricsProvider metrics;
-    private final Counter periodicReconciliationsCounter;
-    private final Counter reconciliationsCounter;
-    private final Counter failedReconciliationsCounter;
-    private final Counter successfulReconciliationsCounter;
-    private final Counter lockedReconciliationsCounter;
-    private final AtomicInteger pausedResourceCounter;
-    private final AtomicInteger resourceCounter;
-    private final Timer reconciliationsTimer;
-    private final Map<String, AtomicInteger> resourcesStateCounter;
+
+    private final Labels selectorLabels;
+    private Map<String, AtomicInteger> resourcesStateCounter;
+    private Map<String, AtomicInteger> resourceCounterMap;
+    private Map<String, AtomicInteger> pausedResourceCounterMap;
+    private Map<String, Counter> periodicReconciliationsCounterMap;
+    private Map<String, Counter> reconciliationsCounterMap;
+    private Map<String, Counter> failedReconciliationsCounterMap;
+    private Map<String, Counter> successfulReconciliationsCounterMap;
+    private Map<String, Counter> lockedReconciliationsCounterMap;
+    private Map<String, Timer> reconciliationsTimerMap;
 
     public AbstractOperator(Vertx vertx, String kind, O resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
         this.vertx = vertx;
@@ -100,44 +102,17 @@ public abstract class AbstractOperator<
         this.resourceOperator = resourceOperator;
         this.selector = (selectorLabels == null || selectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, selectorLabels.toMap()));
         this.metrics = metrics;
+        this.selectorLabels = selectorLabels;
 
-        // Setup metrics
-        String selectorValue = selectorLabels != null ? selectorLabels.toSelectorString() : "";
-        Tags metricTags = Tags.of(Tag.of("kind", kind()), Tag.of("selector", selectorValue));
-
-        periodicReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.periodical",
-                "Number of periodical reconciliations done by the operator",
-                metricTags);
-
-        reconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations",
-                "Number of reconciliations done by the operator for individual resources",
-                metricTags);
-
-        pausedResourceCounter = metrics.gauge(METRICS_PREFIX + "resources.paused",
-                "Number of custom resources the operator sees but does not reconcile due to paused reconciliations",
-                metricTags);
-
-        failedReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.failed",
-                "Number of reconciliations done by the operator for individual resources which failed",
-                metricTags);
-
-        successfulReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.successful",
-                "Number of reconciliations done by the operator for individual resources which were successful",
-                metricTags);
-
-        lockedReconciliationsCounter = metrics.counter(METRICS_PREFIX + "reconciliations.locked",
-                "Number of reconciliations skipped because another reconciliation for the same resource was still running",
-                metricTags);
-
-        resourceCounter = metrics.gauge(METRICS_PREFIX + "resources",
-                "Number of custom resources the operator sees",
-                metricTags);
-
-        reconciliationsTimer = metrics.timer(METRICS_PREFIX + "reconciliations.duration",
-                "The time the reconciliation takes to complete",
-                metricTags);
-
-        resourcesStateCounter = new ConcurrentHashMap<>();
+        resourceCounterMap = new ConcurrentHashMap<>(1);
+        pausedResourceCounterMap = new ConcurrentHashMap<>(1);
+        resourcesStateCounter = new ConcurrentHashMap<>(1);
+        periodicReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+        reconciliationsCounterMap = new ConcurrentHashMap<>(1);
+        failedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+        successfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+        lockedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+        reconciliationsTimerMap = new ConcurrentHashMap<>(1);
     }
 
     @Override
@@ -192,7 +167,7 @@ public abstract class AbstractOperator<
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();
 
-        reconciliationsCounter.increment();
+        getReconciliationsCounter(reconciliation.namespace()).increment();
         Timer.Sample reconciliationTimerSample = Timer.start(metrics.meterRegistry());
 
         Future<Void> handler = withLock(reconciliation, LOCK_TIMEOUT_MS, () -> {
@@ -224,7 +199,7 @@ public abstract class AbstractOperator<
                             createOrUpdate.fail(statusResult.cause());
                         }
                     });
-                    getPausedResourceCounter().getAndIncrement();
+                    getPausedResourceCounter(namespace).getAndIncrement();
                     LOGGER.debugCr(reconciliation, "Reconciliation of {} {} is paused", kind, name);
                     return createOrUpdate.future();
                 } else if (cr.getSpec() == null) {
@@ -496,38 +471,69 @@ public abstract class AbstractOperator<
     private void handleResult(Reconciliation reconciliation, AsyncResult<Void> result, Timer.Sample reconciliationTimerSample) {
         if (result.succeeded()) {
             updateResourceState(reconciliation, true, null);
-            successfulReconciliationsCounter.increment();
-            reconciliationTimerSample.stop(reconciliationsTimer);
+            getSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
+            reconciliationTimerSample.stop(getReconciliationsTimer(reconciliation.namespace()));
             LOGGER.infoCr(reconciliation, "reconciled");
         } else {
             Throwable cause = result.cause();
 
             if (cause instanceof InvalidConfigParameterException) {
                 updateResourceState(reconciliation, false, cause);
-                failedReconciliationsCounter.increment();
-                reconciliationTimerSample.stop(reconciliationsTimer);
+                getFailedReconciliationsCounter(reconciliation.namespace()).increment();
+                reconciliationTimerSample.stop(getReconciliationsTimer(reconciliation.namespace()));
                 LOGGER.warnCr(reconciliation, "Failed to reconcile {}", cause.getMessage());
             } else if (cause instanceof UnableToAcquireLockException) {
-                lockedReconciliationsCounter.increment();
+                getLockedReconciliationsCounter(reconciliation.namespace()).increment();
             } else  {
                 updateResourceState(reconciliation, false, cause);
-                failedReconciliationsCounter.increment();
-                reconciliationTimerSample.stop(reconciliationsTimer);
+                getFailedReconciliationsCounter(reconciliation.namespace()).increment();
+                reconciliationTimerSample.stop(getReconciliationsTimer(reconciliation.namespace()));
                 LOGGER.warnCr(reconciliation, "Failed to reconcile", cause);
             }
         }
     }
 
-    public Counter getPeriodicReconciliationsCounter() {
-        return periodicReconciliationsCounter;
+    @Override
+    public Counter getPeriodicReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, kind(), metrics, selectorLabels, periodicReconciliationsCounterMap, METRICS_PREFIX + "reconciliations.periodical",
+                "Number of periodical reconciliations done by the operator");
     }
 
-    public AtomicInteger getResourceCounter() {
-        return resourceCounter;
+    public Counter getReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, kind(), metrics, selectorLabels, reconciliationsCounterMap, METRICS_PREFIX + "reconciliations",
+                "Number of reconciliations done by the operator for individual resources");
     }
 
-    public AtomicInteger getPausedResourceCounter() {
-        return pausedResourceCounter;
+    public Counter getFailedReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, kind(), metrics, selectorLabels, failedReconciliationsCounterMap, METRICS_PREFIX + "reconciliations.failed",
+                "Number of reconciliations done by the operator for individual resources which failed");
+    }
+
+    public Counter getSuccessfulReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, kind(), metrics, selectorLabels, successfulReconciliationsCounterMap, METRICS_PREFIX + "reconciliations.successful",
+                "Number of reconciliations done by the operator for individual resources which were successful");
+    }
+
+    public Counter getLockedReconciliationsCounter(String namespace) {
+        return Operator.getCounter(namespace, kind(), metrics, selectorLabels, lockedReconciliationsCounterMap, METRICS_PREFIX + "reconciliations.locked",
+                "Number of reconciliations skipped because another reconciliation for the same resource was still running");
+    }
+
+    @Override
+    public AtomicInteger getResourceCounter(String namespace) {
+        return Operator.getGauge(namespace, kind(), metrics, selectorLabels, resourceCounterMap, METRICS_PREFIX + "resources",
+                "Number of custom resources the operator sees");
+    }
+
+    @Override
+    public AtomicInteger getPausedResourceCounter(String namespace) {
+        return Operator.getGauge(namespace, kind(), metrics, selectorLabels, pausedResourceCounterMap, METRICS_PREFIX + "resources.paused",
+                "Number of custom resources the operator sees but does not reconcile due to paused reconciliations");
+    }
+
+    public Timer getReconciliationsTimer(String namespace) {
+        return Operator.getTimer(namespace, kind(), metrics, selectorLabels, reconciliationsTimerMap, METRICS_PREFIX + "reconciliations.duration",
+                "The time the reconciliation takes to complete");
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -105,9 +105,14 @@ public interface Operator {
 
     AtomicInteger getPausedResourceCounter(String namespace);
 
-    public static Counter getCounter(String namespace, String kind, MetricsProvider metrics, Labels selectorLabels, Map<String, Counter> counterMap, String metricName, String metricHelp) {
+    static Counter getCounter(String namespace, String kind, MetricsProvider metrics, Labels selectorLabels, Map<String, Counter> counterMap, String metricName, String metricHelp) {
         String selectorValue = selectorLabels != null ? selectorLabels.toSelectorString() : "";
-        Tags metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        Tags metricTags = null;
+        if (namespace.equals("*")) {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("selector", selectorValue));
+        } else {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        }
 
         Counter counter = counterMap.get(namespace + "/" + kind);
         if (counter == null) {
@@ -117,9 +122,14 @@ public interface Operator {
         return counter;
     }
 
-    public static AtomicInteger getGauge(String namespace, String kind, MetricsProvider metrics, Labels selectorLabels, Map<String, AtomicInteger> gaugeMap, String metricName, String metricHelp) {
+    static AtomicInteger getGauge(String namespace, String kind, MetricsProvider metrics, Labels selectorLabels, Map<String, AtomicInteger> gaugeMap, String metricName, String metricHelp) {
         String selectorValue = selectorLabels != null ? selectorLabels.toSelectorString() : "";
-        Tags metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        Tags metricTags = null;
+        if (namespace.equals("*")) {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("selector", selectorValue));
+        } else {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        }
 
         AtomicInteger gauge = gaugeMap.get(namespace + "/" + kind);
         if (gauge == null) {
@@ -129,9 +139,14 @@ public interface Operator {
         return gauge;
     }
 
-    public static Timer getTimer(String namespace, String kind, MetricsProvider metrics, Labels selectorLabels, Map<String, Timer> timerMap, String metricName, String metricHelp) {
+    static Timer getTimer(String namespace, String kind, MetricsProvider metrics, Labels selectorLabels, Map<String, Timer> timerMap, String metricName, String metricHelp) {
         String selectorValue = selectorLabels != null ? selectorLabels.toSelectorString() : "";
-        Tags metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        Tags metricTags = null;
+        if (namespace.equals("*")) {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("selector", selectorValue));
+        } else {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        }
 
         Timer timer = timerMap.get(namespace + "/" + kind);
         if (timer == null) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -111,7 +111,7 @@ public interface Operator {
         Tags metricTags = null;
         String metricKey = namespace + "/" + kind;
         if (namespace.equals("*")) {
-            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("selector", selectorValue));
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", "*"), Tag.of("selector", selectorValue));
         } else {
             metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Abstraction of an operator which is driven by resources of a given {@link #kind()}.
@@ -70,9 +71,10 @@ public interface Operator {
     default void reconcileThese(String trigger, Set<NamespaceAndName> desiredNames, String namespace, Handler<AsyncResult<Void>> handler) {
         if (desiredNames.size() > 0) {
             List<Future> futures = new ArrayList<>();
-            resourceCounter(namespace).set(desiredNames.size());
+            desiredNames.stream().map(res -> res.getNamespace()).collect(Collectors.toSet()).forEach(ns -> resourceCounter(ns).set(0));
 
             for (NamespaceAndName resourceRef : desiredNames) {
+                resourceCounter(resourceRef.getNamespace()).getAndIncrement();
                 Reconciliation reconciliation = new Reconciliation(trigger, kind(), resourceRef.getNamespace(), resourceRef.getName());
                 futures.add(reconcile(reconciliation));
             }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -111,7 +111,7 @@ public interface Operator {
         Tags metricTags = null;
         String metricKey = namespace + "/" + kind;
         if (namespace.equals("*")) {
-            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", "*"), Tag.of("selector", selectorValue));
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", ""), Tag.of("selector", selectorValue));
         } else {
             metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
         }

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -99,16 +99,12 @@ public class OperatorMetricsTest {
                     MeterRegistry registry = metrics.meterRegistry();
                     Tag selectorTag = Tag.of("selector", selectorLabels != null ? selectorLabels.toSelectorString() : "");
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
@@ -171,16 +167,12 @@ public class OperatorMetricsTest {
                     MeterRegistry registry = metrics.meterRegistry();
                     Tag selectorTag = Tag.of("selector", selectorLabels != null ? selectorLabels.toSelectorString() : "");
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
@@ -244,18 +236,14 @@ public class OperatorMetricsTest {
                     MeterRegistry registry = metrics.meterRegistry();
                     Tag selectorTag = Tag.of("selector", "");
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "resources.paused").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "resources.paused").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "resources.paused").tag("kind", "TestResource").gauge().value(), is(1.0));
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
@@ -304,19 +292,10 @@ public class OperatorMetricsTest {
                     MeterRegistry registry = metrics.meterRegistry();
                     Tag selectorTag = Tag.of("selector", "");
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(1.0));
-
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(0L));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
-
                     async.flag();
                 })));
     }
@@ -371,16 +350,12 @@ public class OperatorMetricsTest {
                     MeterRegistry registry = metrics.meterRegistry();
                     Tag selectorTag = Tag.of("selector", "");
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(1.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(1), is(selectorTag));
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(1), is(selectorTag));
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(1L));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
@@ -447,18 +422,14 @@ public class OperatorMetricsTest {
             MeterRegistry registry = metrics.meterRegistry();
             Tag selectorTag = Tag.of("selector", "");
 
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.periodical").meter().getId().getTags().get(1), is(selectorTag));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.periodical").meter().getId().getTags().get(2), is(selectorTag));
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.periodical").tag("kind", "TestResource").counter().count(), is(1.0));
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(1), is(selectorTag));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(3.0));
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(1), is(selectorTag));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").meter().getId().getTags().get(2), is(selectorTag));
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "TestResource").counter().count(), is(3.0));
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").meter().getId().getTags().get(1), is(selectorTag));
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "TestResource").counter().count(), is(0.0));
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(1), is(selectorTag));
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(0.0));
 
-            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(1), is(selectorTag));
+            assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").meter().getId().getTags().get(2), is(selectorTag));
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().count(), is(3L));
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "TestResource").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
When CO is configured to watch multiple namespaces, for each namespace is created a new verticle. That results in a race where the "slowest" verticle sets the value of the `strimzi_resources{kind="*",selector="",}` metric.
In this PR, I used maps, where keys are namespaces. For each namespace, a set of metrics is created.

```
$ oc get k --all-namespaces
NAMESPACE    NAME           DESIRED KAFKA REPLICAS   DESIRED ZK REPLICAS   READY     WARNINGS
myproject    my-cluster     3                        3                               
myproject    my-cluster-3   3                        3                               
myproject2   my-cluster     3                        3                     True      
myproject2   my-cluster-2   3                        3                     True      
myproject2   my-cluster-3   3                        3                     True 
```
![Snímek z 2021-07-01 13-47-39](https://user-images.githubusercontent.com/19408098/124119537-efd87780-da72-11eb-9b35-3b3604ef3d03.png)

Note:
before this PR the metrics (for example succeeded or failed reconciliations count) had a value (`0`) from the start of the operator.
After this PR the metric is not available until its value is written.


### Checklist
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

