### PR TITLE
Upgrade kafka exporter dependency

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
@@ -88,7 +88,7 @@ public class KafkaExporterSpec implements UnknownPropertyPreserving, Serializabl
     }
 
     @Description("Only log messages with the given severity or above. " +
-            "Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. " +
+            "Valid levels: [`info`, `debug`, `trace`]. " +
             "Default log level is `info`.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public String getLogging() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -231,7 +231,7 @@ public class KafkaExporter extends AbstractModel {
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
 
-        varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_LOGGING, logging));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_LOGGING, Integer.toString(loggingMapping(logging))));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_KAFKA_VERSION, version));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_GROUP_REGEX, groupRegex));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_EXPORTER_TOPIC_REGEX, topicRegex));
@@ -244,6 +244,18 @@ public class KafkaExporter extends AbstractModel {
         addContainerEnvsToExistingEnvs(varList, templateContainerEnvVars);
 
         return varList;
+    }
+
+    private int loggingMapping(String logLevel) {
+        if (logLevel.equalsIgnoreCase("info")) {
+            return 0;
+        } else if (logLevel.equalsIgnoreCase("debug")) {
+            return 1;
+        } else if (logLevel.equalsIgnoreCase("trace")) {
+            return 2;
+        } else {
+            return 0;
+        }
     }
 
     private List<Volume> getVolumes(boolean isOpenShift) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -131,7 +131,7 @@ public class KafkaExporterTest {
 
     private List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
-        expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_LOGGING).withValue(exporterOperatorLogging).build());
+        expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_LOGGING).withValue("1").build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_KAFKA_VERSION).withValue(version).build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_GROUP_REGEX).withValue(groupRegex).build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_TOPIC_REGEX).withValue(topicRegex).build());

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -27,28 +27,28 @@ COPY ./scripts/ $KAFKA_HOME
 # Add Kafka Exporter
 #####
 ENV KAFKA_EXPORTER_HOME=/opt/kafka-exporter
