### PR TITLE
Fix `zookeeperSessionTimeoutSeconds` warning which is logged even when the field is not used

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -42,14 +42,13 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
     public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;
-    public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS = 18;
     public static final String DEFAULT_SECRET_PREFIX = "";
 
     private String watchedNamespace;
     private String image;
     private String secretPrefix;
     private long reconciliationIntervalSeconds = DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS;
-    private long zookeeperSessionTimeoutSeconds = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS;
+    private Long zookeeperSessionTimeoutSeconds;
     private Probe livenessProbe;
     private Probe readinessProbe;
     private ResourceRequirements resources;
@@ -92,11 +91,11 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
     @DeprecatedProperty(description = "This property has been deprecated because ZooKeeper is not used anymore by the User Operator.")
     @PresentInVersions("v1alpha1-v1beta2")
     @Deprecated
-    public long getZookeeperSessionTimeoutSeconds() {
+    public Long getZookeeperSessionTimeoutSeconds() {
         return zookeeperSessionTimeoutSeconds;
     }
 
-    public void setZookeeperSessionTimeoutSeconds(long zookeeperSessionTimeoutSeconds) {
+    public void setZookeeperSessionTimeoutSeconds(Long zookeeperSessionTimeoutSeconds) {
         this.zookeeperSessionTimeoutSeconds = zookeeperSessionTimeoutSeconds;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -77,7 +77,6 @@ public class EntityUserOperatorTest {
     private final String uoImage = "my-user-operator-image";
     private final String secretPrefix = "strimzi-";
     private final int uoReconciliationInterval = 120;
-    private final int uoZookeeperSessionTimeout = 18;
 
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String metricsCMName = "metrics-cm";
@@ -92,7 +91,6 @@ public class EntityUserOperatorTest {
             .withWatchedNamespace(uoWatchedNamespace)
             .withImage(uoImage)
             .withReconciliationIntervalSeconds(uoReconciliationInterval)
-            .withZookeeperSessionTimeoutSeconds(uoZookeeperSessionTimeout)
             .withSecretPrefix(secretPrefix)
             .withLivenessProbe(livenessProbe)
             .withReadinessProbe(readinessProbe)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The removal of ZooKeeper from User operator deprecated the `zookeeperSessionTimeoutSeconds` field. But because it is a `long` with a default value, we now get constant warnings about it being used but deprecated:

```
2021-07-21 12:03:33 WARN  AbstractOperator:94 - Reconciliation #13(timer) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the zookeeperSessionTimeoutSeconds property at path spec.entityOperator.userOperator.zookeeperSessionTimeoutSeconds has been deprecated. This property has been deprecated because ZooKeeper is not used anymore by the User Operator.
```

This PR changes it to `Long` and makes it `null` by default. This way it has no default and the warnings are printed only when the field is really used.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally