### PR TITLE
[MO] - forgotten tag for test case, which uses nodeport

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2164,6 +2164,7 @@ public class ListenersST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @Tag(NODEPORT_SUPPORTED)
     void testAdvertisedHostNamesAppearsInBrokerCerts(ExtensionContext extensionContext) throws CertificateException {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR adding a forgotten tag for the test case, which uses a `Nodeport` listener.

### Checklist

