### PR TITLE
Update inter-broker protocol and message format in examples to 3.0

### DIFF
--- a/packaging/examples/cruise-control/kafka-cruise-control.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/kafka/kafka-ephemeral-single.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral-single.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/kafka/kafka-ephemeral.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/kafka/kafka-persistent-single.yaml
+++ b/packaging/examples/kafka/kafka-persistent-single.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral
     jmxOptions:

--- a/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -25,8 +25,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -40,8 +40,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -19,8 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.8"
-      inter.broker.protocol.version: "2.8"
+      log.message.format.version: "3.0"
+      inter.broker.protocol.version: "3.0"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like we forgot to update the inter-broker protocol version and the message format version to `3.0` in the examples when adding Kafka 3.0 support. This PR adds it.