### PR TITLE
Fix Zookeeper documentation bug causing crashloops

### DIFF
--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-extra-property.yaml
@@ -54,8 +54,8 @@ spec:
       initialDelaySeconds: 10
       timeoutSeconds: 4
     jvmOptions:
-      -Xmx: "512Mi"
-      -Xms: "512Mi"
+      -Xmx: "512M"
+      -Xms: "512M"
     storage:
       type: ephemeral
     metricsConfig:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- __[Documentation]__

### Description

Current example doc was causing crashloops because Xmx values do not accept SI memory units 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

