### PR TITLE
fix helm chart value for `generateNetworkPolicy`

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -117,7 +117,7 @@ spec:
             {{- end }}
             {{- if ne .Values.generateNetworkPolicy true}}
             - name: STRIMZI_NETWORK_POLICY_GENERATION
-              value: {{ .Values.generateNetworkPolicy }}
+              value: {{ .Values.generateNetworkPolicy | quote }}
             {{- end }}
             {{- if ne (int .Values.connectBuildTimeoutMs) 300000 }}
             - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
When trying to set the `generateNetworkPolicy` to `"false"` you get this error:
```
Error: UPGRADE FAILED: template: strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml:118:19: executing "strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml" at <ne .Values.generateNetworkPolicy true>: error calling ne: incompatible types for comparison
```
When trying to set the `generateNetworkPolicy` to `false` you get this error:
```
Error: UPGRADE FAILED: failed to create resource: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found f, error found in #10 byte of ...|,"value":false}],"im|..., bigger context ...|ame":"STRIMZI_NETWORK_POLICY_GENERATION","value":false}],"image":"quay.io/strimzi/operator:0.25.0","|...
```


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

