### PR TITLE
[systemtest][jenkins] Add new profiles - operators and components

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -200,7 +200,7 @@ pipeline {
                             sh(script: "cat ${env.WORKSPACE}/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json")
                             sh(script: "cat ${env.WORKSPACE}/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml")
                         }
-                        lib.runSystemTests(env.WORKSPACE, env.TEST_CASE, env.TEST_PROFILE, env.EXCLUDE_GROUPS, env.TEST_COUNT_RUNNING_IN_PARALLEL)
+                        lib.runSystemTests(env.WORKSPACE, env.TEST_CASE, env.TEST_PROFILE, env.TEST_GROUPS, env.EXCLUDE_GROUPS, env.TEST_COUNT_RUNNING_IN_PARALLEL)
                     }
                 }
             }

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -59,13 +59,18 @@ pipeline {
                         env.TEST_CASE = env.ghprbCommentBody.split('testcase=')[1].split(/\s/)[0]
                     }
                     println("TEST_CASE: ${env.TEST_CASE}")
+
                     if (env.ghprbCommentBody.contains('groups=')) {
                         env.TEST_GROUPS = env.ghprbCommentBody.split('groups=')[1].split(/\s/)[0]
                         if (env.TEST_GROUPS != "flaky") {
                             env.EXCLUDE_GROUPS = env.EXCLUDE_GROUPS + ",flaky"
                         }
+                    } else if (env.ghprbCommentBody.contains('profile=')) {
+                        // in case we want to run specific profile, the -Dgroups should be empty - it overrides the groups from profiles
+                        env.TEST_GROUPS = ""
                     }
                     println("TEST_GROUPS: ${env.TEST_GROUPS}")
+
                     if (env.ghprbCommentBody.contains('profile=')) {
                         env.TEST_PROFILE = env.ghprbCommentBody.split('profile=')[1].split(/\s/)[0]
                     }

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -12,7 +12,8 @@ pipeline {
     }
     parameters {
         string(name: 'TEST_CASE', defaultValue: '*ST', description: 'maven parameter for executing specific tests')
-        string(name: 'TEST_PROFILE', defaultValue: 'acceptance', description: 'maven parameter for executing specific test profile')
+        string(name: 'TEST_PROFILE', defaultValue: 'all', description: 'maven parameter for executing specific test profile')
+        string(name: 'TEST_GROUPS', defaultValue: 'acceptance', description: 'maven parameter for executing specific test groups')
         string(name: 'EXCLUDE', defaultValue: "${DEFAULT_EXCLUDED_GROUPS}", description: 'maven parameter for exclude specific test tag')
         string(name: 'ENV_VARS', defaultValue: "", description: 'maven parameter for setting values of environment variables used in STs')
     }
@@ -51,17 +52,22 @@ pipeline {
                     println("Comment body: ${env.ghprbCommentBody}")
                     env.TEST_CASE = params.TEST_CASE
                     env.TEST_PROFILE = params.TEST_PROFILE
+                    env.TEST_GROUPS = params.TEST_GROUPS
                     env.ENV_VARS = params.ENV_VARS
                     env.EXCLUDE_GROUPS = DEFAULT_EXCLUDED_GROUPS
                     if (env.ghprbCommentBody.contains('testcase=')) {
                         env.TEST_CASE = env.ghprbCommentBody.split('testcase=')[1].split(/\s/)[0]
                     }
                     println("TEST_CASE: ${env.TEST_CASE}")
-                    if (env.ghprbCommentBody.contains('profile=')) {
-                        env.TEST_PROFILE = env.ghprbCommentBody.split('profile=')[1].split(/\s/)[0]
-                        if (env.TEST_PROFILE != "flaky") {
+                    if (env.ghprbCommentBody.contains('groups=')) {
+                        env.TEST_GROUPS = env.ghprbCommentBody.split('groups=')[1].split(/\s/)[0]
+                        if (env.TEST_GROUPS != "flaky") {
                             env.EXCLUDE_GROUPS = env.EXCLUDE_GROUPS + ",flaky"
                         }
+                    }
+                    println("TEST_GROUPS: ${env.TEST_GROUPS}")
+                    if (env.ghprbCommentBody.contains('profile=')) {
+                        env.TEST_PROFILE = env.ghprbCommentBody.split('profile=')[1].split(/\s/)[0]
                     }
                     println("TEST_PROFILE: ${env.TEST_PROFILE}")
                     if (env.ghprbCommentBody.contains('exclude=')) {

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -34,10 +34,11 @@ def buildStrimziImages() {
 }
 
 def runSystemTests(String workspace, String testCases, String testProfile, String testGroups, String excludeGroups, String testsInParallel) {
+    def groupsTag = testGroups.isEmpty() ? "" : "-Dgroups=${testGroups} "
     withMaven(mavenOpts: '-Djansi.force=true') {
         sh(script: "mvn -f ${workspace}/systemtest/pom.xml verify " +
-            "-P ${testProfile}" +
-            "-Dgroups=${testGroups} " +
+            "-P${testProfile} " +
+            "${testGroups}" +
             "-DexcludedGroups=${excludeGroups} " +
             "-Dit.test=${testCases} " +
             "-Djava.net.preferIPv4Stack=true " +

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -33,10 +33,11 @@ def buildStrimziImages() {
     """)
 }
 
-def runSystemTests(String workspace, String testCases, String testProfile, String excludeGroups, String testsInParallel) {
+def runSystemTests(String workspace, String testCases, String testProfile, String testGroups, String excludeGroups, String testsInParallel) {
     withMaven(mavenOpts: '-Djansi.force=true') {
-        sh(script: "mvn -f ${workspace}/systemtest/pom.xml -P all verify " +
-            "-Dgroups=${testProfile} " +
+        sh(script: "mvn -f ${workspace}/systemtest/pom.xml verify " +
+            "-P ${testProfile}" +
+            "-Dgroups=${testGroups} " +
             "-DexcludedGroups=${excludeGroups} " +
             "-Dit.test=${testCases} " +
             "-Djava.net.preferIPv4Stack=true " +

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -38,7 +38,7 @@ def runSystemTests(String workspace, String testCases, String testProfile, Strin
     withMaven(mavenOpts: '-Djansi.force=true') {
         sh(script: "mvn -f ${workspace}/systemtest/pom.xml verify " +
             "-P${testProfile} " +
-            "${testGroups}" +
+            "${groupsTag}" +
             "-DexcludedGroups=${excludeGroups} " +
             "-Dit.test=${testCases} " +
             "-Djava.net.preferIPv4Stack=true " +

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -190,7 +190,7 @@ The following table shows currently used tags:
 
 If your Kubernetes cluster doesn't support for example, Network Policies or NodePort services, you can easily skip those tests with `-DexcludeGroups=networkpolicies,nodeport`.
 
-There is also a mvn profile for the main groups - `acceptance`, `regression`, `smoke`, `bridge` and `all`, but we suggest to use profile with id `all` (default) and then include or exclude specific groups.
+There is also a mvn profile for the main groups - `acceptance`, `regression`, `smoke`, `bridge`, `operators`, `components` and `all`, but we suggest to use profile with id `all` (default) and then include or exclude specific groups.
 If you want specify the profile, use the `-P` flag - for example `-Psmoke`.
 
 All available test groups are listed in [Constants](systemtest/src/main/java/io/strimzi/systemtest/Constants.java) class.

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -287,5 +287,41 @@
             </properties>
         </profile>
 
+        <profile>
+            <id>operators</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    !kafka/**/*ST,
+                    !mirrormaker/**/*ST,
+                    !connect/**/*ST,
+                    !security/**/*ST,
+                    !operators/**/*ST,
+                    !rollingupdate/**/*ST,
+                    !watcher/**/*ST,
+                    !tracing/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>components</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    kafka/**/*ST,
+                    mirrormaker/**/*ST,
+                    connect/**/*ST,
+                    security/**/*ST,
+                    operators/**/*ST,
+                    rollingupdate/**/*ST,
+                    watcher/**/*ST,
+                    tracing/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
     </profiles>
 </project>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR adds new two profiles to our `pom.xml` - `operators` and `components`. This will help us in our automation (Jenkins) - we can deal with tests, that should be run in each profile. Then, if the new package will be created and we'll want to exclude/include it in each profile, it will be much easier to maintain it -> no other extra PRs for Jenkins etc.

Also this PR adds these two new profiles to `TESTING.md` and changes the Jenkins PR jobs to be more configurable. 

### Checklist

- [x] Make sure all tests pass

