### PR TITLE
Upgrade kubernetes-client dependency

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -193,7 +193,7 @@ public class Crds {
     }
 
     public static MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaOperation(KubernetesClient client) {
-        return client.customResources(Kafka.class, KafkaList.class);
+        return client.resources(Kafka.class, KafkaList.class);
     }
 
     public static CustomResourceDefinition kafkaConnect() {
@@ -201,7 +201,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaConnect, KafkaConnectList, Resource<KafkaConnect>> kafkaConnectOperation(KubernetesClient client) {
-        return client.customResources(KafkaConnect.class, KafkaConnectList.class);
+        return client.resources(KafkaConnect.class, KafkaConnectList.class);
     }
 
     public static CustomResourceDefinition kafkaConnector() {
@@ -209,7 +209,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaConnector, KafkaConnectorList, Resource<KafkaConnector>> kafkaConnectorOperation(KubernetesClient client) {
-        return client.customResources(KafkaConnector.class, KafkaConnectorList.class);
+        return client.resources(KafkaConnector.class, KafkaConnectorList.class);
     }
 
     public static CustomResourceDefinition kafkaTopic() {
@@ -217,7 +217,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> topicOperation(KubernetesClient client) {
-        return client.customResources(KafkaTopic.class, KafkaTopicList.class);
+        return client.resources(KafkaTopic.class, KafkaTopicList.class);
     }
 
     public static CustomResourceDefinition kafkaUser() {
@@ -225,7 +225,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserOperation(KubernetesClient client) {
-        return client.customResources(KafkaUser.class, KafkaUserList.class);
+        return client.resources(KafkaUser.class, KafkaUserList.class);
     }
 
     public static CustomResourceDefinition kafkaMirrorMaker() {
@@ -233,7 +233,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaMirrorMaker, KafkaMirrorMakerList, Resource<KafkaMirrorMaker>> mirrorMakerOperation(KubernetesClient client) {
-        return client.customResources(KafkaMirrorMaker.class, KafkaMirrorMakerList.class);
+        return client.resources(KafkaMirrorMaker.class, KafkaMirrorMakerList.class);
     }
 
     public static CustomResourceDefinition kafkaBridge() {
@@ -241,7 +241,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaBridge, KafkaBridgeList, Resource<KafkaBridge>> kafkaBridgeOperation(KubernetesClient client) {
-        return client.customResources(KafkaBridge.class, KafkaBridgeList.class);
+        return client.resources(KafkaBridge.class, KafkaBridgeList.class);
     }
 
     public static CustomResourceDefinition kafkaMirrorMaker2() {
@@ -249,7 +249,7 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>> kafkaMirrorMaker2Operation(KubernetesClient client) {
-        return client.customResources(KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
+        return client.resources(KafkaMirrorMaker2.class, KafkaMirrorMaker2List.class);
     }
 
     public static CustomResourceDefinition kafkaRebalance() {
@@ -257,14 +257,14 @@ public class Crds {
     }
 
     public static MixedOperation<KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>> kafkaRebalanceOperation(KubernetesClient client) {
-        return client.customResources(KafkaRebalance.class, KafkaRebalanceList.class);
+        return client.resources(KafkaRebalance.class, KafkaRebalanceList.class);
     }
 
     public static <T extends CustomResource, L extends CustomResourceList<T>> MixedOperation<T, L, Resource<T>>
             operation(KubernetesClient client,
                       Class<T> cls,
                       Class<L> listCls) {
-        return client.customResources(cls, listCls);
+        return client.resources(cls, listCls);
     }
 
     public static <T extends CustomResource> String kind(Class<T> cls) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -131,7 +131,7 @@ public class ClusterOperatorTest {
             throw new RuntimeException(e);
         }
         MixedOperation mockCms = mock(MixedOperation.class);
-        when(client.customResources(any(), any())).thenReturn(mockCms);
+        when(client.resources(any(), any())).thenReturn(mockCms);
 
         List<String> namespaceList = asList(namespaces.split(" *,+ *"));
         for (String namespace: namespaceList) {
@@ -204,7 +204,7 @@ public class ClusterOperatorTest {
         }
 
         MixedOperation mockCms = mock(MixedOperation.class);
-        when(client.customResources(any(), any())).thenReturn(mockCms);
+        when(client.resources(any(), any())).thenReturn(mockCms);
 
         FilterWatchListMultiDeletable mockFilteredCms = mock(FilterWatchListMultiDeletable.class);
         when(mockFilteredCms.withLabels(any())).thenReturn(mockFilteredCms);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
@@ -508,8 +507,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     private Resource<Kafka> kafkaAssembly(String namespace, String name) {
-        CustomResourceDefinition crd = client.apiextensions().v1().customResourceDefinitions().withName(Kafka.CRD_NAME).get();
-        return client.customResources(CustomResourceDefinitionContext.fromCrd(crd), Kafka.class, KafkaList.class)
+        return client.resources(Kafka.class, KafkaList.class)
                 .inNamespace(namespace).withName(name);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -135,7 +135,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                     assertThat(mockClient.policy().v1beta1().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
                 } else {
                     assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaConnectResources.deploymentName(CLUSTER_NAME)).get(), is(nullValue()));
-                    verify(mockClient, never()).customResources(KafkaConnect.class);
+                    verify(mockClient, never()).resources(KafkaConnect.class);
                 }
                 created.complete();
             })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -139,7 +139,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                     assertThat(mockClient.policy().v1beta1().podDisruptionBudget().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(notNullValue()));
                 } else {
                     assertThat(mockClient.apps().deployments().inNamespace(NAMESPACE).withName(KafkaMirrorMaker2Resources.deploymentName(CLUSTER_NAME)).get(), is(nullValue()));
-                    verify(mockClient, never()).customResources(KafkaMirrorMaker2.class);
+                    verify(mockClient, never()).resources(KafkaMirrorMaker2.class);
                 }
 
                 created.complete();

--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockKube.java
@@ -400,6 +400,17 @@ public class MockKube {
                     }
                     return createOrReplaceable;
                 });
+
+        when(mockClient.resources(any(Class.class), any(Class.class)))
+                .thenAnswer(invocation -> {
+                    Class<CustomResource> crClass = invocation.getArgument(0);
+                    String key = crdKey(crClass);
+                    CreateOrReplaceable createOrReplaceable = crdMixedOps.get(key);
+                    if (createOrReplaceable == null) {
+                        throw new RuntimeException("Unknown CRD " + key);
+                    }
+                    return createOrReplaceable;
+                });
     }
 
     private MixedOperation<StatefulSet, StatefulSetList, RollableScalableResource<StatefulSet>>

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -48,7 +48,7 @@ public class CrdOperator<C extends KubernetesClient,
 
     @Override
     protected MixedOperation<T, L, Resource<T>> operation() {
-        return client.customResources(cls, listCls);
+        return client.resources(cls, listCls);
     }
 
     /**

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -88,7 +88,7 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
 
     @Override
     protected void mocker(KubernetesClient mockClient, MixedOperation op) {
-        when(mockClient.customResources(any(), any())).thenReturn(op);
+        when(mockClient.resources(any(), any())).thenReturn(op);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.6.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.6.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.6.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.7.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.7.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.7.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -14,8 +14,6 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
@@ -1818,7 +1816,7 @@ class KafkaST extends AbstractST {
             .filter(p -> p.getMetadata().getName().startsWith(OPENSHIFT_CLUSTER_NAME))
             .forEach(p -> PodUtils.deletePodWithWait(p.getMetadata().getName()));
 
-        kubeClient(namespaceName).getClient().customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class).inNamespace(namespaceName).delete();
+        kubeClient(namespaceName).getClient().resources(KafkaTopic.class, KafkaTopicList.class).inNamespace(namespaceName).delete();
         kubeClient(namespaceName).getClient().persistentVolumeClaims().inNamespace(namespaceName).delete();
     }
 }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -857,7 +857,7 @@ public class KubeClient {
     }
 
     public <T extends CustomResource, L extends CustomResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass) {
-        return client.customResources(resourceType, listClass); //TODO namespace here
+        return client.resources(resourceType, listClass); //TODO namespace here
     }
 
     // =========================

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -109,7 +109,7 @@ public class K8sImpl implements K8s {
     }
 
     private MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> operation() {
-        return client.customResources(KafkaTopic.class, KafkaTopicList.class);
+        return client.resources(KafkaTopic.class, KafkaTopicList.class);
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -350,7 +350,7 @@ public class Session extends AbstractVerticle {
         try {
             LOGGER.debug("Watching KafkaTopics matching {}", config.get(Config.LABELS).labels());
 
-            Session.this.topicWatch = kubeClient.customResources(KafkaTopic.class, KafkaTopicList.class)
+            Session.this.topicWatch = kubeClient.resources(KafkaTopic.class, KafkaTopicList.class)
                     .inNamespace(config.get(Config.NAMESPACE)).withLabels(config.get(Config.LABELS).labels()).watch(watcher);
             LOGGER.debug("Watching setup");
             promise.complete();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -56,8 +56,8 @@ public class K8sImplTest {
 
         KubernetesClient mockClient = mock(KubernetesClient.class);
         MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> mockResources = mock(MixedOperation.class);
-        when(mockClient.customResources(any(Class.class), any(Class.class))).thenReturn(mockResources);
-        when(mockClient.customResources(any(Class.class), any(Class.class))).thenReturn(mockResources);
+        when(mockClient.resources(any(Class.class), any(Class.class))).thenReturn(mockResources);
+        when(mockClient.resources(any(Class.class), any(Class.class))).thenReturn(mockResources);
         when(mockResources.withLabels(any())).thenReturn(mockResources);
         when(mockResources.inNamespace(any())).thenReturn(mockResources);
         when(mockResources.list()).thenAnswer(invocation -> {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
@@ -542,7 +541,7 @@ public abstract class TopicOperatorBaseIT {
     }
 
     protected MixedOperation<KafkaTopic, KafkaTopicList, Resource<KafkaTopic>> operation() {
-        return kubeClient.customResources(CustomResourceDefinitionContext.fromCrd(Crds.kafkaTopic()), KafkaTopic.class, KafkaTopicList.class);
+        return kubeClient.resources(KafkaTopic.class, KafkaTopicList.class);
     }
 
     protected void waitForTopicInKafka(String topicName) throws InterruptedException, ExecutionException, TimeoutException {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- dependency chore

### Description
Update kubernetes client to 5.7.0

### Checklist
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

