### PR TITLE
Fix reconciliation of TLS users with quotas

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
@@ -9,6 +9,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.user.model.KafkaUserModel;
 import io.strimzi.operator.user.model.QuotaUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -153,7 +154,8 @@ public class QuotasOperator extends AbstractAdminApiOperator<KafkaUserQuotas, Se
 
                     for (ClientQuotaEntity entity : quotas.keySet()) {
                         if (entity.entries().containsKey(ClientQuotaEntity.USER)) {
-                            users.add(entity.entries().get(ClientQuotaEntity.USER));
+                            String username = KafkaUserModel.decodeUsername(entity.entries().get(ClientQuotaEntity.USER));
+                            users.add(username);
                         }
                     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorIT.java
@@ -52,8 +52,8 @@ public class QuotasOperatorIT extends AbstractAdminApiOperatorIT<KafkaUserQuotas
     }
 
     @Override
-    KafkaUserQuotas get() {
-        ClientQuotaFilterComponent c = ClientQuotaFilterComponent.ofEntity(ClientQuotaEntity.USER, USERNAME);
+    KafkaUserQuotas get(String username) {
+        ClientQuotaFilterComponent c = ClientQuotaFilterComponent.ofEntity(ClientQuotaEntity.USER, username);
         ClientQuotaFilter f =  ClientQuotaFilter.contains(List.of(c));
 
         Map<ClientQuotaEntity, Map<String, Double>> quotas;
@@ -63,7 +63,7 @@ public class QuotasOperatorIT extends AbstractAdminApiOperatorIT<KafkaUserQuotas
             throw new RuntimeException("Failed to get quotas", e);
         }
 
-        ClientQuotaEntity cqe = new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, USERNAME));
+        ClientQuotaEntity cqe = new ClientQuotaEntity(Map.of(ClientQuotaEntity.USER, username));
 
         if (quotas.containsKey(cqe)) {
             return QuotaUtils.fromClientQuota(quotas.get(cqe));

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialsOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialsOperatorIT.java
@@ -8,6 +8,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.UserScramCredentialsDescription;
 import org.apache.kafka.common.errors.ResourceNotFoundException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
@@ -31,9 +32,9 @@ public class ScramCredentialsOperatorIT extends AbstractAdminApiOperatorIT<Strin
     }
 
     @Override
-    String get() {
+    String get(String username) {
         try {
-            UserScramCredentialsDescription result = adminClient.describeUserScramCredentials(List.of(USERNAME)).description(USERNAME).get();
+            UserScramCredentialsDescription result = adminClient.describeUserScramCredentials(List.of(username)).description(username).get();
             // The SCRAM-SHA credentials never return back an password. So we return a dummy empty String
             return result != null ? "" : null;
         } catch (ResourceNotFoundException e) {
@@ -54,5 +55,16 @@ public class ScramCredentialsOperatorIT extends AbstractAdminApiOperatorIT<Strin
     @Override
     void assertResources(VertxTestContext context, String expected, String actual) {
         // The password can be never obtained again from Kafka. So there is nothing to do here
+    }
+
+    /**
+     * SCRAM-SHA credentials are valid only for SCRAM users and not for TLS users. So this inherited test is disabled here.
+     *
+     * @param context   Test context
+     */
+    @Test
+    @Override
+    public void testCreateModifyDeleteTlsUsers(VertxTestContext context)    {
+        context.completeNow();
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -92,8 +92,8 @@ public class SimpleAclOperatorIT extends AbstractAdminApiOperatorIT<Set<SimpleAc
     }
 
     @Override
-    Set<SimpleAclRule> get() {
-        KafkaPrincipal principal = new KafkaPrincipal("User", USERNAME);
+    Set<SimpleAclRule> get(String username) {
+        KafkaPrincipal principal = new KafkaPrincipal("User", username);
         AclBindingFilter aclBindingFilter = new AclBindingFilter(ResourcePatternFilter.ANY,
                 new AccessControlEntryFilter(principal.toString(), null, org.apache.kafka.common.acl.AclOperation.ANY, AclPermissionType.ANY));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the Quota operator gets back all resources with quotas for timer based reconciliation, it does not currently properly convert them from the TLS format into the CR format (in case the user is a TLS user, it needs to be converted from `CN=username` to `username`). This is causing issues because it triggers reconciliations for wrong users which might delete the correct ACLs by mistake. It does not show up every-time since the timer runs also the proper reconciliation - so sometimes it cause issues and sometimes not. This problem was discussed in #5689.

This PR properly decodes the username (checks if it is a TLS user and decodes it if needed). It also adds additional tests to cover this.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging