### PR TITLE
Use correct error message when unsupported Kafka version is used in `KafkaMirrorMaker2` CR

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -95,11 +95,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         KafkaMirrorMaker2Spec spec = kafkaMirrorMaker2.getSpec();
         cluster.setOwnerReference(kafkaMirrorMaker2);
 
-        String specVersion = spec.getVersion();
-        if (versions.version(specVersion).compareVersion("2.4.0") < 0) {
-            throw new InvalidResourceException("Kafka MirrorMaker 2.0 is not available in the version at spec.version (" + specVersion + "). Kafka MirrorMaker 2.0 is available in Kafka version 2.4.0 and later.");
-        } 
-        cluster.setImage(versions.kafkaMirrorMaker2Version(spec.getImage(), specVersion));
+        cluster.setImage(versions.kafkaMirrorMaker2Version(spec.getImage(), spec.getVersion()));
 
         List<KafkaMirrorMaker2ClusterSpec> clustersList = ModelUtils.asListOrEmptyList(spec.getClusters());
         cluster.setClusters(clustersList);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1539,19 +1539,6 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @ParallelTest
-    public void testGenerateDeploymentWithOldVersion() {
-        assertThrows(InvalidResourceException.class, () -> {
-            KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
-                    .editSpec()
-                        .withVersion("2.3.1")
-                    .endSpec()
-                    .build();
-
-            KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
-        });
-    }
-
-    @ParallelTest
     public void testNetworkPolicy() {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resourceWithMetrics)
                 .build();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When we added support for Kafka Mirror Maker 2, we added a special check which verifies that the Kafka version used is at least 2.4.0 (because at that point we still supported also Kafka 2.3). This check is not needed anymore since our last supported version is 2.7.0. But it was still there and it causes that when unknown version is configured in the `KafkaMirrorMaker2` resource (such as 3.0.0 which at this point is not release / supported), it returns this weird error:

```
Unsupported Kafka.spec.kafka.version: 3.0.0. Supported versions are:
        [2.1.0, 2.6.2, 2.7.1, 2.8.0, 2.5.1, 2.6.0, 2.6.1, 2.7.0, 2.3.1, 2.4.0, 2.4.1,
        2.5.0, 2.1.1, 2.2.0, 2.2.1, 2.3.0]
```

This is becaue the method used for the original check changes the way it works slightly since the check was introduced. This PR removes the unnecessary check and as a result the situation above returns the proper error:

```
Version 3.0.0 is not supported. Supported versions are: 2.7.0, 2.7.1, 2.8.0.
```

I also double-checked and this problem seems to affect only KMM2 and no other components which give the right error message.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally