### PR TITLE
Add the `other` artifact type to the description in the API docs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
@@ -46,7 +46,7 @@ public abstract class Artifact implements UnknownPropertyPreserving, Serializabl
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Artifact type. " +
-            "Currently, the supported artifact types are `tgz`, `jar`, `zip` and `maven`.")
+            "Currently, the supported artifact types are `tgz`, `jar`, `zip`, `other` and `maven`.")
     public abstract String getType();
 
     @Override

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1766,7 +1766,7 @@ spec:
                                     - zip
                                     - maven
                                     - other
-                                  description: Artifact type. Currently, the supported artifact types are `tgz`, `jar`, `zip` and `maven`.
+                                  description: Artifact type. Currently, the supported artifact types are `tgz`, `jar`, `zip`, `other` and `maven`.
                                 url:
                                   type: string
                                   pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1978,7 +1978,8 @@ spec:
                                 - maven
                                 - other
                                 description: Artifact type. Currently, the supported
-                                  artifact types are `tgz`, `jar`, `zip` and `maven`.
+                                  artifact types are `tgz`, `jar`, `zip`, `other`
+                                  and `maven`.
                               url:
                                 type: string
                                 pattern: ^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like tge `other` type is missing in the description of the artifact `type` field. This Pr adds it there.

### Checklist

- [x] Update documentation