### PR TITLE
[MO] - [system test] -> KafkaUser tls external

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
@@ -51,6 +51,14 @@ public class KafkaUserTemplates {
         return scramShaUser(ResourceManager.kubeClient().getNamespace(), clusterName, name);
     }
 
+    public static KafkaUserBuilder tlsExternalUser(final String namespaceName, final String clusterName, final String name) {
+        return defaultUser(namespaceName, clusterName, name)
+            .withNewSpec()
+                .withNewKafkaUserTlsExternalClientAuthentication()
+                .endKafkaUserTlsExternalClientAuthentication()
+            .endSpec();
+    }
+
     public static KafkaUserBuilder defaultUser(String namespaceName, String clusterName, String name) {
         return new KafkaUserBuilder()
             .withNewMetadata()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -92,7 +92,7 @@ public class KafkaUserUtils {
 
     /**
      * Wait until KafkaUser is in desired state
-     * @param namespaceNAme Namespace name
+     * @param namespaceName Namespace name
      * @param userName name of KafkaUser
      * @param state desired state
      */

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -14,7 +14,6 @@ import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
-import kafka.security.auth.Read;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -14,6 +14,7 @@ import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
+import kafka.security.auth.Read;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -92,16 +93,30 @@ public class KafkaUserUtils {
 
     /**
      * Wait until KafkaUser is in desired state
+     * @param namespaceNAme Namespace name
      * @param userName name of KafkaUser
      * @param state desired state
      */
+    public static boolean waitForKafkaUserStatus(String namespaceName, String userName, Enum<?> state) {
+        KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(namespaceName).withName(userName).get();
+        return ResourceManager.waitForResourceStatus(KafkaUserResource.kafkaUserClient(), kafkaUser, state);
+    }
+
     public static boolean waitForKafkaUserStatus(String userName, Enum<?> state) {
         KafkaUser kafkaUser = KafkaUserResource.kafkaUserClient().inNamespace(kubeClient().getNamespace()).withName(userName).get();
         return ResourceManager.waitForResourceStatus(KafkaUserResource.kafkaUserClient(), kafkaUser, state);
     }
 
+    public static boolean waitForKafkaUserNotReady(String namespaceName, String userName) {
+        return waitForKafkaUserStatus(namespaceName, userName, NotReady);
+    }
+
     public static boolean waitForKafkaUserNotReady(String userName) {
-        return waitForKafkaUserStatus(userName, NotReady);
+        return waitForKafkaUserStatus(kubeClient().getNamespace(), userName, NotReady);
+    }
+
+    public static boolean waitForKafkaUserReady(String namespaceName, String userName) {
+        return waitForKafkaUserStatus(namespaceName, userName, Ready);
     }
 
     public static String removeKafkaUserPart(File kafkaUserFile, String partName) {


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adding a test case for the `tls-external` property used in KafkaUser. The verification process has three steps where:

1. Verify Quotas for `CN=<username>`
2. Verify that secret is not generated for specific `username`
3. Verify that ACLs are properly set.
 
More information [here](https://github.com/strimzi/strimzi-kafka-operator/pull/5249).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass