### PR TITLE
Rebuild Kafka Connect container image on repository change

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -261,13 +261,13 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         if (connectBuild.getBuild() != null) {
             // Build exists => let's build
             KafkaConnectDockerfile dockerfile = connectBuild.generateDockerfile();
-            String newBuildRevision = dockerfile.hashStub();
+            String newBuildRevision = dockerfile.hashStub() + Util.sha1Prefix(connectBuild.getBuild().getOutput().getImage());
             ConfigMap dockerFileConfigMap = connectBuild.generateDockerfileConfigMap(dockerfile);
 
             if (newBuildRevision.equals(buildState.currentBuildRevision)
                     && !buildState.forceRebuild) {
                 // The revision is the same and rebuild was not forced => nothing to do
-                LOGGER.infoCr(reconciliation, "Build configuration did not changed. Nothing new to build. Container image {} will be used.", buildState.currentImage);
+                LOGGER.infoCr(reconciliation, "Build configuration did not change. Nothing new to build. Container image {} will be used.", buildState.currentImage);
                 buildState.desiredImage = buildState.currentImage;
                 buildState.desiredBuildRevision = newBuildRevision;
                 return Future.succeededFuture();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.BuildConfigOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
@@ -364,7 +365,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
 
     @SuppressWarnings({"checkstyle:MethodLength"})
     @Test
-    public void testUpdateWithRebuildOnKube(VertxTestContext context) {
+    public void testUpdateWithPluginChangeOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
                 .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
@@ -522,6 +523,167 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
 
                 async.flag();
             })));
+    }
+
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    @Test
+    public void testUpdateWithBuildImageChangeOnKube(VertxTestContext context) {
+        Plugin plugin1 = new PluginBuilder()
+                .withName("plugin1")
+                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
+                .build();
+
+        KafkaConnect oldKc = new KafkaConnectBuilder()
+                .withNewMetadata()
+                .withName(NAME)
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(1)
+                .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
+                .withNewBuild()
+                .withNewDockerOutput()
+                .withImage("my-connect-build:latest")
+                .withPushSecret("my-docker-credentials")
+                .endDockerOutput()
+                .withPlugins(plugin1)
+                .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectCluster oldConnect = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKc, VERSIONS);
+        KafkaConnectBuild oldBuild = KafkaConnectBuild.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKc, VERSIONS);
+
+        KafkaConnect kc = new KafkaConnectBuilder(oldKc)
+                .editSpec()
+                .editBuild()
+                .withNewDockerOutput()
+                .withImage("my-connect-build-2:blah")
+                .withPushSecret("my-docker-credentials")
+                .endDockerOutput()
+                .withPlugins(plugin1)
+                .endBuild()
+                .endSpec()
+                .build();
+
+        KafkaConnectBuild build = KafkaConnectBuild.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kc, VERSIONS);
+
+        // Prepare and get mocks
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
+        CrdOperator mockConnectOps = supplier.connectOperator;
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        PodOperator mockPodOps = supplier.podOperations;
+        BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
+
+        // Mock KafkaConnector ops
+        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock KafkaConnect ops
+        when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
+        when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
+
+        // Mock and capture service ops
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), anyString(), anyString(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture deployment ops
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
+            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.sha1Prefix(oldBuild.getBuild().getOutput().getImage()));
+            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build-2@sha256:olddigest");
+            return Future.succeededFuture(dep);
+        });
+        when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.scaleDown(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
+        when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture CM ops
+        when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+        ArgumentCaptor<ConfigMap> dockerfileCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), anyString(), eq(KafkaConnectResources.dockerFileConfigMapName(NAME)), dockerfileCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
+
+        // Mock and capture Pod ops
+        ArgumentCaptor<Pod> builderPodCaptor = ArgumentCaptor.forClass(Pod.class);
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), builderPodCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        Pod terminatedPod = new PodBuilder()
+                .withNewMetadata()
+                .withName(KafkaConnectResources.buildPodName(NAME))
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build-2@sha256:blablabla").endTerminated().endState().build())
+                .endStatus()
+                .build();
+        when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
+        when(mockPodOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)))).thenReturn(Future.succeededFuture(null), Future.succeededFuture(terminatedPod));
+
+        // Mock and capture BuildConfig ops
+        when(mockBcOps.reconcile(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildConfigName(NAME)), eq(null))).thenReturn(Future.succeededFuture(ReconcileResult.noop(null)));
+
+        // Mock and capture NP ops
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
+
+        // Mock and capture PDB ops
+        when(mockPdbOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock and capture KafkaConnect ops for status update
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaConnect API client
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+
+        // Prepare and run reconciliation
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
+                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kc, VERSIONS);
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify Deployment
+                    List<Deployment> capturedDeps = depCaptor.getAllValues();
+                    assertThat(capturedDeps, hasSize(1));
+                    Deployment dep = capturedDeps.get(0);
+                    assertThat(dep.getMetadata().getName(), is(connect.getName()));
+                    assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build-2@sha256:blablabla"));
+                    assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+
+                    // Verify ConfigMap
+                    List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
+                    assertThat(capturedCms, hasSize(1));
+                    ConfigMap dockerfileCm = capturedCms.get(0);
+                    assertThat(dockerfileCm.getData().containsKey("Dockerfile"), is(true));
+                    assertThat(dockerfileCm.getData().get("Dockerfile"), is(build.generateDockerfile().getDockerfile()));
+
+                    // Verify builder Pod
+                    List<Pod> capturedBuilderPods = builderPodCaptor.getAllValues();
+                    assertThat(capturedBuilderPods, hasSize(2));
+                    assertThat(capturedBuilderPods.stream().filter(pod -> pod != null).collect(Collectors.toList()), hasSize(1));
+
+                    // Verify status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -80,6 +80,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     private static final String NAME = "my-connect";
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
+    private static final String OUTPUT_IMAGE = "my-connect-build:latest";
+    private static final String OUTPUT_IMAGE_HASH_STUB = Util.sha1Prefix(OUTPUT_IMAGE);
+
     protected static Vertx vertx;
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
 
