### PR TITLE
Tell User Operator whether Kafka Admin API can be used to manage ACLs or not

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
@@ -41,6 +41,13 @@ public abstract class KafkaAuthorization implements UnknownPropertyPreserving, S
             "`custom` authorization type uses user-provided implementation for authorization.")
     public abstract String getType();
 
+    /**
+     * Indicates whether the Authorizer supports the Kafka Admin API to manage ACLs or not.
+     *
+     * @return True if ACLs can be managed using Kafka Admin API. False otherwise.
+     */
+    public abstract boolean supportsAdminApi();
+
     @Override
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationCustom.java
@@ -24,7 +24,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"type", "authorizerClass", "superUsers"})
+@JsonPropertyOrder({"type", "authorizerClass", "superUsers", "supportsAdminApi"})
 @EqualsAndHashCode
 public class KafkaAuthorizationCustom extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
@@ -33,12 +33,22 @@ public class KafkaAuthorizationCustom extends KafkaAuthorization {
 
     private String authorizerClass;
     private List<String> superUsers;
+    private boolean supportsAdminApi = false;
 
     @Description("Must be `" + TYPE_CUSTOM + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_CUSTOM;
+    }
+
+    /**
+     * Custom Authorizer might or might not support the APIs for managing ACLs.
+     *
+     * @return Returns true if the custom authorizer supports APIs for ACL management. False otherwise.
+     */
+    public boolean supportsAdminApi()   {
+        return supportsAdminApi;
     }
 
     @Description("List of super users, which are user principals with unlimited access rights.")
@@ -60,5 +70,16 @@ public class KafkaAuthorizationCustom extends KafkaAuthorization {
 
     public void setAuthorizerClass(String clazz) {
         this.authorizerClass = clazz;
+    }
+
+    @Description("Indicates whether the custom authorizer supports the APIs for managing ACLs using the Kafka Admin API. " +
+            "Defaults to `false`.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean isSupportsAdminApi() {
+        return supportsAdminApi;
+    }
+
+    public void setSupportsAdminApi(boolean supportsAdminApi) {
+        this.supportsAdminApi = supportsAdminApi;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -49,6 +49,16 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         return TYPE_KEYCLOAK;
     }
 
+    /**
+     * When delegation to Kafka Simple Authorizer is enabled, the Kafka Admin API can be used to manage the Kafka ACLs.
+     * If it is disabled, using the Admin API is not possible.
+     *
+     * @return True when delegation to Kafka Simple Authorizer is enabled and the Kafka Admin API can be used to manage Simple ACLs.
+     */
+    public boolean supportsAdminApi()   {
+        return delegateToKafkaAcls;
+    }
+
     @Description("OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.")
     public String getClientId() {
         return clientId;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
@@ -46,6 +46,16 @@ public class KafkaAuthorizationOpa extends KafkaAuthorization {
         return TYPE_OPA;
     }
 
+    /**
+     * OPA Authorizer does not support the APIs to manage ACLs using Kafka Admin API. This method returns always false
+     * for API.
+     *
+     * @return Returns always false for OPA authorizer
+     */
+    public boolean supportsAdminApi()   {
+        return false;
+    }
+
     @Description("List of super users, which is specifically a list of user principals that have unlimited access rights.")
     @Example("- CN=my-user\n" +
              "- CN=my-other-user")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationSimple.java
@@ -41,6 +41,15 @@ public class KafkaAuthorizationSimple extends KafkaAuthorization {
         return TYPE_SIMPLE;
     }
 
+    /**
+     * Simple authorizer is the native Kafka authorizer. This method returns always true for it.
+     *
+     * @return Returns always true for Simple authorizer
+     */
+    public boolean supportsAdminApi()   {
+        return true;
+    }
+
     @Description("List of super users. Should contain list of user principals which should get unlimited access rights.")
     @Example("- CN=my-user\n" +
              "- CN=my-other-user")

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -583,13 +583,15 @@ The `type` property is a discriminator that distinguishes use of the `KafkaAutho
 It must have the value `custom` for the type `KafkaAuthorizationCustom`.
 [options="header"]
 |====
-|Property                |Description
-|type             1.2+<.<a|Must be `custom`.
+|Property                 |Description
+|type              1.2+<.<a|Must be `custom`.
 |string
-|authorizerClass  1.2+<.<a|Authorization implementation class, which must be available in classpath.
+|authorizerClass   1.2+<.<a|Authorization implementation class, which must be available in classpath.
 |string
-|superUsers       1.2+<.<a|List of super users, which are user principals with unlimited access rights.
+|superUsers        1.2+<.<a|List of super users, which are user principals with unlimited access rights.
 |string array
+|supportsAdminApi  1.2+<.<a|Indicates whether the custom authorizer supports the APIs for managing ACLs using the Kafka Admin API. Defaults to `false`.
+|boolean
 |====
 
 [id='type-Rack-{context}']

--- a/documentation/modules/con-securing-client-authorization.adoc
+++ b/documentation/modules/con-securing-client-authorization.adoc
@@ -9,11 +9,20 @@ User authorization is configured using the `authorization` property in `KafkaUse
 The authorization type enabled for a user is specified using the `type` field.
 
 To use simple authorization, you set the `type` property to `simple` in `KafkaUser.spec.authorization`.
-Simple authorization uses the default Kafka authorization plugin, `AclAuthorizer`.
+The simple authorization will use the Kafka Admin API to manage the ACL rules inside your Kafka cluster.
+Whether the ACL management in the User Operator is enabled or not depends on your authorization configuration in the Kafka cluster.
 
-Alternatively, you can use xref:type-KafkaAuthorizationOpa-reference[OPA authorization],
-or if you are already using OAuth 2.0 token based authentication,
-you can also use xref:assembly-oauth-authorization_str[OAuth 2.0 authorization].
+* For simple authorization, ACL management is always enabled.
+* For OPA authorization, ACL management is always disabled and authorization rules have to be configured in the OPA server.
+* For Keycloak authorization, you can manage the ACL rules directly in Keycloak.
+  You can also delegate authorization to the simple authorizer as a fallback option in the configuration.
+  When the delegation to the simple authorizer is enabled, User Operator will enable management of ACL rules as well.
+* When using custom authorization plugin, use the `supportsAdminApi` field in `.spec.kafka.authorization` in the `Kafka` custom resource to enable or disable the support.
+
+If ACL managment is not enabled, Strimzi rejects the resource in case it contains any ACL rules.
+
+If you're using a standalone deployment of the User Operator, the ACL management is enabled by default.
+You can disable it using the `STRIMZI_ACLS_ADMIN_API_SUPPORTED` environment variable.
 
 If no authorization is specified, the User Operator does not provision any access rights for the user.
 Whether such a `KafkaUser` can still access resources depends on the authorizer being used.

--- a/documentation/modules/con-securing-client-authorization.adoc
+++ b/documentation/modules/con-securing-client-authorization.adoc
@@ -10,18 +10,19 @@ The authorization type enabled for a user is specified using the `type` field.
 
 To use simple authorization, you set the `type` property to `simple` in `KafkaUser.spec.authorization`.
 The simple authorization will use the Kafka Admin API to manage the ACL rules inside your Kafka cluster.
-Whether the ACL management in the User Operator is enabled or not depends on your authorization configuration in the Kafka cluster.
+Whether ACL management in the User Operator is enabled or not depends on your authorization configuration in the Kafka cluster.
 
 * For simple authorization, ACL management is always enabled.
-* For OPA authorization, ACL management is always disabled and authorization rules have to be configured in the OPA server.
+* For OPA authorization, ACL management is always disabled.
+  Authorization rules are configured in the OPA server.
 * For Keycloak authorization, you can manage the ACL rules directly in Keycloak.
   You can also delegate authorization to the simple authorizer as a fallback option in the configuration.
-  When the delegation to the simple authorizer is enabled, User Operator will enable management of ACL rules as well.
-* When using custom authorization plugin, use the `supportsAdminApi` field in `.spec.kafka.authorization` in the `Kafka` custom resource to enable or disable the support.
+  When delegation to the simple authorizer is enabled, the User Operator will enable management of ACL rules as well.
+* For custom authorization using a custom authorization plugin, use the `supportsAdminApi` property in the `.spec.kafka.authorization` configuration of the `Kafka` custom resource to enable or disable the support.
 
-If ACL managment is not enabled, Strimzi rejects the resource in case it contains any ACL rules.
+If ACL managment is not enabled, Strimzi rejects a resource if it contains any ACL rules.
 
-If you're using a standalone deployment of the User Operator, the ACL management is enabled by default.
+If you're using a standalone deployment of the User Operator, ACL management is enabled by default.
 You can disable it using the `STRIMZI_ACLS_ADMIN_API_SUPPORTED` environment variable.
 
 If no authorization is specified, the User Operator does not provision any access rights for the user.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -73,6 +73,10 @@ spec:
               value: "-Xmx=512M -Xms=256M"
             - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <15>
               value: "-Djavax.net.debug=verbose -DpropertyName=value"
+            - name: STRIMZI_SECRET_PREFIX <16>
+              value: "kafka-"
+            - name: STRIMZI_ACLS_ADMIN_API_SUPPORTED <17>
+              value: "true"
 ----
 <1> The Kubernetes namespace for the User Operator to watch for `KafkaUser` resources. Only one namespace can be specified.
 <2>  The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
@@ -98,6 +102,11 @@ The default is `365` days.
 The default is `30` days to initiate certificate renewal before the old certificates expire.
 <14> (Optional) The Java options used by the JVM running the User Operator
 <15> (Optional) The debugging (`-D`) options set for the User Operator
+<16> (Optional) Prefix which will be used in the names of Kubernetes secrets created by the User Operator
+<17> (Optional) Indicates whether the Kafka cluster supports management of authorization ACL rules using the Kafka Admin API.
+When set to `false`, the User Operator will reject all resources with `simple` authorization ACL rules.
+This helps to avoid unnecessary exceptions in the Kafka cluster logs.
+The default is `true`.
 
 
 . If you are using TLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -102,7 +102,7 @@ The default is `365` days.
 The default is `30` days to initiate certificate renewal before the old certificates expire.
 <14> (Optional) The Java options used by the JVM running the User Operator
 <15> (Optional) The debugging (`-D`) options set for the User Operator
-<16> (Optional) Prefix which will be used in the names of Kubernetes secrets created by the User Operator
+<16> (Optional) Prefix for the names of Kubernetes secrets created by the User Operator.
 <17> (Optional) Indicates whether the Kafka cluster supports management of authorization ACL rules using the Kafka Admin API.
 When set to `false`, the User Operator will reject all resources with `simple` authorization ACL rules.
 This helps to avoid unnecessary exceptions in the Kafka cluster logs.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -545,6 +545,9 @@ spec:
                           items:
                             type: string
                           description: List of super users, which are user principals with unlimited access rights.
+                        supportsAdminApi:
+                          type: boolean
+                          description: Indicates whether the custom authorizer supports the APIs for managing ACLs using the Kafka Admin API. Defaults to `false`.
                         tlsTrustedCertificates:
                           type: array
                           items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -826,6 +826,11 @@ spec:
                           type: string
                         description: List of super users, which are user principals
                           with unlimited access rights.
+                      supportsAdminApi:
+                        type: boolean
+                        description: Indicates whether the custom authorizer supports
+                          the APIs for managing ACLs using the Kafka Admin API. Defaults
+                          to `false`.
                       tlsTrustedCertificates:
                         type: array
                         items:

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthorizerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthorizerST.java
@@ -201,6 +201,7 @@ public class CustomAuthorizerST extends AbstractST {
                 .editKafka()
                     .withNewKafkaAuthorizationCustom()
                         .withAuthorizerClass(KafkaAuthorizationSimple.AUTHORIZER_CLASS_NAME)
+                        .withSupportsAdminApi(true)
                         .withSuperUsers("CN=" + ADMIN)
                     .endKafkaAuthorizationCustom()
                     .withListeners(new GenericKafkaListenerBuilder()

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -128,7 +128,7 @@ public class KafkaUserOperator extends AbstractOperator<KafkaUser, KafkaUserSpec
         KafkaUserStatus userStatus = new KafkaUserStatus();
 
         try {
-            user = KafkaUserModel.fromCrd(resource, config.getSecretPrefix());
+            user = KafkaUserModel.fromCrd(resource, config.getSecretPrefix(), config.isAclsAdminApiSupported());
             LOGGER.debugCr(reconciliation, "Updating User {} in namespace {}", reconciliation.name(), reconciliation.namespace());
         } catch (Exception e) {
             LOGGER.warnCr(reconciliation, e);

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -31,6 +31,7 @@ public class UserOperatorConfigTest {
         envVars.put(UserOperatorConfig.STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS, "6000");
         envVars.put(UserOperatorConfig.STRIMZI_CLIENTS_CA_VALIDITY, "1000");
         envVars.put(UserOperatorConfig.STRIMZI_CLIENTS_CA_RENEWAL, "10");
+        envVars.put(UserOperatorConfig.STRIMZI_ACLS_ADMIN_API_SUPPORTED, "false");
 
         Map<String, String> labels = new HashMap<>(2);
         labels.put("label1", "value1");
@@ -52,6 +53,7 @@ public class UserOperatorConfigTest {
         assertThat(config.getZookeeperSessionTimeoutMs(), is(Long.parseLong(envVars.get(UserOperatorConfig.STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS))));
         assertThat(config.getClientsCaValidityDays(), is(1000));
         assertThat(config.getClientsCaRenewalDays(), is(10));
+        assertThat(config.isAclsAdminApiSupported(), is(false));
     }
 
     @Test
@@ -122,5 +124,14 @@ public class UserOperatorConfigTest {
         UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
         assertThat(config.getClientsCaValidityDays(), is(CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS));
         assertThat(config.getClientsCaRenewalDays(), is(CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS));
+    }
+
+    @Test
+    public void testFromMapAclsAdminApiSupportedDefaults()  {
+        Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
+        envVars.remove(UserOperatorConfig.STRIMZI_ACLS_ADMIN_API_SUPPORTED);
+
+        UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
+        assertThat(config.isAclsAdminApiSupported(), is(UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -60,7 +60,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testFromCrdTlsUser()   {
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.namespace, is(ResourceUtils.NAMESPACE));
         assertThat(model.name, is(ResourceUtils.NAME));
@@ -78,7 +78,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testFromCrdTlsExternalUser()   {
-        KafkaUserModel model = KafkaUserModel.fromCrd(ResourceUtils.createKafkaUser(new KafkaUserTlsExternalClientAuthentication()), UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(ResourceUtils.createKafkaUser(new KafkaUserTlsExternalClientAuthentication()), UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.namespace, is(ResourceUtils.NAMESPACE));
         assertThat(model.name, is(ResourceUtils.NAME));
@@ -96,7 +96,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testFromCrdQuotaUser()   {
-        KafkaUserModel model = KafkaUserModel.fromCrd(quotasUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(quotasUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.namespace, is(ResourceUtils.NAMESPACE));
         assertThat(model.name, is(ResourceUtils.NAME));
@@ -116,7 +116,7 @@ public class KafkaUserModelTest {
     @Test
     public void testFromCrdQuotaUserWithNullValues()   {
         KafkaUser quotasUserWithNulls = ResourceUtils.createKafkaUserQuotas(null, 2000, null, 10d);
-        KafkaUserModel model = KafkaUserModel.fromCrd(quotasUserWithNulls, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(quotasUserWithNulls, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.namespace, is(ResourceUtils.NAMESPACE));
         assertThat(model.name, is(ResourceUtils.NAME));
@@ -135,7 +135,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testGenerateSecret()    {
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
         Secret generatedSecret = model.generateSecret();
 
@@ -159,7 +159,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecretWithPrefix()    {
         String secretPrefix = "strimzi-";
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, secretPrefix);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, secretPrefix, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
         Secret generatedSecret = model.generateSecret();
 
@@ -196,7 +196,7 @@ public class KafkaUserModelTest {
                 .endSpec()
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(userWithTemplate, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(userWithTemplate, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
         Secret generatedSecret = model.generateSecret();
 
@@ -220,7 +220,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testGenerateSecretGeneratesCertificateWhenNoSecretExistsProvidedByUser()    {
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
         Secret generated = model.generateSecret();
 
@@ -236,7 +236,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testMissingOrWrongCaSecrets()    {
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         Secret emptySecret = new SecretBuilder()
                 .withNewMetadata()
@@ -275,7 +275,7 @@ public class KafkaUserModelTest {
         Secret clientsCaKeySecret = ResourceUtils.createClientsCaKeySecret();
         clientsCaKeySecret.getData().put("ca.key", Base64.getEncoder().encodeToString("different-clients-ca-key".getBytes()));
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCertSecret, clientsCaKeySecret, userCert, 365, 30);
         Secret generatedSecret = model.generateSecret();
 
@@ -293,7 +293,7 @@ public class KafkaUserModelTest {
     public void testGenerateSecretGeneratedCertificateDoesNotChangeFromUserProvided()    {
         Secret userCert = ResourceUtils.createUserSecretTls();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userCert, 365, 30);
         Secret generatedSecret = model.generateSecret();
 
@@ -311,7 +311,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecretGeneratesCertificateWithExistingScramSha()    {
         Secret userCert = ResourceUtils.createUserSecretScramSha();
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userCert, 365, 30);
         Secret generated = model.generateSecret();
 
@@ -327,7 +327,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testGenerateSecretGeneratesKeyStoreWhenOldVersionSecretExists() {
-        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
         Secret oldSecret = model.generateSecret();
 
@@ -335,7 +335,7 @@ public class KafkaUserModelTest {
         oldSecret.getData().remove("user.p12");
         oldSecret.getData().remove("user.password");
 
-        model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, oldSecret, 365, 30);
         Secret generatedSecret = model.generateSecret();
 
@@ -354,7 +354,7 @@ public class KafkaUserModelTest {
 
     @Test
     public void testGenerateSecretGeneratesPasswordWhenNoUserSecretExists()    {
-        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, null);
         Secret generatedSecret = model.generateSecret();
 
@@ -383,7 +383,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecretGeneratesPasswordKeepingExistingScramShaPassword()    {
         Secret scramShaSecret = ResourceUtils.createUserSecretScramSha();
-        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, scramShaSecret, null);
         Secret generated = model.generateSecret();
 
@@ -426,7 +426,7 @@ public class KafkaUserModelTest {
                 .addToData("my-password", DESIRED_BASE64_PASSWORD)
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, desiredPasswordSecret);
         Secret generatedSecret = model.generateSecret();
 
@@ -475,7 +475,7 @@ public class KafkaUserModelTest {
                 .addToData("my-password", DESIRED_BASE64_PASSWORD)
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, scramShaSecret, desiredPasswordSecret);
         Secret generated = model.generateSecret();
 
@@ -520,7 +520,7 @@ public class KafkaUserModelTest {
                 .addToData("my-other-password", DESIRED_BASE64_PASSWORD)
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
             model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, desiredPasswordSecret);
@@ -550,7 +550,7 @@ public class KafkaUserModelTest {
                 .addToData("my-password", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
             model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, desiredPasswordSecret);
         });
@@ -572,7 +572,7 @@ public class KafkaUserModelTest {
                 .endSpec()
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
             model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, null, null);
@@ -584,7 +584,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecretGeneratesPasswordFromExistingTlsSecret()    {
         Secret userCert = ResourceUtils.createUserSecretTls();
-        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         model.maybeGeneratePassword(Reconciliation.DUMMY_RECONCILIATION, passwordGenerator, userCert, null);
         Secret generated = model.generateSecret();
 
@@ -618,7 +618,7 @@ public class KafkaUserModelTest {
         KafkaUser user = ResourceUtils.createKafkaUserTls();
         user.setSpec(new KafkaUserSpec());
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.generateSecret(), is(nullValue()));
     }
@@ -629,7 +629,7 @@ public class KafkaUserModelTest {
         KafkaUser user = ResourceUtils.createKafkaUserTls();
         user.setSpec(new KafkaUserSpec());
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.getSimpleAclRules(), is(nullValue()));
     }
@@ -657,7 +657,7 @@ public class KafkaUserModelTest {
 
         assertThrows(InvalidResourceException.class, () -> {
             // 65 characters => Should throw exception with TLS
-            KafkaUserModel.fromCrd(tooLong, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+            KafkaUserModel.fromCrd(tooLong, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         });
     }
 
@@ -670,7 +670,7 @@ public class KafkaUserModelTest {
                 .endMetadata()
                 .build();
 
-        KafkaUserModel.fromCrd(notTooLong, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel.fromCrd(notTooLong, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
     }
 
     @Test
@@ -682,7 +682,7 @@ public class KafkaUserModelTest {
                 .endMetadata()
                 .build();
 
-        KafkaUserModel.fromCrd(tooLong, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel.fromCrd(tooLong, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
     }
 
     @Test
@@ -697,7 +697,7 @@ public class KafkaUserModelTest {
                 .build();
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
-            KafkaUserModel.fromCrd(emptyPassword, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+            KafkaUserModel.fromCrd(emptyPassword, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         });
 
         assertThat(e.getMessage(), is("Resource requests custom SCRAM-SHA-512 password but doesn't specify the secret name and/or key"));
@@ -718,7 +718,7 @@ public class KafkaUserModelTest {
                 .build();
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> {
-            KafkaUserModel.fromCrd(missingKey, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+            KafkaUserModel.fromCrd(missingKey, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
         });
 
         assertThat(e.getMessage(), is("Resource requests custom SCRAM-SHA-512 password but doesn't specify the secret name and/or key"));
@@ -738,7 +738,7 @@ public class KafkaUserModelTest {
                 .endSpec()
                 .build();
 
-        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(user, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.isUserWithDesiredPassword(), is(true));
         assertThat(model.desiredPasswordSecretKey(), is("my-password"));
@@ -747,10 +747,16 @@ public class KafkaUserModelTest {
 
     @Test
     public void testFromCrdScramShaUserWithoutPasswordParsing()    {
-        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX);
+        KafkaUserModel model = KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
 
         assertThat(model.isUserWithDesiredPassword(), is(false));
         assertThat(model.desiredPasswordSecretKey(), is(nullValue()));
         assertThat(model.desiredPasswordSecretName(), is(nullValue()));
+    }
+
+    @Test
+    public void testFromCrdAclsWithAclsAdminApiSupportMissing()    {
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KafkaUserModel.fromCrd(scramShaUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, false));
+        assertThat(e.getMessage(), is("Simple authorization ACL rules are configured but not supported in the Kafka cluster configuration."));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In Kafka, the Admin API ACL management delegates to the configured ACL authorizer class. However, it is fairly common the the authorizer does not implement these methods. This applies especially in cases where the authorization data are stored in completely separate system such as with the OPA or Keycloak authorizers.

Today, when the `KafkaUser` CR contains the authorization section, the User Operator is always tries to set the ACLs using the Kafka Admin API. While managing the ALCs, it checks for some specific exceptions to detect if the ACL management is not supported and provide more specific errors to the user. But this solution is not perfect since it still calls the Admin API again and again. That can cause unnecessary load to the Kafka cluster but also means that exceptions and errors might be printed in the Kafka logs.

This PR introduces a better solution - it adds a new configuration for the User Operator to indicate whether the configured authorizer does or does not support the management of ACLs using the Kafka Admin API. The User Operator uses the information and either uses the Admin API to manage the ACLs or checks if the resource contains any ACLs and throws an `InvalidResourceConiguration` exception. This reduces the unnecessary Admin API calls and errors int he broker logs.

When the UO is deployed via the CO, it is configured automatically based on the authorization configuration. For OPA authorization, it is always disabled. For Keycloak authorization, it is enabled only when delegation to the simple authorizer is enabled. For simple authorizer it is always enabled. And for the custom authorizer, user can configure whether the custom authorizer implementation does or doesn't support the Admin API.

For the standalone UO, users have to configure this option themselves. The default value is `true` to enable it - this helps to maintain the backwards compatibility => for existing users, this will work as before unless they start using the new configuration value.

This Pr also updates the docs - it also adds the docs for the `STRIMZI_SECRET_PREFIX` option which seems to be missing.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally