### PR TITLE
fix(cluster-operator): correct auto-detection of KUBERNETES_SERVICE_DNS_DOMAIN

### DIFF
--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -3,7 +3,7 @@ export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packagin
 export JAVA_MAIN=io.strimzi.operator.cluster.Main
 
 if [ -z "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then
-  KUBERNETES_SERVICE_DNS_DOMAIN=$(getent hosts kubernetes.default | head -1 | sed "s/.*\skubernetes.default.svc.//")
+  KUBERNETES_SERVICE_DNS_DOMAIN=$(getent hosts kubernetes.default | head -1 | sed "s/.*\skubernetes.default.svc//" | sed "s/\.//")
   if [ -n "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then
     echo "Auto-detected KUBERNETES_SERVICE_DNS_DOMAIN: $KUBERNETES_SERVICE_DNS_DOMAIN"
     export KUBERNETES_SERVICE_DNS_DOMAIN


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

The auto-detection script fails incorrectly when a match is not found and instead of defaulting to the correct `cluster.local` if it doesn't find a cluster domain name, it actually uses all the entries from `getent hosts kubernetes.default`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

