### PR TITLE
[systemtest] Fixups for tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -634,7 +634,7 @@ class LoggingChangeST extends AbstractST {
         long reconciliationSleep = RECONCILIATION_INTERVAL + Duration.ofSeconds(10).toMillis();
         LOGGER.info("Waiting {} ms log not to be empty", reconciliationSleep);
         // wait enough time (at least for reconciliation time + 10) and check whether logs after this time are not empty
-        Thread.sleep(reconciliationSleep);
+        Thread.sleep(reconciliationSleep * 2);
 
         LOGGER.info("Asserting if log will contain no records");
         String coLog = StUtils.getLogFromPodByTime(NAMESPACE, coPodName, STRIMZI_DEPLOYMENT_NAME, "30s");

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -326,6 +326,7 @@ public class TopicST extends AbstractST {
         created = hasTopicInKafka(topicName, TOPIC_CLUSTER_NAME);
         assertThat(created, is(true));
 
+        KafkaTopicUtils.waitForKafkaTopicCreation(topicName);
         KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(NAMESPACE).withName(topicName).get();
         assertThat(kafkaTopic, notNullValue());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -432,11 +432,11 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
+        // CO_OPERATION_TIMEOUT_DEFAULT is set here for ensuring that all operations will be fulfilled successfully
         install = new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(extensionContext)
             .withNamespace(NAMESPACE)
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
-            .withOperationTimeout(Constants.CO_OPERATION_TIMEOUT_SHORT)
             .createInstallation()
             .runInstallation();
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Tests fixes

### Description

This PR fixes several of flaky tests:
```
LoggingChangeST.testDynamicallySetClusterOperatorLoggingLevels - too small sleep for log to not be empty
AlternativeReconcileTriggersST.testAddingAndRemovingJbodVolumes - unable to complete operation (rolling update) - too small operation timeout
TopicST.testSendingMessagesToNonExistingTopic - paralelism problem - topic wasn't created at time when `get()` was executed - added wait for topic creation
MetricsST - add waits to avoid race conditions
```

### Checklist

- [x] Make sure all tests pass

