### PR TITLE
[systemtest][azp] Add azp profiles to pom

### DIFF
--- a/.azure/templates/jobs/acceptance_helm_jobs.yaml
+++ b/.azure/templates/jobs/acceptance_helm_jobs.yaml
@@ -3,7 +3,6 @@ jobs:
     parameters:
       name: 'acceptance_helm'
       display_name: 'acceptance-helm'
-      test_case: '.*ST'
-      groups: 'acceptance'
+      profile: 'acceptance'
       cluster_operator_install_type: 'helm'
       timeout: 240

--- a/.azure/templates/jobs/acceptance_helm_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/acceptance_helm_namespace_rbac_jobs.yaml
@@ -3,8 +3,7 @@ jobs:
     parameters:
       name: 'acceptance_helm_namespace_rbac_scope'
       display_name: 'acceptance-helm-namespace-rbac-scope'
-      test_case: '.*ST'
-      groups: 'acceptance'
+      profile: 'acceptance'
       cluster_operator_install_type: 'helm'
       strimzi_rbac_scope: NAMESPACE
       timeout: 240

--- a/.azure/templates/jobs/acceptance_jobs.yaml
+++ b/.azure/templates/jobs/acceptance_jobs.yaml
@@ -3,7 +3,6 @@ jobs:
     parameters:
       name: 'acceptance'
       display_name: 'acceptance-bundle'
-      test_case: '.*ST'
-      groups: 'acceptance'
+      profile: 'acceptance'
       cluster_operator_install_type: 'bundle'
       timeout: 240

--- a/.azure/templates/jobs/acceptance_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/acceptance_namespace_rbac_jobs.yaml
@@ -3,8 +3,7 @@ jobs:
     parameters:
       name: 'namespace_rbac_scope_acceptance'
       display_name: 'namespace-rbac-scope-acceptance'
-      test_case: '.*ST'
-      groups: 'acceptance'
+      profile: 'acceptance'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       strimzi_rbac_scope: NAMESPACE

--- a/.azure/templates/jobs/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/feature_gates_regression_jobs.yaml
@@ -3,8 +3,7 @@ jobs:
     parameters:
       name: 'feature_gates_regression_kafka'
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
-      test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST,security/oauth/**/*ST'
-      groups: 'regression'
+      profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -12,17 +11,15 @@ jobs:
     parameters:
       name: 'feature_gates_regression_security'
       display_name: 'feature-gates-regression-bundle II. - security'
-      test_case: 'security/**/*ST,!security/oauth/**/*ST'
-      groups: 'regression'
+      profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_connect_tracing_watcher'
-      display_name: 'feature-gates-regression-bundle III. - connect + tracing + watcher'
-      test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
-      groups: 'regression'
+      name: 'feature_gates_regression_dynconfig_tracing_watcher'
+      display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
+      profile: 'azp_dynconfig_tracing_watcher'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -30,8 +27,7 @@ jobs:
     parameters:
       name: 'feature_gates_regression_operators'
       display_name: 'feature-gates-regression-bundle IV. - operators'
-      test_case: 'operators/**/*ST'
-      groups: 'regression'
+      profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -39,17 +35,15 @@ jobs:
     parameters:
       name: 'feature_gates_regression_rollingupdate_watcher'
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
-      test_case: 'rollingupdate/**/*ST'
-      groups: 'regression'
+      profile: 'azp_rolling_update'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'feature_gates_regression_mirrormaker'
-      display_name: 'feature-gates-regression-bundle VI. - mirrormaker + dynamicconfiguration'
-      test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
-      groups: 'regression'
+      display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
+      profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -57,7 +51,6 @@ jobs:
     parameters:
       name: 'feature_gates_regression_all_remaining'
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
-      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
-      groups: 'regression'
+      profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/templates/jobs/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/feature_gates_regression_jobs.yaml
@@ -1,7 +1,7 @@
 jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_kafka'
