### PR TITLE
Adding histogram latency buckets for reconciliation duration

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -11,6 +11,7 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.vertx.micrometer.backends.BackendRegistries;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -64,6 +65,7 @@ public class MicrometerMetricsProvider implements MetricsProvider {
     public Timer timer(String name, String description, Tags tags) {
         return Timer.builder(name)
                 .description(description)
+                .sla(Duration.ofMillis(10), Duration.ofMillis(25), Duration.ofMillis(50), Duration.ofMillis(100), Duration.ofMillis(500), Duration.ofMillis(1000), Duration.ofMillis(5000))
                 .tags(tags)
                 .register(metrics);
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -65,7 +65,7 @@ public class MicrometerMetricsProvider implements MetricsProvider {
     public Timer timer(String name, String description, Tags tags) {
         return Timer.builder(name)
                 .description(description)
-                .sla(Duration.ofMillis(10), Duration.ofMillis(25), Duration.ofMillis(50), Duration.ofMillis(100), Duration.ofMillis(500), Duration.ofMillis(1000), Duration.ofMillis(5000))
+                .sla(Duration.ofMillis(1000), Duration.ofMillis(5000), Duration.ofMillis(10000), Duration.ofMillis(30000), Duration.ofMillis(60000), Duration.ofMillis(120000), Duration.ofMillis(300000))
                 .tags(tags)
                 .register(metrics);
     }


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR address the issue mentioned in #3663. This PR adds histogram latency buckets for `strimzi_reconciliation_duration` metrics. After the addition of this code this we can get the metrics like this :-  

`strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="0.01",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="0.025",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="0.05",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="0.1",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="0.5",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="1.0",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="5.0",} 0.0
strimzi_reconciliations_duration_seconds_bucket{kind="KafkaRebalance",selector="",le="+Inf",} 0.0
strimzi_reconciliations_duration_seconds_count{kind="KafkaRebalance",selector="",} 0.0
strimzi_reconciliations_duration_seconds_sum{kind="KafkaRebalance",selector="",} 0.0 `

For complete metrics :-   
--> https://gist.github.com/ShubhamRwt/31eeb8992d869a87f8bcba61bbd8d787

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

