### PR TITLE
Make `STRIMZI_NETWORK_POLICY_GENERATION` configurable in Helm Chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -176,6 +176,7 @@ the documentation for more details.
 | `nodeSelector`                       | Add a node selector to Operator Pod       | `{}`                                                 |
 | `featureGates`                       | Feature Gates configuration               | ``                                                   |
 | `labelsExclusionPattern`             | Override the exclude pattern for exclude some labels             | `""`  
+| `generateNetworkPolicy`              | Controls whether Strimzi generates network policy resources      | `true`                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -114,6 +114,10 @@ spec:
             - name: STRIMZI_LABELS_EXCLUSION_PATTERN
               value: {{ .Values.labelsExclusionPattern | quote }}
             {{- end }}
+            {{- if .Values.generateNetworkPolicy }}
+            - name: STRIMZI_NETWORK_POLICY_GENERATION
+              value: {{ .Values.generateNetworkPolicy }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -114,7 +114,7 @@ spec:
             - name: STRIMZI_LABELS_EXCLUSION_PATTERN
               value: {{ .Values.labelsExclusionPattern | quote }}
             {{- end }}
-            {{- if .Values.generateNetworkPolicy }}
+            {{- if ne .Values.generateNetworkPolicy true}}
             - name: STRIMZI_NETWORK_POLICY_GENERATION
               value: {{ .Values.generateNetworkPolicy }}
             {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -143,3 +143,5 @@ imageTagOverride: ""
 createGlobalResources: true
 # Override the exclude pattern for exclude some labels
 labelsExclusionPattern: ""
+# Controls whether Strimzi generates network policy resources (By default true)
+generateNetworkPolicy: true

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -92,8 +92,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: STRIMZI_FEATURE_GATES
               value: ""
-            - name: STRIMZI_NETWORK_POLICY_GENERATION
-              value: true
           livenessProbe:
             httpGet:
               path: /healthy

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -92,6 +92,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: STRIMZI_FEATURE_GATES
               value: ""
+            - name: STRIMZI_NETWORK_POLICY_GENERATION
+              value: true
           livenessProbe:
             httpGet:
               path: /healthy


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature


### Description

Fixes issue #5295.
This PR provides the support to make the  `STRIMZI_NETWORK_POLICY_GENERATION`configurable in the helm chart. To make the operator not generate the network policies / use custom policies, user can set the env variable `generateNetworkPolicy` as false in values.yaml
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