-ENV KAFKA_EXPORTER_VERSION=1.3.1-STRIMZI
-ENV KAFKA_EXPORTER_CHECKSUM_AMD64="85e37fe8a7797f53dcf1ef349b3472edc6891d8bb914d1aebb33784bfb850189d47ec989be9a8c764f4fbe991576b81545b04ddbd4ff6946a677066ec0a4619d  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
-ENV KAFKA_EXPORTER_CHECKSUM_ARM64="a594903265f3497c003d90e211480179aa8d42fb58b43456f001d3eea064d1d571e3b5bb9666c6d45382b1611433c5d616d68b742f84045be04c0c18b9df0427  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz"
-ENV KAFKA_EXPORTER_CHECKSUM_PPC64LE="8b72420d2c6aed25b6ddbae7df66be6a07e659fffa6b3f6cae1132de35c7f0a21bde0fcb3fa9234a8a79839589c18940ef01534551b57669dab09544b5af2883  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz"
+ENV KAFKA_EXPORTER_VERSION=1.4.2
+ENV KAFKA_EXPORTER_CHECKSUM_AMD64="42fcd2b303e82e3ea518cffe7c528c2c35f9ecace8427d68f556c8a91894056f9d8a84fb5bdac2c447b91870909f0dbcce5548a061149da4ffbf33e16545d488  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz"
+ENV KAFKA_EXPORTER_CHECKSUM_ARM64="9488d558210834a6e99ab0c26513294fe2e9f6bd95257fa56cd48359fbadcb5b8aa0846d12c58dbccbfb8493f525c55004a2a0e2a539eb594371ff1990c516f0  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz"
+ENV KAFKA_EXPORTER_CHECKSUM_PPC64LE="26648800bd2da699cc4e6bfca475b1bcfee0b2271c1c5a531941d42aea42ed55f8d8fdb103e517b7a8c504798c5b5fc6854e099a1a22b7069b319aecf5d410d2  kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz"
 
 RUN set -ex; \
     if [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
-        curl -LO https://github.com/alesj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz; \
+        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_ARM64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \
         tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz*; \
     elif [[ ${TARGETPLATFORM} = "linux/ppc64le" ]]; then \
-        curl -LO https://github.com/alesj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz; \
+        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_PPC64LE > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \
         tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz*; \
     else \
-        curl -LO https://github.com/alesj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz; \
+        curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_AMD64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-amd64.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \

--- a/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -21,7 +21,7 @@ if [ "$KAFKA_EXPORTER_ENABLE_SARAMA" = "true" ]; then
 fi
 
 if [ -n "$KAFKA_EXPORTER_LOGGING" ]; then
-    loglevel="--log.level=${KAFKA_EXPORTER_LOGGING}"
+    loglevel="--verbosity=${KAFKA_EXPORTER_LOGGING}"
 fi
 
 # shellcheck disable=SC2027
@@ -31,7 +31,7 @@ kafkaserver="--kafka.server="$KAFKA_EXPORTER_KAFKA_SERVER
 
 listenaddress="--web.listen-address=:9404"
 
-allgroups="--legacy.partitions"
+allgroups="--offset.show-all"
 
 tls="--tls.enabled --tls.ca-file=/etc/kafka-exporter/cluster-ca-certs/ca.crt --tls.cert-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.crt  --tls.key-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.key"
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1431,7 +1431,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
-|logging              1.2+<.<a|Only log messages with the given severity or above. Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default log level is `info`.
+|logging              1.2+<.<a|Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`.
 |string
 |enableSaramaLogging  1.2+<.<a|Enable Sarama logging, a Go client library used by the Kafka Exporter.
 |boolean

--- a/documentation/modules/metrics/kafka-exporter/proc_kafka-exporter-configuring.adoc
+++ b/documentation/modules/metrics/kafka-exporter/proc_kafka-exporter-configuring.adoc
@@ -68,7 +68,7 @@ spec:
 <2> A regular expression to specify the consumer groups to include in the metrics.
 <3> A regular expression to specify the topics to include in the metrics.
 <4> link:{BookURLUsing}#con-common-configuration-resources-reference[CPU and memory resources to reserve].
-<5> Logging configuration, to log messages with a given severity (debug, info, warn, error, fatal) or above.
+<5> Logging configuration, to log messages with a given severity (info, debug, trace) or above.
 <6> Boolean to enable Sarama logging, a Go client library used by Kafka Exporter.
 <7> link:{BookURLUsing}#assembly-customizing-kubernetes-resources-str[Customization of deployment templates and pods].
 <8> link:{BookURLUsing}#con-common-configuration-healthchecks-reference[Healthcheck readiness probes].

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5212,7 +5212,7 @@ spec:
                       description: CPU and memory resources to reserve.
                     logging:
                       type: string
-                      description: 'Only log messages with the given severity or above. Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default log level is `info`.'
+                      description: 'Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`.'
                     enableSaramaLogging:
                       type: boolean
                       description: Enable Sarama logging, a Go client library used by the Kafka Exporter.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6137,8 +6137,8 @@ spec:
                   logging:
                     type: string
                     description: 'Only log messages with the given severity or above.
-                      Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default
-                      log level is `info`.'
+                      Valid levels: [`info`, `debug`, `trace`]. Default log level
+                      is `info`.'
                   enableSaramaLogging:
                     type: boolean
                     description: Enable Sarama logging, a Go client library used by


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix
- Enhancement 

### Description
We used custom forked version as the original repo did not seem to be updated for a while. Since then the repo has become active again and all the fixes from our custom versions are present upstream. There is a new release containing all the fixes. 
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/5529

Logging on `trace` level
```
I0917 07:21:34.387290      11 kafka_exporter.go:769] Starting kafka_exporter (version=1.4.2, branch=HEAD, revision=0d5d4ac4ba63948748cc2c53b35ed95c310cd6f2)
I0917 07:21:34.387393      11 kafka_exporter.go:770] Build context (go=go1.17.1, user=root@d6c4c344dbf3, date=20210916-09:43:31)
I0917 07:21:35.446482      11 kafka_exporter.go:254] Done Init Clients
I0917 07:21:35.446626      11 kafka_exporter.go:929] Listening on HTTP :9404
I0917 07:22:01.387501      11 kafka_exporter.go:320] concurrent calls detected, waiting for first to finish
I0917 07:22:01.387637      11 kafka_exporter.go:366] Refreshing client metadata
I0917 07:22:01.565897      11 kafka_exporter.go:637] Fetching consumer group metrics
I0917 07:22:31.387117      11 kafka_exporter.go:320] concurrent calls detected, waiting for first to finish
```
Logging on `info` level
```
I0917 07:20:27.670678      10 kafka_exporter.go:769] Starting kafka_exporter (version=1.4.2, branch=HEAD, revision=0d5d4ac4ba63948748cc2c53b35ed95c310cd6f2)
I0917 07:20:28.758943      10 kafka_exporter.go:929] Listening on HTTP :9404
```



### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

