### PR TITLE
Add `watchAnyNamespace` to the Helm Chart README.md file

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -95,6 +95,7 @@ the documentation for more details.
 | Parameter                            | Description                               | Default                                              |
 | ------------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
 | `watchNamespaces`                    | Comma separated list of additional namespaces for the strimzi-operator to watch | []             |
+| `watchAnyNamespace`                  | Watch the whole Kubernetes cluster (all namespaces) | `false`                                    |
 | `defaultImageRegistry`               | Default image registry for all the images | `quay.io`                                            |
 | `defaultImageRepository`             | Default image registry for all the images | `strimzi`                                            |
 | `defaultImageTag`                    | Default image tag for all the images except Kafka Bridge | `latest`                              |


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Helm Chart README.md file seems to be missing the `watchAnyNamespace` option. This PR adds it there.