### PR TITLE
Add EnvVarConfigProvider to 3rd party libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Move from Scala 2.12 to Scala 2.13. (#5192)
 * Open Policy Agent authorizer updated to a new version supporting Scala 2.13. See the _Changes, deprecations and removals_ sections for more details. (#5192)
 * Allow a custom password to be set for SCRAM-SHA-512 users by referencing a secret in the `KafkaUser` resource
+* Add support for [EnvVar Configuration Provider for Apache Kafka](https://github.com/strimzi/kafka-env-var-config-provider)
 * Add support for `tls-external` authentication to User Operator to allow management of ACLs and Quotas for TLS users with user certificates generated externally (#5249) 
 * Support for disabling the automatic generation of network policies by the Cluster Operator. Set the Cluster Operator's `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` to disable network policies. (#5258)
 * Update User Operator to use Admin API for managing SCRAM-SHA-512 users 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -22,6 +22,7 @@
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>0.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
@@ -34,6 +35,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>env-var-config-provider-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1112/</url>
         </repository>
     </repositories>
 
@@ -324,6 +329,12 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- EnvVar Configuration Provider for Apache Kafka -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-env-var-config-provider</artifactId>
+            <version>${kafka-env-var-config-provider.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -36,10 +36,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>env-var-config-provider-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1112/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -22,6 +22,7 @@
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>0.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
@@ -34,6 +35,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>env-var-config-provider-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1112/</url>
         </repository>
     </repositories>
 
@@ -324,6 +329,12 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- EnvVar Configuration Provider for Apache Kafka -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-env-var-config-provider</artifactId>
+            <version>${kafka-env-var-config-provider.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -36,10 +36,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>env-var-config-provider-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1112/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the [EnvVar Configuration Provider](https://github.com/strimzi/kafka-env-var-config-provider) to the 3rd party libraries and to our Kafka images. Documentation and tests will be done in separate PRs.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md