### PR TITLE
Bump Prometheus JMX Exporter to 0.16.1

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -22,7 +22,7 @@
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>0.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
-        <jmx-prometheus-javaagent.version>0.15.0</jmx-prometheus-javaagent.version>
+        <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <jaeger-client.version>1.3.2</jaeger-client.version>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -22,7 +22,7 @@
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>0.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
-        <jmx-prometheus-javaagent.version>0.15.0</jmx-prometheus-javaagent.version>
+        <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <jaeger-client.version>1.3.2</jaeger-client.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates the Prometheus JMX Exporter to a new version 0.16.1. This should close #5300.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging