### PR TITLE
[MO] - [system tests] -> fix for testKafkaConnectAndConnectorStatus

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -268,8 +268,6 @@ class CustomResourceStatusST extends AbstractST {
             .endSpec()
             .build());
 
-
-
         assertKafkaConnectStatus(1, connectUrl);
         assertKafkaConnectorStatus(CUSTOM_RESOURCE_STATUS_CLUSTER_NAME, 1, "RUNNING|UNASSIGNED", 0, "RUNNING", "source", List.of(EXAMPLE_TOPIC_NAME));
 
@@ -577,13 +575,13 @@ class CustomResourceStatusST extends AbstractST {
     void assertKafkaConnectorStatus(String clusterName, long expectedObservedGeneration, String connectorStates, int taskId, String taskState, String type, List<String> topics) {
         TestUtils.waitFor("KafkaConnector has following values", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> {
-                boolean verificationFormula = false;
+                boolean isKafkaConnectorStatusCorrect = false;
 
                 KafkaConnectorStatus kafkaConnectorStatus = KafkaConnectorResource.kafkaConnectorClient().inNamespace(NAMESPACE).withName(CUSTOM_RESOURCE_STATUS_CLUSTER_NAME).get().getStatus();
                 Map<String, Object> connectorStatus = kafkaConnectorStatus.getConnectorStatus();
                 String currentState = ((LinkedHashMap<String, String>) connectorStatus.get("connector")).get("state");
 
-                verificationFormula =
+                isKafkaConnectorStatusCorrect =
                     kafkaConnectorStatus.getObservedGeneration() == expectedObservedGeneration &&
                         connectorStates.contains(currentState) &&
                         connectorStatus.get("name").equals(CUSTOM_RESOURCE_STATUS_CLUSTER_NAME) &&
@@ -591,7 +589,7 @@ class CustomResourceStatusST extends AbstractST {
                         connectorStatus.get("tasks") != null &&
                         kafkaConnectorStatus.getTopics().equals(topics);
 
-                return verificationFormula;
+                return isKafkaConnectorStatusCorrect;
             });
     }
 


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fix race condition in `testKafkaConnectAndConnectorStatus` test case. The problem here was that when we configure KafkaConnetor with additional config:

```
.editSpec()
   .addToConfig("topic", EXAMPLE_TOPIC_NAME)
.endSpec()
```

and afterwards, check `KafkaConnectorStatus` there was a time window that this status gets updated. So I decrease the TopicReconciliation interval from defaults 120s to 15s and after 5 runs tests always passed. Otherwise with default reconciliation interval test fails once a time...which is not an acceptable behaviour...

### Checklist

- [ ] Make sure all tests pass