+      name: 'feature_gates_regression_kafka_oauth'
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
@@ -33,7 +33,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_rollingupdate_watcher'
+      name: 'feature_gates_regression_rollingupdate'
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update'
       cluster_operator_install_type: 'bundle'
@@ -41,7 +41,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_mirrormaker'
+      name: 'feature_gates_regression_connect_mirrormaker'
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'

--- a/.azure/templates/jobs/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -1,7 +1,7 @@
 jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_regression_kafka'
+      name: 'feature_gates_namespace_rbac_scope_regression_kafka_oauth'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       excludedGroups: 'nodeport'
@@ -51,7 +51,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_regression_mirrormaker'
+      name: 'feature_gates_namespace_rbac_scope_regression_connect_mirrormaker'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       excludedGroups: 'nodeport'

--- a/.azure/templates/jobs/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -2,9 +2,8 @@ jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'feature_gates_namespace_rbac_scope_regression_kafka'
-      display_name: 'feature-gates-namespace-rbac-scope-regression-bundle I. - kafka'
-      test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST'
-      groups: 'regression'
+      display_name: 'feature-gates-namespace-rbac-scope-regression-bundle I. - kafka + oauth'
+      profile: 'azp_kafka_oauth'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -14,8 +13,7 @@ jobs:
     parameters:
       name: 'feature_gates_namespace_rbac_scope_regression_security'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle II. - security'
-      test_case: 'security/**/*ST'
-      groups: 'regression'
+      profile: 'azp_security'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -23,10 +21,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_regression_connect_tracing_watcher'
-      display_name: 'feature-gates-namespace-rbac-scope-regression-bundle III. - connect + tracing + watcher'
-      test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
-      groups: 'regression'
+      name: 'feature_gates_namespace_rbac_scope_regression_dynconfig_tracing_watcher'
+      display_name: 'feature-gates-namespace-rbac-scope-regression-bundle III. - dynconfig + tracing + watcher'
+      profile: 'azp_dynconfig_tracing_watcher'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -34,10 +31,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_egression_operators'
+      name: 'feature_gates_namespace_rbac_scope_regression_operators'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle IV. - operators'
-      test_case: 'operators/**/*ST'
-      groups: 'regression'
+      profile: 'azp_operators'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -45,10 +41,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_regression_rollingupdate_watcher'
+      name: 'feature_gates_namespace_rbac_scope_regression_rollingupdate'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle V. - rollingupdate'
-      test_case: 'rollingupdate/**/*ST'
-      groups: 'regression'
+      profile: 'azp_rolling_update'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -57,9 +52,8 @@ jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'feature_gates_namespace_rbac_scope_regression_mirrormaker'
-      display_name: 'feature-gates-namespace-rbac-scope-regression-bundle VI. - mirrormaker + dynamicconfiguration'
-      test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
-      groups: 'regression'
+      display_name: 'feature-gates-namespace-rbac-scope-regression-bundle VI. - connect + mirrormaker'
+      profile: 'azp_connect_mirrormaker'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -69,9 +63,7 @@ jobs:
     parameters:
       name: 'feature_gates_namespace_rbac_scope_regression_all_remaining'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle VII. - remaining system tests'
-      # !LoggingChangeST is skipped because it can be flaky on Azure
-      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!LoggingChangeST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
-      groups: 'regression'
+      profile: 'azp_rbac_remaining'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/templates/jobs/regression_jobs.yaml
+++ b/.azure/templates/jobs/regression_jobs.yaml
@@ -3,8 +3,7 @@ jobs:
     parameters:
       name: 'regression_kafka'
       display_name: 'regression-bundle I. - kafka + oauth'
-      test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST,security/oauth/**/*ST'
-      groups: 'regression'
+      profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -12,17 +11,15 @@ jobs:
     parameters:
       name: 'regression_security'
       display_name: 'regression-bundle II. - security'
