### PR TITLE
Update dependencies to deal with CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,14 +119,15 @@
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <commons-codec.version>1.13</commons-codec.version>
+        <commons-compress.version>1.21</commons-compress.version>
         <registry.version>1.3.2.Final</registry.version>
 
         <test-containers.version>1.15.2</test-containers.version>
         <docker-java.version>3.2.7</docker-java.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
         <javax.json.version>1.1.4</javax.json.version>
-        <rest-assured.version>4.3.3</rest-assured.version>
-        <rest-assured-json-path.version>4.3.3</rest-assured-json-path.version>
+        <rest-assured.version>4.4.0</rest-assured.version>
+        <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
         <jupiter.version>5.7.0</jupiter.version>
         <junit.platform.version>1.7.0</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
@@ -136,7 +137,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <netty.version>4.1.68.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.69</bouncycastle.version>
         <!-- property to skip surefire tests during failsafe execution -->
         <!--suppress UnresolvedMavenProperty -->
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -792,6 +793,12 @@
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-launcher</artifactId>
                 <version>${junit.platform.version}</version>
+            </dependency>
+            <!-- transitive dep of TestContainers; overridden here to avoid vulnerable version -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Bumps dependencies to deal with the following CVEs:

- CVE-2020-13956
- CVE-2021-36090
- CVE-2021-35515
- CVE-2021-35517

### Checklist

- [x] Make sure all tests pass