### PR TITLE
Add advertised hostnames to certificate SANs even for internal listeners

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1832,6 +1832,12 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         brokerAddress = DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(name), KafkaResources.kafkaStatefulSetName(name) + "-" + pod);
                     }
 
+                    String userConfiguredAdvertisedHostname = ListenersUtils.brokerAdvertisedHost(listener, pod);
+                    if (userConfiguredAdvertisedHostname != null) {
+                        // If user configured a custom advertised hostname, add it to the SAN names used in the certificate
+                        kafkaBrokerDnsNames.computeIfAbsent(pod, k -> new HashSet<>(1)).add(userConfiguredAdvertisedHostname);
+                    }
+
                     kafkaAdvertisedHostnames.add(kafkaCluster.getAdvertisedHostname(listener, pod, brokerAddress));
                     kafkaAdvertisedPorts.add(kafkaCluster.getAdvertisedPort(listener, pod, listener.getPort()));
                 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1833,7 +1833,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     }
 
                     String userConfiguredAdvertisedHostname = ListenersUtils.brokerAdvertisedHost(listener, pod);
-                    if (userConfiguredAdvertisedHostname != null) {
+                    if (userConfiguredAdvertisedHostname != null && listener.isTls()) {
                         // If user configured a custom advertised hostname, add it to the SAN names used in the certificate
                         kafkaBrokerDnsNames.computeIfAbsent(pod, k -> new HashSet<>(1)).add(userConfiguredAdvertisedHostname);
                     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Users can override the advertised hostname on all types of listeners. But only on external listeners, the advertised hostname will be automatically added also to the Subject Alternative Names of the broker certificates. For the internal listeners, it will not. But even with internal listeners the clients will use it and if it is TLS enabled they will need it for hostname verification.

This PR fixes that and adds the user configured advertised hostnames to the certificates also for the TLS enabled internal listeners. This should close #5447.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging