### PR TITLE
Update Cruise Control to version 2.5.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add support for building connector images from the Maven coordinates
 * Allow Kafka Connect Build artifacts to be downloaded from insecure servers (#5542)
 * Configurable authentication, authorization, and SSL for Cruise Control API
+* Update to Cruise Control version 2.5.73
 
 ### Changes, deprecations and removals
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.57</cruise-control.version>
+        <cruise-control.version>2.5.73</cruise-control.version>
         <opa-authorizer.version>1.1.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
@@ -251,6 +251,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Cruise Control -->
         <dependency>
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control-metrics-reporter</artifactId>
@@ -258,7 +259,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.12</artifactId>
+                    <artifactId>kafka_2.13</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>

--- a/docker-images/kafka/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.57</cruise-control.version>
+        <cruise-control.version>2.5.73</cruise-control.version>
         <opa-authorizer.version>1.1.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.1.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
@@ -251,6 +251,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Cruise Control -->
         <dependency>
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control-metrics-reporter</artifactId>
@@ -258,7 +259,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.12</artifactId>
+                    <artifactId>kafka_2.13</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.57</cruise-control.version>
+        <cruise-control.version>2.5.73</cruise-control.version>
     </properties>
 
     <repositories>

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -46,7 +46,8 @@ public class CruiseControlApiST extends AbstractST {
         String response = CruiseControlUtils.callApi(NAMESPACE, CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/state'\n" +
-            "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION]\n"));
+            "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, " +
+                "RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION, RIGHTSIZE]\n"));
 
         response = CruiseControlUtils.callApi(NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
@@ -105,7 +106,8 @@ public class CruiseControlApiST extends AbstractST {
         response = CruiseControlUtils.callApi(NAMESPACE, CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.USER_TASKS, CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/user_tasks'\n" +
-            "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION]\n"));
+            "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, " +
+                "RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION, RIGHTSIZE]\n"));
 
         response = CruiseControlUtils.callApi(NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.USER_TASKS,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates the supported Cruise Control version to `2.5.73`

### Checklist

- [X] Make sure all tests pass
- [X] Update documentation
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Update CHANGELOG.md