### PR TITLE
[azp] Enable javadoc check when building strimzi

### DIFF
--- a/.azure/templates/steps/build_strimzi.yaml
+++ b/.azure/templates/steps/build_strimzi.yaml
@@ -20,5 +20,5 @@ steps:
     publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'
     goals: 'install'
-    options: '-DskipTests -q -Dmaven.javadoc.skip=true -B -V'
+    options: '-DskipTests -B -V'
   displayName: 'Build Strimzi project'


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR enabling javadoc check in `mvn install` command in `build_strimzi.yaml` to prevent future issues.
In `system_test_general.yaml` I kept it, as it should be checked in build phase. 

### Checklist

- [ ] Make sure all tests pass
