### PR TITLE
[systemtest][upgrade] "Fix" upgrade tests when running on k8s server version > 1.21

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -60,7 +60,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
 
     // TODO: make testUpgradeKafkaWithoutVersion to run upgrade with config from StrimziUpgradeST.json
     // main idea of the test and usage of latestReleasedVersion: upgrade CO from version X, kafka Y, to CO version Z and kafka Y + 1 at the end
-    private final String strimziReleaseWithOlderKafkaVersion = "0.22.1";
+    private final String strimziReleaseWithOlderKafkaVersion = "0.23.0";
     private final String strimziReleaseWithOlderKafka = String.format("https://github.com/strimzi/strimzi-kafka-operator/releases/download/%s/strimzi-%s.zip",
             strimziReleaseWithOlderKafkaVersion, strimziReleaseWithOlderKafkaVersion);
 
@@ -77,8 +77,6 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
 
     @Test
     void testUpgradeKafkaWithoutVersion(ExtensionContext extensionContext) throws IOException {
-        JsonObject conversionTool = getConversionToolDataFromUpgradeJSON();
-
         File dir = FileUtils.downloadAndUnzip(strimziReleaseWithOlderKafka);
         File startKafkaPersistent = new File(dir, "strimzi-" + strimziReleaseWithOlderKafkaVersion + "/examples/kafka/kafka-persistent.yaml");
         File startKafkaVersionsYaml = FileUtils.downloadYaml("https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/" + strimziReleaseWithOlderKafkaVersion + "/kafka-versions.yaml");
@@ -93,7 +91,6 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
 
         // Modify + apply installation files
         copyModifyApply(coDir, NAMESPACE, extensionContext);
-        convertCRDs(conversionTool, NAMESPACE);
         // Apply Kafka Persistent without version
         LOGGER.info("Going to deploy Kafka from: {}", startKafkaPersistent.getPath());
         // Change kafka version of it's empty (null is for remove the version)

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -27,10 +27,10 @@
       "continuousClientsMessages": 500
     },
     "environmentInfo": {
-      "maxK8sVersion": "latest",
+      "maxK8sVersion": "1.21",
       "status": "stable",
       "flakyEnvVariable": "none",
-      "reason" : "Test is working on all environment used by QE."
+      "reason" : "Test is working on environment, where k8s server version is < 1.22"
     }
   },
   {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fixup

### Description

This PR changing `maxK8sVersion` for Strimzi version `0.22.1` in our upgrade tests to `1.21`, so when k8s server version, on which we are running these tests, is higher than `1.21`, the test for `0.22.1` will be skipped.

Also it increases the `strimziReleaseWithOlderKafkaVersion`, so we will be able to run `testUpgradeKafkaWithoutVersion` even on newer versions of k8s.

### Checklist

- [x] Make sure all tests pass

