### PR TITLE
Fix `NullPointerException` in `AclRule` when name is not specified

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -137,6 +137,10 @@ public class SimpleAclRuleResource {
                 throw new IllegalArgumentException("Invalid Acl resource type: " + type);
         }
 
+        if (kafkaName == null)   {
+            throw new IllegalArgumentException("Name is required for resource type: " + type);
+        }
+
         return new ResourcePattern(kafkaType, kafkaName, kafkaPattern);
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class SimpleAclRuleResourceTest {
@@ -282,5 +283,24 @@ public class SimpleAclRuleResourceTest {
                 .build();
         ResourcePattern expectedKafkaTransactionalIdResourcePattern = new ResourcePattern(ResourceType.TRANSACTIONAL_ID, "my-transactionalId", PatternType.LITERAL);
         assertThat(SimpleAclRuleResource.fromCrd(resource).toKafkaResourcePattern(), is(expectedKafkaTransactionalIdResourcePattern));
+    }
+
+    @Test
+    public void testFromCrdToKafkaResourceWithoutName()  {
+        // Consumer group without specified name
+        AclRuleResource groupResource = new AclRuleGroupResourceBuilder()
+                .withPatternType(AclResourcePatternType.LITERAL)
+                .build();
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> SimpleAclRuleResource.fromCrd(groupResource).toKafkaResourcePattern());
+        assertThat(e.getMessage(), is("Name is required for resource type: GROUP"));
+
+        // Topic without specified name
+        AclRuleResource topicResource = new AclRuleTopicResourceBuilder()
+                .withPatternType(AclResourcePatternType.LITERAL)
+                .build();
+
+        e = assertThrows(IllegalArgumentException.class, () -> SimpleAclRuleResource.fromCrd(topicResource).toKafkaResourcePattern());
+        assertThat(e.getMessage(), is("Name is required for resource type: TOPIC"));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResourceTest.java
@@ -286,7 +286,7 @@ public class SimpleAclRuleResourceTest {
     }
 
     @Test
-    public void testFromCrdToKafkaResourceWithoutName()  {
+    public void testFromCrdToKafkaResourceWithoutNameThrows()  {
         // Consumer group without specified name
         AclRuleResource groupResource = new AclRuleGroupResourceBuilder()
                 .withPatternType(AclResourcePatternType.LITERAL)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the `AclRule`, the `name` field is not required on the CRD level. This is expected since some resource types do not use name. But for the types such as group or topic, the name is required. When it is not set, Kafka throws `NullPointerException`:

```
2021-08-04 18:52:31 WARN  AbstractOperator:516 - Reconciliation #2727(timer) KafkaUser(myproject/my-user): Failed to reconcile
java.lang.NullPointerException: name
	at java.util.Objects.requireNonNull(Objects.java:246) ~[?:?]
	at org.apache.kafka.common.resource.ResourcePattern.<init>(ResourcePattern.java:50) ~[org.apache.kafka.kafka-clients-2.8.0.jar:?]
	at io.strimzi.operator.user.model.acl.SimpleAclRuleResource.toKafkaResourcePattern(SimpleAclRuleResource.java:140) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.model.acl.SimpleAclRule.toKafkaAclBinding(SimpleAclRule.java:116) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.getAclBindings(SimpleAclOperator.java:161) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.internalCreate(SimpleAclOperator.java:95) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.internalUpdate(SimpleAclOperator.java:125) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.lambda$reconcile$0(SimpleAclOperator.java:79) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:82) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:43) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.Promise.complete(Promise.java:66) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.strimzi.operator.common.Util.lambda$kafkaFutureToVertxFuture$4(Util.java:363) ~[io.strimzi.operator-common-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:96) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:59) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:37) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) [io.netty.netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

This PR checks the name value and if it is null it throws a slightly nicer exception:

```
2021-08-04 18:54:14 WARN  AbstractOperator:481 - Reconciliation #1(watch) KafkaUser(myproject/my-user): Failed to reconcile
java.lang.IllegalArgumentException: Name is required for resource type: TOPIC
	at io.strimzi.operator.user.model.acl.SimpleAclRuleResource.toKafkaResourcePattern(SimpleAclRuleResource.java:141) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.model.acl.SimpleAclRule.toKafkaAclBinding(SimpleAclRule.java:116) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.getAclBindings(SimpleAclOperator.java:161) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.internalCreate(SimpleAclOperator.java:95) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.internalUpdate(SimpleAclOperator.java:125) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.strimzi.operator.user.operator.SimpleAclOperator.lambda$reconcile$0(SimpleAclOperator.java:79) ~[io.strimzi.user-operator-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:82) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:43) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.Promise.complete(Promise.java:66) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.strimzi.operator.common.Util.lambda$kafkaFutureToVertxFuture$4(Util.java:363) ~[io.strimzi.operator-common-0.25.0-SNAPSHOT.jar:0.25.0-SNAPSHOT]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:96) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:59) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:37) ~[io.vertx.vertx-core-4.1.2.jar:4.1.2]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) [io.netty.netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.66.Final.jar:4.1.66.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally