### PR TITLE
Await preferred leadership rolling

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -298,7 +298,6 @@ public class KafkaRoller {
                             e);
                 } else {
                     long delay1 = ctx.backOff.delayMs();
-                    e.printStackTrace();
                     LOGGER.infoCr(reconciliation, "Could not roll pod {} due to {}, retrying after at least {}ms",
                             podId, e, delay1);
                     schedule(podId, delay1, TimeUnit.MILLISECONDS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -100,8 +100,10 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
@@ -623,6 +625,10 @@ public class ResourceUtils {
                     throw new RuntimeException(e);
                 }
                 when(mock.describeConfigs(any())).thenReturn(dcfr);
+
+                ElectLeadersResult electLeadersMock = mock(ElectLeadersResult.class);
+                when(electLeadersMock.partitions()).thenReturn(KafkaFuture.completedFuture(Map.of()));
+                when(mock.electLeaders(any(), any())).thenReturn(electLeadersMock);
                 return mock;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -635,6 +636,11 @@ public class KafkaRollerTest {
                 @Override
                 Future<Boolean> canRoll(int podId) {
                     return canRollFn.apply(podId);
+                }
+
+                @Override
+                Future<Set<TopicPartition>> partitionsWithPreferredButNotCurrentLeader(int broker) {
+                    return Future.succeededFuture(Set.of());
                 }
             };
         }

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <module>mirror-maker-agent</module>
         <module>tracing-agent</module>
         <module>test</module>
-        <module>test-container</module>
+        <!-- <module>test-container</module> -->
         <module>crd-annotations</module>
         <module>crd-generator</module>
         <module>api</module>


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR changes how we do rolling restarts. Rather than just waiting for a broker to be available (which can lead to the next broker being restarted before the last has caught up, also also leaves the cluster unbalanced at the end of a rolling restart, since the last-rolled broker won't be leading any partitions) we required availability and then leadership of all the partitions of which the just-rolled broker is the preferred leader.

This will (obviously) slow down rolling in the general case, but frequently the restarted broker will catch up fairly quickly.

The 30s wait time is pretty much arbitrary and I'm open to tuning this.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

