### PR TITLE
Deprecate the `KafkaMirrorMaker` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 * imageRepositoryOverride,imageRegistryOverride and imageTagOverride are now removed from values.yaml. defaultImageRepository, defaultImageRegistry and defaultImageTag values are introduced in helm charts which sets the default registry, repository and tags for the images. Now the registry, repository and tag for a single image can be configured as per the requirement.
 * The OpenShift Templates were removed from the examples and are no longer supported (#5548)
+* Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
+  As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
+  The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
+  As a replacement, use the `KafkaMirrorMaker2` custom resource with the [`IdentityReplicationPolicy`](https://strimzi.io/docs/operators/latest/using.html#unidirectional_replication_activepassive).
 
 ## 0.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
 
 * imageRepositoryOverride,imageRegistryOverride and imageTagOverride are now removed from values.yaml. defaultImageRepository, defaultImageRegistry and defaultImageTag values are introduced in helm charts which sets the default registry, repository and tags for the images. Now the registry, repository and tag for a single image can be configured as per the requirement.
 * The OpenShift Templates were removed from the examples and are no longer supported (#5548)
-* Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
+* Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
   As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
-  The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
+  The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
   As a replacement, use the `KafkaMirrorMaker2` custom resource with the [`IdentityReplicationPolicy`](https://strimzi.io/docs/operators/latest/using.html#unidirectional_replication_activepassive).
 
 ## 0.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * imageRepositoryOverride,imageRegistryOverride and imageTagOverride are now removed from values.yaml. defaultImageRepository, defaultImageRegistry and defaultImageTag values are introduced in helm charts which sets the default registry, repository and tags for the images. Now the registry, repository and tag for a single image can be configured as per the requirement.
 * The OpenShift Templates were removed from the examples and are no longer supported (#5548)
 * Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
-  As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
+  As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well. (#5617)
   The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
   As a replacement, use the `KafkaMirrorMaker2` custom resource with the [`IdentityReplicationPolicy`](https://strimzi.io/docs/operators/latest/using.html#unidirectional_replication_activepassive).
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -94,8 +95,9 @@ import static java.util.Collections.unmodifiableList;
 @EqualsAndHashCode
 @Version(Constants.V1BETA2)
 @Group(Constants.STRIMZI_GROUP)
+@Deprecated
+@DeprecatedType(replacedWithType = io.strimzi.api.kafka.model.KafkaMirrorMaker2.class)
 public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, KafkaMirrorMakerStatus> implements Namespaced, UnknownPropertyPreserving {
-
     private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -41,6 +41,8 @@ import java.util.Map;
  *     <li>A Kafka Mirror Maker Deployment and related Services</li>
  * </ul>
  */
+// Deprecation is suppressed because of KafkaMirrorMaker
+@SuppressWarnings("deprecation")
 public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList, Resource<KafkaMirrorMaker>, KafkaMirrorMakerSpec, KafkaMirrorMakerStatus> {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaMirrorMakerAssemblyOperator.class.getName());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -50,7 +50,8 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.vertx.core.Vertx;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
+// Deprecation is suppressed because of KafkaMirrorMaker
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "deprecation"})
 public class ResourceOperatorSupplier {
     public final SecretOperator secretOperations;
     public final ServiceOperator serviceOperations;

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
@@ -12,7 +12,7 @@ MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror
 
 If you are using MirrorMaker, you configure the `KafkaMirrorMaker` resource.
 
-IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
+IMPORTANT: Kafka MirrorMaker 1 (referred to as just _MirrorMaker_ in the documentation) has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.  
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
 The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the xref:unidirectional_replication_activepassive[`IdentityReplicationPolicy`].

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
@@ -12,6 +12,11 @@ MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror
 
 If you are using MirrorMaker, you configure the `KafkaMirrorMaker` resource.
 
+IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
+As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
+The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
+As a replacement, use the `KafkaMirrorMaker2` custom resource with the xref:unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
+
 The following procedure shows how the resource is configured:
 
 * xref:configuring-kafka-mirror-maker-{context}[Configuring Kafka MirrorMaker]

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
@@ -12,9 +12,9 @@ MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror
 
 If you are using MirrorMaker, you configure the `KafkaMirrorMaker` resource.
 
-IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
+IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
-The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
+The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the xref:unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
 
 The following procedure shows how the resource is configured:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2476,6 +2476,9 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [id='type-KafkaMirrorMaker-{context}']
 ### `KafkaMirrorMaker` schema reference
 
+*The type `KafkaMirrorMaker` has been deprecated.*
+Please use xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`] instead.
+
 
 [options="header"]
 |====

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -10,6 +10,12 @@ This procedure shows how to deploy a Kafka MirrorMaker cluster to your Kubernete
 
 The deployment uses a YAML file to provide the specification to create a `KafkaMirrorMaker` or `KafkaMirrorMaker2` resource depending on the version of MirrorMaker deployed.
 
+IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
+As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
+The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
+As a replacement, use the `KafkaMirrorMaker2` custom resource with the `IdentityReplicationPolicy`.
+As a replacement, use the `KafkaMirrorMaker2` custom resource with the link:{BookURLUsing}#unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
+
 Strimzi provides xref:deploy-examples-{context}[example configuration files].
 In this procedure, we use the following example files:
 

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -13,7 +13,6 @@ The deployment uses a YAML file to provide the specification to create a `KafkaM
 IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
 The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
-As a replacement, use the `KafkaMirrorMaker2` custom resource with the `IdentityReplicationPolicy`.
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the link:{BookURLUsing}#unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
 
 Strimzi provides xref:deploy-examples-{context}[example configuration files].

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -10,9 +10,9 @@ This procedure shows how to deploy a Kafka MirrorMaker cluster to your Kubernete
 
 The deployment uses a YAML file to provide the specification to create a `KafkaMirrorMaker` or `KafkaMirrorMaker2` resource depending on the version of MirrorMaker deployed.
 
-IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.O.
+IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
-The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.
+The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the link:{BookURLUsing}#unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
 
 Strimzi provides xref:deploy-examples-{context}[example configuration files].

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -10,7 +10,7 @@ This procedure shows how to deploy a Kafka MirrorMaker cluster to your Kubernete
 
 The deployment uses a YAML file to provide the specification to create a `KafkaMirrorMaker` or `KafkaMirrorMaker2` resource depending on the version of MirrorMaker deployed.
 
-IMPORTANT: Kafka MirrorMaker 1 has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
+IMPORTANT: Kafka MirrorMaker 1 (referred to as just _MirrorMaker_ in the documentation) has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
 The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the link:{BookURLUsing}#unidirectional_replication_activepassive[`IdentityReplicationPolicy`].

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -20,6 +20,8 @@ public class ResourceOperation {
         return getTimeoutForResourceReadiness("default");
     }
 
+    // Deprecation is suppressed because of KafkaMirrorMaker
+    @SuppressWarnings("deprecation")
     public static long getTimeoutForResourceReadiness(String kind) {
         long timeout;
 
@@ -77,6 +79,8 @@ public class ResourceOperation {
         return getTimeoutForResourceDeletion("default");
     }
 
+    // Deprecation is suppressed because of KafkaMirrorMaker
+    @SuppressWarnings("deprecation")
     public static long getTimeoutForResourceDeletion(String kind) {
         long timeout;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -16,6 +16,8 @@ import io.strimzi.systemtest.resources.ResourceManager;
 
 import java.util.function.Consumer;
 
+// Deprecation is suppressed because of KafkaMirrorMaker
+@SuppressWarnings("deprecation")
 public class KafkaMirrorMakerResource implements ResourceType<KafkaMirrorMaker> {
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMakerTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMakerTemplates.java
@@ -19,6 +19,8 @@ import io.strimzi.test.TestUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
+// Deprecation is suppressed because of KafkaMirrorMaker
+@SuppressWarnings("deprecation")
 public class KafkaMirrorMakerTemplates {
 
     private KafkaMirrorMakerTemplates() {}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMakerUtils.java
@@ -22,6 +22,8 @@ public class KafkaMirrorMakerUtils {
      * @param clusterName name of KafkaMirrorMaker cluster
      * @param state desired state - like Ready
      */
+    // Deprecation is suppressed because of KafkaMirrorMaker
+    @SuppressWarnings("deprecation")
     public static boolean waitForKafkaMirrorMakerStatus(String namespaceName, String clusterName, Enum<?>  state) {
         KafkaMirrorMaker kafkaMirrorMaker = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get();
         return ResourceManager.waitForResourceStatus(KafkaMirrorMakerResource.kafkaMirrorMakerClient(), kafkaMirrorMaker, state);


### PR DESCRIPTION
### Type of change

- Task

### Description

Kafka Mirror Maker 1 has been deprecated in Kafka 3.0.0. This PR deprecates also the `KafkaMIrrorMaker` CR to make sure users are aware of it and use `KafkaMirrorMaker2` instead. We can remove `KafkaMIrrorMaker` when we add support for Kafka 4.0 (Mirror Maker 1 is removed in Kafka 4.0.0).

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md