### PR TITLE
Update OPA Authorizer plugin to version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.26.0
 
+* Update the Open Policy Agent Authorizer to version [1.1.0](https://github.com/Bisnode/opa-kafka-plugin/releases/tag/v1.1.0)
 
 ### Changes, deprecations and removals
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.7.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <cruise-control.version>2.5.57</cruise-control.version>
-        <opa-authorizer.version>1.0.0</opa-authorizer.version>
+        <opa-authorizer.version>1.1.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <cruise-control.version>2.5.57</cruise-control.version>
-        <opa-authorizer.version>1.0.0</opa-authorizer.version>
+        <opa-authorizer.version>1.1.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the OPA Authorizer to a newer version 1.1.0 which was not available in Maven when we originally moved to Scala 2.13 and was pushed there only later. No breaking changes this time ;-).

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md