### PR TITLE
ST: Apply Roles when CO use namespace-rbac and cluster wide options properly

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -97,6 +97,7 @@ public interface Constants {
     String INGRESS = "Ingress";
     String CLUSTER_ROLE_BINDING = "ClusterRoleBinding";
     String ROLE_BINDING = "RoleBinding";
+    String ROLE = "Role";
     String DEPLOYMENT_CONFIG = "DeploymentConfig";
     String SECRET = "Secret";
     String KAFKA_EXPORTER_DEPLOYMENT = "KafkaWithExporter";

--- a/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
@@ -9,6 +9,7 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.kubernetes.ClusterRoleBindingResource;
 import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.resources.kubernetes.RoleBindingResource;
+import io.strimzi.systemtest.resources.kubernetes.RoleResource;
 import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.resources.specific.HelmResource;
 import io.strimzi.systemtest.resources.specific.OlmResource;
@@ -105,6 +106,10 @@ public class SetupClusterOperator {
             prepareEnvForOperator(extensionContext, namespaceInstallTo, bindingsNamespaces);
             if (Environment.isNamespaceRbacScope()) {
                 // if roles only, only deploy the rolebindings
+                for (String namespace : bindingsNamespaces) {
+                    applyRoles(namespace);
+                    applyRoleBindings(extensionContext, namespaceInstallTo, namespace);
+                }
                 applyRoleBindings(extensionContext, namespaceInstallTo, namespaceInstallTo);
             } else {
                 applyBindings(extensionContext, namespaceInstallTo, bindingsNamespaces);
@@ -284,6 +289,23 @@ public class SetupClusterOperator {
         RoleBindingResource.roleBinding(extensionContext, Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml", namespace, bindingsNamespace);
         // 031-RoleBinding
         RoleBindingResource.roleBinding(extensionContext, Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml", namespace, bindingsNamespace);
+    }
+
+    public static void applyRoles(String namespace) {
+        File roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml");
+        RoleResource.role(switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml");
+        RoleResource.role(switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml");
+        RoleResource.role(switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml");
+        RoleResource.role(switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml");
+        RoleResource.role(switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -33,7 +33,7 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
     }
     @Override
     public void delete(RoleBinding resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRoleBinding(resource.getMetadata().getName());
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRoleBinding(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }
     @Override
     public boolean waitForReadiness(RoleBinding resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -45,7 +45,7 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
         RoleBinding roleBinding = getRoleBindingFromYaml(yamlPath);
         if (Environment.isNamespaceRbacScope()) {
             LOGGER.info("Replacing ClusterRole RoleRef for Role RoleRef");
-            roleBinding.getRoleRef().setKind("Role");
+            roleBinding.getRoleRef().setKind(Constants.ROLE);
         }
 
         return createRoleBinding(

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.kubernetes;
+
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.ResourceType;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class RoleResource implements ResourceType<Role> {
+
+    private static final Logger LOGGER = LogManager.getLogger(RoleResource.class);
+
+    @Override
+    public String getKind() {
+        return Constants.ROLE;
+    }
+    @Override
+    public Role get(String namespace, String name) {
+        return ResourceManager.kubeClient().namespace(namespace).getRole(name);
+    }
+    @Override
+    public void create(Role resource) {
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceRole(resource);
+    }
+    @Override
+    public void delete(Role resource) {
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRole(resource.getMetadata().getName());
+    }
+    @Override
+    public boolean waitForReadiness(Role resource) {
+        return resource != null;
+    }
+
+    public static Role role(String yamlPath, String namespace) {
+        LOGGER.info("Creating Role from {} in namespace {}", yamlPath, namespace);
+        Role role = getRoleFromYaml(yamlPath);
+
+        return createRole(
+            new RoleBuilder(role)
+                .editMetadata()
+                    .withNamespace(namespace)
+                .endMetadata()
+                .build(),
+                namespace);
+    }
+
+    public static Role createRole(Role role, String clientNamespace) {
+        ResourceManager.kubeClient().namespace(clientNamespace).createOrReplaceRole(role);
+        return role;
+    }
+
+    private static Role getRoleFromYaml(String yamlPath) {
+        return TestUtils.configFromYaml(yamlPath, Role.class);
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
@@ -31,7 +31,7 @@ public class RoleResource implements ResourceType<Role> {
     }
     @Override
     public void delete(Role resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRole(resource.getMetadata().getName());
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRole(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }
     @Override
     public boolean waitForReadiness(Role resource) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -604,7 +604,7 @@ public class MetricsST extends AbstractST {
             .withExtensionContext(extensionContext)
             .withNamespace(FIRST_NAMESPACE)
             .withWatchingNamespaces(FIRST_NAMESPACE + "," + SECOND_NAMESPACE)
-            .withBindingsNamespaces(Arrays.asList(FIRST_NAMESPACE, SECOND_NAMESPACE))
+            .withBindingsNamespaces(List.of(FIRST_NAMESPACE, SECOND_NAMESPACE))
             .createInstallation()
             .runInstallation();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -597,8 +597,6 @@ public class MetricsST extends AbstractST {
         cluster.setNamespace(SECOND_NAMESPACE);
 
         NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(SECOND_NAMESPACE));
-        SetupClusterOperator.applyRoleBindings(extensionContext, FIRST_NAMESPACE, SECOND_NAMESPACE);
-        install.applyClusterOperatorInstallFiles(SECOND_NAMESPACE);
 
         cluster.setNamespace(FIRST_NAMESPACE);
 
@@ -606,7 +604,7 @@ public class MetricsST extends AbstractST {
             .withExtensionContext(extensionContext)
             .withNamespace(FIRST_NAMESPACE)
             .withWatchingNamespaces(FIRST_NAMESPACE + "," + SECOND_NAMESPACE)
-            .withBindingsNamespaces(Collections.singletonList(FIRST_NAMESPACE))
+            .withBindingsNamespaces(Arrays.asList(FIRST_NAMESPACE, SECOND_NAMESPACE))
             .createInstallation()
             .runInstallation();
 

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -45,7 +45,6 @@ public class HelmClient {
                 .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
                 .collect(Collectors.joining(","));
         Exec.exec(null, wait(namespace(command("install",
-                "--replace",
                 releaseName,
                 "--set-string", values,
                 "--timeout", INSTALL_TIMEOUT_SECONDS,

--- a/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/HelmClient.java
@@ -45,6 +45,7 @@ public class HelmClient {
                 .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
                 .collect(Collectors.joining(","));
         Exec.exec(null, wait(namespace(command("install",
+                "--replace",
                 releaseName,
                 "--set-string", values,
                 "--timeout", INSTALL_TIMEOUT_SECONDS,

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -844,6 +844,18 @@ public class KubeClient {
         client.rbac().roleBindings().inNamespace(getNamespace()).withName(name).delete();
     }
 
+    public Role createOrReplaceRole(Role role) {
+        return client.rbac().roles().inNamespace(getNamespace()).createOrReplace(role);
+    }
+
+    public Role getRole(String name) {
+        return client.rbac().roles().inNamespace(getNamespace()).withName(name).get();
+    }
+
+    public void deleteRole(String name) {
+        client.rbac().roles().inNamespace(getNamespace()).withName(name).delete();
+    }
+
     public <T extends CustomResource, L extends CustomResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass) {
         return client.customResources(resourceType, listClass); //TODO namespace here
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -840,8 +840,8 @@ public class KubeClient {
         return client.rbac().roleBindings().inNamespace(getNamespace()).withName(name).get();
     }
 
-    public void deleteRoleBinding(String name) {
-        client.rbac().roleBindings().inNamespace(getNamespace()).withName(name).delete();
+    public void deleteRoleBinding(String namespace, String name) {
+        client.rbac().roleBindings().inNamespace(namespace).withName(name).delete();
     }
 
     public Role createOrReplaceRole(Role role) {
@@ -852,8 +852,8 @@ public class KubeClient {
         return client.rbac().roles().inNamespace(getNamespace()).withName(name).get();
     }
 
-    public void deleteRole(String name) {
-        client.rbac().roles().inNamespace(getNamespace()).withName(name).delete();
+    public void deleteRole(String namespace, String name) {
+        client.rbac().roles().inNamespace(namespace).withName(name).delete();
     }
 
     public <T extends CustomResource, L extends CustomResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR fixes the way how roles are created for namespace-rbac mode of CO.

### Checklist

- [x] Make sure all tests pass

