### PR TITLE
Add custom labels and annotations for JMX secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update the Open Policy Agent Authorizer to version [1.1.0](https://github.com/Bisnode/opa-kafka-plugin/releases/tag/v1.1.0)
 * Expose JMX port on Zookeeper nodes via a headless service.
+* Allow configuring labels and annotations for JMX authentication secrets
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -27,7 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({
         "statefulset", "pod", "bootstrapService", "brokersService", "externalBootstrapService", "perPodService",
         "externalBootstrapRoute", "perPodRoute", "externalBootstrapIngress", "perPodIngress", "persistentVolumeClaim",
-        "podDisruptionBudget", "kafkaContainer", "initContainer", "clusterCaCert", "serviceAccount"})
+        "podDisruptionBudget", "kafkaContainer", "initContainer", "clusterCaCert", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
 public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -49,6 +49,7 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private ContainerTemplate initContainer;
     private ResourceTemplate clusterRoleBinding;
     private ResourceTemplate serviceAccount;
+    private ResourceTemplate jmxSecret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka `StatefulSet`.")
@@ -219,6 +220,15 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     public void setServiceAccount(ResourceTemplate serviceAccount) {
         this.serviceAccount = serviceAccount;
+    }
+
+    @Description("Template for Secret of the Kafka Cluster JMX authentication")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getJmxSecret() {
+        return jmxSecret;
+    }
+    public void setJmxSecret(ResourceTemplate jmxSecret) {
+        this.jmxSecret = jmxSecret;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -25,7 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "apiService", "connectContainer", "initContainer", "podDisruptionBudget",
-        "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig", "buildServiceAccount"})
+        "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig", "buildServiceAccount", "jmxSecret"})
 @EqualsAndHashCode
 public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -42,6 +42,7 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
     private ResourceTemplate clusterRoleBinding;
     private ResourceTemplate serviceAccount;
     private ResourceTemplate buildServiceAccount;
+    private ResourceTemplate jmxSecret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Connect `Deployment`.")
@@ -165,6 +166,15 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
 
     public void setBuildServiceAccount(ResourceTemplate buildServiceAccount) {
         this.buildServiceAccount = buildServiceAccount;
+    }
+
+    @Description("Template for Secret of the Kafka Connect Cluster JMX authentication.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getJmxSecret() {
+        return jmxSecret;
+    }
+    public void setJmxSecret(ResourceTemplate jmxSecret) {
+        this.jmxSecret = jmxSecret;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
@@ -25,7 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "deployment", "pod", "apiService", "podDisruptionBudget", "mirrorMaker2Container", "serviceAccount"})
+        "deployment", "pod", "apiService", "podDisruptionBudget", "mirrorMaker2Container", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
 public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -36,6 +36,7 @@ public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyP
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate mirrorMaker2Container;
     private ResourceTemplate serviceAccount;
+    private ResourceTemplate jmxSecret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka MirrorMaker 2.0 `Deployment`.")
@@ -96,6 +97,15 @@ public class KafkaMirrorMaker2Template implements Serializable, UnknownPropertyP
 
     public void setServiceAccount(ResourceTemplate serviceAccount) {
         this.serviceAccount = serviceAccount;
+    }
+
+    @Description("Template for Secret of the Kafka MirrorMaker 2 Cluster JMX authentication.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getJmxSecret() {
+        return jmxSecret;
+    }
+    public void setJmxSecret(ResourceTemplate jmxSecret) {
+        this.jmxSecret = jmxSecret;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "statefulset", "pod", "clientService", "nodesService", "persistentVolumeClaim",
-        "podDisruptionBudget", "zookeeperContainer", "serviceAccount"})
+        "podDisruptionBudget", "zookeeperContainer", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
 public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -39,6 +39,7 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate zookeeperContainer;
     private ResourceTemplate serviceAccount;
+    private ResourceTemplate jmxSecret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for ZooKeeper `StatefulSet`.")
@@ -119,6 +120,15 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
 
     public void setServiceAccount(ResourceTemplate serviceAccount) {
         this.serviceAccount = serviceAccount;
+    }
+
+    @Description("Template for Secret of the Zookeeper Cluster JMX authentication")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getJmxSecret() {
+        return jmxSecret;
+    }
+    public void setJmxSecret(ResourceTemplate jmxSecret) {
+        this.jmxSecret = jmxSecret;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -286,6 +286,8 @@ public abstract class AbstractModel {
     protected Map<String, String> templateClusterRoleBindingAnnotations;
     protected Map<String, String> templateServiceAccountLabels;
     protected Map<String, String> templateServiceAccountAnnotations;
+    protected Map<String, String> templateJmxSecretLabels;
+    protected Map<String, String> templateJmxSecretAnnotations;
 
     protected List<Condition> warningConditions = new ArrayList<>(0);
 
@@ -923,8 +925,8 @@ public abstract class AbstractModel {
                 .build();
     }
 
-    protected Secret createSecret(String name, Map<String, String> data) {
-        return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data);
+    protected Secret createSecret(String name, Map<String, String> data, Map<String, String> customAnnotations, Map<String, String> customLabels) {
+        return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, customAnnotations, customLabels);
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> annotations) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -101,6 +101,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * AbstractModel an abstract base model for all components of the {@code Kafka} custom resource
  */
@@ -354,7 +356,7 @@ public abstract class AbstractModel {
      * @return The selector labels as an instance of the Labels object.
      */
     public Labels getSelectorLabels() {
-        return getLabelsWithStrimziName(name, Collections.emptyMap()).strimziSelectorLabels();
+        return getLabelsWithStrimziName(name, emptyMap()).strimziSelectorLabels();
     }
 
     /**
@@ -925,7 +927,11 @@ public abstract class AbstractModel {
                 .build();
     }
 
-    protected Secret createSecret(String name, Map<String, String> data, Map<String, String> customAnnotations, Map<String, String> customLabels) {
+    protected Secret createSecret(String name, Map<String, String> data) {
+        return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, emptyMap(), emptyMap());
+    }
+
+    protected Secret createJmxSecret(String name, Map<String, String> data, Map<String, String> customAnnotations, Map<String, String> customLabels) {
         return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, customAnnotations, customLabels);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -931,8 +931,8 @@ public abstract class AbstractModel {
         return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, emptyMap(), emptyMap());
     }
 
-    protected Secret createJmxSecret(String name, Map<String, String> data, Map<String, String> customAnnotations, Map<String, String> customLabels) {
-        return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, customAnnotations, customLabels);
+    protected Secret createJmxSecret(String name, Map<String, String> data) {
+        return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> annotations) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1329,7 +1329,7 @@ public class KafkaCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createJmxSecret(KafkaCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
+        return createJmxSecret(KafkaCluster.jmxSecretName(cluster), data);
     }
 
     private List<ContainerPort> getContainerPortList() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -95,7 +95,6 @@ import java.util.stream.Collectors;
 
 import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithOAuth;
 import static java.util.Collections.addAll;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static io.strimzi.operator.cluster.model.CruiseControl.CRUISE_CONTROL_METRIC_REPORTER;
@@ -1314,7 +1313,7 @@ public class KafkaCluster extends AbstractModel {
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
-        return createSecret(KafkaCluster.brokersSecretName(cluster), data, emptyMap(), emptyMap());
+        return createSecret(KafkaCluster.brokersSecretName(cluster), data);
     }
 
     /**
@@ -1330,7 +1329,7 @@ public class KafkaCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createSecret(KafkaCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
+        return createJmxSecret(KafkaCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }
 
     private List<ContainerPort> getContainerPortList() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -752,7 +752,7 @@ public class KafkaConnectCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createJmxSecret(KafkaConnectCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
+        return createJmxSecret(KafkaConnectCluster.jmxSecretName(cluster), data);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -752,7 +752,7 @@ public class KafkaConnectCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createSecret(KafkaConnectCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
+        return createJmxSecret(KafkaConnectCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -290,6 +290,11 @@ public class KafkaConnectCluster extends AbstractModel {
                 kafkaConnect.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
             }
 
+            if (template.getJmxSecret() != null && template.getJmxSecret().getMetadata() != null) {
+                kafkaConnect.templateJmxSecretLabels = template.getJmxSecret().getMetadata().getLabels();
+                kafkaConnect.templateJmxSecretAnnotations = template.getJmxSecret().getMetadata().getAnnotations();
+            }
+
             ModelUtils.parsePodDisruptionBudgetTemplate(kafkaConnect, template.getPodDisruptionBudget());
         }
 
@@ -747,7 +752,7 @@ public class KafkaConnectCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createSecret(KafkaConnectCluster.jmxSecretName(cluster), data);
+        return createSecret(KafkaConnectCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -54,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * ModelUtils is a utility class that holds generic static helper functions
  * These are generally to be used within the classes that extend the AbstractModel class
@@ -188,16 +190,18 @@ public class ModelUtils {
             data.put(keyCertName + ".password", certAndKey.storePasswordAsBase64String());
         }
 
-        return createSecret(secretName, namespace, labels, ownerReference, data);
+        return createSecret(secretName, namespace, labels, ownerReference, data, emptyMap(), emptyMap());
     }
 
-    public static Secret createSecret(String name, String namespace, Labels labels, OwnerReference ownerReference, Map<String, String> data) {
+    public static Secret createSecret(String name, String namespace, Labels labels, OwnerReference ownerReference,
+                                      Map<String, String> data, Map<String, String> customAnnotations, Map<String, String> customLabels) {
         if (ownerReference == null) {
             return new SecretBuilder()
                     .withNewMetadata()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(labels.toMap())
+                        .withLabels(Util.mergeLabelsOrAnnotations(labels.toMap(), customLabels))
+                    .withAnnotations(customAnnotations)
                     .endMetadata()
                     .withType("Opaque")
                     .withData(data)
@@ -208,7 +212,8 @@ public class ModelUtils {
                         .withName(name)
                         .withOwnerReferences(ownerReference)
                         .withNamespace(namespace)
-                        .withLabels(labels.toMap())
+                        .withLabels(Util.mergeLabelsOrAnnotations(labels.toMap(), customLabels))
+                        .withAnnotations(customAnnotations)
                     .endMetadata()
                     .withType("Opaque")
                     .withData(data)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -201,7 +201,7 @@ public class ModelUtils {
                         .withName(name)
                         .withNamespace(namespace)
                         .withLabels(Util.mergeLabelsOrAnnotations(labels.toMap(), customLabels))
-                    .withAnnotations(customAnnotations)
+                        .withAnnotations(customAnnotations)
                     .endMetadata()
                     .withType("Opaque")
                     .withData(data)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -764,6 +764,6 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createJmxSecret(ZookeeperCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
+        return createJmxSecret(ZookeeperCluster.jmxSecretName(cluster), data);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -750,9 +751,11 @@ public class ZookeeperCluster extends AbstractModel {
     /**
      * Generate the Secret containing the username and password to secure the jmx port on the zookeeper nodes
      *
+     * @param jmxSecretAnnotations The additional annotations of the {@code Secret} created.
+     * @param jmxSecretLabels The additional labels of the {@code Secret} created.
      * @return The generated Secret
      */
-    public Secret generateJmxSecret() {
+    public Secret generateJmxSecret(Map<String, String> jmxSecretAnnotations, Map<String, String> jmxSecretLabels) {
         Map<String, String> data = new HashMap<>(2);
         String[] keys = {SECRET_JMX_USERNAME_KEY, SECRET_JMX_PASSWORD_KEY};
         PasswordGenerator passwordGenerator = new PasswordGenerator(16);
@@ -760,6 +763,16 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createSecret(ZookeeperCluster.jmxSecretName(cluster), data);
+        return new SecretBuilder()
+                .withNewMetadata()
+                .withName(ZookeeperCluster.jmxSecretName(cluster))
+                .withOwnerReferences(createOwnerReference())
+                .withNamespace(namespace)
+                .withLabels(Util.mergeLabelsOrAnnotations(labels.toMap(), jmxSecretLabels))
+                .withAnnotations(jmxSecretAnnotations)
+                .endMetadata()
+                .withType("Opaque")
+                .withData(data)
+                .build();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -59,8 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Base64;
 
-import static java.util.Collections.emptyMap;
-
 
 public class ZookeeperCluster extends AbstractModel {
     protected static final String APPLICATION_NAME = "zookeeper";
@@ -545,7 +543,7 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
             data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
-        return createSecret(ZookeeperCluster.nodesSecretName(cluster), data, emptyMap(), emptyMap());
+        return createSecret(ZookeeperCluster.nodesSecretName(cluster), data);
     }
 
     @Override
@@ -766,6 +764,6 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createSecret(ZookeeperCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
+        return createJmxSecret(ZookeeperCluster.jmxSecretName(cluster), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1230,11 +1230,24 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkJmxSecret() {
+            Map<String, String> jmxSecretLabels = emptyMap();
+            Map<String, String> jmxSecretAnnotations = emptyMap();
+
+            if (kafkaAssembly.getSpec().getZookeeper() != null
+                    && kafkaAssembly.getSpec().getZookeeper().getTemplate() != null
+                    && kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret() != null
+                    && kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret().getMetadata() != null) {
+                jmxSecretAnnotations = kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret().getMetadata().getAnnotations();
+                jmxSecretLabels = kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret().getMetadata().getLabels();
+            }
             if (zkCluster.isJmxAuthenticated()) {
                 Future<Secret> secretFuture = secretOperations.getAsync(namespace, ZookeeperCluster.jmxSecretName(name));
+                Map<String, String> finalJmxSecretAnnotations = jmxSecretAnnotations;
+                Map<String, String> finalJmxSecretLabels = jmxSecretLabels;
                 return secretFuture.compose(secret -> {
                     if (secret == null) {
-                        return withVoid(secretOperations.reconcile(reconciliation, namespace, ZookeeperCluster.jmxSecretName(name), zkCluster.generateJmxSecret()));
+                        return withVoid(secretOperations.reconcile(reconciliation, namespace, ZookeeperCluster.jmxSecretName(name),
+                                zkCluster.generateJmxSecret(finalJmxSecretAnnotations, finalJmxSecretLabels)));
                     }
                     return withVoid(Future.succeededFuture(ReconcileResult.noop(secret)));
                 });
@@ -2464,12 +2477,24 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaJmxSecret() {
+            Map<String, String> jmxSecretLabels = emptyMap();
+            Map<String, String> jmxSecretAnnotations = emptyMap();
+
+            if (kafkaAssembly.getSpec().getKafka() != null
+                    && kafkaAssembly.getSpec().getKafka().getTemplate() != null
+                    && kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret() != null
+                    && kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret().getMetadata() != null) {
+                jmxSecretAnnotations = kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret().getMetadata().getAnnotations();
+                jmxSecretLabels = kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret().getMetadata().getLabels();
+            }
             if (kafkaCluster.isJmxAuthenticated()) {
                 Future<Secret> secretFuture = secretOperations.getAsync(namespace, KafkaCluster.jmxSecretName(name));
+                Map<String, String> finalJmxSecretAnnotations = jmxSecretAnnotations;
+                Map<String, String> finalJmxSecretLabels = jmxSecretLabels;
                 return secretFuture.compose(res -> {
                     if (res == null) {
                         return withVoid(secretOperations.reconcile(reconciliation, namespace, KafkaCluster.jmxSecretName(name),
-                                kafkaCluster.generateJmxSecret()));
+                                kafkaCluster.generateJmxSecret(finalJmxSecretAnnotations, finalJmxSecretLabels)));
                     }
                     return withVoid(Future.succeededFuture(this));
                 });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1230,24 +1230,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> zkJmxSecret() {
-            Map<String, String> jmxSecretLabels = emptyMap();
-            Map<String, String> jmxSecretAnnotations = emptyMap();
-
-            if (kafkaAssembly.getSpec().getZookeeper() != null
-                    && kafkaAssembly.getSpec().getZookeeper().getTemplate() != null
-                    && kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret() != null
-                    && kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret().getMetadata() != null) {
-                jmxSecretAnnotations = kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret().getMetadata().getAnnotations();
-                jmxSecretLabels = kafkaAssembly.getSpec().getZookeeper().getTemplate().getJmxSecret().getMetadata().getLabels();
-            }
             if (zkCluster.isJmxAuthenticated()) {
                 Future<Secret> secretFuture = secretOperations.getAsync(namespace, ZookeeperCluster.jmxSecretName(name));
-                Map<String, String> finalJmxSecretAnnotations = jmxSecretAnnotations;
-                Map<String, String> finalJmxSecretLabels = jmxSecretLabels;
                 return secretFuture.compose(secret -> {
                     if (secret == null) {
                         return withVoid(secretOperations.reconcile(reconciliation, namespace, ZookeeperCluster.jmxSecretName(name),
-                                zkCluster.generateJmxSecret(finalJmxSecretAnnotations, finalJmxSecretLabels)));
+                                zkCluster.generateJmxSecret()));
                     }
                     return withVoid(Future.succeededFuture(ReconcileResult.noop(secret)));
                 });
@@ -2477,24 +2465,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaJmxSecret() {
-            Map<String, String> jmxSecretLabels = emptyMap();
-            Map<String, String> jmxSecretAnnotations = emptyMap();
-
-            if (kafkaAssembly.getSpec().getKafka() != null
-                    && kafkaAssembly.getSpec().getKafka().getTemplate() != null
-                    && kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret() != null
-                    && kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret().getMetadata() != null) {
-                jmxSecretAnnotations = kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret().getMetadata().getAnnotations();
-                jmxSecretLabels = kafkaAssembly.getSpec().getKafka().getTemplate().getJmxSecret().getMetadata().getLabels();
-            }
             if (kafkaCluster.isJmxAuthenticated()) {
                 Future<Secret> secretFuture = secretOperations.getAsync(namespace, KafkaCluster.jmxSecretName(name));
-                Map<String, String> finalJmxSecretAnnotations = jmxSecretAnnotations;
-                Map<String, String> finalJmxSecretLabels = jmxSecretLabels;
                 return secretFuture.compose(res -> {
                     if (res == null) {
                         return withVoid(secretOperations.reconcile(reconciliation, namespace, KafkaCluster.jmxSecretName(name),
-                                kafkaCluster.generateJmxSecret(finalJmxSecretAnnotations, finalJmxSecretLabels)));
+                                kafkaCluster.generateJmxSecret()));
                     }
                     return withVoid(Future.succeededFuture(this));
                 });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -311,25 +311,25 @@ public class KafkaClusterTest {
 
         Kafka kafka = new KafkaBuilder(kafkaAssembly)
                 .editSpec()
-                .editKafka()
-                .withJmxOptions(new KafkaJmxOptionsBuilder()
-                        .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
-                                .build())
-                        .build())
-                .withNewTemplate()
-                .withNewJmxSecret()
-                .withNewMetadata()
-                .withAnnotations(customAnnotations)
-                .withLabels(customLabels)
-                .endMetadata()
-                .endJmxSecret()
-                .endTemplate()
-                .endKafka()
+                    .editKafka()
+                        .withJmxOptions(new KafkaJmxOptionsBuilder()
+                            .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
+                                  .build())
+                            .build())
+                        .withNewTemplate()
+                            .withNewJmxSecret()
+                                .withNewMetadata()
+                                    .withAnnotations(customAnnotations)
+                                    .withLabels(customLabels)
+                                .endMetadata()
+                            .endJmxSecret()
+                        .endTemplate()
+                    .endKafka()
                 .endSpec()
                 .build();
 
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        Secret jmxSecret = kc.generateJmxSecret(customAnnotations, customLabels);
+        Secret jmxSecret = kc.generateJmxSecret();
 
         for (Map.Entry<String, String> entry : customAnnotations.entrySet()) {
             assertThat(jmxSecret.getMetadata().getAnnotations(), hasEntry(entry.getKey(), entry.getValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -49,6 +49,7 @@ import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.MetricsConfig;
@@ -115,6 +116,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -295,6 +297,46 @@ public class KafkaClusterTest {
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
 
         checkOwnerReference(kc.createOwnerReference(), headless);
+    }
+
+    @ParallelTest
+    public void testJmxSecretCustomLabelsAndAnnotations() {
+        Map<String, String> customLabels = new HashMap<>(2);
+        customLabels.put("label1", "value1");
+        customLabels.put("label2", "value2");
+
+        Map<String, String> customAnnotations = new HashMap<>(2);
+        customAnnotations.put("anno1", "value3");
+        customAnnotations.put("anno2", "value4");
+
+        Kafka kafka = new KafkaBuilder(kafkaAssembly)
+                .editSpec()
+                .editKafka()
+                .withJmxOptions(new KafkaJmxOptionsBuilder()
+                        .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
+                                .build())
+                        .build())
+                .withNewTemplate()
+                .withNewJmxSecret()
+                .withNewMetadata()
+                .withAnnotations(customAnnotations)
+                .withLabels(customLabels)
+                .endMetadata()
+                .endJmxSecret()
+                .endTemplate()
+                .endKafka()
+                .endSpec()
+                .build();
+
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
+        Secret jmxSecret = kc.generateJmxSecret(customAnnotations, customLabels);
+
+        for (Map.Entry<String, String> entry : customAnnotations.entrySet()) {
+            assertThat(jmxSecret.getMetadata().getAnnotations(), hasEntry(entry.getKey(), entry.getValue()));
+        }
+        for (Map.Entry<String, String> entry : customLabels.entrySet()) {
+            assertThat(jmxSecret.getMetadata().getLabels(), hasEntry(entry.getKey(), entry.getValue()));
+        }
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -252,29 +252,29 @@ public class ZookeeperClusterTest {
     public void testCreateClusterWithZookeeperJmxEnabled() {
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
-                .withName(cluster)
-                .withNamespace(namespace)
+                    .withName(cluster)
+                    .withNamespace(namespace)
                 .endMetadata()
                 .withNewSpec()
-                .withNewKafka()
-                .withReplicas(3)
-                .withNewEphemeralStorage()
-                .endEphemeralStorage()
-                .endKafka()
-                .withNewZookeeper()
-                .withJmxOptions(new KafkaJmxOptionsBuilder()
-                        .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withJmxOptions(new KafkaJmxOptionsBuilder()
+                            .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
                                 .build())
-                        .build())
-                .withReplicas(3)
-                .withNewEphemeralStorage()
-                .endEphemeralStorage()
-                .endZookeeper()
+                            .build())
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
                 .endSpec()
                 .build();
 
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, KafkaVersionTestUtils.getKafkaVersionLookup());
-        Secret jmxSecret = zookeeperCluster.generateJmxSecret(emptyMap(), emptyMap());
+        Secret jmxSecret = zookeeperCluster.generateJmxSecret();
 
         assertThat(jmxSecret.getData(), hasKey("jmx-username"));
         assertThat(jmxSecret.getData(), hasKey("jmx-password"));
@@ -292,25 +292,25 @@ public class ZookeeperClusterTest {
 
         Kafka kafka = new KafkaBuilder(ka)
                 .editSpec()
-                .editZookeeper()
-                .withJmxOptions(new KafkaJmxOptionsBuilder()
-                        .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
+                    .editZookeeper()
+                        .withJmxOptions(new KafkaJmxOptionsBuilder()
+                            .withAuthentication(new KafkaJmxAuthenticationPasswordBuilder()
                                 .build())
-                        .build())
-                .withNewTemplate()
-                .withNewJmxSecret()
-                .withNewMetadata()
-                .withAnnotations(customAnnotations)
-                .withLabels(customLabels)
-                .endMetadata()
-                .endJmxSecret()
-                .endTemplate()
-                .endZookeeper()
+                            .build())
+                        .withNewTemplate()
+                            .withNewJmxSecret()
+                                .withNewMetadata()
+                                    .withAnnotations(customAnnotations)
+                                    .withLabels(customLabels)
+                                .endMetadata()
+                            .endJmxSecret()
+                        .endTemplate()
+                    .endZookeeper()
                 .endSpec()
                 .build();
 
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        Secret jmxSecret = kc.generateJmxSecret(customAnnotations, customLabels);
+        ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
+        Secret jmxSecret = zookeeperCluster.generateJmxSecret();
 
         for (Map.Entry<String, String> entry : customAnnotations.entrySet()) {
             assertThat(jmxSecret.getMetadata().getAnnotations(), hasEntry(entry.getKey(), entry.getValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1113,10 +1113,10 @@ public class KafkaAssemblyOperatorTest {
                 emptyList()
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.jmxSecretName(clusterName))).thenReturn(
-                Future.succeededFuture(originalKafkaCluster.generateJmxSecret(emptyMap(), emptyMap()))
+                Future.succeededFuture(originalKafkaCluster.generateJmxSecret())
         );
         when(mockSecretOps.getAsync(clusterNamespace, ZookeeperCluster.jmxSecretName(clusterName))).thenReturn(
-                Future.succeededFuture(originalZookeeperCluster.generateJmxSecret(emptyMap(), emptyMap()))
+                Future.succeededFuture(originalZookeeperCluster.generateJmxSecret())
         );
         when(mockSecretOps.getAsync(clusterNamespace, ZookeeperCluster.nodesSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1113,10 +1113,10 @@ public class KafkaAssemblyOperatorTest {
                 emptyList()
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.jmxSecretName(clusterName))).thenReturn(
-                Future.succeededFuture(originalKafkaCluster.generateJmxSecret())
+                Future.succeededFuture(originalKafkaCluster.generateJmxSecret(emptyMap(), emptyMap()))
         );
         when(mockSecretOps.getAsync(clusterNamespace, ZookeeperCluster.jmxSecretName(clusterName))).thenReturn(
-                Future.succeededFuture(originalZookeeperCluster.generateJmxSecret())
+                Future.succeededFuture(originalZookeeperCluster.generateJmxSecret(emptyMap(), emptyMap()))
         );
         when(mockSecretOps.getAsync(clusterNamespace, ZookeeperCluster.nodesSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -814,6 +814,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |serviceAccount            1.2+<.<a|Template for the Kafka service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|jmxSecret                 1.2+<.<a|Template for Secret of the Kafka Cluster JMX authentication.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |clusterRoleBinding        1.2+<.<a|Template for the Kafka ClusterRoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
@@ -1066,6 +1068,8 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |zookeeperContainer     1.2+<.<a|Template for the ZooKeeper container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |serviceAccount         1.2+<.<a|Template for the ZooKeeper service account.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|jmxSecret              1.2+<.<a|Template for Secret of the Zookeeper Cluster JMX authentication.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1814,6 +1814,8 @@ Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Kaf
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |buildServiceAccount  1.2+<.<a|Template for the Kafka Connect Build service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|jmxSecret            1.2+<.<a|Template for Secret of the Kafka Connect Cluster JMX authentication.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
 [id='type-DeploymentTemplate-{context}']

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -190,7 +190,7 @@ spec:
     # ...
 ----
 
-For more information on configuring template properties, see xref:assembly-customizing-kubernetes-resources-str[].== Adding labels and annotations to Secrets
+For more information on configuring template properties, see xref:assembly-customizing-kubernetes-resources-str[].
 
 == Disabling `ownerReference` in the CA Secrets
 

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -192,46 +192,6 @@ spec:
 
 For more information on configuring template properties, see xref:assembly-customizing-kubernetes-resources-str[].== Adding labels and annotations to Secrets
 
-By configuring the `jmxSecret` template property in the `Kafka` custom resource, you can add custom labels and annotations to the JMX authentication Secrets created by the Cluster Operator.
-Labels and annotations are useful for identifying objects and adding contextual information.
-You configure template properties in Strimzi custom resources.
-
-.Example template customization to add labels and annotations to Secrets
-[source,yaml,subs=attributes+]
-----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
-metadata:
-  name: my-cluster
-spec:
-  kafka:
-    # ...
-    template:
-      jmxSecret:
-        metadata:
-          labels:
-            label1: value1
-            label2: value2
-          annotations:
-            annotation1: value1
-            annotation2: value2
-    # ...
-  zookeeper:
-    # ...
-    template:
-      jmxSecret:
-        metadata:
-          labels:
-            label1: value1
-            label2: value2
-          annotations:
-            annotation1: value1
-            annotation2: value2
-    # ...
-----
-
-For more information on configuring template properties, see xref:assembly-customizing-kubernetes-resources-str[].
-
 == Disabling `ownerReference` in the CA Secrets
 
 By default, the Cluster and Client CA Secrets are created with an `ownerReference` property that is set to the `Kafka` custom resource.

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -190,6 +190,46 @@ spec:
     # ...
 ----
 
+For more information on configuring template properties, see xref:assembly-customizing-kubernetes-resources-str[].== Adding labels and annotations to Secrets
+
+By configuring the `jmxSecret` template property in the `Kafka` custom resource, you can add custom labels and annotations to the JMX authentication Secrets created by the Cluster Operator.
+Labels and annotations are useful for identifying objects and adding contextual information.
+You configure template properties in Strimzi custom resources.
+
+.Example template customization to add labels and annotations to Secrets
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    # ...
+    template:
+      jmxSecret:
+        metadata:
+          labels:
+            label1: value1
+            label2: value2
+          annotations:
+            annotation1: value1
+            annotation2: value2
+    # ...
+  zookeeper:
+    # ...
+    template:
+      jmxSecret:
+        metadata:
+          labels:
+            label1: value1
+            label2: value2
+          annotations:
+            annotation1: value1
+            annotation2: value2
+    # ...
+----
+
 For more information on configuring template properties, see xref:assembly-customizing-kubernetes-resources-str[].
 
 == Disabling `ownerReference` in the CA Secrets

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1573,6 +1573,26 @@ spec:
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
                           description: Template for Secret with Kafka Cluster certificate public key.
+                        jmxSecret:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels added to the resource template.
+                                    Can be applied to different resources such as `StatefulSets`,
+                                    `Deployments`, `Pods`, `Secrets` and `Services`.
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Annotations added to the resource template.
+                                    Can be applied to different resources such as `StatefulSets`,
+                                    `Deployments`, `Pods`, `Secrets` and `Services`.
+                              description: Metadata applied to the resource.
+                          description: Template for Secret of the Kafka Cluster JMX authentication.
                         serviceAccount:
                           type: object
                           properties:
@@ -2464,6 +2484,26 @@ spec:
                                       type: string
                               description: Security context for the container.
                           description: Template for the ZooKeeper container.
+                        jmxSecret:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels added to the resource template.
+                                    Can be applied to different resources such as `StatefulSets`,
+                                    `Deployments`, `Pods`, `Secrets` and `Services`.
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Annotations added to the resource template.
+                                    Can be applied to different resources such as `StatefulSets`,
+                                    `Deployments`, `Pods`, `Secrets` and `Services`.
+                              description: Metadata applied to the resource.
+                          description: Template for Secret of the Zookeeper Cluster JMX authentication.
                         serviceAccount:
                           type: object
                           properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1573,26 +1573,6 @@ spec:
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
                           description: Template for Secret with Kafka Cluster certificate public key.
-                        jmxSecret:
-                          type: object
-                          properties:
-                            metadata:
-                              type: object
-                              properties:
-                                labels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: Labels added to the resource template.
-                                    Can be applied to different resources such as `StatefulSets`,
-                                    `Deployments`, `Pods`, `Secrets` and `Services`.
-                                annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: Annotations added to the resource template.
-                                    Can be applied to different resources such as `StatefulSets`,
-                                    `Deployments`, `Pods`, `Secrets` and `Services`.
-                              description: Metadata applied to the resource.
-                          description: Template for Secret of the Kafka Cluster JMX authentication.
                         serviceAccount:
                           type: object
                           properties:
@@ -1609,6 +1589,22 @@ spec:
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
                           description: Template for the Kafka service account.
+                        jmxSecret:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Metadata applied to the resource.
+                          description: Template for Secret of the Kafka Cluster JMX authentication.
                         clusterRoleBinding:
                           type: object
                           properties:
@@ -2484,26 +2480,6 @@ spec:
                                       type: string
                               description: Security context for the container.
                           description: Template for the ZooKeeper container.
-                        jmxSecret:
-                          type: object
-                          properties:
-                            metadata:
-                              type: object
-                              properties:
-                                labels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: Labels added to the resource template.
-                                    Can be applied to different resources such as `StatefulSets`,
-                                    `Deployments`, `Pods`, `Secrets` and `Services`.
-                                annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: Annotations added to the resource template.
-                                    Can be applied to different resources such as `StatefulSets`,
-                                    `Deployments`, `Pods`, `Secrets` and `Services`.
-                              description: Metadata applied to the resource.
-                          description: Template for Secret of the Zookeeper Cluster JMX authentication.
                         serviceAccount:
                           type: object
                           properties:
@@ -2520,6 +2496,22 @@ spec:
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
                           description: Template for the ZooKeeper service account.
+                        jmxSecret:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Metadata applied to the resource.
+                          description: Template for Secret of the Zookeeper Cluster JMX authentication.
                       description: Template for ZooKeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                   required:
                     - replicas

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1582,6 +1582,26 @@ spec:
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                       description: Template for the Kafka Connect Build service account.
+                    jmxSecret:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, `Secrets` and `Services`.
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, `Secrets` and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Secret of the Kafka Connect Cluster JMX authentication.
                   description: Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
                 externalConfiguration:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1591,15 +1591,11 @@ spec:
                             labels:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
-                              description: Labels added to the resource template.
-                                Can be applied to different resources such as `StatefulSets`,
-                                `Deployments`, `Pods`, `Secrets` and `Services`.
+                              description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
-                              description: Annotations added to the resource template.
-                                Can be applied to different resources such as `StatefulSets`,
-                                `Deployments`, `Pods`, `Secrets` and `Services`.
+                              description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                       description: Template for Secret of the Kafka Connect Cluster JMX authentication.
                   description: Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1685,18 +1685,13 @@ spec:
                             labels:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
-                              description: Labels added to the resource template. Can
-                                be applied to different resources such as `StatefulSets`,
-                                `Deployments`, `Pods`, and `Services`.
+                              description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                             annotations:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
-                              description: Annotations added to the resource template.
-                                Can be applied to different resources such as `StatefulSets`,
-                                `Deployments`, `Pods`, and `Services`.
+                              description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
-                      description: Template for Secret of the Kafka Connect Cluster
-                        JMX authentication.
+                      description: Template for Secret of the Kafka Connect Cluster JMX authentication.
                   description: Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
                 externalConfiguration:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1676,6 +1676,27 @@ spec:
                               description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                           description: Metadata applied to the resource.
                       description: Template for the Kafka Connect Build service account.
+                    jmxSecret:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: Labels added to the resource template. Can
+                                be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Secret of the Kafka Connect Cluster
+                        JMX authentication.
                   description: Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
                 externalConfiguration:
                   type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -2039,6 +2039,27 @@ spec:
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
                         description: Template for the Kafka service account.
+                      jmxSecret:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for Secret of the Kafka Cluster JMX
+                          authentication.
                       clusterRoleBinding:
                         type: object
                         properties:
@@ -3065,6 +3086,27 @@ spec:
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
                         description: Template for the ZooKeeper service account.
+                      jmxSecret:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for Secret of the Zookeeper Cluster
+                          JMX authentication.
                     description: Template for ZooKeeper cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1748,6 +1748,27 @@ spec:
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
                     description: Template for the Kafka Connect Build service account.
+                  jmxSecret:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Labels added to the resource template. Can
+                              be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Annotations added to the resource template.
+                              Can be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                        description: Metadata applied to the resource.
+                    description: Template for Secret of the Kafka Connect Cluster
+                      JMX authentication.
                 description: Template for Kafka Connect and Kafka Mirror Maker 2 resources.
                   The template allows users to specify how the `Deployment`, `Pods`
                   and `Service` are generated.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1874,6 +1874,27 @@ spec:
                               `Deployments`, `Pods`, and `Services`.
                         description: Metadata applied to the resource.
                     description: Template for the Kafka Connect Build service account.
+                  jmxSecret:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Labels added to the resource template. Can
+                              be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Annotations added to the resource template.
+                              Can be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                        description: Metadata applied to the resource.
+                    description: Template for Secret of the Kafka Connect Cluster
+                      JMX authentication.
                 description: Template for Kafka Connect and Kafka Mirror Maker 2 resources.
                   The template allows users to specify how the `Deployment`, `Pods`
                   and `Service` are generated.


### PR DESCRIPTION
Signed-off-by: faresoueslati <fares.oueslati@blablacar.com>

### Type of change

- Enhancement / new feature

### Description

Allowing the user to annotate and add labels to the secret containing the JMX credentials generated by the operator. Like what it's already done for the secret containing the cluster ca certificate for instance.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

