### PR TITLE
Get the non-deprecated alternative in the Mirror Maker error message

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -29,7 +29,7 @@ import lombok.EqualsAndHashCode;
 @JsonPropertyOrder({
         "version", "replicas", "image", "consumer", "producer", "resources", "whitelist", "include", "jvmOptions",
         "logging", "metricsConfig", "tracing", "template"})
-@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("whitelist")), @OneOf.Alternative(@OneOf.Alternative.Property("include"))})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("include")), @OneOf.Alternative(@OneOf.Alternative.Property("whitelist"))})
 @EqualsAndHashCode
 public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics {
     private static final long serialVersionUID = 1L;

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1125,13 +1125,13 @@ spec:
                   description: Pod readiness checking.
               oneOf:
                 - properties:
-                    whitelist: {}
-                  required:
-                    - whitelist
-                - properties:
                     include: {}
                   required:
                     - include
+                - properties:
+                    whitelist: {}
+                  required:
+                    - whitelist
               required:
                 - replicas
                 - consumer

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1297,13 +1297,13 @@ spec:
                 description: Pod readiness checking.
             oneOf:
             - properties:
-                whitelist: {}
-              required:
-              - whitelist
-            - properties:
                 include: {}
               required:
               - include
+            - properties:
+                whitelist: {}
+              required:
+              - whitelist
             required:
             - replicas
             - consumer


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

As part of the inclusive language work, the `KafkaMirrorMaker` resource has now deprecated field `whitelist` and a new field `include`. These are alternatives and one of them should be used. Right now, `whitelist` is listed as the first alternative. So when none of the two fields is specified, this is the error one gets:

```
The KafkaMirrorMaker "my-mirror-maker" is invalid:
* <nil>: Invalid value: "": "spec" must validate one and only one schema (oneOf). Found none valid
* spec.whitelist: Required value
```

This is suboptimal because it refers to the deprecated fields. Changing the order of the alternatives gets the `include` field into the error:

```
The KafkaMirrorMaker "my-mirror-maker" is invalid:
* <nil>: Invalid value: "": "spec" must validate one and only one schema (oneOf). Found none valid
* spec.include: Required value
```

which is the preferred option. This PR changes the order to get the right error message when needed.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally