### PR TITLE
[systemtest] Test check for JMX metrics on Zookeper nodes with secret custom labels and annotations

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/JmxST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/JmxST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.metrics;
 
+import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPassword;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -17,9 +18,14 @@ import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.specific.JmxUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Collections;
+import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -27,11 +33,13 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(REGRESSION)
 public class JmxST extends AbstractST {
 
     public static final String NAMESPACE = "jmx-cluster-test";
+    private static final Logger LOGGER = LogManager.getLogger(JmxST.class);
 
     @ParallelNamespaceTest
     @Tag(CONNECT)
@@ -67,6 +75,46 @@ public class JmxST extends AbstractST {
 
         assertThat("Result from Kafka JMX doesn't contain right version of Kafka, result: " + kafkaResults, kafkaResults, containsString("version = " + Environment.ST_KAFKA_VERSION));
         assertThat("Result from KafkaConnect JMX doesn't contain right version of Kafka, result: " + kafkaConnectResults, kafkaConnectResults, containsString("version = " + Environment.ST_KAFKA_VERSION));
+    }
+
+    @ParallelNamespaceTest
+    void testJmxOnZookeeperNodesWithSecretLabelsAndAnnotations(ExtensionContext extensionContext) {
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
+        final String zkSecretName = clusterName + "-zookeeper-jmx";
+
+        Map<String, String> jmxSecretLabels = Collections.singletonMap("my-label", "my-value");
+        Map<String, String> jmxSecretAnnotations = Collections.singletonMap("my-annotation", "some-value");
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3)
+            .editSpec()
+                .editOrNewZookeeper()
+                    .withNewJmxOptions()
+                        .withAuthentication(new KafkaJmxAuthenticationPassword())
+                    .endJmxOptions()
+                    .editOrNewTemplate()
+                        .withNewJmxSecret()
+                            .withNewMetadata()
+                                .withLabels(jmxSecretLabels)
+                                .withAnnotations(jmxSecretAnnotations)
+                            .endMetadata()
+                        .endJmxSecret()
+                    .endTemplate()
+                .endZookeeper()
+            .endSpec()
+            .build());
+
+        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
+        String clientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
+        Secret jmxZkSecret = kubeClient().getSecret(namespaceName, zkSecretName);
+
+        String zkResults = JmxUtils.execJmxTermAndGetResult(namespaceName, KafkaResources.zookeeperHeadlessServiceName(clusterName), zkSecretName, clientsPodName, "bean org.apache.ZooKeeperService:name0=ReplicatedServer_id1\nget -i *");
+        assertThat("Result from Zookeeper JMX doesn't contain right quorum size, result: " + zkResults, zkResults, containsString("QuorumSize = 3"));
+
+        LOGGER.info("Checking that Zookeeper JMX secret is created with custom labels and annotations");
+        assertTrue(jmxZkSecret.getMetadata().getLabels().entrySet().containsAll(jmxSecretLabels.entrySet()));
+        assertTrue(jmxZkSecret.getMetadata().getAnnotations().entrySet().containsAll(jmxSecretAnnotations.entrySet()));
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

After #5413 we should be able to work with JMX metrics on Zookeeper headless service. This PR adds test which checks this together with adding custom labels and annotations to JMX secret - done in #5451 .

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