@@ -111,7 +114,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -214,7 +217,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
@@ -264,7 +267,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -386,7 +389,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -500,7 +503,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
@@ -543,7 +546,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                 .withNewBuild()
                 .withNewDockerOutput()
-                .withImage("my-connect-build:latest")
+                .withImage(OUTPUT_IMAGE)
                 .withPushSecret("my-docker-credentials")
                 .endDockerOutput()
                 .withPlugins(plugin1)
@@ -709,7 +712,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1, plugin2)
@@ -782,7 +785,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewMetadata()
                     .withName(KafkaConnectResources.buildPodName(NAME))
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub()))
+                    .withAnnotations(singletonMap(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB))
                 .endMetadata()
                 .withNewSpec()
                 .endSpec()
@@ -834,7 +837,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
@@ -879,7 +882,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -1005,7 +1008,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
@@ -1053,7 +1056,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1, plugin2)
@@ -1181,7 +1184,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
@@ -1223,7 +1226,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -1263,7 +1266,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
             Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub());
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
             return Future.succeededFuture(dep);
         });
@@ -1311,7 +1314,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();
@@ -1349,7 +1352,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -1452,7 +1455,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:rebuiltblablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify ConfigMap
                 List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -80,6 +80,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     private static final String NAME = "my-connect";
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
+    private static final String OUTPUT_IMAGE = "my-connect-build:latest";
+    private static final String OUTPUT_IMAGE_HASH_STUB = Util.sha1Prefix(OUTPUT_IMAGE);
+
     protected static Vertx vertx;
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
 
@@ -110,7 +113,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -175,7 +178,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .endSpec()
                 .withNewStatus()
                     .withPhase("Complete")
-                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutputDockerImageReference(OUTPUT_IMAGE)
                     .withNewOutput()
                         .withNewTo()
                             .withImageDigest("sha256:blablabla")
@@ -219,7 +222,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
@@ -255,7 +258,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -378,7 +381,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -459,7 +462,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .endSpec()
                 .withNewStatus()
                     .withPhase("Complete")
-                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutputDockerImageReference(OUTPUT_IMAGE)
                     .withNewOutput()
                         .withNewTo()
                             .withImageDigest("sha256:blablabla")
@@ -503,7 +506,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
@@ -540,7 +543,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                 .withNewBuild()
                 .withNewDockerOutput()
-                .withImage("my-connect-build:latest")
+                .withImage(OUTPUT_IMAGE)
                 .withPushSecret("my-docker-credentials")
                 .endDockerOutput()
                 .withPlugins(plugin1)
@@ -704,7 +707,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -745,7 +748,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
             Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub());
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
             return Future.succeededFuture(dep);
         });
@@ -791,7 +794,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub()));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
@@ -825,7 +828,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -866,7 +869,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
             Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage()));
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
             dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true");
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
             return Future.succeededFuture(dep);
@@ -895,7 +898,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .endSpec()
                 .withNewStatus()
                     .withPhase("Complete")
-                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutputDockerImageReference(OUTPUT_IMAGE)
                     .withNewOutput()
                         .withNewTo()
                             .withImageDigest("sha256:rebuiltblablabla")
@@ -937,7 +940,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:rebuiltblablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
@@ -979,7 +982,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -1070,7 +1073,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .endSpec()
                 .withNewStatus()
                     .withPhase("Complete")
-                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutputDockerImageReference(OUTPUT_IMAGE)
                     .withNewOutput()
                         .withNewTo()
                             .withImageDigest("sha256:blablabla")
@@ -1127,7 +1130,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
@@ -1167,7 +1170,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -1258,7 +1261,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .endSpec()
                 .withNewStatus()
                     .withPhase("Complete")
-                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutputDockerImageReference(OUTPUT_IMAGE)
                     .withNewOutput()
                         .withNewTo()
                             .withImageDigest("sha256:blablabla")
@@ -1315,7 +1318,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();
@@ -1357,7 +1360,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     .withBootstrapServers("my-cluster-kafka-bootstrap:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
-                            .withImage("my-connect-build:latest")
+                            .withImage(OUTPUT_IMAGE)
                             .withPushSecret("my-docker-credentials")
                         .endDockerOutput()
                         .withPlugins(plugin1)
@@ -1448,7 +1451,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 .endSpec()
                 .withNewStatus()
                     .withPhase("Complete")
-                    .withNewOutputDockerImageReference("my-connect-build:latest")
+                    .withNewOutputDockerImageReference(OUTPUT_IMAGE)
                     .withNewOutput()
                         .withNewTo()
                             .withImageDigest("sha256:blablabla")
@@ -1505,7 +1508,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 Deployment dep = capturedDeps.get(0);
                 assertThat(dep.getMetadata().getName(), is(connect.getName()));
                 assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
-                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB));
 
                 // Verify BuildConfig
                 List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the value of `build.output.image` of a `KafkaConnect` resources is changed, make sure we trigger a rebuild to push the image to the new repository. Unfortunately, this is not possible if the tag changes for now.

Note: I opened this PR as draft for now. @scholzj could you maybe give it a quick look and tell me if I'm in the right direction? I have tested those changes and they work as expected but didn't write any tests so far because I wanted to run it by you first.

Resolves #5636

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

