### PR TITLE
Delete all temporary files after OpenSSL

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -301,11 +301,15 @@ public class OpenSslCertManager implements CertManager {
         } finally {
             delete(tmpKey);
             delete(database);
-            // File created by OpenSSL
-            delete(new File(database.toString() + ".old").toPath());
+            if (database != null) {
+                // File created by OpenSSL
+                delete(new File(database + ".old").toPath());
+            }
             delete(attr);
-            // File created by OpenSSL
-            delete(new File(attr.toString() + ".old").toPath());
+            if (attr != null) {
+                // File created by OpenSSL
+                delete(new File(attr + ".old").toPath());
+            }
             delete(newCertsDir);
             delete(csrFile);
             delete(defaultConfig);
@@ -464,9 +468,15 @@ public class OpenSslCertManager implements CertManager {
             cmd.exec(false);
         } finally {
             delete(database);
-            delete(new File(database.toString() + ".old").toPath());
+            if (database != null) {
+                // File created by OpenSSL
+                delete(new File(database + ".old").toPath());
+            }
             delete(attr);
-            delete(new File(attr.toString() + ".old").toPath());
+            if (attr != null) {
+                // File created by OpenSSL
+                delete(new File(attr + ".old").toPath());
+            }
             delete(newCertsDir);
             delete(defaultConfig);
             delete(sna);

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -301,8 +301,10 @@ public class OpenSslCertManager implements CertManager {
         } finally {
             delete(tmpKey);
             delete(database);
+            // File created by OpenSSL
             delete(new File(database.toString() + ".old").toPath());
             delete(attr);
+            // File created by OpenSSL
             delete(new File(attr.toString() + ".old").toPath());
             delete(newCertsDir);
             delete(csrFile);

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -231,6 +231,7 @@ public class OpenSslCertManager implements CertManager {
 
         // Generate a CSR for the key
         Path tmpKey = null;
+        Path sna = null;
         Path defaultConfig = null;
         Path csrFile = null;
         Path newCertsDir = null;
@@ -253,10 +254,10 @@ public class OpenSslCertManager implements CertManager {
             }
 
             csrFile = Files.createTempFile(null, null);
-            defaultConfig = buildConfigFile(subject, true);
+            sna = buildConfigFile(subject, true);
             new OpensslArgs("openssl", "req")
                     .opt("-new")
-                    .optArg("-config", defaultConfig, true)
+                    .optArg("-config", sna, true)
                     .optArg("-key", tmpKey)
                     .optArg("-out", csrFile)
                     .optArg("-subj", subject)
@@ -300,10 +301,13 @@ public class OpenSslCertManager implements CertManager {
         } finally {
             delete(tmpKey);
             delete(database);
+            delete(new File(database.toString() + ".old").toPath());
             delete(attr);
+            delete(new File(attr.toString() + ".old").toPath());
             delete(newCertsDir);
             delete(csrFile);
             delete(defaultConfig);
+            delete(sna);
         }
     }
 
@@ -458,7 +462,9 @@ public class OpenSslCertManager implements CertManager {
             cmd.exec(false);
         } finally {
             delete(database);
+            delete(new File(database.toString() + ".old").toPath());
             delete(attr);
+            delete(new File(attr.toString() + ".old").toPath());
             delete(newCertsDir);
             delete(defaultConfig);
             delete(sna);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

OpenSSL is used by the `certificate-manager` module to generate CAs and certificates. Right now, OpenSSL leaves behind different temporary files. Here is just some short sample:

```
0017764865660554477.tmp.attr.old  1896019205349712978.tmp.old
10017764865660554477.tmp.old	   189708349585953829.tmp.attr.old
10071348451873188086.tmp.attr.old  189708349585953829.tmp.old
10071348451873188086.tmp.old	   1910429830862354799.tmp.attr.old
10135581015099738268.tmp.attr.old  1910429830862354799.tmp.old
10135581015099738268.tmp.old	   1969567011789896005.tmp.attr.old
10206119257692791063.tmp.attr.old  1969567011789896005.tmp.old
10206119257692791063.tmp.old	   198115121186160261.tmp.attr.old
10221955494522477998.tmp.attr.old  198115121186160261.tmp.old
10221955494522477998.tmp.old	   2021194047670659694.tmp.attr.old
10262065112801078767.tmp.attr.old  2021194047670659694.tmp.old
10262065112801078767.tmp.old	   2028396144260272534.tmp.attr.old
10405973791414521066.tmp.attr.old  2028396144260272534.tmp.old
10405973791414521066.tmp.old	   2033371714392613117.tmp.attr.old
10449912870152364771.tmp.attr.old  2033371714392613117.tmp.old
10449912870152364771.tmp.old	   2036166917379989993.tmp.attr.old
10457702786899866330.tmp.attr.old  2036166917379989993.tmp.old
10457702786899866330.tmp.old	   2044174666051734643.tmp.attr.old
10504490293499293752.tmp.attr.old  2044174666051734643.tmp.old
10504490293499293752.tmp.old	   2062225419010282565.tmp
10559391470235180431.tmp.attr.old  2087065670414314317.tmp
```

This becomes more of a problem now when the `/tmp` folder has limited size. This PR makes sure all of these files are deleted.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally