### PR TITLE
[systemtest] JmxST - add dynamic waits and collect ZK metrics with right bean

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/JmxUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/JmxUtils.java
@@ -48,7 +48,7 @@ public class JmxUtils {
         return cmdKubeClient().execInPod(podName, cmd).out().trim();
     }
 
-    public static String waitForJmxMetrics(String namespace, String serviceName, String secretName, String podName, String commands) {
+    public static String collectJmxMetricsWithWait(String namespace, String serviceName, String secretName, String podName, String commands) {
         Secret jmxSecret = kubeClient(namespace).getSecret(secretName);
 
         LOGGER.info("Getting username and password for service: {} and secret: {}", serviceName, secretName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/JmxST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/JmxST.java
@@ -93,13 +93,13 @@ public class JmxST extends AbstractST {
 
         Secret jmxZkSecret = kubeClient().getSecret(namespaceName, zkSecretName);
 
-        String kafkaResults = JmxUtils.waitForJmxMetrics(namespaceName, KafkaResources.brokersServiceName(clusterName), kafkaJmxSecretName, clientsPodName, "bean kafka.server:type=app-info\nget -i *");
-        String kafkaConnectResults = JmxUtils.waitForJmxMetrics(namespaceName, KafkaConnectResources.serviceName(clusterName), connectJmxSecretName, clientsPodName, "bean kafka.connect:type=app-info\nget -i *");
+        String kafkaResults = JmxUtils.collectJmxMetricsWithWait(namespaceName, KafkaResources.brokersServiceName(clusterName), kafkaJmxSecretName, clientsPodName, "bean kafka.server:type=app-info\nget -i *");
+        String kafkaConnectResults = JmxUtils.collectJmxMetricsWithWait(namespaceName, KafkaConnectResources.serviceName(clusterName), connectJmxSecretName, clientsPodName, "bean kafka.connect:type=app-info\nget -i *");
 
-        String zkBeans = JmxUtils.waitForJmxMetrics(namespaceName, KafkaResources.zookeeperHeadlessServiceName(clusterName), zkSecretName, clientsPodName, "domain org.apache.ZooKeeperService\nbeans");
+        String zkBeans = JmxUtils.collectJmxMetricsWithWait(namespaceName, KafkaResources.zookeeperHeadlessServiceName(clusterName), zkSecretName, clientsPodName, "domain org.apache.ZooKeeperService\nbeans");
         String zkBean = Arrays.asList(zkBeans.split("\\n")).stream().filter(bean -> bean.matches("org.apache.ZooKeeperService:name[0-9]+=ReplicatedServer_id[0-9]+")).findFirst().get();
 
-        String zkResults = JmxUtils.waitForJmxMetrics(namespaceName, KafkaResources.zookeeperHeadlessServiceName(clusterName), zkSecretName, clientsPodName, "bean " + zkBean + "\nget -i *");
+        String zkResults = JmxUtils.collectJmxMetricsWithWait(namespaceName, KafkaResources.zookeeperHeadlessServiceName(clusterName), zkSecretName, clientsPodName, "bean " + zkBean + "\nget -i *");
 
         assertThat("Result from Kafka JMX doesn't contain right version of Kafka, result: " + kafkaResults, kafkaResults, containsString("version = " + Environment.ST_KAFKA_VERSION));
         assertThat("Result from KafkaConnect JMX doesn't contain right version of Kafka, result: " + kafkaConnectResults, kafkaConnectResults, containsString("version = " + Environment.ST_KAFKA_VERSION));


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Because of race conditions, I'm adding dynamic waits for collecting JMX metrics and also fixing issue with variable ZK bean name (depended on node where we connect).

### Checklist

- [x] Make sure all tests pass

