### PR TITLE
Use all public keys from Cluster CA in `ZookeeperScaler` and in `DefaultAdminClientProvider`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -279,7 +279,7 @@ public class ZookeeperScaler implements AutoCloseable {
             try {
                 ZKClientConfig clientConfig = new ZKClientConfig();
 
-                trustStoreFile = Util.createFileTrustStore(getClass().getName(), "p12", Ca.cert(clusterCaCertSecret, Ca.CA_CRT), trustStorePassword.toCharArray());
+                trustStoreFile = Util.createFileTrustStore(getClass().getName(), "p12", Ca.certs(clusterCaCertSecret), trustStorePassword.toCharArray());
                 keyStoreFile = Util.createFileStore(getClass().getName(), "p12", Util.decodeFromSecret(coKeySecret, "cluster-operator.p12"));
 
                 clientConfig.setProperty("zookeeper.clientCnxnSocket", "org.apache.zookeeper.ClientCnxnSocketNetty");

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -50,7 +50,7 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
         if (clusterCaCertSecret != null) {
             PasswordGenerator pg = new PasswordGenerator(12);
             trustStorePassword = pg.generate();
-            truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.cert(clusterCaCertSecret, Ca.CA_CRT), trustStorePassword.toCharArray());
+            truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.certs(clusterCaCertSecret), trustStorePassword.toCharArray());
         }
 
         try {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.function.BooleanSupplier;
@@ -239,16 +240,22 @@ public class Util {
      *
      * @param prefix Prefix which will be used for the filename
      * @param suffix Suffix which will be used for the filename
-     * @param certificate X509 certificate to put inside the Truststore
+     * @param certificates X509 certificates to put inside the Truststore
      * @param password Password protecting the Truststore
      * @return File with the Truststore
      */
-    public static File createFileTrustStore(String prefix, String suffix, X509Certificate certificate, char[] password) {
+    public static File createFileTrustStore(String prefix, String suffix, Set<X509Certificate> certificates, char[] password) {
         try {
             KeyStore trustStore = null;
             trustStore = KeyStore.getInstance("PKCS12");
             trustStore.load(null, password);
-            trustStore.setEntry(certificate.getSubjectDN().getName(), new KeyStore.TrustedCertificateEntry(certificate), null);
+
+            int aliasIndex = 0;
+            for (X509Certificate certificate : certificates) {
+                trustStore.setEntry(certificate.getSubjectDN().getName() + "-" + aliasIndex, new KeyStore.TrustedCertificateEntry(certificate), null);
+                aliasIndex++;
+            }
+
             return store(prefix, suffix, trustStore, password);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During Cluster CA renewal, the Cluster CA secret might contain multiple public keys belonging to different generation of the CA. It is important for all components to load all of them to allow smooth rollout of CA changes, when the components might need to trust both the old and new CA. This applies also to the `ZookeeperScaler` as well as to the `DefaultAdminClientProvider`. They should not use only the `ca.crt` but all `*.crt` files. Without that, they will be unable to connect for example during renewals of own Cluster CAs.

This PR changes both above mentioned classes to load all CRT files. It allows them to connect to the ZooKeeper and Kafka clusters during the update of own Cluster CA. This fix relates to #5466, but does not seem to fix it completely, it is just a first step to it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging