### PR TITLE
[systemtest] Remove 0.25 and add 0.26 to upgrade and downgrade

### DIFF
--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -1,21 +1,21 @@
 [
   {
     "fromVersion":"HEAD",
-    "toVersion":"0.25.0",
+    "toVersion":"0.26.0",
     "fromExamples":"HEAD",
-    "toExamples":"strimzi-0.25.0",
+    "toExamples":"strimzi-0.26.0",
     "urlFrom":"HEAD",
-    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.25.0/strimzi-0.25.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.26.0/strimzi-0.26.0.zip",
     "generateTopics": true,
     "additionalTopics": 2,
-    "oldestKafka": "2.7.0",
+    "oldestKafka": "2.8.0",
     "imagesAfterOperatorDowngrade": {
-      "zookeeper": "strimzi/kafka:0.25.0-kafka-2.8.0",
-      "kafka": "strimzi/kafka:0.25.0-kafka-2.8.0",
-      "topicOperator": "strimzi/operator:0.25.0",
-      "userOperator": "strimzi/operator:0.25.0"
+      "zookeeper": "strimzi/kafka:0.26.0-kafka-3.0.0",
+      "kafka": "strimzi/kafka:0.26.0-kafka-3.0.0",
+      "topicOperator": "strimzi/operator:0.26.0",
+      "userOperator": "strimzi/operator:0.26.0"
     },
-    "deployKafkaVersion": "2.8.0",
+    "deployKafkaVersion": "3.0.0",
     "client": {
       "continuousClientsMessages": 500
     },

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -68,9 +68,9 @@
     }
   },
   {
-    "fromVersion":"0.25.0",
-    "fromExamples":"strimzi-0.25.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.25.0/strimzi-0.25.0.zip",
+    "fromVersion":"0.26.0",
+    "fromExamples":"strimzi-0.26.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.26.0/strimzi-0.26.0.zip",
     "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",
@@ -78,7 +78,7 @@
     },
     "generateTopics": true,
     "additionalTopics": 2,
-    "oldestKafka": "2.7.0",
+    "oldestKafka": "2.8.0",
     "imagesBeforeKafkaUpgrade": {
       "zookeeper": "strimzi/kafka:latest-kafka-2.8.0",
       "kafka": "strimzi/kafka:latest-kafka-2.8.0",


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test check

### Description

This PR removes 0.25.0 from upgrade and downgrade tests and adds 0.26.0 after the release.

### Checklist

- [x] Make sure all tests pass
