### PR TITLE
[systemtest] Add proper wait for `Job` to be ready

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -94,6 +94,7 @@ public interface Constants {
     String STATEFUL_SET = "StatefulSet";
     String POD = "Pod";
     String NETWORK_POLICY = "NetworkPolicy";
+    String JOB = "job";
 
     /**
      * Kafka Bridge JSON encoding with JSON embedded format

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
@@ -29,6 +29,6 @@ public class JobResource implements ResourceType<Job> {
     }
     @Override
     public boolean waitForReadiness(Job resource) {
-        return JobUtils.waitForJobRunning(resource.getMetadata().getNamespace(), resource.getMetadata().getNamespace());
+        return JobUtils.waitForJobRunning(resource.getMetadata().getName(), resource.getMetadata().getNamespace());
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.resources.kubernetes;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 
 public class JobResource implements ResourceType<Job> {
 
@@ -28,6 +29,6 @@ public class JobResource implements ResourceType<Job> {
     }
     @Override
     public boolean waitForReadiness(Job resource) {
-        return resource != null;
+        return JobUtils.waitForJobRunning(resource.getMetadata().getNamespace(), resource.getMetadata().getNamespace());
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -55,14 +55,15 @@ public class JobUtils {
      * Wait for specific Job Running active status
      * @param jobName job name
      * @param namespace namespace
-     * @param timeout timeout in ms after which we assume that job runs
      */
-    public static void waitForJobRunning(String jobName, String namespace, long timeout) {
+    public static boolean waitForJobRunning(String jobName, String namespace) {
         LOGGER.info("Waiting for job: {} will be in active state", jobName);
-        TestUtils.waitFor("job active", Constants.GLOBAL_POLL_INTERVAL, timeout,
+        TestUtils.waitFor("job active", Constants.GLOBAL_POLL_INTERVAL, ResourceOperation.getTimeoutForResourceReadiness(Constants.JOB),
             () -> {
                 JobStatus jb = kubeClient().namespace(namespace).getJobStatus(jobName);
                 return jb.getActive() > 0;
             });
+
+        return true;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -20,7 +20,6 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.annotations.IsolatedTest;
@@ -29,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +109,6 @@ public class FeatureGatesST extends AbstractST {
 
         resourceManager.createResource(extensionContext, kafkaBasicClientJob.producerStrimzi().build());
         resourceManager.createResource(extensionContext, kafkaBasicClientJob.consumerStrimzi().build());
-        JobUtils.waitForJobRunning(consumerName, NAMESPACE, Duration.ofSeconds(20).toMillis());
 
         LOGGER.info("Delete first found Kafka broker pod.");
         kubeClient(NAMESPACE).deletePod(NAMESPACE, kafkaPod);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes problem with waiting on `Job` to become ready - until now we had there just check, that `resource != null`, which doesn't determine, if the `Job` is really created and if there is some pod, that is up and running.

### Checklist

- [x] Make sure all tests pass

