### PR TITLE
[DOC] kafka static quota plugin

### DIFF
--- a/documentation/assemblies/managing/assembly-management-tasks.adoc
+++ b/documentation/assemblies/managing/assembly-management-tasks.adoc
@@ -22,6 +22,9 @@ include::modules/con-service-discovery.adoc[leveloffset=+1]
 //Recover a cluster from a PV
 include::assembly-cluster-recovery-volume.adoc[leveloffset=+1]
 
+//Setting static broker limits
+include::modules/proc-setting-broker-limits.adoc[leveloffset=+1]
+
 //tuning for clients
 include::assembly-tuning-config.adoc[leveloffset=+1]
 

--- a/documentation/modules/managing/con-broker-config-properties.adoc
+++ b/documentation/modules/managing/con-broker-config-properties.adoc
@@ -586,3 +586,7 @@ group.initial.rebalance.delay.ms=3000
 The delay is the amount of time that the coordinator waits for members to join. The longer the delay,
 the more likely it is that all the members will join in time and avoid a rebalance.
 But the delay also prevents the group from consuming until the period has ended.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:proc-setting-broker-limits-str[Setting limits on brokers using the Kafka Static Quota plugin]

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -17,10 +17,14 @@ For example, you can set a byte-rate threshold of 40 MBps for producers.
 If you have two producers running, they are each limited to a throughput of 20 MBps.
 
 Storage quotas throttle Kafka disk storage limits between a soft limit and hard limit.
+The limits apply to all available disk space.
 Producers are slowed gradually between the soft and hard limit.
 The limits prevent disks filling up too quickly and exceeding disk capacity.
 Full disks can lead to issues that are hard to rectify.
 The hard limit is the maximum storage limit.
+
+NOTE: For JBOD storage, the limit applies across all disks. 
+If a broker is using two 1 TB disks and the quota is 1.1 TB, one disk might fill and the other disk will be almost empty.
 
 .Prerequisites
 

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -8,22 +8,22 @@
 
 [role="_abstract"]
 Use the _Kafka Static Quota_ plugin to set throughput and storage limits on brokers in your Kafka cluster.
-You can set a byte-rate threshold and storage quotas for clients interacting with your brokers.
 You enable the plugin and set limits by configuring the `Kafka` resource.
+You can set a byte-rate threshold and storage quotas to put limits on the clients interacting with your brokers.
 
 You can set byte-rate thresholds for producer and consumer bandwidth.
 The total limit is distributed across all clients accessing the broker.
 For example, you can set a byte-rate threshold of 40 MBps for producers.
-If you have two producers running, they are each limited to a throughput of 20 MBps.
+If two producers are running, they are each limited to a throughput of 20 MBps.
 
 Storage quotas throttle Kafka disk storage limits between a soft limit and hard limit.
 The limits apply to all available disk space.
 Producers are slowed gradually between the soft and hard limit.
-The limits prevent disks filling up too quickly and exceeding disk capacity.
+The limits prevent disks filling up too quickly and exceeding their capacity.
 Full disks can lead to issues that are hard to rectify.
 The hard limit is the maximum storage limit.
 
-NOTE: For JBOD storage, the limit applies across all disks. 
+NOTE: For JBOD storage, the limit applies across all disks.
 If a broker is using two 1 TB disks and the quota is 1.1 TB, one disk might fill and the other disk will be almost empty.
 
 .Prerequisites
@@ -59,7 +59,7 @@ spec:
 <3> Sets the consumer byte-rate threshold. 1 MBps in this example.
 <4> Sets the lower soft limit for storage. 400 GB in this example.
 <5> Sets the higher hard limit for storage. 500 GB in this example.
-<6> Sets the interval between checks on storage. 5 seconds in this example. You can set this to 0 to disable the check.
+<6> Sets the interval in seconds between checks on storage. 5 seconds in this example. You can set this to 0 to disable the check.
 
 . Update the resource.
 +

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// assembly-management-tasks.adoc
+
+[id='proc-setting-broker-limits-{context}']
+
+= Setting limits on brokers using the Kafka Static Quota plugin
+
+[role="_abstract"]
+Use the _Kafka Static Quota_ plugin to set throughput and storage limits on brokers in your Kafka cluster.
+You can set a byte-rate threshold and storage quotas for clients interacting with your brokers.
+You enable the plugin and set limits by configuring the `Kafka` resource.
+
+You can set byte-rate thresholds for producer and consumer bandwidth.
+The total limit is distributed across all clients accessing the broker.
+For example, you can set a byte-rate threshold of 40 MBps for producers.
+If you have two producers running, they are each limited to a throughput of 20 MBps.
+
+Storage quotas throttle Kafka disk storage limits between a soft limit and hard limit.
+Producers are slowed gradually between the soft and hard limit.
+The limits prevent disks filling up too quickly and exceeding disk capacity.
+Full disks can lead to issues that are hard to rectify.
+The hard limit is the maximum storage limit.
+
+.Prerequisites
+
+* The Cluster Operator that manages the Kafka cluster is running.
+
+.Procedure
+
+. Add the plugin properties to the `config` of the `Kafka` resource.
++
+The plugin properties are shown in this example configuration.
++
+.Example Kafka Static Quota plugin configuration
+[source,yaml,options="nowrap",subs="+attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    config:
+      client.quota.callback.class: io.strimzi.kafka.quotas.StaticQuotaCallback <1>
+      client.quota.callback.static.produce: 1000000 <2>
+      client.quota.callback.static.fetch: 1000000 <3>
+      client.quota.callback.static.storage.soft: 400000000000 <4>
+      client.quota.callback.static.storage.hard: 500000000000 <5>
+      client.quota.callback.static.storage.check-interval: 5 <6>
+----
+<1> Loads the Kafka Static Quota plugin.
+<2> Sets the producer byte-rate threshold. 1 MBps in this example.
+<3> Sets the consumer byte-rate threshold. 1 MBps in this example.
+<4> Sets the lower soft limit for storage. 400 GB in this example.
+<5> Sets the higher hard limit for storage. 500 GB in this example.
+<6> Sets the interval between checks on storage. 5 seconds in this example. You can set this to 0 to disable the check.
+
+. Update the resource.
++
+[source,shell,subs=+quotes]
+kubectl apply -f _KAFKA-CONFIG-FILE_
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:con-broker-config-properties-str[Kafka broker configuration tuning]
+* xref:user_quotas[Setting user quotas]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Adds a new procedure to the _Managing Strimzi_ section of the _Using Strimzi_ guide.
The procedure describes how to configure the `Kafka` resource to include the _Kafka Static Quota_ plugin.
The procedure also describes the configuration options. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

