### PR TITLE
Fixing minor issue in the command to run interactive pod container during generation of reassignment.json

### DIFF
--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -117,7 +117,7 @@ For example, `my-cluster-cluster-ca-cert`.
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl run -ti --restart=Never --image={DockerKafkaImageCurrent} _INTERACTIVE-POD-NAME_ -- /bin/sh -c "sleep 3600"
+kubectl run --restart=Never --image={DockerKafkaImageCurrent} _INTERACTIVE-POD-NAME_ -- /bin/sh -c "sleep 3600"
 ----
 +
 Replace _INTERACTIVE-POD-NAME_ with the name of the pod.


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Minor fix in the command for running the interactive pod container.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

