### PR TITLE
fix the zookeeper description

### DIFF
--- a/documentation/modules/overview/con-kafka-concepts-components.adoc
+++ b/documentation/modules/overview/con-kafka-concepts-components.adoc
@@ -16,7 +16,7 @@ Each of the other Kafka components interact with the Kafka cluster to perform sp
 
 image:overview/kafka-concepts-supporting-components.png[Data flows between several Kafka components and the Kafka cluster. See the component descriptions after this image.]
 
-Apache ZooKeeper:: Apache ZooKeeper is a core dependency for Kafka as it provides a cluster coordination service, storing and tracking the status of brokers and consumers. ZooKeeper is also used for leader election of partitions.
+Apache ZooKeeper:: Apache ZooKeeper is a core dependency for Kafka as it provides a cluster coordination service, storing and tracking the status of brokers and consumers. ZooKeeper is also used for controller election.
 Kafka Connect:: Kafka Connect is an integration toolkit for streaming data between Kafka brokers and other systems using _Connector_ plugins.
 Kafka Connect provides a framework for integrating Kafka with an external data source or target, such as a database, for import or export of data using connectors.
 Connectors are plugins that provide the connection configuration needed.


### PR DESCRIPTION
Signed-off-by: Luke Chen <showuon@gmail.com>

### Type of change

_Select the type of your PR_

- Documentation

### Description

ZooKeeper in Kafka is not responsible for leader election of partitions. The partition leader election is managed by controller. Fix it by replacing "leader election of partitions" with "controller election".

REF: https://stackoverflow.com/a/52426734

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [v] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

