### PR TITLE
[MO] - [system test] -> unify installation

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/SetupClusterOperator.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.kubernetes.ClusterRoleBindingResource;
@@ -53,6 +54,7 @@ public class SetupClusterOperator {
     private List<String> bindingsNamespaces;
     private long operationTimeout;
     private long reconciliationInterval;
+    private List<EnvVar> extraEnvVars;
 
     SetupClusterOperator() {}
     SetupClusterOperator(SetupClusterOperatorBuilder builder) {
@@ -63,6 +65,7 @@ public class SetupClusterOperator {
         this.bindingsNamespaces = builder.bindingsNamespaces;
         this.operationTimeout = builder.operationTimeout;
         this.reconciliationInterval = builder.reconciliationInterval;
+        this.extraEnvVars = builder.extraEnvVars;
 
         // assign defaults is something is not specified
         if (this.clusterOperatorName == null || this.clusterOperatorName.isEmpty()) this.clusterOperatorName = Constants.STRIMZI_DEPLOYMENT_NAME;
@@ -140,6 +143,7 @@ public class SetupClusterOperator {
                     .withWatchingNamespaces(namespaceToWatch)
                     .withOperationTimeout(operationTimeout)
                     .withReconciliationInterval(reconciliationInterval)
+                    .withExtraEnvVars(extraEnvVars)
                     .buildBundleInstance()
                     .buildBundleDeployment()
                     .build());
@@ -163,6 +167,7 @@ public class SetupClusterOperator {
         private List<String> bindingsNamespaces;
         private long operationTimeout;
         private long reconciliationInterval;
+        private List<EnvVar> extraEnvVars;
 
         public SetupClusterOperatorBuilder withExtensionContext(ExtensionContext extensionContext) {
             this.extensionContext = extensionContext;
@@ -190,6 +195,12 @@ public class SetupClusterOperator {
         }
         public SetupClusterOperatorBuilder withReconciliationInterval(long reconciliationInterval) {
             this.reconciliationInterval = reconciliationInterval;
+            return self();
+        }
+
+        // currently supported only for Bundle installation
+        public SetupClusterOperatorBuilder withExtraEnvVars(List<EnvVar> envVars) {
+            this.extraEnvVars = envVars;
             return self();
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -146,7 +146,8 @@ public class BundleResource implements ResourceType<Deployment> {
             .withNamespace(namespaceInstallTo)
             .withWatchingNamespaces(namespaceToWatch)
             .withOperationTimeout(operationTimeout)
-            .withReconciliationInterval(reconciliationInterval);
+            .withReconciliationInterval(reconciliationInterval)
+            .withExtraEnvVars(extraEnvVars);
     }
 
     public DeploymentBuilder buildBundleDeployment() {
@@ -202,6 +203,8 @@ public class BundleResource implements ResourceType<Deployment> {
             // for kafka
             envVars.add(new EnvVar("STRIMZI_IMAGE_PULL_SECRETS", Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET, null));
         }
+        // adding custom evn vars specified by user in installation
+        if (extraEnvVars != null) envVars.addAll(extraEnvVars);
 
         // Apply updated env variables
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -19,7 +19,6 @@ import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
-import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
@@ -267,17 +266,11 @@ class NamespaceDeletionRecoveryST extends AbstractST {
 
     private void recreateClusterOperator(ExtensionContext extensionContext) {
         // Recreate CO
-
-        install.applyClusterOperatorInstallFiles(NAMESPACE);
-        SetupClusterOperator.applyBindings(extensionContext, NAMESPACE);
-        // 060-Deployment
-        resourceManager.createResource(extensionContext,
-            new BundleResource.BundleResourceBuilder()
-                .withName(Constants.STRIMZI_DEPLOYMENT_NAME)
-                .withNamespace(NAMESPACE)
-                .buildBundleInstance()
-                .buildBundleDeployment()
-                .build());
+        install = new SetupClusterOperator.SetupClusterOperatorBuilder()
+            .withExtensionContext(extensionContext)
+            .withNamespace(NAMESPACE)
+            .createInstallation()
+            .runInstallation();
     }
 
     private void deleteAndRecreateNamespace() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceRbacScopeOperatorST.java
@@ -6,11 +6,9 @@ package io.strimzi.systemtest.operators;
 
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.resources.operator.BundleResource;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import org.apache.logging.log4j.LogManager;
@@ -41,7 +39,12 @@ class NamespaceRbacScopeOperatorST extends AbstractST {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         assumeTrue(Environment.isNamespaceRbacScope());
-        prepareEnvironment(extensionContext);
+
+        install = new SetupClusterOperator.SetupClusterOperatorBuilder()
+            .withExtensionContext(extensionContext)
+            .withNamespace(NAMESPACE)
+            .createInstallation()
+            .runInstallation();
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3)
             .editMetadata()
@@ -61,18 +64,5 @@ class NamespaceRbacScopeOperatorST extends AbstractST {
             })
             .collect(Collectors.toList());
         assertThat(strimziClusterRoles, is(Collections.emptyList()));
-    }
-
-    private void prepareEnvironment(ExtensionContext extensionContext) {
-        install.prepareEnvForOperator(extensionContext, NAMESPACE);
-        SetupClusterOperator.applyBindings(extensionContext, NAMESPACE);
-        // 060-Deployment
-        resourceManager.createResource(extensionContext,
-            new BundleResource.BundleResourceBuilder()
-                .withName(Constants.STRIMZI_DEPLOYMENT_NAME)
-                .withNamespace(NAMESPACE)
-                .buildBundleInstance()
-                .buildBundleDeployment()
-                .build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -491,17 +491,12 @@ public class SpecificST extends AbstractST {
     void setup(ExtensionContext extensionContext) {
         sharedExtensionContext = extensionContext;
 
-
         LOGGER.info(BridgeUtils.getBridgeVersion());
-        install.prepareEnvForOperator(sharedExtensionContext, NAMESPACE);
 
-        SetupClusterOperator.applyBindings(sharedExtensionContext, NAMESPACE);
-        // 060-Deployment
-        resourceManager.createResource(sharedExtensionContext,
-            new BundleResource.BundleResourceBuilder()
-                .withNamespace(NAMESPACE)
-                .buildBundleInstance()
-                .buildBundleDeployment()
-                .build());
+        install = new SetupClusterOperator.SetupClusterOperatorBuilder()
+            .withExtensionContext(sharedExtensionContext)
+            .withNamespace(NAMESPACE)
+            .createInstallation()
+            .runInstallation();
     }
 }


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR is trying to unify installation Cluster Operators in our system tests. Some tests cases using  installation with the following format:
```
resourceManager.createResource(extensionContext,
            new BundleResource.BundleResourceBuilder()
                 ...
```

This approach is in most cases bad because it explicitly deploys BundleFormat and completely ignores other types of installation such as Helm or Olm. 

Correct way how to deploy operator is:

```
install = new SetupClusterOperator.SetupClusterOperatorBuilder()
            .withExtensionContext(extensionContext)
                ...
```


### Checklist

- [x] Make sure all tests pass