### PR TITLE
Add FluxCD Kustomize labels to the exclude pattern

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -97,7 +97,7 @@ public class Labels {
      * Used to exclude parent CR's labels from being assigned to provisioned subresources
      */
     public static final Pattern STRIMZI_LABELS_EXCLUSION_PATTERN = Pattern.compile(System.getenv()
-            .getOrDefault("STRIMZI_LABELS_EXCLUSION_PATTERN", "^app.kubernetes.io/(?!part-of).*"));
+            .getOrDefault("STRIMZI_LABELS_EXCLUSION_PATTERN", "(^app.kubernetes.io/(?!part-of).*|^kustomize.toolkit.fluxcd.io.*)"));
 
     /**
      * The empty set of labels.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As discussed #5242, FluxCD Kustomize is adding bucnh of labels containing among other things some checksums which might change fairly often. Right now, we mirror these labels to the operands and it is causing unnecessary rolling updates. This Pr updates the default value for the `STRIMZI_LABELS_EXCLUSION_PATTERN` environment variable to exclude these labels by default and not mirror them to the operands.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md