### PR TITLE
Update Mirror Maker 2 Extensions and OAuth for Kafka 3.0.0

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -16,11 +16,11 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
         <cruise-control.version>2.5.73</cruise-control.version>
         <opa-authorizer.version>1.1.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
-        <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
+        <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
@@ -35,6 +35,14 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>mm2extensions-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1120</url>
+        </repository>
+        <repository>
+            <id>oauth-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1122</url>
         </repository>
     </repositories>
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -786,7 +786,6 @@ class MirrorMaker2ST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @Disabled("Disabled because of issue with IdentityReplicationPolicy -> messages are not mirrored from source to target cluster")
     void testIdentityReplicationPolicy(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -55,7 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled("Due to fatal exception when deploying Kafka. Should be enabled after new version of Strimzi OAuth will be released")
 public class OauthAuthorizationST extends OauthAbstractST {
     protected static final Logger LOGGER = LogManager.getLogger(OauthAuthorizationST.class);
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the Mirror Maker 2 Extensions (1.1.0) and OAuth library (0.9.0) to new versions which should be compatible with Kafka 3.0.0. It also enables the related tests.

This is currently a draft using the RC releases.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally