### PR TITLE
[DOC] Fix some lists and other uses of `*`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -85,7 +85,7 @@ public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics
     }
 
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. " +
-            "Mirroring two topics named A and B is achieved by using the expression `'A|B'`. Or, as a special case, you can mirror all topics using the regular expression '*'. " +
+            "Mirroring two topics named A and B is achieved by using the expression `A|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. " +
             "You can also specify multiple regular expressions separated by commas.")
     @DeprecatedProperty(movedToPath = "spec.include")
     @PresentInVersions("v1alpha1-v1beta2")
@@ -99,7 +99,7 @@ public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics
     }
 
     @Description("List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. " +
-            "Mirroring two topics named A and B is achieved by using the expression `'A|B'`. Or, as a special case, you can mirror all topics using the regular expression '*'. " +
+            "Mirroring two topics named A and B is achieved by using the expression `A|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. " +
             "You can also specify multiple regular expressions separated by commas.")
     public String getInclude() {
         return include;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -84,7 +84,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
 
     @Description("Defines which address type should be used as the node address. " +
             "Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. " +
-            "By default, the addresses will be used in the following order (the first one found will be used):\n" +
+            "By default, the addresses will be used in the following order (the first one found will be used):\n\n" +
             "* `ExternalDNS`\n" +
             "* `ExternalIP`\n" +
             "* `InternalDNS`\n" +

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerSpec.adoc
@@ -6,7 +6,7 @@ Configures Kafka MirrorMaker.
 Use the `include` property to configure a list of topics that Kafka MirrorMaker mirrors from the source to the target Kafka cluster.
 
 The property allows any regular expression from the simplest case with a single topic name to complex patterns.
-For example, you can mirror topics A and B using "A|B" or all topics using "*".
+For example, you can mirror topics A and B using `A|B` or all topics using `*`.
 You can also pass multiple regular expressions separated by commas to the Kafka MirrorMaker.
 
 [id='property-mm-producer-consumer-{context}']

--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -113,6 +113,7 @@ spec:
 <1> (Required) List of connector plugins and their artifacts.
 
 Strimzi supports the following types of artifacts:
+
 * JAR files, which are downloaded and used directly
 * TGZ archives, which are downloaded and unpacked
 * Other artifacts, which are downloaded and used directly

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -306,6 +306,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |maxConnections                1.2+<.<a|The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
 |integer
 |preferredNodePortAddressType  1.2+<.<a|Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
+
 * `ExternalDNS`
 * `ExternalIP`
 * `InternalDNS`
@@ -2476,9 +2477,9 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerSpec.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|whitelist       1.2+<.<a|*The `whitelist` property has been deprecated, and should now be configured using `spec.include`.* List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `'A\|B'`. Or, as a special case, you can mirror all topics using the regular expression '*'. You can also specify multiple regular expressions separated by commas.
+|whitelist       1.2+<.<a|*The `whitelist` property has been deprecated, and should now be configured using `spec.include`.* List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas.
 |string
-|include         1.2+<.<a|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `'A\|B'`. Or, as a special case, you can mirror all topics using the regular expression '*'. You can also specify multiple regular expressions separated by commas.
+|include         1.2+<.<a|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas.
 |string
 |jvmOptions      1.2+<.<a|JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -338,6 +338,7 @@ spec:
                                   - Hostname
                                 description: |-
                                   Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
+
                                   * `ExternalDNS`
                                   * `ExternalIP`
                                   * `InternalDNS`

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -400,10 +400,10 @@ spec:
                   description: CPU and memory resources to reserve.
                 whitelist:
                   type: string
-                  description: List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `'A\|B'`. Or, as a special case, you can mirror all topics using the regular expression '*'. You can also specify multiple regular expressions separated by commas.
+                  description: List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas.
                 include:
                   type: string
-                  description: List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `'A\|B'`. Or, as a special case, you can mirror all topics using the regular expression '*'. You can also specify multiple regular expressions separated by commas.
+                  description: List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas.
                 jvmOptions:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -555,6 +555,7 @@ spec:
                               - Hostname
                               description: |-
                                 Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
+
                                 * `ExternalDNS`
                                 * `ExternalIP`
                                 * `InternalDNS`

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -496,17 +496,17 @@ spec:
                 description: List of topics which are included for mirroring. This
                   option allows any regular expression using Java-style regular expressions.
                   Mirroring two topics named A and B is achieved by using the expression
-                  `'A\|B'`. Or, as a special case, you can mirror all topics using
-                  the regular expression '*'. You can also specify multiple regular
-                  expressions separated by commas.
+                  `A\|B`. Or, as a special case, you can mirror all topics using the
+                  regular expression `*`. You can also specify multiple regular expressions
+                  separated by commas.
               include:
                 type: string
                 description: List of topics which are included for mirroring. This
                   option allows any regular expression using Java-style regular expressions.
                   Mirroring two topics named A and B is achieved by using the expression
-                  `'A\|B'`. Or, as a special case, you can mirror all topics using
-                  the regular expression '*'. You can also specify multiple regular
-                  expressions separated by commas.
+                  `A\|B`. Or, as a special case, you can mirror all topics using the
+                  regular expression `*`. You can also specify multiple regular expressions
+                  separated by commas.
               jvmOptions:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes several lists which were not properly rendered in our documentation because of missing preceding empty line. It also fixed the formatting for some other `*` occurrences to have it properly formatted and rendered as code.