-      test_case: 'security/**/*ST,!security/oauth/**/*ST'
-      groups: 'regression'
+      profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'regression_connect_tracing_watcher'
-      display_name: 'regression-bundle III. - connect + tracing + watcher'
-      test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
-      groups: 'regression'
+      name: 'regression_dynconfig_tracing_watcher'
+      display_name: 'regression-bundle III. - dynconfig + tracing + watcher'
+      profile: 'azp_dynconfig_tracing_watcher'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -30,8 +27,7 @@ jobs:
     parameters:
       name: 'regression_operators'
       display_name: 'regression-bundle IV. - operators'
-      test_case: 'operators/**/*ST'
-      groups: 'regression'
+      profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -39,17 +35,15 @@ jobs:
     parameters:
       name: 'regression_rollingupdate_watcher'
       display_name: 'regression-bundle V. - rollingupdate'
-      test_case: 'rollingupdate/**/*ST'
-      groups: 'regression'
+      profile: 'azp_rolling_update'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'regression_mirrormaker'
-      display_name: 'regression-bundle VI. - mirrormaker + dynamicconfiguration'
-      test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
-      groups: 'regression'
+      display_name: 'regression-bundle VI. - connect + mirrormaker'
+      profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -57,7 +51,6 @@ jobs:
     parameters:
       name: 'regression_all_remaining'
       display_name: 'regression-bundle VII. - remaining system tests'
-      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
-      groups: 'regression'
+      profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/templates/jobs/regression_jobs.yaml
+++ b/.azure/templates/jobs/regression_jobs.yaml
@@ -33,7 +33,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'regression_rollingupdate_watcher'
+      name: 'regression_rollingupdate'
       display_name: 'regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update'
       cluster_operator_install_type: 'bundle'
@@ -41,7 +41,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'regression_mirrormaker'
+      name: 'regression_connect_mirrormaker'
       display_name: 'regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'

--- a/.azure/templates/jobs/regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/regression_namespace_rbac_jobs.yaml
@@ -2,9 +2,8 @@ jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'namespace_rbac_scope_regression_kafka'
-      display_name: 'namespace-rbac-scope-regression-bundle I. - kafka'
-      test_case: 'kafka/**/*ST,!kafka/dynamicconfiguration/**/*ST'
-      groups: 'regression'
+      display_name: 'namespace-rbac-scope-regression-bundle I. - kafka + oauth'
+      profile: 'azp_kafka_oauth'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -14,8 +13,7 @@ jobs:
     parameters:
       name: 'namespace_rbac_scope_regression_security'
       display_name: 'namespace-rbac-scope-regression-bundle II. - security'
-      test_case: 'security/**/*ST'
-      groups: 'regression'
+      profile: 'azp_security'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -24,9 +22,8 @@ jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'namespace_rbac_scope_regression_connect_tracing_watcher'
-      display_name: 'namespace-rbac-scope-regression-bundle III. - connect + tracing + watcher'
-      test_case: 'connect/**/*ST,tracing/**/*ST,watcher/**/*ST'
-      groups: 'regression'
+      display_name: 'namespace-rbac-scope-regression-bundle III. - dynconfig + tracing + watcher'
+      profile: 'azp_dynconfig_tracing_watcher'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -36,8 +33,7 @@ jobs:
     parameters:
       name: 'rnamespace_rbac_scope_egression_operators'
       display_name: 'namespace-rbac-scope-regression-bundle IV. - operators'
-      test_case: 'operators/**/*ST'
-      groups: 'regression'
+      profile: 'azp_operators'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -47,8 +43,7 @@ jobs:
     parameters:
       name: 'namespace_rbac_scope_regression_rollingupdate_watcher'
       display_name: 'namespace-rbac-scope-regression-bundle V. - rollingupdate'
-      test_case: 'rollingupdate/**/*ST'
-      groups: 'regression'
+      profile: 'azp_rolling_update'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -57,9 +52,8 @@ jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
       name: 'namespace_rbac_scope_regression_mirrormaker'
-      display_name: 'namespace-rbac-scope-regression-bundle VI. - mirrormaker + dynamicconfiguration'
-      test_case: 'mirrormaker/**/*ST,kafka/dynamicconfiguration/**/*ST'
-      groups: 'regression'
+      display_name: 'namespace-rbac-scope-regression-bundle VI. - connect + mirrormaker'
+      profile: 'azp_connect_mirrormaker'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -69,9 +63,7 @@ jobs:
     parameters:
       name: 'namespace_rbac_scope_regression_all_remaining'
       display_name: 'namespace-rbac-scope-regression-bundle VII. - remaining system tests'
-      # !LoggingChangeST is skipped because it can be flaky on Azure
-      test_case: '!kafka/**/*ST,!mirrormaker/**/*ST,!connect/**/*ST,!security/**/*ST,!LoggingChangeST,!operators/**/*ST,!rollingupdate/**/*ST,!watcher/**/*ST,!tracing/**/*ST'
-      groups: 'regression'
+      profile: 'azp_rbac_remaining'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/templates/jobs/regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/regression_namespace_rbac_jobs.yaml
@@ -1,7 +1,7 @@
 jobs:
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'namespace_rbac_scope_regression_kafka'
+      name: 'namespace_rbac_scope_regression_kafka_oauth'
       display_name: 'namespace-rbac-scope-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       excludedGroups: 'nodeport'
@@ -21,7 +21,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'namespace_rbac_scope_regression_connect_tracing_watcher'
+      name: 'namespace_rbac_scope_regression_dynconfig_tracing_watcher'
       display_name: 'namespace-rbac-scope-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_tracing_watcher'
       excludedGroups: 'nodeport'
@@ -31,7 +31,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'rnamespace_rbac_scope_egression_operators'
+      name: 'namespace_rbac_scope_regression_operators'
       display_name: 'namespace-rbac-scope-regression-bundle IV. - operators'
       profile: 'azp_operators'
       excludedGroups: 'nodeport'
@@ -41,7 +41,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'namespace_rbac_scope_regression_rollingupdate_watcher'
+      name: 'namespace_rbac_scope_regression_rollingupdate'
       display_name: 'namespace-rbac-scope-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update'
       excludedGroups: 'nodeport'
@@ -51,7 +51,7 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'namespace_rbac_scope_regression_mirrormaker'
+      name: 'namespace_rbac_scope_regression_connect_mirrormaker'
       display_name: 'namespace-rbac-scope-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       excludedGroups: 'nodeport'

--- a/.azure/templates/jobs/upgrade_jobs.yaml
+++ b/.azure/templates/jobs/upgrade_jobs.yaml
@@ -3,8 +3,7 @@ jobs:
     parameters:
       name: 'strimzi_upgrade'
       display_name: 'strimzi-upgrade-bundle'
-      test_case: 'upgrade/**/*ST,!KafkaUpgradeDowngradeST'
-      groups: 'upgrade'
+      profile: 'azp_upgrade'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -12,7 +11,6 @@ jobs:
     parameters:
       name: 'kafka_upgrade_downgrade'
       display_name: 'kafka-upgrade-downgrade-bundle'
-      test_case: 'KafkaUpgradeDowngradeST'
-      groups: 'upgrade'
+      profile: 'azp_kafka_upgrade'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -2,8 +2,6 @@
 parameters:
   name: ''
   display_name: ''
-  test_case: ''
-  groups: ''
   profile: ''
   excludedGroups: ''
   cluster_operator_install_type: ''
@@ -81,7 +79,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-P${{ parameters.profile }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled=${{ parameters.run_parallel }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
+        options: '-P${{ parameters.profile }} -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled=${{ parameters.run_parallel }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -4,6 +4,7 @@ parameters:
   display_name: ''
   test_case: ''
   groups: ''
+  profile: ''
   excludedGroups: ''
   cluster_operator_install_type: ''
   timeout: ''
@@ -68,7 +69,7 @@ jobs:
 
     - bash: ".azure/scripts/setup_upgrade.sh"
       displayName: "Setup environment for upgrade"
-      condition: eq('${{ parameters.groups }}', 'upgrade')
+      condition: contains('${{ parameters.profile }}', 'upgrade')
 
     - task: Maven@3
       inputs:
@@ -80,7 +81,7 @@ jobs:
         publishJUnitResults: true
         testResultsFiles: '**/failsafe-reports/TEST-*.xml'
         goals: 'verify'
-        options: '-Dgroups=${{ parameters.groups }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled=${{ parameters.run_parallel }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
+        options: '-P${{ parameters.profile }} -Dit.test="${{ parameters.test_case }}" -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} -Dmaven.javadoc.skip=true -B -V -Dfailsafe.rerunFailingTestsCount=2 -Djunit.jupiter.execution.parallel.enabled=${{ parameters.run_parallel }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism="${{ parameters.parallel }}"'
       env:
         DOCKER_TAG: $(docker_tag)
         BRIDGE_IMAGE: "latest-released"

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -294,10 +294,11 @@
                 <groups>regression</groups>
                 <it.test>
                     !kafka/**/*ST,
+                    !bridge/**/*ST,
+                    !cruisecontrol/**/*ST,
                     !mirrormaker/**/*ST,
                     !connect/**/*ST,
                     !security/**/*ST,
-                    !operators/**/*ST,
                     !rollingupdate/**/*ST,
                     !watcher/**/*ST,
                     !tracing/**/*ST
@@ -312,10 +313,11 @@
                 <groups>regression</groups>
                 <it.test>
                     kafka/**/*ST,
+                    bridge/**/*ST,
+                    cruisecontrol/**/*ST,
                     mirrormaker/**/*ST,
                     connect/**/*ST,
                     security/**/*ST,
-                    operators/**/*ST,
                     rollingupdate/**/*ST,
                     watcher/**/*ST,
                     tracing/**/*ST
@@ -323,5 +325,135 @@
             </properties>
         </profile>
 
+        <profile>
+            <id>azp_kafka_oauth</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    kafka/**/*ST,
+                    !kafka/dynamicconfiguration/**/*ST,
+                    security/oauth/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_security</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    security/**/*ST,
+                    !security/oauth/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_dynconfig_tracing_watcher</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    kafka/dynamicconfiguration/**/*ST,
+                    tracing/**/*ST,
+                    watcher/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_rolling_update</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    rollingupdate/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_connect_mirrormaker</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    connect/**/*ST,
+                    mirrormaker/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_operators</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    operators/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_remaining</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    !kafka/**/*ST,
+                    !mirrormaker/**/*ST,
+                    !connect/**/*ST,
+                    !security/**/*ST,
+                    !operators/**/*ST,
+                    !rollingupdate/**/*ST,
+                    !watcher/**/*ST,
+                    !tracing/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_rbac_remaining</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    !kafka/**/*ST,
+                    !mirrormaker/**/*ST,
+                    !connect/**/*ST,
+                    !security/**/*ST,
+                    !operators/**/*ST,
+                    !rollingupdate/**/*ST,
+                    !watcher/**/*ST,
+                    !tracing/**/*ST,
+                    !LoggingChangeST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_upgrade</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>upgrade</groups>
+                <it.test>
+                    !KafkaUpgradeDowngradeST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>azp_kafka_upgrade</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>upgrade</groups>
+                <it.test>
+                    KafkaUpgradeDowngradeST
+                </it.test>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR adds `azure` profiles to systemtest `pom.xml` - they should simplify pipelines declaration. If we will want to change something for one pipeline type (like `rollingupdate`) we just simply edit the profile. Also this PR includes fixes of typos and little reorganization of running packages - so all pipelines will run for +/- same time.

### Checklist

- [x] Make sure all tests pass

