### PR TITLE
A sketch of how we could support cancellation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/Cancellable.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/Cancellable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+interface Cancellable {
+    boolean isCancelled();
+
+    void cancel();
+
+    static Cancellable atomic() {
+        return new Cancellable() {
+
+            private volatile boolean cancelled = false;
+
+            @Override
+            public boolean isCancelled() {
+                return cancelled;
+            }
+
+            @Override
+            public void cancel() {
+                cancelled = true;
+            }
+        };
+    }
+
+    static Cancellable future(java.util.concurrent.Future<?> future) {
+        return new Cancellable() {
+            @Override
+            public boolean isCancelled() {
+                return future.isCancelled();
+            }
+
+            @Override
+            public void cancel() {
+                future.cancel(true);
+            }
+        };
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZookeeperScalerProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZookeeperScalerProvider.java
@@ -30,6 +30,6 @@ public class DefaultZookeeperScalerProvider implements ZookeeperScalerProvider {
      * @return  ZookeeperScaler instance
      */
     public ZookeeperScaler createZookeeperScaler(Reconciliation reconciliation, Vertx vertx, String zookeeperConnectionString, Function<Integer, String> zkNodeAddress, Secret clusterCaCertSecret, Secret coKeySecret, long operationTimeoutMs) {
-        return new ZookeeperScaler(reconciliation, vertx, zooAdminProvider, zookeeperConnectionString, zkNodeAddress, clusterCaCertSecret, coKeySecret, operationTimeoutMs);
+        return new ZookeeperScaler(reconciliation, zooAdminProvider, zookeeperConnectionString, zkNodeAddress, clusterCaCertSecret, coKeySecret, operationTimeoutMs);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -122,7 +122,6 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -633,7 +632,6 @@ public class ResourceUtils {
             @Override
             public ZookeeperScaler createZookeeperScaler(Reconciliation reconciliation, Vertx vertx, String zookeeperConnectionString, Function<Integer, String> zkNodeAddress, Secret clusterCaCertSecret, Secret coKeySecret, long operationTimeoutMs) {
                 ZookeeperScaler mockZooScaler = mock(ZookeeperScaler.class);
-                when(mockZooScaler.scale(anyInt())).thenReturn(Future.succeededFuture());
                 return mockZooScaler;
             }
         };

--- a/operator-common/src/main/java/io/strimzi/operator/common/Reconciliation.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Reconciliation.java
@@ -4,16 +4,11 @@
  */
 package io.strimzi.operator.common;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <p>Represents an attempt synchronize the state of some K8S resources (an "assembly") in a single namespace with a
@@ -63,23 +58,5 @@ public class Reconciliation {
 
     public String toString() {
         return "Reconciliation #" + id + "(" + trigger + ") " + kind() + "(" + namespace() + "/" + name() + ")";
-    }
-
-    public <T> Future<T> run(Vertx vertx, Callable<T> callable) {
-        synchronized (this) {
-            if (executorService == null) {
-                executorService = Executors.newSingleThreadScheduledExecutor();
-            }
-        }
-        Promise<T> p = Promise.promise();
-        executorService.submit(() -> {
-            try {
-                T result = callable.call();
-                vertx.runOnContext(i -> p.tryComplete(result));
-            } catch (Exception e) {
-                vertx.runOnContext(i -> p.tryFail(e));
-            }
-        });
-        return p.future();
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -23,7 +23,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UtilTest {
     @Test
@@ -187,5 +190,26 @@ public class UtilTest {
 
         selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1", "label3", "value3")).build());
         assertThat(matchesSelector(selector, testResource), is(false));
+    }
+
+    @Test
+    public void testPoll() throws InterruptedException {
+        int[] calls = new int[]{0};
+        assertTrue(Util.await(Reconciliation.DUMMY_RECONCILIATION, "test", 10, 50, () -> {
+            calls[0] += 1;
+            return true;
+        }));
+        assertEquals(1, calls[0]);
+
+        calls[0] = 0;
+        assertTrue(Util.await(Reconciliation.DUMMY_RECONCILIATION, "test", 10, 50, () -> {
+            calls[0] += 1;
+            return calls[0] == 2;
+        }));
+        assertEquals(2, calls[0]);
+
+        assertFalse(Util.await(Reconciliation.DUMMY_RECONCILIATION, "test", 10, 50, () -> {
+            return false;
+        }));
     }
 }


### PR DESCRIPTION
This PR is a sketch of how we might support cancellation and thus fix #4869 based on thoughts following [this comment](https://github.com/strimzi/strimzi-kafka-operator/pull/4996#issuecomment-899558964).

It illustrates:

* Moving away from using vertx. This is done by having an executor service bound to a `ReconciliationState`. In this case we're using a new executor for each `ReconciliationState` instance, but I don't think that's really where we'd end up. Rather we'd likely use an executor service with a pool of threads. 
* I've changed the `ZookeeperScaler` to not use vertx, and also the places where we were using `waitFor` for readiness etc use a busy loop with calls to `sleep`. The main thing about these changes is we allow `InterruptedException` to propagate all the way out to the executor.  It should be possible to use the executor service and schedule a task to check for the poll condition, but using sleep was quicker for now. 
* `Executor.submit` returns a `java.util.concurrent.Future` which supports cancellation. Calling `cancel(true)` on such a future (with a util.concurrent `ExecutorService`) will interrupt any thread that's running the task corresponding to that Future. 
* Using the `Cancellable` abstraction, we can cancel reconciliations for individual CRs. If they're running at the time of cancellation then the Future is used to cancel the task. Otherwise we just mark the task cancelled and it won't be possible to `run` any task for it. I've not yet hooked to the `KAO.cancel` to the watcher. In reality some of this really belongs in the `AbstractOperator`.

There's a whole bunch of stuff still to decide including:
* should we sleep or use the `ScheduledExecutorService` when awaiting conditions?
* We'd need to refactor KafkaRoller to use the common `ScheduledExecutorService`
* Is `cancellations` keyed on `metadata.uid` and only used for CR deletion?
* Is removing the dependency on vertx something we have/ought to do as part of this? Or are we prepared to accept the complexity of a hybrid model?
* Can we actually use a pool of threads? If we're not dropping vertx this assumes we have the resources for a bunch more threads.

But hopefully this shows enough of the moving parts to stimulate some discussion.