### PR TITLE
Copy systests imagePullSecrets from default-ns to target-ns

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
-import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -129,7 +128,7 @@ public class SetupClusterOperator {
             }
 
             // copy image-pull secret
-            if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
                 StUtils.copyImagePullSecret(namespaceInstallTo);
             }
             // 060-Deployment

--- a/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
@@ -14,6 +14,7 @@ import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.resources.specific.HelmResource;
 import io.strimzi.systemtest.resources.specific.OlmResource;
 import io.strimzi.systemtest.templates.kubernetes.ClusterRoleBindingTemplates;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.Exec;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
+import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -124,6 +126,11 @@ public class SetupClusterOperator {
                     // if RBAC is enable we don't run tests in parallel mode and with that said we don't create another namespaces
                     createClusterRoleBindings();
                 }
+            }
+
+            // copy image-pull secret
+            if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+                StUtils.copyImagePullSecret(namespaceInstallTo);
             }
             // 060-Deployment
             ResourceManager.setCoDeploymentName(clusterOperatorName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -195,14 +195,16 @@ public class BundleResource implements ResourceType<Deployment> {
             );
         }
 
-        // Apply updated env variables
-        clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
-
         if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            // for strimzi-operator
             List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
             clusterOperator.getSpec().getTemplate().getSpec().setImagePullSecrets(imagePullSecrets);
+            // for kafka
+            envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_SECRETS", Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET, null));
         }
 
+        // Apply updated env variables
+        clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
         return new DeploymentBuilder(clusterOperator)
             .editMetadata()
                 .withName(name)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -24,8 +24,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
 
-import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
-
 public class BundleResource implements ResourceType<Deployment> {
     private static final Logger LOGGER = LogManager.getLogger(BundleResource.class);
 
@@ -200,8 +198,8 @@ public class BundleResource implements ResourceType<Deployment> {
         // Apply updated env variables
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
 
-        if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
-            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
             clusterOperator.getSpec().getTemplate().getSpec().setImagePullSecrets(imagePullSecrets);
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.resources.operator;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.systemtest.Constants;
@@ -20,7 +21,10 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
+
+import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 
 public class BundleResource implements ResourceType<Deployment> {
     private static final Logger LOGGER = LogManager.getLogger(BundleResource.class);
@@ -195,6 +199,11 @@ public class BundleResource implements ResourceType<Deployment> {
 
         // Apply updated env variables
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);
+
+        if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            clusterOperator.getSpec().getTemplate().getSpec().setImagePullSecrets(imagePullSecrets);
+        }
 
         return new DeploymentBuilder(clusterOperator)
             .editMetadata()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.test.TestUtils.toYamlString;
 
 public class KafkaClientsTemplates {
@@ -107,8 +106,8 @@ public class KafkaClientsTemplates {
     private static PodSpec createClientSpec(String namespaceName, boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
                                             String listenerName, String secretPrefix, KafkaUser... kafkaUsers) {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
-        if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
-            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
             podSpecBuilder.withImagePullSecrets(imagePullSecrets);
         }
         ContainerBuilder containerBuilder = new ContainerBuilder()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaClientsTemplates.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.templates.crd;
 
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -30,9 +31,12 @@ import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.Charset;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.test.TestUtils.toYamlString;
 
 public class KafkaClientsTemplates {
@@ -103,6 +107,10 @@ public class KafkaClientsTemplates {
     private static PodSpec createClientSpec(String namespaceName, boolean tlsListener, String kafkaClientsName, boolean hostnameVerification,
                                             String listenerName, String secretPrefix, KafkaUser... kafkaUsers) {
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+        if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
         ContainerBuilder containerBuilder = new ContainerBuilder()
             .withName(kafkaClientsName)
             .withImage(Environment.TEST_CLIENT_IMAGE)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 public class KafkaTemplates {
@@ -237,7 +236,7 @@ public class KafkaTemplates {
                     .endTopicOperator()
                 .endEntityOperator()
             .endSpec();
-        if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
             addImagePullSecret(builder);
         }
         return builder;
@@ -261,7 +260,7 @@ public class KafkaTemplates {
     }
 
     private static KafkaBuilder addImagePullSecret(KafkaBuilder builder) {
-        List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+        List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
         PodTemplate podTemplate = new PodTemplate();
         podTemplate.setImagePullSecrets(imagePullSecrets);
         KafkaClusterTemplate kafkaClusterTemplate = new KafkaClusterTemplateBuilder().withPod(podTemplate).build();

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
@@ -21,13 +20,6 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
-import io.strimzi.api.kafka.model.template.EntityOperatorTemplate;
-import io.strimzi.api.kafka.model.template.EntityOperatorTemplateBuilder;
-import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
-import io.strimzi.api.kafka.model.template.KafkaClusterTemplateBuilder;
-import io.strimzi.api.kafka.model.template.PodTemplate;
-import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplate;
-import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplateBuilder;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -37,7 +29,6 @@ import io.strimzi.test.k8s.KubeClusterResource;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.List;
 
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
@@ -187,7 +178,7 @@ public class KafkaTemplates {
     }
 
     private static KafkaBuilder defaultKafka(Kafka kafka, String name, int kafkaReplicas, int zookeeperReplicas) {
-        KafkaBuilder builder = new KafkaBuilder(kafka)
+        return new KafkaBuilder(kafka)
             .withNewMetadata()
                 .withName(name)
                 .withNamespace(kubeClient().getNamespace())
@@ -236,10 +227,6 @@ public class KafkaTemplates {
                     .endTopicOperator()
                 .endEntityOperator()
             .endSpec();
-        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
-            addImagePullSecret(builder);
-        }
-        return builder;
     }
 
     public static KafkaBuilder kafkaFromYaml(File yamlFile, String clusterName, int kafkaReplicas, int zookeeperReplicas) {
@@ -257,28 +244,6 @@ public class KafkaTemplates {
                     .withReplicas(zookeeperReplicas)
                 .endZookeeper()
             .endSpec();
-    }
-
-    private static KafkaBuilder addImagePullSecret(KafkaBuilder builder) {
-        List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
-        PodTemplate podTemplate = new PodTemplate();
-        podTemplate.setImagePullSecrets(imagePullSecrets);
-        KafkaClusterTemplate kafkaClusterTemplate = new KafkaClusterTemplateBuilder().withPod(podTemplate).build();
-        ZookeeperClusterTemplate zookeeperClusterTemplate = new ZookeeperClusterTemplateBuilder().withPod(podTemplate).build();
-        EntityOperatorTemplate entityOperatorTemplate = new EntityOperatorTemplateBuilder().withPod(podTemplate).build();
-
-        builder.editSpec()
-            .editKafka()
-                .withTemplate(kafkaClusterTemplate)
-            .endKafka()
-            .editZookeeper()
-                .withTemplate(zookeeperClusterTemplate)
-            .endZookeeper()
-            .editEntityOperator()
-                .withTemplate(entityOperatorTemplate)
-            .endEntityOperator()
-            .endSpec();
-        return builder;
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -39,7 +39,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.strimzi.systemtest.Constants.PARALLEL_NAMESPACE;
-import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
@@ -393,16 +392,16 @@ public class StUtils {
      * @param namespace the target namespace
      */
     public static void copyImagePullSecret(String namespace) {
-        LOGGER.info("Checking if secret {} is in the default namespace", SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
-        if (kubeClient("default").getSecret(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET) == null) {
-            throw new RuntimeException(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET + " is not in the default namespace!");
+        LOGGER.info("Checking if secret {} is in the default namespace", Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
+        if (kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET) == null) {
+            throw new RuntimeException(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET + " is not in the default namespace!");
         }
-        Secret pullSecret = kubeClient("default").getSecret(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
+        Secret pullSecret = kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
         kubeClient(namespace).createSecret(new SecretBuilder()
                 .withApiVersion("v1")
                 .withKind("Secret")
                 .withNewMetadata()
-                .withName(SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET)
+                .withName(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET)
                 .endMetadata()
                 .withType("kubernetes.io/dockerconfigjson")
                 .withData(Collections.singletonMap(".dockerconfigjson", pullSecret.getData().get(".dockerconfigjson")))

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -401,7 +401,7 @@ public class StUtils {
                 .withApiVersion("v1")
                 .withKind("Secret")
                 .withNewMetadata()
-                .withName(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET)
+                    .withName(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET)
                 .endMetadata()
                 .withType("kubernetes.io/dockerconfigjson")
                 .withData(Collections.singletonMap(".dockerconfigjson", pullSecret.getData().get(".dockerconfigjson")))

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -47,6 +47,7 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -593,6 +594,9 @@ public abstract class AbstractST implements TestSeparator {
 
                     cluster.createNamespace(extensionContext, namespaceTestCase);
                     NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceTestCase));
+                    if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+                        StUtils.copyImagePullSecret(namespaceTestCase);
+                    }
                 }
             }
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -47,7 +47,6 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static io.strimzi.systemtest.Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET;
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -594,7 +593,7 @@ public abstract class AbstractST implements TestSeparator {
 
                     cluster.createNamespace(extensionContext, namespaceTestCase);
                     NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceTestCase));
-                    if (SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+                    if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
                         StUtils.copyImagePullSecret(namespaceTestCase);
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

### Type of change
- Enhancement or Bug fix

### Description
Although the documentation (https://github.com/strimzi/strimzi-kafka-operator/blob/main/development-docs/TESTING.md#using-private-registries) mentions that systemtests can be executed against a protected registry by setting the image pull secret name to SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET, the images are not pulled.

The background to this issue is found at https://cloud-native.slack.com/archives/CMH3Q3SNP/p1624464225264000

In this proposed change, the provided secret placed in the default namespace is copied to the target namespace and the installed resources will refer to this secret so that the images can be pulled.

I would appreciate for any comments. It was not clear to me which approach is preferable, whether to refer to the secret over the pod template's imagePullSecrets or over env variable STRIMZI_IMAGE_PULL_SECRETS. I have not added any tests yet but tested with the existing systemtests against a protected registry. If the approach proposed is correct, I can add some tests.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

