### PR TITLE
docs: Add a note for DBZ connectors

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -65,6 +65,8 @@ $ tree ./_my-plugins_/
     ├── protobuf-java-2.6.1.jar
     └── README.md
 ----
++
+NOTE: This example uses the Debezium connectors for MongoDB, MySQL, and PostgreSQL. Debezium running in Kafka Connect looks the same as any other Kafka Connect task.
 
 . Build the container image.
 


### PR DESCRIPTION
Signed-off-by: Daniel Laing <dlaing@redhat.com>

### Type of change

- Documentation

### Description

Guide updated: Deploying and Upgrading AMQ Streams

Adds a note to "Creating a Docker image from the Kafka Connect base image". Explains that Debezium running in Kafka Connect looks the same as any other Kafka Connect task.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

