### PR TITLE
[MO] - Azure balance our pipelines execution time

### DIFF
--- a/.azure/templates/jobs/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/feature_gates_regression_jobs.yaml
@@ -17,9 +17,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_dynconfig_tracing_watcher'
+      name: 'feature_gates_regression_dynconfig_listeners_tracing_watcher'
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
-      profile: 'azp_dynconfig_tracing_watcher'
+      profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -33,9 +33,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_rollingupdate'
+      name: 'feature_gates_regression_rollingupdate_bridge'
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
-      profile: 'azp_rolling_update'
+      profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 

--- a/.azure/templates/jobs/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -21,9 +21,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_regression_dynconfig_tracing_watcher'
+      name: 'feature_gates_namespace_rbac_scope_regression_dynconfig_listeners_tracing_watcher'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle III. - dynconfig + tracing + watcher'
-      profile: 'azp_dynconfig_tracing_watcher'
+      profile: 'azp_dynconfig_listeners_tracing_watcher'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -41,9 +41,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_namespace_rbac_scope_regression_rollingupdate'
+      name: 'feature_gates_namespace_rbac_scope_regression_rollingupdate_bridge'
       display_name: 'feature-gates-namespace-rbac-scope-regression-bundle V. - rollingupdate'
-      profile: 'azp_rolling_update'
+      profile: 'azp_rolling_update_bridge'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/.azure/templates/jobs/regression_jobs.yaml
+++ b/.azure/templates/jobs/regression_jobs.yaml
@@ -17,9 +17,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'regression_dynconfig_tracing_watcher'
+      name: 'regression_dynconfig_listeners_tracing_watcher'
       display_name: 'regression-bundle III. - dynconfig + tracing + watcher'
-      profile: 'azp_dynconfig_tracing_watcher'
+      profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 
@@ -33,9 +33,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'regression_rollingupdate'
+      name: 'regression_rollingupdate_bridge'
       display_name: 'regression-bundle V. - rollingupdate'
-      profile: 'azp_rolling_update'
+      profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
       timeout: 360
 

--- a/.azure/templates/jobs/regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/regression_namespace_rbac_jobs.yaml
@@ -21,9 +21,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'namespace_rbac_scope_regression_dynconfig_tracing_watcher'
+      name: 'namespace_rbac_scope_regression_dynconfig_listeners_tracing_watcher'
       display_name: 'namespace-rbac-scope-regression-bundle III. - dynconfig + tracing + watcher'
-      profile: 'azp_dynconfig_tracing_watcher'
+      profile: 'azp_dynconfig_listeners_tracing_watcher'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360
@@ -41,9 +41,9 @@ jobs:
 
   - template: '../steps/system_test_general.yaml'
     parameters:
-      name: 'namespace_rbac_scope_regression_rollingupdate'
+      name: 'namespace_rbac_scope_regression_rollingupdate_bridge'
       display_name: 'namespace-rbac-scope-regression-bundle V. - rollingupdate'
-      profile: 'azp_rolling_update'
+      profile: 'azp_rolling_update_bridge'
       excludedGroups: 'nodeport'
       cluster_operator_install_type: 'bundle'
       timeout: 360

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -315,7 +315,6 @@
                     !kafka/listeners/*ST,
                     !kafka/dynamicconfiguration/**/*ST,
                     !kafka/ConfigProviderST,
-                    !operators/topic/ThrottlingQuotaST,
                     security/oauth/**/*ST,
                     security/custom/*ST,
                     security/OpaIntegrationST
@@ -383,7 +382,8 @@
                 <skipTests>false</skipTests>
                 <groups>regression</groups>
                 <it.test>
-                    operators/**/*ST
+                    operators/**/*ST,
+                    !operators/topic/ThrottlingQuotaST
                 </it.test>
             </properties>
         </profile>


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR balance our regression pipelines (execution time). I have compares all times for Test suites and somehow re-arranged them in the best way possible. Result:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/30839163/136658551-285223c4-fc9e-4db6-925c-3fa459697ee7.png">

Note:
After the OPA issue is resolved, we can enable this test suite and it will increase the execution time of the First pipeline which is currently the most un-balanced but still ok from MPOV.
<img width="1463" alt="image" src="https://user-images.githubusercontent.com/30839163/136674666-2404c19d-c182-45a5-ac52-11b4d7366347.png">



### Checklist

- [ ] Make sure all tests pass