### PR TITLE
Set `ownerReference` in the `KafkaRebalance` `ConfigMap`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -10,12 +10,14 @@ import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Toleration;
@@ -542,5 +544,23 @@ public class ModelUtils {
             model.setMetricsEnabled(true);
             model.setMetricsConfigInCm(resourceWithMetrics.getMetricsConfig());
         }
+    }
+
+    /**
+     * Creates the OwnerReference based on the resource passed as parameter
+     *
+     * @param owner     The resource which should be the owner
+     *
+     * @return          The new OwnerReference
+     */
+    public static OwnerReference createOwnerReference(HasMetadata owner)   {
+        return new OwnerReferenceBuilder()
+                .withApiVersion(owner.getApiVersion())
+                .withKind(owner.getKind())
+                .withName(owner.getMetadata().getName())
+                .withUid(owner.getMetadata().getUid())
+                .withBlockOwnerDeletion(false)
+                .withController(false)
+                .build();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -3,6 +3,7 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.cluster.operator.assembly;
+
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
@@ -27,6 +28,7 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -634,11 +636,11 @@ public class KafkaRebalanceAssemblyOperator
                 brokerLoadBeforeOptimization, brokerLoadAfterOptimization);
 
         ConfigMap rebalanceMap = new ConfigMapBuilder()
-                .withApiVersion("v1")
                 .withNewMetadata()
-                .withNamespace(kafkaRebalance.getMetadata().getNamespace())
-                .withName(kafkaRebalance.getMetadata().getName())
-                .withLabels(Collections.singletonMap("app", "strimzi"))
+                    .withNamespace(kafkaRebalance.getMetadata().getNamespace())
+                    .withName(kafkaRebalance.getMetadata().getName())
+                    .withLabels(Collections.singletonMap("app", "strimzi"))
+                    .withOwnerReferences(ModelUtils.createOwnerReference(kafkaRebalance))
                 .endMetadata()
                 .withData(Collections.singletonMap(BROKER_LOAD_KEY, beforeAndAfterBrokerLoad.encode()))
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -546,5 +547,24 @@ public class ModelUtilsTest {
         Labels nsLabels = Labels.fromMap(singletonMap("labelKey", "labelValue"));
         ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", nsLabels);
         assertThat(peer.getNamespaceSelector().getMatchLabels(), is(nsLabels.toMap()));
+    }
+
+    @ParallelTest
+    public void testCreateOwnerReference()   {
+        Kafka owner = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName("my-kafka")
+                    .withUid("some-uid")
+                .endMetadata()
+                .build();
+
+        OwnerReference ref = ModelUtils.createOwnerReference(owner);
+
+        assertThat(ref.getApiVersion(), is(owner.getApiVersion()));
+        assertThat(ref.getKind(), is(owner.getKind()));
+        assertThat(ref.getName(), is(owner.getMetadata().getName()));
+        assertThat(ref.getUid(), is(owner.getMetadata().getUid()));
+        assertThat(ref.getBlockOwnerDeletion(), is(false));
+        assertThat(ref.getController(), is(false));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using the `KafkaRebalance` resource to rebalance the Kafka cluster using Cruise Control, Strimzi now generates a new config map with the detailed before and after data. This Config Map is missing the owner reference so it cannot be tracked back to the `KafkaRebalance` resource and is not deleted when the resource is deleted. This PR fixes that and sets the owner reference.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally