### PR TITLE
Fix the offset and transaction state topic configurations in Quickstart book

### DIFF
--- a/documentation/modules/quickstart/proc-creating-kafka-cluster.adoc
+++ b/documentation/modules/quickstart/proc-creating-kafka-cluster.adoc
@@ -57,9 +57,9 @@ spec:
         size: 100Gi
         deleteClaim: false
     config:
-      offsets.topic.replication.factor: 3
-      transaction.state.log.replication.factor: 3
-      transaction.state.log.min.isr: 2
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
   zookeeper:
     replicas: 1
     storage:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The Quickstart book currently uses a Kafka cluster with one Zoo and one Kafka node. But it uses replication factor 3 for offsets and transaction states. That does not work with single Kafka node. This PR changes the settings to make them work.

This should fix #5400.

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging