### PR TITLE
Kafka Connect (and MM2) logging hierarchy 3

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -477,7 +477,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         });
         Map<String, String> desiredMap = new OrderedProperties().addStringPairs(Util.expandVars(desiredLogging)).asMap();
 
-        fetchedLoggers.entrySet().forEach(fetchedLogger -> updateLoggers.put(fetchedLogger.getKey(), getLevel(fetchedLogger.getKey(), fetchedLoggers, desiredMap)));
+        fetchedLoggers.entrySet().forEach(fetchedLogger -> updateLoggers.put(fetchedLogger.getKey(), getLevel(fetchedLogger.getKey(), desiredMap)));
         addToLoggers(defaultLogging.asMap(), updateLoggers);
         addToLoggers(desiredMap, updateLoggers);
 
@@ -494,7 +494,6 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     protected String getLevel(String logger, Map<String, String> desired) {
-
         // direct hit
         if (desired.keySet().contains("log4j.logger." + logger)) {
             return desired.get("log4j.logger." + logger);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -8,10 +8,12 @@ package io.strimzi.operator.cluster.operator.assembly;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Supplier;
@@ -473,9 +475,11 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
             }
             return k1.compareTo(k2);
         });
-        updateLoggers.putAll(fetchedLoggers);
+        Map<String, String> desiredMap = new OrderedProperties().addStringPairs(Util.expandVars(desiredLogging)).asMap();
+
+        fetchedLoggers.entrySet().forEach(fetchedLogger -> updateLoggers.put(fetchedLogger.getKey(), getLevel(fetchedLogger.getKey(), fetchedLoggers, desiredMap)));
         addToLoggers(defaultLogging.asMap(), updateLoggers);
-        addToLoggers(new OrderedProperties().addStringPairs(Util.expandVars(desiredLogging)).asMap(), updateLoggers);
+        addToLoggers(desiredMap, updateLoggers);
 
         if (updateLoggers.equals(fetchedLoggers)) {
             return Future.succeededFuture(false);
@@ -487,6 +491,25 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
             }
             return result.map(true);
         }
+    }
+
+    protected String getLevel(String logger, Map<String, String> desired) {
+
+        // direct hit
+        if (desired.keySet().contains("log4j.logger." + logger)) {
+            return desired.get("log4j.logger." + logger);
+        }
+
+        Map<String, String> desiredSortedReverse = new TreeMap<>(Comparator.reverseOrder());
+        desiredSortedReverse.putAll(desired);
+        //desired contains substring of logger, search in reversed order to find the most specific match
+        Optional<Map.Entry<String, String>> opt = desiredSortedReverse.entrySet().stream().filter(entry -> ("log4j.logger." + logger).startsWith(entry.getKey())).findFirst();
+        if (opt.isPresent()) {
+            return opt.get().getValue();
+        }
+
+        //nothing found, use root level
+        return getLoggerLevelFromAppenderCouple(Util.expandVar(desired.get("log4j.rootLogger"), desired));
     }
 
     private void addToLoggers(Map<String, String> entries, Map<String, String> updateLoggers) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -307,11 +307,11 @@ public class KafkaConnectApiTest {
         KafkaConnectApiImpl client = new KafkaConnectApiImpl(vertx);
         OrderedProperties ops = new OrderedProperties();
         ops.addStringPairs(desired);
-        assertEquals(client.getLevel("foo.bar", ops.asMap()), "TRACE");
-        assertEquals(client.getLevel("foo.lala", ops.asMap()), "WARN");
-        assertEquals(client.getLevel("bar.faa", ops.asMap()), rootLevel);
-        assertEquals(client.getLevel("org", ops.asMap()), "TRACE");
-        assertEquals(client.getLevel("oorg.eclipse.jetty.util.thread.strategy.EatWhatYouKill", ops.asMap()), "DEBUG");
-        assertEquals(client.getLevel("oorg.eclipse.group.art", ops.asMap()), rootLevel);
+        assertEquals("TRACE", client.getEffectiveLevel("foo.bar", ops.asMap()));
+        assertEquals("WARN", client.getEffectiveLevel("foo.lala", ops.asMap()));
+        assertEquals(rootLevel, client.getEffectiveLevel("bar.faa", ops.asMap()));
+        assertEquals("TRACE", client.getEffectiveLevel("org", ops.asMap()));
+        assertEquals("DEBUG", client.getEffectiveLevel("oorg.eclipse.jetty.util.thread.strategy.EatWhatYouKill", ops.asMap()));
+        assertEquals(rootLevel, client.getEffectiveLevel("oorg.eclipse.group.art", ops.asMap()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -290,4 +290,28 @@ public class KafkaConnectApiTest {
                             async.flag();
                         }))));
     }
+
+    @IsolatedTest
+    public void testHierarchy() {
+        String rootLevel = "TRACE";
+        String desired = "log4j.rootLogger=" + rootLevel + ", CONSOLE\n" +
+                "log4j.logger.oorg.apache.zookeeper=WARN\n" +
+                "log4j.logger.oorg.I0Itec.zkclient=INFO\n" +
+                "log4j.logger.oorg.reflections.Reflection=INFO\n" +
+                "log4j.logger.oorg.reflections=FATAL\n" +
+                "log4j.logger.foo=WARN\n" +
+                "log4j.logger.foo.bar=TRACE\n" +
+                "log4j.logger.oorg.eclipse.jetty.util=DEBUG\n" +
+                "log4j.logger.foo.bar.quux=DEBUG";
+
+        KafkaConnectApiImpl client = new KafkaConnectApiImpl(vertx);
+        OrderedProperties ops = new OrderedProperties();
+        ops.addStringPairs(desired);
+        assertEquals(client.getLevel("foo.bar", ops.asMap()), "TRACE");
+        assertEquals(client.getLevel("foo.lala", ops.asMap()), "WARN");
+        assertEquals(client.getLevel("bar.faa", ops.asMap()), rootLevel);
+        assertEquals(client.getLevel("org", ops.asMap()), "TRACE");
+        assertEquals(client.getLevel("oorg.eclipse.jetty.util.thread.strategy.EatWhatYouKill", ops.asMap()), "DEBUG");
+        assertEquals(client.getLevel("oorg.eclipse.group.art", ops.asMap()), rootLevel);
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1124,8 +1124,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Waiting for log4j.properties will contain desired settings");
         TestUtils.waitFor("Logger init levels", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
-                    + ":8083/admin/loggers/root").out().contains("OFF")
+            () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://localhost:8083/admin/loggers/root").out().contains("OFF")
         );
 
         LOGGER.info("Changing log levels");
@@ -1151,14 +1150,11 @@ class LoggingChangeST extends AbstractST {
         kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(mm2LoggingMap);
 
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
-                    + ":8083/admin/loggers/root").out().contains("INFO")
+            () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://localhost:8083/admin/loggers/root").out().contains("INFO")
                     // not set logger should inherit parent level (in this case 'org.eclipse.jetty.util.thread')
-                    && cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
-                    + ":8083/admin/loggers/org.eclipse.jetty.util.thread.strategy.EatWhatYouKill").out().contains("WARN")
+                    && cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://localhost:8083/admin/loggers/org.eclipse.jetty.util.thread.strategy.EatWhatYouKill").out().contains("WARN")
                     // logger with not set parent should inherit root
