### PR TITLE
`isReady` now returns `boolean` and not `Boolean`

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperator.java
@@ -47,13 +47,13 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
      *
      * @param namespace The namespace.
      * @param name The resource name.
-     * @return Whether the resource in in the Ready state.
+     * @return Whether the resource is in the Ready state.
      */
     public boolean isReady(String namespace, String name) {
         R resourceOp = operation().inNamespace(namespace).withName(name);
         T resource = resourceOp.get();
         if (resource != null)   {
-            return Boolean.TRUE.equals(resourceOp.isReady());
+            return resourceOp.isReady();
         } else {
             return false;
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -121,7 +121,7 @@ public class DeploymentConfigOperator extends AbstractScalableResourceOperator<O
         DeploymentConfig resource = resourceOp.get();
         
         if (resource != null)   {
-            return Boolean.TRUE.equals(resourceOp.isReady());
+            return resourceOp.isReady();
         } else {
             return false;
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Fabric8 `isReady` method now returns `boolean` and not `Boolean` anymore. So we do not need to compare it with `Boolean.TRUE` anymore to avoid returning `null` as we did in the past.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally