### PR TITLE
[DOC] Custom CA certificates cannot be installed in PKCS12 format

### DIFF
--- a/documentation/modules/security/proc-installing-your-own-ca-certificates.adoc
+++ b/documentation/modules/security/proc-installing-your-own-ca-certificates.adoc
@@ -9,9 +9,6 @@ This procedure describes how to install your own CA certificates and keys instea
 
 You can use this procedure to install your own cluster or client CA certificates.
 
-The procedure describes renewal of CA certificates in PEM format.
-You can also use certificates in PKCS #12 format.
-
 .Prerequisites
 
 * The Cluster Operator is running.

--- a/documentation/modules/security/proc-renewing-your-own-ca-certificates.adoc
+++ b/documentation/modules/security/proc-renewing-your-own-ca-certificates.adoc
@@ -11,7 +11,6 @@ If you are using your own certificates, the Cluster Operator will not renew them
 Therefore, it is important that you follow this procedure during the renewal period of the certificate in order to replace CA certificates that will soon expire.
 
 The procedure describes the renewal of CA certificates in PEM format.
-You can also use certificates in PKCS #12 format.
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The documentation suggests that custom CA certificates can be provided in the PKCS12 format. But this i snot the case. This PR fixes the issue. It also removes the incorrect statement about renewal in the installation guide.

### Checklist

- [x] Update documentation