### PR TITLE
[DOC] Clarify that `*` can be used as a wildcard in ACL rules

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
@@ -53,6 +53,19 @@ A name is specified as a `literal` or a `prefix` using the `patternType` propert
 * Literal names are taken exactly as they are specified in the `name` field.
 * Prefix names use the value from the `name` as a prefix, and will apply the rule to all resources with names starting with the value.
 
+When `patternType` is set as `literal`, you can set the name to `*` to indicate that the rule applies to all resources.
+
+.Example ACL rule which allows the user to read messages from all topics
+[source,yaml,subs="attributes+"]
+----
+    acls:
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        operation: Read
+----
+
 [id='property-acl-type-{context}']
 === `type`
 

--- a/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
@@ -1,4 +1,4 @@
-Configures access control rule for a `KafkaUser` when brokers are using the `AclAuthorizer`.
+Configures access control rules for a `KafkaUser` when brokers are using the `AclAuthorizer`.
 
 .Example `KafkaUser` configuration with authorization
 [source,yaml,subs="attributes+"]
@@ -51,11 +51,11 @@ Cluster type resources have no name.
 A name is specified as a `literal` or a `prefix` using the `patternType` property.
 
 * Literal names are taken exactly as they are specified in the `name` field.
-* Prefix names use the value from the `name` as a prefix, and will apply the rule to all resources with names starting with the value.
+* Prefix names use the `name` value as a prefix and then apply the rule to all resources with names starting with that value.
 
 When `patternType` is set as `literal`, you can set the name to `*` to indicate that the rule applies to all resources.
 
-.Example ACL rule which allows the user to read messages from all topics
+.Example ACL rule that allows the user to read messages from all topics
 [source,yaml,subs="attributes+"]
 ----
     acls:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

In the ACL rules, the `name` field can be set to `*` to indicate that the rule applies to all resources. This was missing in the docs and it often comes up as a question. This PR adds it to the docs to have it covered.