### PR TITLE
Disable zookeeper sasl client

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -284,6 +284,7 @@ public class ZookeeperScaler implements AutoCloseable {
 
                 clientConfig.setProperty("zookeeper.clientCnxnSocket", "org.apache.zookeeper.ClientCnxnSocketNetty");
                 clientConfig.setProperty("zookeeper.client.secure", "true");
+                clientConfig.setProperty("zookeeper.sasl.client", "false");
                 clientConfig.setProperty("zookeeper.ssl.trustStore.location", trustStoreFile.getAbsolutePath());
                 clientConfig.setProperty("zookeeper.ssl.trustStore.password", trustStorePassword);
                 clientConfig.setProperty("zookeeper.ssl.trustStore.type", "PKCS12");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The zookeeper sasl client is enabled by default in the zookeeper client.  Strimzi's ZK integration doesn't use SASL so it may as well be disabled.  This avoids the pointless initialisation of the `ZooKeeperSaslClient` and needless Zookeeper events/misleading logging when connections fail.

```
2021-10-12 15:22:40 INFO  ClientCnxn:1112 - Opening socket connection to server test-instance-zookeeper-2.test-instance-zookeeper-nodes.kafka-c5hj1l4gttmd1ave559g.svc/10.129.5.111:2181. Will not attempt to authenticate using SASL (unknown error)
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

