### PR TITLE
Add pre-check to self-closing-watch to handle missed events

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -93,17 +93,18 @@ public class ResourceSupport {
      * returning a Future which completes when {@code watchFn} returns non-null
      * to some event on the watchable, or after a timeout.
      *
-     * The given {@code watchFn} will be invoked on a worked thread when the
+     * The given {@code watchFn} will be invoked on a worker thread when the
      * Kubernetes resources changes, so may block.
      * When the {@code watchFn} returns non-null the watch will be closed and then
      * the future returned from this method will be completed on the context thread.
      *
      * In some cases such as resource deletion, it might happen that the resource is deleted already before the watch is
-     * started and as a result the watch never completes. The {@code preCheckFn} will be invoked on a worked thread
+     * started and as a result the watch never completes. The {@code preCheckFn} will be invoked on a worker thread
      * after the watch has been created. It is expected to double check if we still need to wait for the watch to fire.
      * When the {@code preCheckFn} returns non-null the watch will be closed and the future returned from this method
-     * will be completed on the context thread. In the deletion example described above, the {@code preCheckFn} can
-     * check if the resource still exists and close the watch in case it was already deleted.
+     * will be completed with the result of the {@code preCheckFn} on the context thread. In the deletion example
+     * described above, the {@code preCheckFn} can check if the resource still exists and close the watch in case it was
+     * already deleted.
      *
      * @param reconciliation Reconciliation marker used for logging
      * @param watchable The watchable - used to watch the resource.

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -166,18 +166,14 @@ public class ResourceSupport {
 
                     // Pre-check is done after the watch is open to make sure we did not missed the event. In the worst
                     // case, both pre-check and watch complete the future. But at least one should always complete it.
-                    vertx.executeBlocking(f -> {
-                        U apply = preCheckFn.apply(gettable.get());
-                        if (apply != null) {
-                            LOGGER.debugCr(reconciliation, "Pre-check is already complete, no need to wait for the watch: {}", watchFnDescription);
-                            donePromise.tryComplete(apply);
-                            vertx.cancelTimer(timerId);
-                        } else {
-                            LOGGER.debugCr(reconciliation, "Pre-check is not complete yet, let's wait for the watch: {}", watchFnDescription);
-                        }
-
-                        f.complete();
-                    });
+                    U apply = preCheckFn.apply(gettable.get());
+                    if (apply != null) {
+                        LOGGER.debugCr(reconciliation, "Pre-check is already complete, no need to wait for the watch: {}", watchFnDescription);
+                        donePromise.tryComplete(apply);
+                        vertx.cancelTimer(timerId);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "Pre-check is not complete yet, let's wait for the watch: {}", watchFnDescription);
+                    }
 
                     watchPromise.complete(watch);
                 } catch (Throwable t) {
@@ -196,11 +192,11 @@ public class ResourceSupport {
                                 f.tryComplete(apply);
                                 vertx.cancelTimer(timerId);
                             } else {
-                                LOGGER.debugOp("Not yet satisfied: {}", watchFnDescription);
+                                LOGGER.debugCr(reconciliation, "Not yet satisfied: {}", watchFnDescription);
                             }
                         } catch (Throwable t) {
                             if (!f.tryFail(t)) {
-                                LOGGER.infoCr(reconciliation, "Ignoring exception thrown while " +
+                                LOGGER.debugCr(reconciliation, "Ignoring exception thrown while " +
                                         "evaluating watch {} because the future was already completed", watchFnDescription, t);
                             }
                         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.client.dsl.Deletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.Listable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
+import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -24,6 +25,7 @@ import io.vertx.core.Vertx;
 import java.io.Closeable;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public class ResourceSupport {
     public static final long DEFAULT_TIMEOUT_MS = 300_000;
@@ -96,21 +98,34 @@ public class ResourceSupport {
      * When the {@code watchFn} returns non-null the watch will be closed and then
      * the future returned from this method will be completed on the context thread.
      *
-     * @param watchable The watchable.
+     * In some cases such as resource deletion, it might happen that the resource is deleted already before the watch is
+     * started and as a result the watch never completes. The {@code preCheckFn} will be invoked on a worked thread
+     * after the watch has been created. It is expected to double check if we still need to wait for the watch to fire.
+     * When the {@code preCheckFn} returns non-null the watch will be closed and the future returned from this method
+     * will be completed on the context thread. In the deletion example described above, the {@code preCheckFn} can
+     * check if the resource still exists and close the watch in case it was already deleted.
+     *
+     * @param reconciliation Reconciliation marker used for logging
+     * @param watchable The watchable - used to watch the resource.
+     * @param gettable The Gettable - used to get the resource in the pre-check.
      * @param operationTimeoutMs The timeout in ms.
      * @param watchFnDescription A description of what {@code watchFn} is watching for.
      *                           E.g. "observe ${condition} of ${kind} ${namespace}/${name}".
-     * @param watchFn The function to determine
+     * @param watchFn The function to determine if the event occured
+     * @param preCheckFn Pre-check function to avoid situation when the watch is never fired because ot was started too late.
      * @param <T> The type of watched resource.
      * @param <U> The result type of the {@code watchFn}.
      *
      * @return A Futures which completes when the {@code watchFn} returns non-null
      * in response to some Kubenetes even on the watched resource(s).
      */
-    <T, U> Future<U> selfClosingWatch(Watchable<Watcher<T>> watchable,
+    <T, U> Future<U> selfClosingWatch(Reconciliation reconciliation,
+                                      Watchable<Watcher<T>> watchable,
+                                      Gettable<T> gettable,
                                       long operationTimeoutMs,
                                       String watchFnDescription,
-                                      BiFunction<Watcher.Action, T, U> watchFn) {
+                                      BiFunction<Watcher.Action, T, U> watchFn,
+                                      Function<T, U> preCheckFn) {
 
         return new Watcher<T>() {
             private final Promise<Watch> watchPromise;
@@ -135,7 +150,7 @@ public class ResourceSupport {
 
                     closeFuture.onComplete(closeResult ->
                         vertx.runOnContext(ignored2 -> {
-                            LOGGER.debugOp("Completing watch future");
+                            LOGGER.debugCr(reconciliation, "Completing watch future");
                             if (joinResult.succeeded() && closeResult.succeeded()) {
                                 resultPromise.complete(joinResult.result().resultAt(1));
                             } else {
@@ -147,7 +162,23 @@ public class ResourceSupport {
 
                 try {
                     Watch watch = watchable.watch(this);
-                    LOGGER.debugOp("Opened watch {} for evaluation of {}", watch, watchFnDescription);
+                    LOGGER.debugCr(reconciliation, "Opened watch {} for evaluation of {}", watch, watchFnDescription);
+
+                    // Pre-check is done after the watch is open to make sure we did not missed the event. In the worst
+                    // case, both pre-check and watch complete the future. But at least one should always complete it.
+                    vertx.executeBlocking(f -> {
+                        U apply = preCheckFn.apply(gettable.get());
+                        if (apply != null) {
+                            LOGGER.debugCr(reconciliation, "Pre-check is already complete, no need to wait for the watch: {}", watchFnDescription);
+                            donePromise.tryComplete(apply);
+                            vertx.cancelTimer(timerId);
+                        } else {
+                            LOGGER.debugCr(reconciliation, "Pre-check is not complete yet, let's wait for the watch: {}", watchFnDescription);
+                        }
+
+                        f.complete();
+                    });
+
                     watchPromise.complete(watch);
                 } catch (Throwable t) {
                     watchPromise.fail(t);
@@ -161,6 +192,7 @@ public class ResourceSupport {
                         try {
                             U apply = watchFn.apply(action, resource);
                             if (apply != null) {
+                                LOGGER.debugCr(reconciliation, "Satisfied: {}", watchFnDescription);
                                 f.tryComplete(apply);
                                 vertx.cancelTimer(timerId);
                             } else {
@@ -168,7 +200,7 @@ public class ResourceSupport {
                             }
                         } catch (Throwable t) {
                             if (!f.tryFail(t)) {
-                                LOGGER.debugOp("Ignoring exception thrown while " +
+                                LOGGER.infoCr(reconciliation, "Ignoring exception thrown while " +
                                         "evaluating watch {} because the future was already completed", watchFnDescription, t);
                             }
                         }
@@ -188,7 +220,7 @@ public class ResourceSupport {
     /**
      * Asynchronously deletes the given resource(s), returning a Future which completes on the context thread.
      * <strong>Note: The API server can return asynchronously, meaning the resource is still accessible from the API server
-     * after the returned Future completes. Use {@link #selfClosingWatch(Watchable, long, String, BiFunction)}
+     * after the returned Future completes. Use {@link #selfClosingWatch(Reconciliation, Watchable, Gettable, long, String, BiFunction, Function)}
      * to provide server-synchronous semantics.</strong>
      *
      * @param resource The resource(s) to delete.
@@ -198,12 +230,11 @@ public class ResourceSupport {
         return executeBlocking(
             blockingFuture -> {
                 try {
-                    Boolean delete = resource.delete();
-                    if (!Boolean.TRUE.equals(delete)) {
-                        blockingFuture.fail(new RuntimeException(resource + " could not be deleted (returned " + delete + ")"));
-                    } else {
-                        blockingFuture.complete();
-                    }
+                    // Returns TRUE when resource was deleted and FALSE when it was not found (see BaseOperation Fabric8 class)
+                    // In both cases we return success since the end-result has been achieved
+                    // Throws an exception for other errors
+                    resource.delete();
+                    blockingFuture.complete();
                 } catch (Throwable t) {
                     blockingFuture.fail(t);
                 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -465,12 +466,57 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         AbstractNonNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
-        op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getName(), null).onComplete(context.failing(e -> {
+        op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getName(), null).onComplete(context.succeeding(rrDeleted -> {
             verify(mockResource).delete();
             context.verify(() -> assertThat("Watch was not closed", watchWasClosed.get(), is(true)));
             async.flag();
         }));
     }
 
+    // This tests the pre-check which should stop the self-closing-watch in case the resource is deleted before the
+    // watch is opened.
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(VertxTestContext context) {
+        T resource = resource();
+        AtomicBoolean watchWasClosed = new AtomicBoolean(false);
+        Resource mockResource = mock(resourceType());
+
+        AtomicInteger getInvocations = new AtomicInteger(0);
+        when(mockResource.get()).thenAnswer(invocation -> {
+            // First get needs to return the resource to trigger deletion
+            // Next gets return null since the resource was already deleted
+            if (getInvocations.getAndIncrement() < 1) {
+                return resource;
+            } else {
+                return null;
+            }
+        });
+        when(mockResource.withGracePeriod(anyLong())).thenReturn(mockResource);
+        when(mockResource.delete()).thenReturn(Boolean.FALSE);
+        when(mockResource.watch(any())).thenAnswer(invocation -> {
+            return (Watch) () -> {
+                watchWasClosed.set(true);
+            };
+        });
+
+        NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(mockCms.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNonNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+
+        Checkpoint async = context.checkpoint();
+        op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getName(), null).onComplete(context.succeeding(rrDeleted -> {
+            verify(mockResource).delete();
+            context.verify(() -> assertThat("Watch was not closed", watchWasClosed.get(), is(true)));
+            async.flag();
+        }));
+    }
 }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
@@ -16,6 +16,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.when;
 
 public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenShiftClient, BuildConfig,
@@ -66,5 +67,11 @@ public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenSh
     @Test
     public void testCreateWhenExistsWithChangeIsAPatch(VertxTestContext context) {
         testCreateWhenExistsWithChangeIsAPatch(context, false);
+    }
+
+    @Override
+    @Test
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(VertxTestContext context) {
+        assumeTrue(false, "BuildConfigOperator does not use self-closing watch so this test should be skipped");
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
@@ -115,5 +116,11 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
         createResourceOperations(vertx, mockClient)
             .updateStatusAsync(Reconciliation.DUMMY_RECONCILIATION, resource())
             .onComplete(context.succeeding(kafka -> async.flag()));
+    }
+
+    @Override
+    @Test
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted(VertxTestContext context) {
+        assumeTrue(false, "CrdOperator does not use self-closing watch so this test should be skipped");
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When deleting resources we usually go through the following process:
1) Check if the resource exists and if it does ...
2) ... Create a deletion watch
3) ... Delete the resource
4) ... Wait for steps 2 and 3 to succeed

In Kubernetes API, each of these steps is separate. So it can happen that the step 1 says the resource still exists, but in steps 2 and 3 it will be already deleted. This seems to happen regularly in the User Operator. Unlike CO, the UO handles the deletion of resources and does not rely purely on garbage collection. So the user secrets seem to be deleted in parallel by GC and by UO. That seems to very often raise the race condition between step 1 and steps 2 and 3 and cause the reconciliation to fail.

It fails in two different way:
a) The deletion watch is started only after the resource is deleted. So it never receives the `DELETE` event and completes
b) The `delete()` call returns `false` because the resource does not exist anymore.

To handle a), this PR adds additional pre-check function into the self-closing-watch. The pre-check function is called after the watch is opened and checks whether the resource is deleted. So even if the resource is deleted before the watch is created and we get no deletion event, the pre-check should find it and close the watch. In the worst case, both pre-check and the close the watch which should not be a problem.

For b), we should treat the `false` result as success. If the resource was not found, then maybe we didn't deleted it ... but who cares, the desired state was achieved. This behaviour is also changed in this PR.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally