### PR TITLE
[systemtest] Add test for predefining SCRAM-SHA user password

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -189,4 +189,11 @@ public class SecretUtils {
         }
         return cacert;
     }
+
+    public static void waitForUserPasswordChange(String namespaceName, String secretName, String expectedEncodedPassword) {
+        LOGGER.info("Waiting for user password will be changed to {} in secret: {}", expectedEncodedPassword, secretName);
+        TestUtils.waitFor(String.format("user password will be changed to: %s in secret: %s", expectedEncodedPassword, secretName),
+            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> kubeClient().namespace(namespaceName).getSecret(secretName).getData().get("password").equals(expectedEncodedPassword));
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2094,7 +2094,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         kubeClient().namespace(namespaceName).createSecret(password);
-        assertThat("Password in secret is not correct", kubeClient().namespace(namespaceName).getSecret(secretName).getData().get("password"), is(secondEncodedPassword));
+        SecretUtils.waitForUserPasswordChange(namespaceName, userName, secondEncodedPassword);
 
         LOGGER.info("We need to recreate Kafka Clients deployment, so the correct password from secret will be taken");
         resourceManager.deleteResource(kubeClient().getDeployment(kafkaClientsName));

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest.kafka.listeners;
 
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaUser;
@@ -22,6 +24,7 @@ import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClie
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaBasicExampleClients;
 import io.strimzi.systemtest.security.CertAndKeyFiles;
 import io.strimzi.systemtest.security.SystemTestCertAndKey;
 import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
@@ -45,6 +48,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -2006,6 +2011,77 @@ public class ListenersST extends AbstractST {
         KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).delete();
     }
 
+    @ParallelNamespaceTest
+    void testMessagesTlsScramShaWithPredefinedPassword(ExtensionContext extensionContext) {
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
+        final String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
+        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+
+        final String secretName = clusterName + "-secret";
+        final String encodedPassword = Base64.getEncoder().encodeToString("asdasd".getBytes(StandardCharsets.UTF_8));
+
+        Secret password = new SecretBuilder()
+            .withNewMetadata()
+                .withName(secretName)
+            .endMetadata()
+            .addToData("password", encodedPassword)
+            .build();
+
+        kubeClient().namespace(namespaceName).createSecret(password);
+
+        KafkaUser kafkaUser = KafkaUserTemplates.scramShaUser(clusterName, userName)
+            .editSpec()
+                .withNewKafkaUserScramSha512ClientAuthentication()
+                    .withNewPassword()
+                        .withNewValueFrom()
+                            .withNewSecretKeyRef("password", secretName, false)
+                        .endValueFrom()
+                    .endPassword()
+                .endKafkaUserScramSha512ClientAuthentication()
+            .endSpec()
+            .build();
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3)
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                        .withPort(9096)
+                        .withTls(true)
+                        .withNewKafkaListenerAuthenticationScramSha512Auth()
+                        .endKafkaListenerAuthenticationScramSha512Auth()
+                        .build())
+                .endKafka()
+            .endSpec()
+            .build(),
+            kafkaUser,
+            KafkaTopicTemplates.topic(clusterName, topicName).build()
+        );
+
+        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, kafkaUser).build());
+
+        final String kafkaClientsPodName =
+            kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
+
+        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+            .withUsingPodName(kafkaClientsPodName)
+            .withTopicName(topicName)
+            .withNamespaceName(namespaceName)
+            .withClusterName(clusterName)
+            .withKafkaUsername(userName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .build();
+
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            internalKafkaClient.sendMessagesTls(),
+            internalKafkaClient.receiveMessagesTls()
+        );
+    }
+
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         install = new SetupClusterOperator.SetupClusterOperatorBuilder()
@@ -2018,7 +2094,7 @@ public class ListenersST extends AbstractST {
     }
 
     @AfterEach
-    void afterEach(ExtensionContext extensionContext) throws Exception {
+    void afterEach(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         kubeClient(namespaceName).getClient().persistentVolumeClaims().inNamespace(namespaceName).delete();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2081,8 +2081,9 @@ public class ListenersST extends AbstractST {
             .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
             .build();
 
+        int sentMessages = internalKafkaClient.sendMessagesTls();
         internalKafkaClient.checkProducedAndConsumedMessages(
-            internalKafkaClient.sendMessagesTls(),
+            sentMessages,
             internalKafkaClient.receiveMessagesTls()
         );
 
@@ -2099,17 +2100,18 @@ public class ListenersST extends AbstractST {
         resourceManager.deleteResource(kubeClient().getDeployment(kafkaClientsName));
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, kafkaUser).build());
 
-        LOGGER.info("Sending/receiving messages with new password");
+        LOGGER.info("Receiving messages with new password");
 
         kafkaClientsPodName =
             kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
 
         internalKafkaClient = internalKafkaClient.toBuilder()
             .withUsingPodName(kafkaClientsPodName)
+            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
             .build();
 
         internalKafkaClient.checkProducedAndConsumedMessages(
-            internalKafkaClient.sendMessagesTls(),
+            sentMessages,
             internalKafkaClient.receiveMessagesTls()
         );
     }


### PR DESCRIPTION
### Type of change

- New test

### Description

After #5217 we are able to predefine password for SCRAM-SHA user in secret and then use it for connecting to the broker (send/receive messages etc.). This PR adds test for this new feature - create new secret with encoded password, create `KafkaUser` with `secretKeyRef`, connecting to broker, send/receive messages, change password in secret and repeat whole process.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

