### PR TITLE
[systemtest] Upgrade - fix check if Kafka version is in supported Kafka versions list

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -194,6 +194,10 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
         return kafkaVersions.stream().map(item -> item.version()).collect(Collectors.toList()).contains(kafkaVersion);
     }
 
+    public static boolean supportedVersionsContainsVersion(String kafkaVersion) {
+        return supportedKafkaVersions.stream().map(item -> item.version()).collect(Collectors.toList()).contains(kafkaVersion);
+    }
+
     public static TestKafkaVersion getSpecificVersion(String kafkaVersion) {
         // One specific version will always be only once in the list
         return kafkaVersions.stream().filter(it -> it.version.equals(kafkaVersion)).collect(Collectors.toList()).get(0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -267,7 +267,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         logPodImages(clusterName);
         changeClusterOperator(testParameters, NAMESPACE, extensionContext);
 
-        if (TestKafkaVersion.containsVersion(getDefaultKafkaVersionPerStrimzi(testParameters.getString("fromVersion")).version())) {
+        if (TestKafkaVersion.supportedVersionsContainsVersion(getDefaultKafkaVersionPerStrimzi(testParameters.getString("fromVersion")).version())) {
             waitForKafkaClusterRollingUpdate();
         }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes issue in our upgrade tests - in check, if Kafka version, with which we deployed our Kafka cluster, is in list of supported versions - until now we checked that Kafka version is in list of all Kafka versions inside the `kafka-versions.yaml`, so it was always true and we always waited for rolling update - that's wrong, because when we upgrade CO to version, where certain Kafka version is not supported, we are waiting for RU instead of changing Kafka version to supported one.

### Checklist

- [x] Make sure all tests pass

