### PR TITLE
Exposed connector metrics and updated grafana dash

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -1043,6 +1043,239 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "displayMode": "color-text",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connector"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 42,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value #A"
+          }
+        ]
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count by (status, connector) (kafka_connect_connector_status{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Connector Status",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Time",
+                "connector",
+                "status"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Time": 2,
+              "connector": 0,
+              "status": 1
+            },
+            "renameByName": {
+              "Time": "Update Time",
+              "connector": "Connector",
+              "status": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 41,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count by (connector, task, status) (kafka_connect_connector_task_status{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Connector Task Status",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Time",
+                "connector",
+                "status",
+                "task"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Time": 3,
+              "connector": 0,
+              "status": 2,
+              "task": 1
+            },
+            "renameByName": {
+              "Time": "Update Time",
+              "connector": "Connector",
+              "status": "Status",
+              "task": "Task"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "refresh": "5s",

--- a/packaging/examples/metrics/kafka-connect-metrics.yaml
+++ b/packaging/examples/metrics/kafka-connect-metrics.yaml
@@ -91,15 +91,25 @@ data:
       help: "Kafka $1 JMX metric type $2"
       type: GAUGE
 
+    #kafka.connect:type=connector-metrics,connector="{connector}"
+    - pattern: 'kafka.(.+)<type=connector-metrics, connector=(.+)><>(connector-class|connector-type|connector-version|status): (.+)'
+      name: kafka_connect_connector_$3
+      value: 1
+      labels:
+        connector: "$2"
+        $3: "$4"
+      help: "Kafka Connect $3 JMX metric type connector"
+      type: GAUGE
+
     #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
     - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
-      name: kafka_connect_connector_status
+      name: kafka_connect_connector_task_status
       value: 1
       labels:
         connector: "$1"
         task: "$2"
         status: "$3"
-      help: "Kafka Connect JMX Connector status"
+      help: "Kafka Connect JMX Connector task status"
       type: GAUGE
 
     #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"


### PR DESCRIPTION
Signed-off-by: alexivsn alex@securenative.com

**Type of change**
Enhancement / Bugfix

**Description**
Currently, for Kafka Connect JMX metrics, connector status is not exposed, but instead, the status of the task are exposed under the name of kafka_connect_connector_status which is misleading and when the connector fails to start there is JMX metrics available since the task is down, I have exposed metrics from connector-metrics MBean based on official confluent documentation and updated existing connector task status name from kafka_connect_connector_status to kafka_connect_connector_task_status

**Issue**
#5551

**Status**
The changes have been validated with the JMX exporter and the connector operator, please see the screenshots that are attached below:
![image](https://user-images.githubusercontent.com/1618071/133816212-50b281ca-3c86-4d9c-9e83-3b1abc1e5f90.png)
![image](https://user-images.githubusercontent.com/1618071/133816765-00323ad0-e830-4f45-85fe-442f1b55d89a.png)

P.S. updated the files in the correct package folder as previous changes failed the build, also added modifications to the Kafka Connect Grafana dashboard template