### PR TITLE
[systemtest] Add test for Maven coords plugin in Connect build

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -64,7 +64,7 @@ public class ClientUtils {
         LOGGER.info("Waiting for producer/consumer:{} to finished", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
             () -> {
-                LOGGER.info("Job {} in namespace {}, has status {}", jobName, namespace, kubeClient().namespace(namespace).getJobStatus(jobName));
+                LOGGER.debug("Job {} in namespace {}, has status {}", jobName, namespace, kubeClient().namespace(namespace).getJobStatus(jobName));
                 return kubeClient().namespace(namespace).checkSucceededJobStatus(jobName);
             });
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

This PR adds test for #5407 - as an example I used the Camel Timer Connector.
Also I'm changing `Logger` level in `ClientUtils` to `debug` -> we don't need this kind of information on `info` level.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

