### PR TITLE
Update the Vertx dependency to 4.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>
-        <vertx.version>4.1.4</vertx.version>
-        <vertx-junit5.version>4.1.4</vertx-junit5.version>
+        <vertx.version>4.1.5</vertx.version>
+        <vertx-junit5.version>4.1.5</vertx-junit5.version>
         <log4j.version>2.14.1</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
@@ -133,7 +133,7 @@
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <gson.version>2.8.2</gson.version>
-        <vertx.kafka.client>4.1.4</vertx.kafka.client>
+        <vertx.kafka.client>4.1.5</vertx.kafka.client>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <netty.version>4.1.68.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Description

Vertx 4.1.5 is available now.This PR updates the vertx dependency to 4.1.5

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

