### PR TITLE
[MO] - [fix] -> list specific user

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -233,7 +233,7 @@ class UserST extends AbstractST {
             .endMetadata()
             .build());
 
-        String command = "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type users";
+        String command = "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --user " + userName;
         LOGGER.debug("Command for kafka-configs.sh {}", command);
 
         ExecResult result = cmdKubeClient(NAMESPACE).execInPod(KafkaResources.kafkaPodName(userClusterName, 0), "/bin/bash", "-c", command);


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes listing quotas. We can't guarantee that the asserted quotas will be what we excepted (for a particular user if we run it `in parallel`). 

reference -> https://github.com/strimzi/strimzi-kafka-operator/pull/5576

> So, how do you know that for example assertThat(result.out().contains("request_percentage=" + reqPerc), is(true)) actually asserts quota from this particular user and not from another user?


### Checklist

- [ ] Make sure all tests pass


