### PR TITLE
Cold backup script fixes

### DIFF
--- a/tools/cold-backup/README.md
+++ b/tools/cold-backup/README.md
@@ -1,10 +1,12 @@
 ## Strimzi backup
 
-Bash script for cold/offline backups of Kafka clusters on Kubernetes/OpenShift. Only local file system is supported. Make sure to have enough free space in the target directory.
+Bash script for offline (_cold_) backups of Kafka clusters on Kubernetes or OpenShift. The script only supports a local file system. Make sure you have enough free disk space in the target directory.
 
-If you think you do not need a backup strategy for Kafka because of its embedded data replication, then consider the impact of a misconfiguration, bug or security breach that deleted all your data. For hot/online backups, you can use storage snapshotting or streaming into object storage.
+If you think you don't need a backup strategy for Kafka because of its embedded data replication, then consider the impact of a misconfiguration, bug, or security breach that deletes all of your data. For online (_hot_) backups, you can use storage snapshotting or stream into object storage.
 
-To run the script, the Kubernetes user must have permission to work with PVC and Strimzi custom resources. The procedure will stop the Cluster Operator and selected cluster for the duration of the backup. Before restoring the Kafka cluster you need to make sure to have the right version of Strimzi CRDs installed. If you have a single cluster-wide Cluster Operator, then you need to scale it down manually. You can run backup and restore procedures for different Kafka clusters in parallel. Only the local file system is supported. Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafka Bridge custom resources.
+Run the script as a Kubernetes user with permission to work with PVC and Strimzi custom resources. 
+
+The procedure will stop the Cluster Operator and selected cluster for the duration of the backup. Before restoring the Kafka cluster you need to make sure to have the right version of Strimzi CRDs installed. If you have a single cluster-wide Cluster Operator, then you need to scale it down manually. You can run backup and restore procedures for different Kafka clusters in parallel. Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafka Bridge custom resources.
 
 ## Requirements
 

--- a/tools/cold-backup/README.md
+++ b/tools/cold-backup/README.md
@@ -1,18 +1,21 @@
 # Strimzi backup
+
 Bash script for cold/offline backups of Kafka clusters on Kubernetes/OpenShift.
+Only local file system is supported. Make sure to have enough free space in the target directory.
 
-If you think you do not need a backup strategy for Kafka because of its embedded data replication,
-then consider the impact of a misconfiguration, bug or security breach that deleted all your data.
-For hot/online backups, you can use storage snapshotting or streaming into object storage.
+If you think you do not need a backup strategy for Kafka because of its embedded data replication, then consider the 
+impact of a misconfiguration, bug or security breach that deleted all your data. For hot/online backups, you can use 
+storage snapshotting or streaming into object storage.
 
-To run the script, the Kubernetes user must have permission to work with PVC and Strimzi custom resources.
-The procedure will stop the Cluster Operator and selected cluster for the duration of the backup. Before
-restoring the Kafka cluster you need to make sure to have the right version of Strimzi CRDs installed.
-If you have a single cluster-wide Cluster Operator, then you need to scale it down manually. You can run
-backup and restore procedures for different Kafka clusters in parallel. Only the local file system is supported.
-Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafka Bridge custom resources.
+To run the script, the Kubernetes user must have permission to work with PVC and Strimzi custom resources. The procedure 
+will stop the Cluster Operator and selected cluster for the duration of the backup. Before restoring the Kafka cluster 
+you need to make sure to have the right version of Strimzi CRDs installed. If you have a single cluster-wide Cluster 
+Operator, then you need to scale it down manually. You can run backup and restore procedures for different Kafka 
+clusters in parallel. Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafka Bridge custom 
+resources.
 
 ## Requirements
+
 - bash 5+ (GNU)
 - tar 1.33+ (GNU)
 - kubectl 1.16+ (K8s CLI)
@@ -22,7 +25,11 @@ Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafk
 - enough disk space
 
 ## Test procedure
+
 ```sh
+CLIENT_IMAGE="quay.io/strimzi/kafka:latest-kafka-2.8.0"
+krun() { kubectl run client -it --rm=true --restart=Never --image=$CLIENT_IMAGE -- $@; }
+
 # deploy a test cluster
 kubectl create namespace myproject
 kubectl config set-context --current --namespace="myproject"
@@ -30,28 +37,23 @@ kubectl create -f ./install/cluster-operator
 kubectl create -f ./examples/kafka/kafka-persistent.yaml
 kubectl create -f ./examples/topic/kafka-topic.yaml
 
-# send 100000 messages and consume them
-kubectl run kafka-producer-perf-test -it \
-    --image="quay.io/strimzi/kafka:latest-kafka-2.8.0" \
-    --rm="true" --restart="Never" -- bin/kafka-producer-perf-test.sh \
-    --topic my-topic --record-size 1000 --num-records 100000 --throughput -1 \
-    --producer-props acks=1 bootstrap.servers=my-cluster-kafka-bootstrap:9092
+# send and consume 100000 messages
+krun ./bin/kafka-producer-perf-test.sh \
+  --producer-props acks=1 bootstrap.servers=my-cluster-kafka-bootstrap:9092 \
+  --topic my-topic --record-size 1000 --num-records 100000 --throughput -1
 
-kubectl exec -it my-cluster-kafka-0 -c kafka -- \
-    bin/kafka-console-consumer.sh --bootstrap-server :9092 \
-    --topic my-topic --group my-group --from-beginning --timeout-ms 15000
+krun ./bin/kafka-consumer-perf-test.sh \
+  --broker-list my-cluster-kafka-bootstrap:9092 \
+  --topic my-topic --group my-group --messages 100000 --timeout 15000
 
 # save consumer group offsets
-kubectl exec -it my-cluster-kafka-0 -c kafka -- \
-    bin/kafka-consumer-groups.sh --bootstrap-server :9092 \
-    --group my-group --describe > /tmp/offsets.txt
+krun ./bin/kafka-consumer-groups.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 \
+  --group my-group --describe > /tmp/my-offsets.txt
 
 # send additional 12345 messages
-kubectl run kafka-producer-perf-test -it \
-    --image="quay.io/strimzi/kafka:latest-kafka-2.8.0" \
-    --rm="true" --restart="Never" -- bin/kafka-producer-perf-test.sh \
-    --topic my-topic --record-size 1000 --num-records 12345 --throughput -1 \
-    --producer-props acks=1 bootstrap.servers=my-cluster-kafka-bootstrap:9092
+krun ./bin/kafka-producer-perf-test.sh \
+  --producer-props acks=1 bootstrap.servers=my-cluster-kafka-bootstrap:9092 \
+  --topic my-topic --record-size 1000 --num-records 12345 --throughput -1
 
 # run backup procedure
 ./tools/cold-backup/run.sh backup -n myproject -c my-cluster -t /tmp/my-cluster.zip
@@ -65,18 +67,18 @@ kubectl create -f ./install/cluster-operator
 ./tools/cold-backup/run.sh restore -n myproject -c my-cluster -s /tmp/my-cluster.zip
 
 # check consumer group offsets (expected: current-offset match)
-cat /tmp/offsets.txt
-kubectl exec -it my-cluster-kafka-0 -c kafka -- \
-    bin/kafka-consumer-groups.sh --bootstrap-server :9092 \
-    --group my-group --describe
+cat /tmp/my-offsets.txt
+
+krun ./bin/kafka-consumer-groups.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 \
+  --group my-group --describe
 
 # check consumer group recovery (expected: 12345)
-kubectl exec -it my-cluster-kafka-0 -c kafka -- \
-    bin/kafka-console-consumer.sh --bootstrap-server :9092 \
-    --topic my-topic --group my-group --from-beginning --timeout-ms 15000
+krun ./bin/kafka-consumer-perf-test.sh \
+  --broker-list my-cluster-kafka-bootstrap:9092 \
+  --topic my-topic --group my-group --messages 1000000 --timeout 5000
 
 # check total number of messages (expected: 112345)
-kubectl exec -it my-cluster-kafka-0 -c kafka -- \
-    bin/kafka-console-consumer.sh --bootstrap-server :9092 \
-    --topic my-topic --group new-group --from-beginning --timeout-ms 15000
+krun ./bin/kafka-consumer-perf-test.sh \
+  --broker-list my-cluster-kafka-bootstrap:9092 \
+  --topic my-topic --group new-group --messages 1000000 --timeout 15000
 ```

--- a/tools/cold-backup/templates/patch.json
+++ b/tools/cold-backup/templates/patch.json
@@ -2,8 +2,9 @@
     "spec": {
         "containers": [
             {
-                "name": "dummy",
-                "image": "centos:7",
+                "name": "strimzi-backup",
+                "image": "registry.access.redhat.com/ubi8/ubi:8.4",
+                "imagePullPolicy": "IfNotPresent",
                 "command": [
                     "/bin/bash",
                     "-c",


### PR DESCRIPTION
- Switch to ubi8 image
- Store backup data inside target dir instead of /tmp
- Ignore the sporadic file changed error
- Remove incremental backup option (not working)

These fixes are the result of a real use case, where the script was failing mainly because of the tar issue, but they also didn't have enough free space on /tmp that is used as staging area. 