### PR TITLE
doc: Minor addition to Network Policy Generation doc

### DIFF
--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -100,8 +100,8 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 == Network policies
 
 By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
+This `NetworkPolicy` allows applications to connect to listeners in all namespaces. 
 
-A `NetworkPolicy` grants a listener access to applications in all namespaces.
 If you want to restrict access to a listener at the network level to only selected applications or namespaces, 
 use the `networkPolicyPeers` property.
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -100,20 +100,21 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 == Network policies
 
 By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
-This `NetworkPolicy` allows applications to connect to listeners in all namespaces. 
+This `NetworkPolicy` allows applications to connect to listeners in all namespaces.
+Use network policies as part of the listener authentication configuration. 
 
-If you want to restrict access to a listener at the network level to only selected applications or namespaces, 
-use the `networkPolicyPeers` property.
-
-Use network policies as part of the listener authentication configuration.
+If you want to restrict access to a listener at the network level to only selected applications or namespaces, use the `networkPolicyPeers` property.
 Each listener can have a different xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] configuration.
-
 For more information on network policy peers, refer to the {K8sNetworkPolicyPeerAPI}.
 
 If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` in the Cluster Operator configuration.
 For more information, see xref:ref-operator-cluster-{context}[Cluster Operator configuration]. 
 
 NOTE: Your configuration of Kubernetes must support ingress `NetworkPolicies` in order to use network policies in Strimzi.
+
+.Additional resources
+
+* xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] 
 
 == Additional listener configuration options
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -99,16 +99,18 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 [id='assembly-kafka-broker-listener-network-policies-{context}']
 == Network policies
 
-Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
-By default, a `NetworkPolicy` grants access to a listener to all applications and namespaces.
+By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
+By default, a `NetworkPolicy` grants a listener access to all applications and namespaces.
 
-If you want to restrict access to a listener at the network level to only selected applications or namespaces,
-use the `networkPolicyPeers` property.
+If you want to restrict access to a listener at the network level to only selected applications or namespaces, use the `networkPolicyPeers` property.
 
 Use network policies as part of the listener authentication configuration.
 Each listener can have a different `networkPolicyPeers` configuration.
 
-For more information, refer to the xref:configuration-listener-network-policy-reference[Listener network policies] section and the {K8sNetworkPolicyPeerAPI}.
+For more information, refer to the xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] section and the {K8sNetworkPolicyPeerAPI}.
+
+If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false`, in the Cluster Operator configuration.
+For more information, see xref:ref-operator-cluster-{context}[Cluster Operator configuration]. 
 
 NOTE: Your configuration of Kubernetes must support ingress `NetworkPolicies` in order to use network policies in Strimzi.
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -100,8 +100,8 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 == Network policies
 
 By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
-By default, a `NetworkPolicy` grants a listener access to all applications and namespaces.
 
+A `NetworkPolicy` grants a listener access to all applications and namespaces.
 If you want to restrict access to a listener at the network level to only selected applications or namespaces, 
 use the `networkPolicyPeers` property.
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -101,7 +101,7 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 
 By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
 
-A `NetworkPolicy` grants a listener access to all applications and namespaces.
+A `NetworkPolicy` grants a listener access to applications in all namespaces.
 If you want to restrict access to a listener at the network level to only selected applications or namespaces, 
 use the `networkPolicyPeers` property.
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -108,7 +108,7 @@ use the `networkPolicyPeers` property.
 Use network policies as part of the listener authentication configuration.
 Each listener can have a different xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] configuration.
 
-For more information, refer to the xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] section and the {K8sNetworkPolicyPeerAPI}.
+For more information on network policy peers, refer to the {K8sNetworkPolicyPeerAPI}.
 
 If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false`, in the Cluster Operator configuration.
 For more information, see xref:ref-operator-cluster-{context}[Cluster Operator configuration]. 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -102,7 +102,8 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
 By default, a `NetworkPolicy` grants a listener access to all applications and namespaces.
 
-If you want to restrict access to a listener at the network level to only selected applications or namespaces, use the `networkPolicyPeers` property.
+If you want to restrict access to a listener at the network level to only selected applications or namespaces, 
+use the `networkPolicyPeers` property.
 
 Use network policies as part of the listener authentication configuration.
 Each listener can have a different `networkPolicyPeers` configuration.

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -106,7 +106,7 @@ If you want to restrict access to a listener at the network level to only select
 use the `networkPolicyPeers` property.
 
 Use network policies as part of the listener authentication configuration.
-Each listener can have a different `networkPolicyPeers` configuration.
+Each listener can have a different xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] configuration.
 
 For more information, refer to the xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] section and the {K8sNetworkPolicyPeerAPI}.
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -110,7 +110,7 @@ Each listener can have a different xref:configuration-listener-network-policy-re
 
 For more information on network policy peers, refer to the {K8sNetworkPolicyPeerAPI}.
 
-If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false`, in the Cluster Operator configuration.
+If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` in the Cluster Operator configuration.
 For more information, see xref:ref-operator-cluster-{context}[Cluster Operator configuration]. 
 
 NOTE: Your configuration of Kubernetes must support ingress `NetworkPolicies` in order to use network policies in Strimzi.


### PR DESCRIPTION
### Type of change

- Documentation

RELATES TO #5258 

### Description

Guide updated: _Using Strimzi_

A very small addition to **Listener authentication > Network policies** to explain that network policy generation is configurable.

Also corrects the name of a cross-reference to `networkPolicyPeers`.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging - RELATES TO #5258 
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

