### PR TITLE
[systemtest] Add 0.25.0 to upgrade and downgrade tests

### DIFF
--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -1,19 +1,19 @@
 [
   {
     "fromVersion":"HEAD",
-    "toVersion":"0.24.0",
+    "toVersion":"0.25.0",
     "fromExamples":"HEAD",
-    "toExamples":"strimzi-0.24.0",
+    "toExamples":"strimzi-0.25.0",
     "urlFrom":"HEAD",
-    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.25.0/strimzi-0.25.0.zip",
     "generateTopics": true,
     "additionalTopics": 2,
     "oldestKafka": "2.7.0",
     "imagesAfterOperatorDowngrade": {
-      "zookeeper": "strimzi/kafka:0.24.0-kafka-2.8.0",
-      "kafka": "strimzi/kafka:0.24.0-kafka-2.8.0",
-      "topicOperator": "strimzi/operator:0.24.0",
-      "userOperator": "strimzi/operator:0.24.0"
+      "zookeeper": "strimzi/kafka:0.25.0-kafka-2.8.0",
+      "kafka": "strimzi/kafka:0.25.0-kafka-2.8.0",
+      "topicOperator": "strimzi/operator:0.25.0",
+      "userOperator": "strimzi/operator:0.25.0"
     },
     "deployKafkaVersion": "2.8.0",
     "client": {

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -34,9 +34,9 @@
     }
   },
   {
-    "fromVersion":"0.23.0",
-    "fromExamples":"strimzi-0.23.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.23.0/strimzi-0.23.0.zip",
+    "fromVersion":"0.24.0",
+    "fromExamples":"strimzi-0.24.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
     "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",
@@ -44,7 +44,7 @@
     },
     "generateTopics": true,
     "additionalTopics": 2,
-    "oldestKafka": "2.6.0",
+    "oldestKafka": "2.7.0",
     "imagesBeforeKafkaUpgrade": {
       "zookeeper": "strimzi/kafka:latest-kafka-2.7.0",
       "kafka": "strimzi/kafka:latest-kafka-2.7.0",
@@ -68,9 +68,9 @@
     }
   },
   {
-    "fromVersion":"0.24.0",
-    "fromExamples":"strimzi-0.24.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.24.0/strimzi-0.24.0.zip",
+    "fromVersion":"0.25.0",
+    "fromExamples":"strimzi-0.25.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.25.0/strimzi-0.25.0.zip",
     "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",
@@ -80,8 +80,8 @@
     "additionalTopics": 2,
     "oldestKafka": "2.7.0",
     "imagesBeforeKafkaUpgrade": {
-      "zookeeper": "strimzi/kafka:latest-kafka-2.7.0",
-      "kafka": "strimzi/kafka:latest-kafka-2.7.0",
+      "zookeeper": "strimzi/kafka:latest-kafka-2.8.0",
+      "kafka": "strimzi/kafka:latest-kafka-2.8.0",
       "topicOperator": "strimzi/operator:latest",
       "userOperator": "strimzi/operator:latest"
     },


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test check

### Description

This PR adds `0.25.0` to upgrade and downgrade JSONs, and removing the `0.23.0` from `StrimziUpgradeST.json`

### Checklist

- [ ] Make sure all tests pass
