### PR TITLE
Init Container uses same value of resources as kafka resources

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1545,28 +1545,18 @@ public class KafkaCluster extends AbstractModel {
         List<Container> initContainers = new ArrayList<>(1);
 
         if (rack != null || !ListenersUtils.nodePortListeners(listeners).isEmpty()) {
-            Container initContainer;
+            Container initContainer = new ContainerBuilder()
+                    .withName(INIT_NAME)
+                    .withImage(initImage)
+                    .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
+                    .withEnv(getInitContainerEnvVars())
+                    .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
+                    .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
+                    .withSecurityContext(templateInitContainerSecurityContext)
+                    .build();
+
             if (getResources() != null) {
-                initContainer = new ContainerBuilder()
-                        .withName(INIT_NAME)
-                        .withImage(initImage)
-                        .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
-                        .withResources(getResources())
-                        .withEnv(getInitContainerEnvVars())
-                        .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
-                        .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
-                        .withSecurityContext(templateInitContainerSecurityContext)
-                        .build();
-            } else {
-                initContainer = new ContainerBuilder()
-                        .withName(INIT_NAME)
-                        .withImage(initImage)
-                        .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
-                        .withEnv(getInitContainerEnvVars())
-                        .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
-                        .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
-                        .withSecurityContext(templateInitContainerSecurityContext)
-                        .build();
+                initContainer.setResources(getResources());
             }
             initContainers.add(initContainer);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -14,9 +14,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Service;
@@ -1548,24 +1545,29 @@ public class KafkaCluster extends AbstractModel {
         List<Container> initContainers = new ArrayList<>(1);
 
         if (rack != null || !ListenersUtils.nodePortListeners(listeners).isEmpty()) {
-            ResourceRequirements resources = new ResourceRequirementsBuilder()
-                    .addToRequests("cpu", new Quantity("100m"))
-                    .addToRequests("memory", new Quantity("128Mi"))
-                    .addToLimits("cpu", new Quantity("1"))
-                    .addToLimits("memory", new Quantity("256Mi"))
-                    .build();
-
-            Container initContainer = new ContainerBuilder()
-                    .withName(INIT_NAME)
-                    .withImage(initImage)
-                    .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
-                    .withResources(resources)
-                    .withEnv(getInitContainerEnvVars())
-                    .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
-                    .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
-                    .withSecurityContext(templateInitContainerSecurityContext)
-                    .build();
-
+            Container initContainer;
+            if (getResources() != null) {
+                initContainer = new ContainerBuilder()
+                        .withName(INIT_NAME)
+                        .withImage(initImage)
+                        .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
+                        .withResources(getResources())
+                        .withEnv(getInitContainerEnvVars())
+                        .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
+                        .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
+                        .withSecurityContext(templateInitContainerSecurityContext)
+                        .build();
+            } else {
+                initContainer = new ContainerBuilder()
+                        .withName(INIT_NAME)
+                        .withImage(initImage)
+                        .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
+                        .withEnv(getInitContainerEnvVars())
+                        .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
+                        .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
+                        .withSecurityContext(templateInitContainerSecurityContext)
+                        .build();
+            }
             initContainers.add(initContainer);
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -529,37 +529,23 @@ public class KafkaConnectCluster extends AbstractModel {
         List<Container> initContainers = new ArrayList<>(1);
 
         if (rack != null) {
-            Container initContainer;
-            if (getInitContainerResourceResourceRequirements() != null) {
-                initContainer = new ContainerBuilder()
-                        .withName(INIT_NAME)
-                        .withImage(initImage)
-                        .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
-                        .withResources(getInitContainerResourceResourceRequirements())
-                        .withEnv(getInitContainerEnvVars())
-                        .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
-                        .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
-                        .withSecurityContext(templateInitContainerSecurityContext)
-                        .build();
-            } else {
-                initContainer = new ContainerBuilder()
-                        .withName(INIT_NAME)
-                        .withImage(initImage)
-                        .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
-                        .withEnv(getInitContainerEnvVars())
-                        .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
-                        .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
-                        .withSecurityContext(templateInitContainerSecurityContext)
-                        .build();
+            Container initContainer = new ContainerBuilder()
+                    .withName(INIT_NAME)
+                    .withImage(initImage)
+                    .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
+                    .withEnv(getInitContainerEnvVars())
+                    .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
+                    .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
+                    .withSecurityContext(templateInitContainerSecurityContext)
+                    .build();
+
+            if (getResources() != null) {
+                initContainer.setResources(getResources());
             }
             initContainers.add(initContainer);
         }
 
         return initContainers;
-    }
-
-    private ResourceRequirements getInitContainerResourceResourceRequirements() {
-        return getResources();
     }
 
     protected String getCommand() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -16,7 +16,6 @@ import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Service;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR resolves the issue mentioned in #5372. This PR makes the init Container resources configurable in such a way that the value of resources which were configured for kafka resources are used for setting the resources of the Init Containter also.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

