### PR TITLE
Expose connector metrics

### DIFF
--- a/examples/metrics/kafka-connect-metrics.yaml
+++ b/examples/metrics/kafka-connect-metrics.yaml
@@ -91,15 +91,25 @@ data:
       help: "Kafka $1 JMX metric type $2"
       type: GAUGE
 
+    #kafka.connect:type=connector-metrics,connector="{connector}"
+    - pattern: 'kafka.(.+)<type=connector-metrics, connector=(.+)><>(connector-class|connector-type|connector-version|status): (.+)'
+      name: kafka_connect_connector_$3
+      value: 1
+      labels:
+        connector: "$2"
+        $3: "$4"
+      help: "Kafka Connect $3 JMX metric type connector"
+      type: GAUGE
+      
     #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
     - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
-      name: kafka_connect_connector_status
+      name: kafka_connect_connector_task_status
       value: 1
       labels:
         connector: "$1"
         task: "$2"
         status: "$3"
-      help: "Kafka Connect JMX Connector status"
+      help: "Kafka Connect JMX Connector task status"
       type: GAUGE
 
     #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"


### PR DESCRIPTION
Signed-off-by: alexivsn <alex@securenative.com>

### Type of change

Enhancement / Bugfix

### Description

Currently, for Kafka Connect JMX metrics, connector status is not exposed, instead, the status of the task are exposed under the name of kafka_connect_connector_status which is misleading and when the connector fails to start there is JMX metrics available since the task is down, I have exposed metrics from connector-metrics MBean based on official confluent documentation and updated existing connector task status name from  kafka_connect_connector_status to kafka_connect_connector_task_status

https://github.com/strimzi/strimzi-kafka-operator/discussions/5551

The changes have been validated with JMX exporter, screenshot are attached below:
![image](https://user-images.githubusercontent.com/1618071/133465690-7e39e1a5-6aed-4e07-94f5-9ac69848d13e.png)
![image](https://user-images.githubusercontent.com/1618071/133465915-6173bc65-07ff-4248-8f6b-352482f97f4b.png)


