### PR TITLE
[systemtest] Add stability wait into `testLoggingHierarchy` and fix race condition

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1210,10 +1210,8 @@ class LoggingChangeST extends AbstractST {
         );
 
         LOGGER.info("Checking if KafkaConnector {} doesn't inherit logger from KafkaConnect", connectorClassName);
-        connectorLogger = cmdKubeClient().namespace(namespaceName).execInPod(kafkaClientsPodName, "curl",
-            "http://" + KafkaConnectResources.serviceName(clusterName) + ":8083/admin/loggers/" + connectorClassName).out();
 
-        assertTrue(connectorLogger.contains("ERROR"));
+        KafkaConnectorUtils.loggerStabilityWait(namespaceName, clusterName, kafkaClientsPodName, "ERROR", connectorClassName);
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR add stability wait for Connector logger. Currently, in our last assert where we are checking that Connector logger is not change, sometimes, the race condition happen. After adding the stability wait the issue seemed to be fixed - and also, the stability wait checks that connector logger is not changed during some time.

### Checklist

- [x] Make sure all tests pass