-                    && cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
-                    + ":8083/admin/loggers/org.apache.kafka.connect.runtime.WorkerTask").out().contains("INFO")
+                    && cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://localhost:8083/admin/loggers/org.apache.kafka.connect.runtime.WorkerTask").out().contains("INFO")
         );
 
         assertThat("MirrorMaker2 pod should not roll", DeploymentUtils.depSnapshot(namespaceName, KafkaMirrorMaker2Resources.deploymentName(clusterName)), equalTo(mm2Snapshot));

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1121,7 +1121,6 @@ class LoggingChangeST extends AbstractST {
         String kafkaMM2PodName = kubeClient().namespace(namespaceName).listPods(namespaceName, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getName();
 
         Map<String, String> mm2Snapshot = DeploymentUtils.depSnapshot(namespaceName, KafkaMirrorMaker2Resources.deploymentName(clusterName));
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
 
         LOGGER.info("Waiting for log4j.properties will contain desired settings");
         TestUtils.waitFor("Logger init levels", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -1302,6 +1301,8 @@ class LoggingChangeST extends AbstractST {
 
         InlineLogging inlineWarn = new InlineLogging();
         inlineWarn.setLoggers(Collections.singletonMap("connect.root.logger.level", "WARN"));
+
+        inlineWarn.setLoggers(Map.of("connect.root.logger.level", "WARN", "log4j.logger." + connectorClassName, "ERROR"));
 
         KafkaConnectResource.replaceKafkaConnectResourceInSpecificNamespace(clusterName, connect -> connect.getSpec().setLogging(inlineWarn), namespaceName);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1065,6 +1065,107 @@ class LoggingChangeST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @Tag(ROLLING_UPDATE)
+    void testMM2LoggingLevelsHierarchy(ExtensionContext extensionContext) {
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName + "-source", 3).build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName + "-target", 3).build());
+        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
+
+        String log4jConfig =
+                "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+                        "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
+                        "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                        "log4j.rootLogger=OFF, CONSOLE\n" +
+                        "log4j.logger.org.apache.zookeeper=ERROR\n" +
+                        "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
+                        "log4j.logger.org.eclipse.jetty.util.thread=FATAL\n" +
+                        "log4j.logger.org.apache.kafka.connect.runtime.WorkerTask=OFF\n" +
+                        "log4j.logger.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill=OFF\n" +
+                        "log4j.logger.org.reflections=ERROR";
+
+        String externalCmName = "external-cm";
+
+        ConfigMap mm2LoggingMap = new ConfigMapBuilder()
+                .withNewMetadata()
+                .addToLabels("app", "strimzi")
+                .withName(externalCmName)
+                .withNamespace(namespaceName)
+                .endMetadata()
+                .withData(Collections.singletonMap("log4j.properties", log4jConfig))
+                .build();
+
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(mm2LoggingMap);
+
+        ExternalLogging mm2XternalLogging = new ExternalLoggingBuilder()
+                .withNewValueFrom()
+                .withConfigMapKeyRef(
+                        new ConfigMapKeySelectorBuilder()
+                                .withName(externalCmName)
+                                .withKey("log4j.properties")
+                                .build()
+                )
+                .endValueFrom()
+                .build();
+
+        resourceManager.createResource(extensionContext,
+            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, clusterName + "-target", clusterName + "-source", 1, false)
+                .editOrNewSpec()
+                    .withLogging(mm2XternalLogging)
+                .endSpec()
+                .build());
+
+        String kafkaMM2PodName = kubeClient().namespace(namespaceName).listPods(namespaceName, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getName();
+
+        Map<String, String> mm2Snapshot = DeploymentUtils.depSnapshot(namespaceName, KafkaMirrorMaker2Resources.deploymentName(clusterName));
+        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
+
+        LOGGER.info("Waiting for log4j.properties will contain desired settings");
+        TestUtils.waitFor("Logger init levels", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
+                    + ":8083/admin/loggers/root").out().contains("OFF")
+        );
+
+        LOGGER.info("Changing log levels");
+        String updatedLog4jConfig =
+                "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
+                        "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
+                        "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                        "log4j.rootLogger=INFO, CONSOLE\n" +
+                        "log4j.logger.org.apache.zookeeper=ERROR\n" +
+                        "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
+                        "log4j.logger.org.eclipse.jetty.util.thread=WARN\n" +
+                        "log4j.logger.org.reflections=ERROR";
+
+        mm2LoggingMap = new ConfigMapBuilder()
+                .withNewMetadata()
+                .addToLabels("app", "strimzi")
+                .withName(externalCmName)
+                .withNamespace(namespaceName)
+                .endMetadata()
+                .withData(Collections.singletonMap("log4j.properties", updatedLog4jConfig))
+                .build();
+
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(mm2LoggingMap);
+
+        TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
+                    + ":8083/admin/loggers/root").out().contains("INFO")
+                    // not set logger should inherit parent level (in this case 'org.eclipse.jetty.util.thread')
+                    && cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
+                    + ":8083/admin/loggers/org.eclipse.jetty.util.thread.strategy.EatWhatYouKill").out().contains("WARN")
+                    // logger with not set parent should inherit root
+                    && cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://" + KafkaMirrorMaker2Resources.serviceName(clusterName)
+                    + ":8083/admin/loggers/org.apache.kafka.connect.runtime.WorkerTask").out().contains("INFO")
+        );
+
+        assertThat("MirrorMaker2 pod should not roll", DeploymentUtils.depSnapshot(namespaceName, KafkaMirrorMaker2Resources.deploymentName(clusterName)), equalTo(mm2Snapshot));
+    }
+
+    @ParallelNamespaceTest
     void testNotExistingCMSetsDefaultLogging(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String defaultProps = TestUtils.getFileAsString(TestUtils.USER_PATH + "/../cluster-operator/src/main/resources/kafkaDefaultLoggingProperties");

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1087,7 +1087,7 @@ class LoggingChangeST extends AbstractST {
                         "log4j.logger.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill=OFF\n" +
                         "log4j.logger.org.reflections=ERROR";
 
-        String externalCmName = "external-cm";
+        String externalCmName = "external-cm-hierarchy";
 
         ConfigMap mm2LoggingMap = new ConfigMapBuilder()
                 .withNewMetadata()


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Changing the root (or any higher) level did not take an effect. It is caused by creating a request map from whatever was fetched. So the unset lower levels were considered to be set and the higher level logging level was not assigned to them.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

