### PR TITLE
[DOCS] Remove the `zookeeperSessionTimeoutSeconds` option from UO docs

### DIFF
--- a/documentation/modules/configuring/con-configuring-user-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-user-operator.adoc
@@ -16,10 +16,6 @@ Default is the namespace where the Kafka cluster is deployed.
 The interval between periodic reconciliations in seconds.
 Default `120`.
 
-`zookeeperSessionTimeoutSeconds`::
-The ZooKeeper session timeout in seconds.
-Default `18`.
-
 `image`::
 The `image` property can be used to configure the container image which will be used.
 For more details about configuring custom container images, see xref:con-common-configuration-images-reference[].


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The option `zookeeperSessionTimeoutSeconds` is not supported by the User Operator anymore since it does not use ZooKeeper now. This PR removes it form the docs.