### PR TITLE
docs: minor updates to using strimzi

### DIFF
--- a/documentation/assemblies/assembly-securing-external-listeners.adoc
+++ b/documentation/assemblies/assembly-securing-external-listeners.adoc
@@ -2,8 +2,8 @@
 //
 // assembly-securing-access.adoc
 
-[id='assembly-configuring-external-listeners-{context}']
-= Configuring external listeners
+[id='assembly-accessing-kafka-external-clients-{context}']
+= Accessing Kafka from external clients
 
 Use an external listener to expose your Strimzi Kafka cluster to a client outside a Kubernetes environment.
 

--- a/documentation/modules/con-securing-client-authentication.adoc
+++ b/documentation/modules/con-securing-client-authentication.adoc
@@ -16,12 +16,13 @@ Supported authentication types:
 * `scram-sha-512` for SCRAM-SHA-512 authentication
 
 If `tls` or `scram-sha-512` is specified, the User Operator creates authentication credentials when it creates the user.
-If `tls-external` is specified, the user is expected to use TLS client authentication, but no authentication credentials are created.
+If `tls-external` is specified, the user still uses TLS client authentication, but no authentication credentials are created.
+Use this option when you're providing your own certificates.
 When no authentication type is specified, the User Operator does not create the user or its credentials.
 
-Use `tls-external` to authenticate with TLS using a certificate issued outside the User Operator.
+You can use `tls-external` to authenticate with TLS using a certificate issued outside the User Operator.
 The User Operator does not generate a TLS certificate or a secret.
-You can still manage user authorization through the User Operator  in the same way as with the `tls` mechanism.
+You can still manage user authorization through the User Operator in the same way as with the `tls` mechanism.
 This means that you use the `CN=__USER-NAME__` format when specifying ACL rules and quotas.
 _USER-NAME_ is the common name given in a TLS certificate.
 

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -10,7 +10,7 @@ For clients inside the Kubernetes cluster, you can create `plain` (without encry
 For clients outside the Kubernetes cluster, you create _external_ listeners and specify a connection mechanism,
 which can be `nodeport`, `loadbalancer`, `ingress` or `route` (on OpenShift).
 
-For more information on the configuration options for connecting an external client, see xref:assembly-configuring-external-listeners-str[Configuring external listeners].
+For more information on the configuration options for connecting an external client, see xref:assembly-accessing-kafka-external-clients-str[Accessing Kafka from external clients].
 
 Supported authentication options:
 
@@ -101,20 +101,20 @@ When a `KafkaUser.spec.authentication.type` is configured with `scram-sha-512` t
 
 By default, Strimzi automatically creates a `NetworkPolicy` resource for every listener that is enabled on a Kafka broker.
 This `NetworkPolicy` allows applications to connect to listeners in all namespaces.
-Use network policies as part of the listener authentication configuration. 
+Use network policies as part of the listener authentication configuration.
 
 If you want to restrict access to a listener at the network level to only selected applications or namespaces, use the `networkPolicyPeers` property.
 Each listener can have a different xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] configuration.
 For more information on network policy peers, refer to the {K8sNetworkPolicyPeerAPI}.
 
 If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` in the Cluster Operator configuration.
-For more information, see xref:ref-operator-cluster-{context}[Cluster Operator configuration]. 
+For more information, see xref:ref-operator-cluster-{context}[Cluster Operator configuration].
 
 NOTE: Your configuration of Kubernetes must support ingress `NetworkPolicies` in order to use network policies in Strimzi.
 
 .Additional resources
 
-* xref:configuration-listener-network-policy-reference[`networkPolicyPeers`] 
+* xref:configuration-listener-network-policy-reference[`networkPolicyPeers`]
 
 == Additional listener configuration options
 

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -201,7 +201,7 @@ xref:scaling-clusters-{context}[scale clusters].
 <12> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners.
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism xref:assembly-securing-kafka-brokers-str[specified as mutual TLS, SCRAM-SHA-512 or token-based OAuth 2.0].
-<15> External listener configuration specifies xref:assembly-configuring-external-listeners-str[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
+<15> External listener configuration specifies xref:assembly-accessing-kafka-external-clients-str[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
 <16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates on any listener with enabled TLS encryption.
 <17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
 <18> The `config` specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].

--- a/documentation/modules/oauth/con-oauth-authentication-flow.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-flow.adoc
@@ -5,27 +5,27 @@
 [id='con-oauth-authentication-flow-{context}']
 = OAuth 2.0 authentication mechanisms
 
-Strimzi supports the OAUTHBEARER and PLAIN mechanisms for OAuth 2.0 authentication. 
-Both mechanisms allow Kafka clients to establish authenticated sessions with Kafka brokers. 
+Strimzi supports the OAUTHBEARER and PLAIN mechanisms for OAuth 2.0 authentication.
+Both mechanisms allow Kafka clients to establish authenticated sessions with Kafka brokers.
 The authentication flow between clients, the authorization server, and Kafka brokers is different for each mechanism.
 
-We recommend that you configure clients to use OAUTHBEARER whenever possible. 
-OAUTHBEARER provides a higher level of security than PLAIN because client credentials are _never_ shared with Kafka brokers. 
-Consider using PLAIN only with Kafka clients that do not support OAUTHBEARER. 
+We recommend that you configure clients to use OAUTHBEARER whenever possible.
+OAUTHBEARER provides a higher level of security than PLAIN because client credentials are _never_ shared with Kafka brokers.
+Consider using PLAIN only with Kafka clients that do not support OAUTHBEARER.
 
 If necessary, OAUTHBEARER and PLAIN can be enabled together, on the same `oauth` listener.
 
 .OAUTHBEARER overview
 
-Kafka supports the OAUTHBEARER authentication mechanism, however it must be explicitly configured. 
-Also, many Kafka client tools use libraries that provide basic support for OAUTHBEARER at the protocol level. 
+Kafka supports the OAUTHBEARER authentication mechanism, however it must be explicitly configured.
+Also, many Kafka client tools use libraries that provide basic support for OAUTHBEARER at the protocol level.
 
-To ease application development, Strimzi provides an _OAuth callback handler_ for the upstream Kafka Client Java libraries (but not for other libraries). 
-Therefore, you do not need to write your own callback handlers for such clients. 
-An application client can use the callback handler to provide the access token. 
+To ease application development, Strimzi provides an _OAuth callback handler_ for the upstream Kafka Client Java libraries (but not for other libraries).
+Therefore, you do not need to write your own callback handlers for such clients.
+An application client can use the callback handler to provide the access token.
 Clients written in other languages, such as Go, must use custom code to connect to the authorization server and obtain the access token.
 
-With OAUTHBEARER, the client initiates a session with the Kafka broker for credentials exchange, where credentials take the form of a bearer token provided by the callback handler. 
+With OAUTHBEARER, the client initiates a session with the Kafka broker for credentials exchange, where credentials take the form of a bearer token provided by the callback handler.
 Using the callbacks, you can configure token provision in one of three ways:
 
 * Client ID and Secret (by using the OAuth 2.0 client credentials mechanism)
@@ -34,7 +34,7 @@ Using the callbacks, you can configure token provision in one of three ways:
 
 * A long-lived refresh token, obtained manually at configuration time
 
-OAUTHBEARER is automatically enabled in the `oauth` listener configuration for the Kafka broker. 
+OAUTHBEARER is automatically enabled in the `oauth` listener configuration for the Kafka broker.
 You can set the `enableOauthBearer` property to `true`, though this is not required.
 
 [source,yaml,subs="attributes+"]
@@ -53,10 +53,10 @@ OAUTHBEARER authentication can only be used by Kafka clients that support the OA
 
 .PLAIN overview
 
-PLAIN is a simple authentication mechanism used by all Kafka client tools (including developer tools such as kafkacat). 
-To enable PLAIN to be used together with OAuth 2.0 authentication, Strimzi includes server-side callbacks and calls this _OAuth 2.0 over PLAIN_. 
+PLAIN is a simple authentication mechanism used by all Kafka client tools (including developer tools such as kcat). 
+To enable PLAIN to be used together with OAuth 2.0 authentication, Strimzi includes server-side callbacks and calls this _OAuth 2.0 over PLAIN_.
 
-With the Strimzi implementation of PLAIN, the client credentials are not stored in ZooKeeper. 
+With the Strimzi implementation of PLAIN, the client credentials are not stored in ZooKeeper.
 Instead, client credentials are handled centrally behind a compliant authorization server, similar to when OAUTHBEARER authentication is used.
 
 When used with the OAuth 2.0 over PLAIN callbacks, Kafka clients authenticate with Kafka brokers using either of the following methods:
@@ -65,17 +65,17 @@ When used with the OAuth 2.0 over PLAIN callbacks, Kafka clients authenticate wi
 
 * A long-lived access token, obtained manually at configuration time
 
-The client must be enabled to use PLAIN authentication, and provide a `username` and `password`. 
-If the password is prefixed with `$accessToken:` followed by the value of the access token, the Kafka broker will interpret the password as the access token. 
+The client must be enabled to use PLAIN authentication, and provide a `username` and `password`.
+If the password is prefixed with `$accessToken:` followed by the value of the access token, the Kafka broker will interpret the password as the access token.
 Otherwise, the Kafka broker will interpret the `username` as the client ID and the `password` as the client secret.
 
-If the `password` is set as the access token, the `username` must be set to the same principal name that the Kafka broker obtains from the access token. 
-The process depends on how you configure username extraction using `userNameClaim`, `fallbackUserNameClaim`, `fallbackUsernamePrefix`, or `userInfoEndpointUri`. 
+If the `password` is set as the access token, the `username` must be set to the same principal name that the Kafka broker obtains from the access token.
+The process depends on how you configure username extraction using `userNameClaim`, `fallbackUserNameClaim`, `fallbackUsernamePrefix`, or `userInfoEndpointUri`.
 It also depends on your authorization server; in particular, how it maps client IDs to account names.
 
 To use PLAIN, you must enable it in the `oauth` listener configuration for the Kafka broker.
 
-In the following example, PLAIN is enabled in addition to OAUTHBEARER, which is enabled by default. 
+In the following example, PLAIN is enabled in addition to OAUTHBEARER, which is enabled by default.
 If you want to use PLAIN only, you can disable OAUTHBEARER by setting `enableOauthBearer` to `false`.
 
 [source,yaml,subs="+quotes,attributes+"]

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -28,7 +28,7 @@ For more information on securing access to Kafka brokers, see xref:assembly-secu
 
 .Configuring external listeners for client access outside Kubernetes
 You can configure external listeners for client access outside a Kubernetes environment using a specified connection mechanism, such as a loadbalancer.
-For more information on the configuration options for connecting an external client, see xref:assembly-configuring-external-listeners-str[Configuring external listeners].
+For more information on the configuration options for connecting an external client, see xref:assembly-accessing-kafka-external-clients-str[Accessing Kafka from external clients].
 
 .Listener certificates
 You can provide your own server certificates, called _Kafka listener certificates_, for TLS listeners or external listeners which have TLS encryption enabled.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Minor updates to teh _Using Strimzi_ guide

- Updates name of kafkacat in doc to kcat
- Updates the _Configuring external listeners_ chapter title to _Accessing Kafka from external clients_
- Makes the `tls-external` config description clearer

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

