### PR TITLE
Set the labels on `kafka_server_socket_server_metrics_connections_tls_info` correctly

### DIFF
--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -94,10 +94,10 @@ data:
       name: kafka_server_$1_connections_tls_info
       type: GAUGE
       labels:
-        listener: "$2"
-        networkProcessor: "$3"
-        protocol: "$4"
-        cipher: "$5"
+        cipher: "$2"
+        protocol: "$3"
+        listener: "$4"
+        networkProcessor: "$5"
     - pattern: kafka.server<type=(.+), clientSoftwareName=(.+), clientSoftwareVersion=(.+), listener=(.+), networkProcessor=(.+)><>connections
       name: kafka_server_$1_connections_software
       type: GAUGE


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes wrong labels on the `kafka_server_socket_server_metrics_connections_tls_info` metric. The labels are mixed up with the values (e.g. cipher shows network processor as value, listener has cipher suite as value).

This should close #5604.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging