### PR TITLE
[DOC] Fix the list of resources watched by the CO

### DIFF
--- a/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
+++ b/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
@@ -22,7 +22,9 @@ The Cluster Operator watches for changes to the following resources:
 * `KafkaConnect` for the Kafka Connect cluster.
 * `KafkaConnector` for creating and managing connectors in a Kafka Connect cluster.
 * `KafkaMirrorMaker` for the Kafka MirrorMaker instance.
-* `KafkaBridge` for the Kafka Bridge instance
+* `KafkaMirrorMaker2` for the Kafka MirrorMaker 2 instance.
+* `KafkaBridge` for the Kafka Bridge instance.
+* `KafkaRebalance` for the Cruise Control optimization requests.
 
 When one of these resources is created in the Kubernetes cluster, the operator gets the cluster description from the resource and starts creating a new cluster for the resource by creating the necessary Kubernetes resources, such as StatefulSets, Services and ConfigMaps.
 

--- a/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
+++ b/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
@@ -22,7 +22,7 @@ The Cluster Operator watches for changes to the following resources:
 * `KafkaConnect` for the Kafka Connect cluster.
 * `KafkaConnector` for creating and managing connectors in a Kafka Connect cluster.
 * `KafkaMirrorMaker` for the Kafka MirrorMaker instance.
-* `KafkaMirrorMaker2` for the Kafka MirrorMaker 2 instance.
+* `KafkaMirrorMaker2` for the Kafka MirrorMaker 2.0 instance.
 * `KafkaBridge` for the Kafka Bridge instance.
 * `KafkaRebalance` for the Cruise Control optimization requests.
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This Pr fixes the list of custom resources watched by the Cluster Operator which is in the deploying guide and is missing some of the CRs.

### Checklist

- [x] Update documentation