### PR TITLE
Prometheus alert examples: Fix broken alert regex and change from absolute to relative threshold

### DIFF
--- a/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -10,13 +10,13 @@ spec:
   - name: kafka
     rules:
     - alert: KafkaRunningOutOfSpace
-      expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-([0-9]+)?-(.+)-kafka-[0-9]+"} < 5368709120
+      expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data(-[0-9]+)?-(.+)-kafka-[0-9]+"} * 100 / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data(-[0-9]+)?-(.+)-kafka-[0-9]+"} < 15
       for: 10s
       labels:
         severity: warning
       annotations:
         summary: 'Kafka is running out of free disk space'
-        description: 'There are only {{ $value }} bytes available at {{ $labels.persistentvolumeclaim }} PVC'
+        description: 'There are only {{ $value }} percent available at {{ $labels.persistentvolumeclaim }} PVC'
     - alert: UnderReplicatedPartitions
       expr: kafka_server_replicamanager_underreplicatedpartitions > 0
       for: 10s


### PR DESCRIPTION
Signed-off-by: Patrick Nick <patrick.nick@helvetia.ch>

### Type of change

- Documentation

### Description

Fixes #5716 

The alert regex was broken (it didn't match the PVC names that Strimzi generates). This PR fixes the regex.

It also changes from absolute (5 GB) to relative (15%) for alerting on disk space.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

