### PR TITLE
Load all certificates in Kafka Exporter

### DIFF
--- a/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -24,6 +24,13 @@ if [ -n "$KAFKA_EXPORTER_LOGGING" ]; then
     loglevel="--verbosity=${KAFKA_EXPORTER_LOGGING}"
 fi
 
+# Combine all the certs in the cluster CA into one file
+CA_CERTS=/tmp/cluster-ca.crt
+for cert in /etc/kafka-exporter/cluster-ca-certs/*.crt; do
+  sed -z '$ s/\n$//' "$cert" >> "$CA_CERTS"
+  echo "" >> "$CA_CERTS"
+done
+
 # shellcheck disable=SC2027
 version="--kafka.version=\""$KAFKA_EXPORTER_KAFKA_VERSION"\""
 
@@ -33,7 +40,7 @@ listenaddress="--web.listen-address=:9404"
 
 allgroups="--offset.show-all"
 
-tls="--tls.enabled --tls.ca-file=/etc/kafka-exporter/cluster-ca-certs/ca.crt --tls.cert-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.crt  --tls.key-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.key"
+tls="--tls.enabled --tls.ca-file=$CA_CERTS --tls.cert-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.crt  --tls.key-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.key"
 
 # starting Kafka Exporter with final configuration
 cat <<EOT > /tmp/run.sh


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During certificate renewals and replacement of private keys, the Cluster CA secret might contain more than one public key. The operands need to load all of them to be able to work during the rollouts when the other components might be using both the old and new certificate (they will always use only one of them, but e.g. one broker might already have the new while other has still the old).

This currently does not happen and the Exporter uses only the `ca.crt` file. As a result, during Cluster CA key replacement, it will start crash-looping instead of rolling smoothly.

This PR changes the logic and uses all `*.crt` files in the Kafka Exporter startup script. Thanks to this, Kafka Exporter rolls fine without crash-looping when replacing certificates..

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally