### PR TITLE
Fix missing " in the external configuration example

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc
@@ -242,6 +242,6 @@ spec:
     ssl.truststore.type: PEM
     ssl.truststore.location: "${directory:/opt/kafka/external-configuration/connector-config:ca.crt}"
     ssl.keystore.type: PEM
-    ssl.keystore.location: ${directory:/opt/kafka/external-configuration/connector-config:user.key}"
+    ssl.keystore.location: "${directory:/opt/kafka/external-configuration/connector-config:user.key}"
     #...
 ----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This is a minor fix to the documentation where we are missing `"` in one example.

### Checklist

- [x] Update documentation