### PR TITLE
Config-model-generator execution on Maven build

### DIFF
--- a/config-model-generator/Makefile
+++ b/config-model-generator/Makefile
@@ -7,7 +7,6 @@ docker_tag:
 docker_push:
 
 java_build:
-	./build-config-models.sh build
 
 spotbugs:
 	mvn $(MVN_ARGS) spotbugs:check
@@ -18,7 +17,7 @@ clean:
 	rm ../cluster-operator/src/main/resources/kafka-*-config-model.json || true
 	./build-config-models.sh clean
 
-#include ../Makefile.maven
+include ../Makefile.maven
 
 .PHONY: build clean release
 

--- a/config-model-generator/build-config-models.sh
+++ b/config-model-generator/build-config-models.sh
@@ -15,7 +15,7 @@ then
 
     for version in "${versions[@]}"
     do
-        mvn ${MVN_ARGS} verify exec:java \
+        mvn ${MVN_ARGS} exec:java \
         "-Dkafka-metadata-version=$version" \
         "-Dconfig-model-file=../cluster-operator/src/main/resources/kafka-${version}-config-model.json"
     done

--- a/config-model-generator/pom.xml
+++ b/config-model-generator/pom.xml
@@ -67,6 +67,32 @@
                         <argument>${config-model-file}</argument>
                     </arguments>
                 </configuration>
+                <executions>
+                    <execution>
+                        <!-- This execution is included here to generate the required files as part of the regular
+                             Maven build so that a successful `mvn clean install` isn't contingent on running make first.
+                             This helps with two scenarios:
+                                1) Tests failing in cluster-operator because no Kafka configuration existed
+                                2) Tests failing in cluster-operator because config files for now unsupported Kafka versions still exist -->
+                        <id>generate-config-models</id>
+
+                        <!-- Need a phase after compile (so that the class exists), but before test -->
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+
+                        <!-- Use the shell script instead of executing directly, as we need to execute KafkaConfigModelGenerator
+                             once for every supported version, and the existing shell scripts already handle determing what those versions are -->
+                        <configuration>
+                            <executable>${project.basedir}${file.separator}build-config-models.sh</executable>
+                            <arguments>
+                                <argument>build</argument>
+                            </arguments>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/test-container/src/test/java/io/strimzi/StrimziKafkaContainerIT.java
+++ b/test-container/src/test/java/io/strimzi/StrimziKafkaContainerIT.java
@@ -21,9 +21,9 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class StrimziKafkaContainerTest {
+public class StrimziKafkaContainerIT {
 
-    private static final Logger LOGGER = LogManager.getLogger(StrimziKafkaContainerTest.class);
+    private static final Logger LOGGER = LogManager.getLogger(StrimziKafkaContainerIT.class);
 
     private StrimziKafkaContainer systemUnderTest;
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Binds generation of Kafka config model files to a Maven build phase to prevent cluster-operator tests failing in a couple of scenarios when `maven verify/install` etc. are been run without running `make` goals first. 

Scenarios were:
1) Tests failing in cluster-operator because no Kafka config files existed in its resources directory
2) Tests failing in cluster-operator because config files for now unsupported Kafka versions still exist in its resource directory.

### Checklist

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

