### PR TITLE
Make `STRIMZI_CONNECT_BUILD_TIMEOUT_MS` environment variable configurable in Helm chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -177,6 +177,7 @@ the documentation for more details.
 | `featureGates`                       | Feature Gates configuration               | ``                                                   |
 | `labelsExclusionPattern`             | Override the exclude pattern for exclude some labels             | `""`  
 | `generateNetworkPolicy`              | Controls whether Strimzi generates network policy resources      | `true`                        |
+| `connectBuildTimeoutMs`              | Overrides the default timeout value for building new Kafka Connect    | `300000`                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -118,7 +118,7 @@ spec:
             - name: STRIMZI_NETWORK_POLICY_GENERATION
               value: {{ .Values.generateNetworkPolicy }}
             {{- end }}
-            {{- if ne (.Values.connectBuildTimeoutMs | quote) "300000" }}
+            {{- if ne (int .Values.connectBuildTimeoutMs) 300000 }}
             - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
               value: {{ .Values.connectBuildTimeoutMs | quote }}
             {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -118,6 +118,10 @@ spec:
             - name: STRIMZI_NETWORK_POLICY_GENERATION
               value: {{ .Values.generateNetworkPolicy }}
             {{- end }}
+            {{- if ne (.Values.connectBuildTimeoutMs | quote) "300000" }}
+            - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
+              value: {{ .Values.connectBuildTimeoutMs | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -145,3 +145,5 @@ createGlobalResources: true
 labelsExclusionPattern: ""
 # Controls whether Strimzi generates network policy resources (By default true)
 generateNetworkPolicy: true
+# Override the value for Connect build timeout
+connectBuildTimeoutMs: 300000


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR is a part of issue[ #4031](https://github.com/strimzi/strimzi-kafka-operator/issues/4031). These changes makes the `STRIMZI_CONNECT_BUILD_TIMEOUT_MS` env var configurable in helm charts.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

