### PR TITLE
Set KStreams RF

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
@@ -151,7 +151,7 @@ public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Seria
     }
 
 
-    @Description("Logging configuration")
+    @Description("Logging configuration.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
         return logging;

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -129,7 +129,7 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
         this.readinessProbe = readinessProbe;
     }
 
-    @Description("Logging configuration")
+    @Description("Logging configuration.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public Logging getLogging() {
         return logging;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -108,6 +108,7 @@ public class EntityTopicOperatorTest {
         List<EnvVar> expected = new ArrayList<>();
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_RESOURCE_LABELS).withValue(ModelUtils.defaultResourceLabels(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_KAFKA_BOOTSTRAP_SERVERS).withValue(EntityTopicOperator.defaultBootstrapServers(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_KAFKA_STREAMS_REPLICATION_FACTOR).withValue(String.valueOf(replicas)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_ZOOKEEPER_CONNECT).withValue(String.format("%s:%d", "localhost", EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_PORT)).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_WATCHED_NAMESPACE).withValue(toWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(toReconciliationInterval * 1000)).build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -130,7 +130,7 @@ public class MetricsST extends AbstractST {
     void testKafkaTopicPartitions() {
         Pattern topicPartitions = Pattern.compile("kafka_server_replicamanager_partitioncount ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         ArrayList<Double> values = MetricsCollector.collectSpecificMetric(topicPartitions, kafkaMetricsData);
-        assertThat("Topic partitions count doesn't match expected value", values.stream().mapToDouble(i -> i).sum(), is(423.0));
+        assertThat("Topic partitions count doesn't match expected value", values.stream().mapToDouble(i -> i).sum(), is(425.0));
     }
 
     @ParallelTest

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Config.java
@@ -131,6 +131,7 @@ public class Config {
     public static final String TC_STALE_RESULT_TIMEOUT_MS = "STRIMZI_STALE_RESULT_TIMEOUT_MS";
 
     public static final String TC_USE_ZOOKEEPER_TOPIC_STORE = "STRIMZI_USE_ZOOKEEPER_TOPIC_STORE";
+    public static final String TC_KAFKA_STREAMS_REPLICATION_FACTOR = "STRIMZI_KAFKA_STREAMS_REPLICATION_FACTOR";
 
     private static final Map<String, Value<?>> CONFIG_VALUES = new HashMap<>();
 
@@ -139,6 +140,9 @@ public class Config {
 
     /** A comma-separated list of kafka bootstrap servers. */
     public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value<>(TC_KAFKA_BOOTSTRAP_SERVERS, STRING, true);
+
+    /** Kafka Streams replication factor */
+    public static final Value<String> KAFKA_STREAMS_REPLICATION_FACTOR = new Value<>(TC_KAFKA_STREAMS_REPLICATION_FACTOR, STRING, "-1");
 
     /** The kubernetes namespace in which to operate. */
     public static final Value<String> NAMESPACE = new Value<>(TC_NAMESPACE, STRING, true);
@@ -240,6 +244,7 @@ public class Config {
         addConfigValue(configValues, APPLICATION_ID);
         addConfigValue(configValues, STALE_RESULT_TIMEOUT_MS);
         addConfigValue(configValues, USE_ZOOKEEPER_TOPIC_STORE);
+        addConfigValue(configValues, KAFKA_STREAMS_REPLICATION_FACTOR);
     }
 
     static void addConfigValue(Map<String, Value<?>> configValues, Value<?> cv) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -132,7 +132,7 @@ public class K8sImpl implements K8s {
             try {
                 try {
                     LOGGER.debug("Creating event {}", event);
-                    client.v1().events().inNamespace(namespace).create(event);
+                    client.v1().events().inNamespace(event.getMetadata().getNamespace()).create(event);
                 } catch (KubernetesClientException e) {
                     LOGGER.error("Error creating event {}", event, e);
                 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -301,6 +301,7 @@ public class Session extends AbstractVerticle {
         Properties kafkaClientProps = new Properties();
         kafkaClientProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(Config.KAFKA_BOOTSTRAP_SERVERS));
         kafkaClientProps.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, config.get(Config.APPLICATION_ID));
+        kafkaClientProps.setProperty(StreamsConfig.REPLICATION_FACTOR_CONFIG, config.get(Config.KAFKA_STREAMS_REPLICATION_FACTOR));
 
         String securityProtocol = config.get(Config.SECURITY_PROTOCOL);
         boolean tlsEnabled = Boolean.parseBoolean(config.get(Config.TLS_ENABLED));


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
The `REPLICATION_FACTOR_CONFIG` is never set and thus it is always set to broker's default. Setting this value to `min(kafkaReplicas, 3)`. Value 3 is from this [recommendation](https://kafka.apache.org/22/documentation/streams/developer-guide/config-streams#replication-factor).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

