### PR TITLE
docs: remove S2I references

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
@@ -86,7 +86,7 @@ You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endp
 
 [id='property-kafka-connect-logging-{context}']
 === `logging`
-Kafka Connect (and Kafka Connect with Source2Image support) has its own configurable loggers:
+Kafka Connect has its own configurable loggers:
 
 * `connect.root.logger.level`
 * `log4j.logger.org.reflections`

--- a/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
@@ -10,7 +10,6 @@ This chapter describes how to configure different aspects of the supported deplo
 
 * Kafka clusters
 * Kafka Connect clusters
-* Kafka Connect clusters with _Source2Image_ support
 * Kafka MirrorMaker
 * Kafka Bridge
 * Cruise Control

--- a/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
@@ -11,8 +11,6 @@ The Cluster Operator is used to deploy a Kafka cluster and other Kafka component
 
 The Cluster Operator is deployed using YAML installation files.
 
-NOTE: On OpenShift, a Kafka Connect deployment can incorporate a Source2Image feature to provide a convenient way to add additional connectors.
-
 [role="_additional-resources"]
 .Additional resources
 * link:{BookURLDeploying}#cluster-operator-str[Deploying the Cluster Operator^] in the _Deploying and Upgrading Strimzi_ guide.

--- a/documentation/assemblies/tracing/assembly-distributed-tracing.adoc
+++ b/documentation/assemblies/tracing/assembly-distributed-tracing.adoc
@@ -7,14 +7,14 @@
 
 Distributed tracing allows you to track the progress of transactions between applications in a distributed system. In a microservices architecture, tracing tracks the progress of transactions between services. Trace data is useful for monitoring application performance and investigating issues with target systems and end-user applications.
 
-In Strimzi, tracing facilitates the end-to-end tracking of messages: from source systems to Kafka, and then from Kafka to target systems and applications. It complements the metrics that are available to view in link:{BookURLDeploying}#assembly-metrics-setup-{context}[Grafana dashboards], as well as the component loggers. 
+In Strimzi, tracing facilitates the end-to-end tracking of messages: from source systems to Kafka, and then from Kafka to target systems and applications. It complements the metrics that are available to view in link:{BookURLDeploying}#assembly-metrics-setup-{context}[Grafana dashboards], as well as the component loggers.
 
 [discrete]
 == How Strimzi supports tracing
 
 Support for tracing is built in to the following components:
 
-* Kafka Connect (including Kafka Connect with Source2Image support)
+* Kafka Connect
 * MirrorMaker
 * MirrorMaker 2.0
 * Strimzi Kafka Bridge

--- a/documentation/assemblies/tracing/assembly-setting-up-tracing-mirror-maker-connect-bridge.adoc
+++ b/documentation/assemblies/tracing/assembly-setting-up-tracing-mirror-maker-connect-bridge.adoc
@@ -4,7 +4,7 @@
 [id='assembly-setting-up-tracing-mirror-maker-connect-bridge-{context}']
 = Setting up tracing for MirrorMaker, Kafka Connect, and the Kafka Bridge
 
-Distributed tracing is supported for MirrorMaker, MirrorMaker 2.0, Kafka Connect (including Kafka Connect with Source2Image support), and the Strimzi Kafka Bridge.
+Distributed tracing is supported for MirrorMaker, MirrorMaker 2.0, Kafka Connect, and the Strimzi Kafka Bridge.
 
 .Tracing in MirrorMaker and MirrorMaker 2.0
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Removes _Source2Image_ references in the docs, which will not be supported in the next release.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

