### PR TITLE
[jenkins] Add building of Kafka config models to PR job

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -152,6 +152,13 @@ pipeline {
                 }
             }
         }
+        stage("Build Kafka config models") {
+            steps {
+                script {
+                    lib.buildKafkaConfigModels()
+                }
+            }
+        }
         stage('Build images') {
             when {
                 environment name: 'TEST_ONLY', value: 'false'

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -84,4 +84,10 @@ def postGithubPrComment(def file) {
     }
 }
 
+def buildKafkaConfigModels() {
+    dir("${workspace}/config-model-generator") {
+        sh(script: "./build-config-models.sh build -Dstyle.color=always")
+    }
+}
+
 return this


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR adds stage for building Kafka config models, so we will be able to run the `DynamicConfigurationSharedST`, which needs config models to `testDynConfiguration`.

### Checklist

- [x] Make sure all tests pass

