### PR TITLE
Add `insecure` flag to allow downloadable artifacts to be pulled from badly secured servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Allow configuring labels and annotations for JMX authentication secrets
 * Enable Cruise Control anomaly.detection configurations
 * Add support for building connector images from the Maven coordinates
-* Allow Kafka Connect Build artifacts to be downloaded from insecure servers 
+* Allow Kafka Connect Build artifacts to be downloaded from insecure servers (#5542)
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Allow configuring labels and annotations for JMX authentication secrets
 * Enable Cruise Control anomaly.detection configurations
 * Add support for building connector images from the Maven coordinates
+* Allow Kafka Connect Build artifacts to be downloaded from insecure servers 
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
@@ -25,6 +25,7 @@ public abstract class DownloadableArtifact extends Artifact {
 
     private String url;
     private String sha512sum;
+    private Boolean insecure;
 
     @Description("URL of the artifact which will be downloaded. " +
             "Strimzi does not do any security scanning of the downloaded artifacts. " +
@@ -52,5 +53,16 @@ public abstract class DownloadableArtifact extends Artifact {
 
     public void setSha512sum(String sha512sum) {
         this.sha512sum = sha512sum;
+    }
+
+    @Description("By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. " +
+            "By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getInsecure() {
+        return insecure;
+    }
+
+    public void setInsecure(Boolean insecure) {
+        this.insecure = insecure;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
@@ -55,8 +55,9 @@ public abstract class DownloadableArtifact extends Artifact {
         this.sha512sum = sha512sum;
     }
 
-    @Description("By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. " +
-            "By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.")
+    @Description("By default, connections using TLS are verified to check they are secure. " +
+            "The server certificate used must be valid, trusted, and contain the server name. " +
+            "By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getInsecure() {
         return insecure;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum" })
+@JsonPropertyOrder({ "url", "sha512sum", "insecure" })
 @EqualsAndHashCode
 public class JarArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
@@ -20,7 +20,7 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum", "fileName" })
+@JsonPropertyOrder({ "url", "sha512sum", "fileName", "insecure" })
 @EqualsAndHashCode
 public class OtherArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum" })
+@JsonPropertyOrder({ "url", "sha512sum", "insecure" })
 @EqualsAndHashCode
 public class TgzArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum" })
+@JsonPropertyOrder({ "url", "sha512sum", "insecure" })
 @EqualsAndHashCode
 public class ZipArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
@@ -282,6 +282,16 @@ public class KafkaConnectDockerfile {
         }
     }
 
+    private Cmd downloadArtifact(String artifactDir, String artifactPath, DownloadableArtifact artifact)  {
+        Cmd cmd = run("mkdir", "-p", artifactDir);
+
+        if (Boolean.TRUE.equals(artifact.getInsecure()))    {
+            return cmd.andRun("curl", "-k", "-L", "--output", artifactPath, artifact.getUrl());
+        } else {
+            return cmd.andRun("curl", "-L", "--output", artifactPath, artifact.getUrl());
+        }
+    }
+
     /**
      * Add command sequence for downloading files and checking their checksums.
      *
@@ -322,8 +332,7 @@ public class KafkaConnectDockerfile {
      * @param artifactPath      Full path of the artifact
      */
     private void addUnmodifiedArtifact(PrintWriter writer, DownloadableArtifact art, String artifactDir, String artifactPath) {
-        Cmd run = run("mkdir", "-p", artifactDir)
-                .andRun("curl", "-L", "--output", artifactPath, art.getUrl());
+        Cmd run = downloadArtifact(artifactDir, artifactPath, art);
 
         if (art.getSha512sum() != null && !art.getSha512sum().isEmpty()) {
             // Checksum exists => we need to check it
@@ -350,8 +359,7 @@ public class KafkaConnectDockerfile {
         String artifactDir = connectorPath + "/" + artifactHash;
         String archivePath = connectorPath + "/" + artifactHash + ".tgz";
 
-        Cmd run = run("mkdir", "-p", artifactDir)
-                .andRun("curl", "-L", "--output", archivePath, tgz.getUrl());
+        Cmd run = downloadArtifact(artifactDir, archivePath, tgz);
 
         if (tgz.getSha512sum() != null && !tgz.getSha512sum().isEmpty()) {
             // Checksum exists => we need to check it
@@ -380,8 +388,7 @@ public class KafkaConnectDockerfile {
         String artifactDir = connectorPath + "/" + artifactHash;
         String archivePath = connectorPath + "/" + artifactHash + ".zip";
 
-        Cmd run = run("mkdir", "-p", artifactDir)
-                .andRun("curl", "-L", "--output", archivePath, zip.getUrl());
+        Cmd run = downloadArtifact(artifactDir, archivePath, zip);
 
         if (zip.getSha512sum() != null && !zip.getSha512sum().isEmpty()) {
             // Checksum exists => we need to check it

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2002,7 +2002,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
 |string
-|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
 |type       1.2+<.<a|Must be `jar`.
 |string
@@ -2021,7 +2021,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
 |string
-|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
 |type       1.2+<.<a|Must be `tgz`.
 |string
@@ -2040,7 +2040,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
 |string
-|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
 |type       1.2+<.<a|Must be `zip`.
 |string
@@ -2084,7 +2084,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |fileName   1.2+<.<a|Name under which the artifact will be stored.
 |string
-|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
 |type       1.2+<.<a|Must be `other`.
 |string

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2002,6 +2002,8 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
 |string
+|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|boolean
 |type       1.2+<.<a|Must be `jar`.
 |string
 |====
@@ -2019,6 +2021,8 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
 |string
+|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|boolean
 |type       1.2+<.<a|Must be `tgz`.
 |string
 |====
@@ -2036,6 +2040,8 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
 |string
+|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|boolean
 |type       1.2+<.<a|Must be `zip`.
 |string
 |====
@@ -2078,6 +2084,8 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |string
 |fileName   1.2+<.<a|Name under which the artifact will be stored.
 |string
+|insecure   1.2+<.<a|By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+|boolean
 |type       1.2+<.<a|Must be `other`.
 |string
 |====

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1754,7 +1754,7 @@ spec:
                                   description: Maven group id. Applicable to the `maven` artifact type only.
                                 insecure:
                                   type: boolean
-                                  description: By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
+                                  description: By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
                                 repository:
                                   type: string
                                   description: Maven repository to download the artifact from. Applicable to the `maven` artifact type only.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1752,6 +1752,9 @@ spec:
                                 group:
                                   type: string
                                   description: Maven group id. Applicable to the `maven` artifact type only.
+                                insecure:
+                                  type: boolean
+                                  description: By default, every connection using TLS is verified to be secure - that the server's certificate is trusted and contains the server name. By setting this option to `true`, all TLS verifications wil be disabled and the artifact will be downloaded even from a server otherwise considered insecure.
                                 repository:
                                   type: string
                                   description: Maven repository to download the artifact from. Applicable to the `maven` artifact type only.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1960,12 +1960,12 @@ spec:
                                   artifact type only.
                               insecure:
                                 type: boolean
-                                description: By default, every connection using TLS
-                                  is verified to be secure - that the server's certificate
-                                  is trusted and contains the server name. By setting
-                                  this option to `true`, all TLS verifications wil
-                                  be disabled and the artifact will be downloaded
-                                  even from a server otherwise considered insecure.
+                                description: By default, connections using TLS are
+                                  verified to check they are secure. The server certificate
+                                  used must be valid, trusted, and contain the server
+                                  name. By setting this option to `true`, all TLS
+                                  verification is disabled and the artifact will be
+                                  downloaded, even when the server is considered insecure.
                               repository:
                                 type: string
                                 description: Maven repository to download the artifact

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1958,6 +1958,14 @@ spec:
                                 type: string
                                 description: Maven group id. Applicable to the `maven`
                                   artifact type only.
+                              insecure:
+                                type: boolean
+                                description: By default, every connection using TLS
+                                  is verified to be secure - that the server's certificate
+                                  is trusted and contains the server name. By setting
+                                  this option to `true`, all TLS verifications wil
+                                  be disabled and the artifact will be downloaded
+                                  even from a server otherwise considered insecure.
                               repository:
                                 type: string
                                 description: Maven repository to download the artifact


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kafka Connect Build has currently several artifact types which just download the artifacts from a remote server - usually using HTTP(S). In some cases, the remote HTTPS server might be badly secured (e.g. expired cert, self-signed cert, wrong hostname etc.) and the download might fail. This is correct as a default behaviour. But it would be nice to give users possibility to override this if they really want to do it.

This PR adds the option `insecure` to indicate that the artifact should be downloaded even from insecure server. Internally, this results in the `-k` option being added to the `curl` command. But most tools have similar options in case we use different tool in the future for the downloads. The new option applies to `jar`,  `other`, `zip` and `tgz` artifacts.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md