### PR TITLE
Support for External IPs (Kafka) and Persistent Storage (Kafka Connect)

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.connect.build.Build;
+import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
@@ -27,7 +28,7 @@ import java.util.Map;
         "bootstrapServers", "tls", "authentication", "config", "resources",
         "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions",
         "affinity", "tolerations", "logging", "metrics", "tracing",
-        "template", "externalConfiguration"})
+        "template", "externalConfiguration", "storage"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
@@ -42,6 +43,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     private String bootstrapServers;
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
+    private SingleVolumeStorage storage;
     private Build build;
 
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
@@ -101,6 +103,16 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     public void setAuthentication(KafkaClientAuthentication authentication) {
         this.authentication = authentication;
+    }
+
+    @Description("Storage configuration (disk). Cannot be updated.")
+    @JsonProperty(required = true)
+    public SingleVolumeStorage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(SingleVolumeStorage storage) {
+        this.storage = storage;
     }
 
     @Description("Configures how the Connect container image should be built. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBootstrap.java
@@ -38,6 +38,7 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
     private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
+    private List<String> externalIPs;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -109,6 +110,16 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
 
     public void setLoadBalancerIP(String loadBalancerIP) {
         this.loadBalancerIP = loadBalancerIP;
+    }
+
+    @Description("External IPs to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getExternalIPs() {
+        return externalIPs;
+    }
+
+    public void setExternalIPs(List<String> externalIPs) {
+        this.externalIPs = externalIPs;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
@@ -16,6 +16,7 @@ import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -42,6 +43,7 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
     private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
+    private List<String> externalIPs;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -133,6 +135,16 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
 
     public void setLoadBalancerIP(String loadBalancerIP) {
         this.loadBalancerIP = loadBalancerIP;
+    }
+
+    @Description("External IPs to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getExternalIPs() {
+        return externalIPs;
+    }
+
+    public void setExternalIPs(List<String> externalIPs) {
+        this.externalIPs = externalIPs;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/storage/PersistentClaimStorageOverride.java
@@ -34,6 +34,7 @@ public class PersistentClaimStorageOverride  implements Serializable, UnknownPro
 
     private Integer broker;
     private String storageClass;
+    private String mountPath;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Id of the kafka broker (broker identifier)")
@@ -54,6 +55,15 @@ public class PersistentClaimStorageOverride  implements Serializable, UnknownPro
 
     public void setStorageClass(String storageClass) {
         this.storageClass = storageClass;
+    }
+
+    @Description("The mount path to use, overriding the default /var/lib/kafka/data.")
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public void setMountPath(String mountPath) {
+        this.mountPath = mountPath;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -25,7 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "apiService", "connectContainer", "initContainer", "podDisruptionBudget",
-        "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig", "buildServiceAccount", "jmxSecret"})
+        "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig", "buildServiceAccount", "jmxSecret", "persistentVolumeClaim"})
 @EqualsAndHashCode
 public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -43,6 +43,7 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
     private ResourceTemplate serviceAccount;
     private ResourceTemplate buildServiceAccount;
     private ResourceTemplate jmxSecret;
+    private ResourceTemplate persistentVolumeClaim;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Connect `Deployment`.")
@@ -175,6 +176,16 @@ public class KafkaConnectTemplate implements Serializable, UnknownPropertyPreser
     }
     public void setJmxSecret(ResourceTemplate jmxSecret) {
         this.jmxSecret = jmxSecret;
+    }
+
+    @Description("Template for the Kafka Connect persistent volume claim.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getPersistentVolumeClaim() {
+        return persistentVolumeClaim;
+    }
+
+    public void setPersistentVolumeClaim(ResourceTemplate persistentVolumeClaim) {
+        this.persistentVolumeClaim = persistentVolumeClaim;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -867,6 +867,10 @@ public abstract class AbstractModel {
      * @return PersistentVolumeClaim
      */
     protected PersistentVolumeClaim createPersistentVolumeClaim(int ordinalId, String name, PersistentClaimStorage storage) {
+        return createPersistentVolumeClaim(ordinalId, name, storage, "ReadWriteOnce");
+    }
+
+    protected PersistentVolumeClaim createPersistentVolumeClaim(int ordinalId, String name, PersistentClaimStorage storage, String accessMode) {
         Map<String, Quantity> requests = new HashMap<>(1);
         requests.put("storage", new Quantity(storage.getSize(), null));
 
@@ -897,7 +901,7 @@ public abstract class AbstractModel {
                     .withAnnotations(Util.mergeLabelsOrAnnotations(Collections.singletonMap(ANNO_STRIMZI_IO_DELETE_CLAIM, Boolean.toString(storage.isDeleteClaim())), templatePersistentVolumeClaimAnnotations))
                 .endMetadata()
                 .withNewSpec()
-                    .withAccessModes("ReadWriteOnce")
+                    .withAccessModes(accessMode)
                     .withNewResources()
                         .withRequests(requests)
                     .endResources()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -832,6 +832,10 @@ public class KafkaCluster extends AbstractModel {
             }
 
             if (KafkaListenerType.LOADBALANCER == listener.getType() || KafkaListenerType.NODEPORT == listener.getType()) {
+                List<String> eip = ListenersUtils.bootstrapExternalIPs(listener);
+                if (eip != null && !eip.isEmpty()) {
+                    service.getSpec().setExternalIPs(eip);
+                }
                 ExternalTrafficPolicy etp = ListenersUtils.externalTrafficPolicy(listener);
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());
@@ -901,6 +905,10 @@ public class KafkaCluster extends AbstractModel {
             }
 
             if (KafkaListenerType.LOADBALANCER == listener.getType() || KafkaListenerType.NODEPORT == listener.getType()) {
+                List<String> eip = ListenersUtils.brokerExternalIPs(listener, pod);
+                if (eip != null && !eip.isEmpty()) {
+                    service.getSpec().setExternalIPs(eip);
+                }
                 ExternalTrafficPolicy etp = ListenersUtils.externalTrafficPolicy(listener);
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -637,4 +637,39 @@ public class ListenersUtils {
             return "ClusterIP";
         }
     }
+
+    /**
+     * Finds bootstrap service external IPs
+     *
+     * @param listener  Listener for which the external IPs should be found
+     * @return          External IPs or null if not specified
+     */
+    public static List<String> bootstrapExternalIPs(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null
+                && listener.getConfiguration().getBootstrap() != null) {
+            return listener.getConfiguration().getBootstrap().getExternalIPs();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Finds broker service external IPs
+     *
+     * @param listener  Listener for which the external IPs should be found
+     * @param pod       Pod ID for which we should get the configuration option
+     * @return          External IPs or null if not specified
+     */
+    public static List<String> brokerExternalIPs(GenericKafkaListener listener, int pod)    {
+        if (listener.getConfiguration() != null
+                && listener.getConfiguration().getBrokers() != null) {
+            return listener.getConfiguration().getBrokers().stream()
+                    .filter(broker -> broker != null && broker.getBroker() != null && broker.getBroker() == pod && broker.getExternalIPs() != null)
+                    .map(GenericKafkaListenerConfigurationBroker::getExternalIPs)
+                    .findAny()
+                    .orElse(null);
+        } else {
+            return null;
+        }
+    }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -362,6 +362,8 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string
 |annotations       1.2+<.<a|Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
+|externalIPs       1.2+<.<a|External IPs to the resource.
+|string array
 |labels            1.2+<.<a|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
@@ -396,6 +398,8 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string
 |annotations     1.2+<.<a|Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
 |map
+|externalIPs     1.2+<.<a|External IPs to the resource.
+|string array
 |labels          1.2+<.<a|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
@@ -403,7 +407,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 [id='type-EphemeralStorage-{context}']
 ### `EphemeralStorage` schema reference
 
-Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes use of the `EphemeralStorage` type from xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`].
@@ -422,7 +426,7 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 [id='type-PersistentClaimStorage-{context}']
 ### `PersistentClaimStorage` schema reference
 
-Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes use of the `PersistentClaimStorage` type from xref:type-EphemeralStorage-{context}[`EphemeralStorage`].
@@ -454,11 +458,13 @@ Used in: xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
 
 [options="header"]
 |====
-|Property       |Description
-|class   1.2+<.<a|The storage class to use for dynamic volume allocation for this broker.
+|Property          |Description
+|class      1.2+<.<a|The storage class to use for dynamic volume allocation for this broker.
 |string
-|broker  1.2+<.<a|Id of the kafka broker (broker identifier).
+|broker     1.2+<.<a|Id of the kafka broker (broker identifier).
 |integer
+|mountPath  1.2+<.<a|The mount path to use, overriding the default /var/lib/kafka/data.
+|string
 |====
 
 [id='type-JbodStorage-{context}']
@@ -1601,6 +1607,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
+|storage                1.2+<.<a|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
+|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
 |build                  1.2+<.<a|Configures how the Connect container image should be built. Optional.
 |xref:type-Build-{context}[`Build`]
 |clientRackInitImage    1.2+<.<a|The image of the init container used for initializing the `client.rack`.
@@ -1789,32 +1797,34 @@ Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Kaf
 
 [options="header"]
 |====
-|Property                    |Description
-|deployment           1.2+<.<a|Template for Kafka Connect `Deployment`.
+|Property                      |Description
+|deployment             1.2+<.<a|Template for Kafka Connect `Deployment`.
 |xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
-|pod                  1.2+<.<a|Template for Kafka Connect `Pods`.
+|pod                    1.2+<.<a|Template for Kafka Connect `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|apiService           1.2+<.<a|Template for Kafka Connect API `Service`.
+|apiService             1.2+<.<a|Template for Kafka Connect API `Service`.
 |xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
-|connectContainer     1.2+<.<a|Template for the Kafka Connect container.
+|connectContainer       1.2+<.<a|Template for the Kafka Connect container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|initContainer        1.2+<.<a|Template for the Kafka init container.
+|initContainer          1.2+<.<a|Template for the Kafka init container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|podDisruptionBudget  1.2+<.<a|Template for Kafka Connect `PodDisruptionBudget`.
+|podDisruptionBudget    1.2+<.<a|Template for Kafka Connect `PodDisruptionBudget`.
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
-|serviceAccount       1.2+<.<a|Template for the Kafka Connect service account.
+|serviceAccount         1.2+<.<a|Template for the Kafka Connect service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|clusterRoleBinding   1.2+<.<a|Template for the Kafka Connect ClusterRoleBinding.
+|clusterRoleBinding     1.2+<.<a|Template for the Kafka Connect ClusterRoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|buildPod             1.2+<.<a|Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+|buildPod               1.2+<.<a|Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|buildContainer       1.2+<.<a|Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
+|buildContainer         1.2+<.<a|Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|buildConfig          1.2+<.<a|Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
+|buildConfig            1.2+<.<a|Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|buildServiceAccount  1.2+<.<a|Template for the Kafka Connect Build service account.
+|buildServiceAccount    1.2+<.<a|Template for the Kafka Connect Build service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|jmxSecret            1.2+<.<a|Template for Secret of the Kafka Connect Cluster JMX authentication.
+|jmxSecret              1.2+<.<a|Template for Secret of the Kafka Connect Cluster JMX authentication.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|persistentVolumeClaim  1.2+<.<a|Template for the Kafka Connect persistent volume claim.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -420,6 +420,11 @@ spec:
                                     such as External DNS. This field can be used only
                                     with `loadbalancer`, `nodeport`, `route`, or `ingress`
                                     type listeners.
+                                externalIPs:
+                                  type: array
+                                  items:
+                                    type: string
+                                  description: External IPs to the resource.
                                 labels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
@@ -477,6 +482,11 @@ spec:
                                       as External DNS. This field can be used only
                                       with `loadbalancer`, `nodeport`, or `ingress`
                                       type listeners.
+                                  externalIPs:
+                                    type: array
+                                    items:
+                                      type: string
+                                    description: External IPs to the resource.
                                   labels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
@@ -677,6 +687,10 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
+                            mountPath:
+                              type: string
+                              description: The mount path to use, overriding the default
+                                /var/lib/kafka/data.
                         description: Overrides for individual brokers. The `overrides`
                           field allows to specify a different configuration for different
                           brokers.
@@ -736,6 +750,10 @@ spec:
                                   broker:
                                     type: integer
                                     description: Id of the kafka broker (broker identifier).
+                                  mountPath:
+                                    type: string
+                                    description: The mount path to use, overriding
+                                      the default /var/lib/kafka/data.
                               description: Overrides for individual brokers. The `overrides`
                                 field allows to specify a different configuration
                                 for different brokers.
@@ -2124,6 +2142,10 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
+                            mountPath:
+                              type: string
+                              description: The mount path to use, overriding the default
+                                /var/lib/kafka/data.
                         description: Overrides for individual brokers. The `overrides`
                           field allows to specify a different configuration for different
                           brokers.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1769,6 +1769,27 @@ spec:
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster
                       JMX authentication.
+                  persistentVolumeClaim:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Labels added to the resource template. Can
+                              be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Annotations added to the resource template.
+                              Can be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect persistent volume
+                      claim.
                 description: Template for Kafka Connect and Kafka Mirror Maker 2 resources.
                   The template allows users to specify how the `Deployment`, `Pods`
                   and `Service` are generated.
@@ -1876,6 +1897,65 @@ spec:
                       the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect
                   pods and use them to configure connectors.
+              storage:
+                type: object
+                properties:
+                  class:
+                    type: string
+                    description: The storage class to use for dynamic volume allocation.
+                  deleteClaim:
+                    type: boolean
+                    description: Specifies if the persistent volume claim has to be
+                      deleted when the cluster is un-deployed.
+                  id:
+                    type: integer
+                    minimum: 0
+                    description: Storage identification number. It is mandatory only
+                      for storage volumes defined in a storage of type 'jbod'.
+                  overrides:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        class:
+                          type: string
+                          description: The storage class to use for dynamic volume
+                            allocation for this broker.
+                        broker:
+                          type: integer
+                          description: Id of the kafka broker (broker identifier).
+                        mountPath:
+                          type: string
+                          description: The mount path to use, overriding the default
+                            /var/lib/kafka/data.
+                    description: Overrides for individual brokers. The `overrides`
+                      field allows to specify a different configuration for different
+                      brokers.
+                  selector:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: Specifies a specific persistent volume to use. It
+                      contains key:value pairs representing labels for selecting such
+                      a volume.
+                  size:
+                    type: string
+                    description: When type=persistent-claim, defines the size of the
+                      persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                  sizeLimit:
+                    type: string
+                    pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                    description: When type=ephemeral, defines the total amount of
+                      local storage required for this EmptyDir volume (for example
+                      1Gi).
+                  type:
+                    type: string
+                    enum:
+                    - ephemeral
+                    - persistent-claim
+                    description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
+                required:
+                - type
+                description: Storage configuration (disk). Cannot be updated.
               build:
                 type: object
                 properties:
@@ -2066,6 +2146,7 @@ spec:
                   the client.rack consumer configuration.
             required:
             - bootstrapServers
+            - storage
             description: The specification of the Kafka Connect cluster.
           status:
             type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1895,6 +1895,27 @@ spec:
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster
                       JMX authentication.
+                  persistentVolumeClaim:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Labels added to the resource template. Can
+                              be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Annotations added to the resource template.
+                              Can be applied to different resources such as `StatefulSets`,
+                              `Deployments`, `Pods`, and `Services`.
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect persistent volume
+                      claim.
                 description: Template for Kafka Connect and Kafka Mirror Maker 2 resources.
                   The template allows users to specify how the `Deployment`, `Pods`
                   and `Service` are generated.


### PR DESCRIPTION
### Type of change

- Bugfix
X Enhancement / new feature
- Refactoring
- Documentation

### Description

Added external IPs to Kafka external listener -- both bootstrap and brokers, to enable cross cluster traffic.
Added persistent storage to Kafka Connect, to enable storage sharing across Connect replicas / pods.
Added test cases.

### Checklist

- [ X] Write tests
- [ X] Make sure all tests pass
- [ X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards