### PR TITLE
Update kubernetes client to 5.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.7.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.7.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.7.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.7.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.7.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.7.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Dependency

### Description
`jandex` dependency version update has been reverted.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

