### PR TITLE
Update packages in the Maven builder image before pushing it

### DIFF
--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.10
+
+USER root
+
+# Add strimzi user with UID 1001
+# The user is in the group 0 to have access to the mounted volumes and storage
+RUN useradd -r -m -u 1001 -g 0 strimzi
+
+RUN microdnf update \
+    && microdnf clean all
+
+USER 1001

--- a/docker-images/maven-builder/Makefile
+++ b/docker-images/maven-builder/Makefile
@@ -1,14 +1,8 @@
 PROJECT_NAME := maven-builder
-MAVEN_IMAGE = registry.access.redhat.com/ubi8/openjdk-11:1.3-18
-
-docker_build:
-	# The Maven image used for building new Kafka Connect images from Maven coordinates.
-	# We just pull the one released, retag it and push it to our repository to have our versioning on
-	# it and have it stored there in our other images.
-	$(DOCKER_CMD) pull $(MAVEN_IMAGE)
-	$(DOCKER_CMD) tag $(MAVEN_IMAGE) strimzi/$(PROJECT_NAME):latest
-	$(DOCKER_CMD) tag $(MAVEN_IMAGE) strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+DOCKER_TAG ?= latest
 
 include ../../Makefile.docker
 
-.PHONY: build clean release
+.PHONY: build clean tag
+
+docker_build: docker_build_default


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Maven Builder image is currently just a copy of the original Red Hat UBI OpenJDK image. It seems to contain vulnerabilities. This PR changes the way we tag and build it to also run `microdnf update` on the image as we do it with the other images.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally