### PR TITLE
Minor fixes to `KafkaAssemblyOperator` and `ClusterCa` classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -79,7 +79,6 @@ public class ClusterCa extends Ca {
         return "cluster-ca";
     }
 
-    @SuppressWarnings("deprecation")
     public void initCaSecrets(List<Secret> secrets) {
         for (Secret secret: secrets) {
             String name = secret.getMetadata().getName();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -713,7 +713,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * It is not necessary when the CA certificate is replace while retaining the existing key.
          */
         Future<ReconciliationState> rollingUpdateForNewCaKey() {
-            List<String> reason = new ArrayList<>(4);
+            List<String> reason = new ArrayList<>(2);
             if (this.clusterCa.keyReplaced()) {
                 reason.add("trust new cluster CA certificate signed by new key");
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR does to very minor fixes to the `KafkaAssemblyOperator` and `ClusterCa` classes:
* Removes the annotation to suppress deprecation warning which does not seem to be needed anymore
* Use the correct default size for an array with possible rolling update reasons

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally