### PR TITLE
[DOC] We should not suggest 1 partition is enough

### DIFF
--- a/documentation/modules/operators/con-topic-operator-store.adoc
+++ b/documentation/modules/operators/con-topic-operator-store.adoc
@@ -69,7 +69,7 @@ spec:
     min.insync.replicas: 2 <3>
   #...
 ----
-<1> The number of partitions for the topic. Generally, 1 partition is sufficient.
+<1> The number of partitions for the topic.
 <2> The number of replica topic partitions. Currently, this cannot be changed in the `KafkaTopic` resource, but it can be changed using the `kafka-reassign-partitions.sh` tool.
 <3> The minimum number of replica partitions that a message must be successfully written to, or an exception is raised.
 

--- a/documentation/modules/operators/con-topic-operator-store.adoc
+++ b/documentation/modules/operators/con-topic-operator-store.adoc
@@ -63,7 +63,7 @@ metadata:
   labels:
     strimzi.io/cluster: my-cluster
 spec:
-  partitions: 1 <1>
+  partitions: 10 <1>
   replicas: 3 <2>
   config:
     min.insync.replicas: 2 <3>


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

Right now, our [docs](https://strimzi.io/docs/operators/latest/full/using.html#topic_operator_topic_replication_and_scaling) suggest that one partition per topic is sufficient. I think this is wrong and we should not suggest that.

### Checklist

- [x] Update documentation