### PR TITLE
KMM2 should not be ready when incorrectly configured

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -131,6 +131,7 @@ public class KafkaResources {
      * Returns the address (<em>&lt;host&gt;</em>.<em>&lt;namespace&gt;</em>.svc:<em>&lt;port&gt;</em>)
      * of the internal plain bootstrap {@code Service} for a {@code Kafka} cluster of the given name and namespace.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @param namespace  The {@code metadata.namespace} of the {@code Kafka} resource.
      * @return The address of the corresponding bootstrap {@code Service}.
      * @see #tlsBootstrapAddress(String)
      */

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -128,18 +128,6 @@ public class KafkaResources {
     }
 
     /**
-     * Returns the address (<em>&lt;host&gt;</em>.<em>&lt;namespace&gt;</em>.svc:<em>&lt;port&gt;</em>)
-     * of the internal plain bootstrap {@code Service} for a {@code Kafka} cluster of the given name and namespace.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @param namespace  The {@code metadata.namespace} of the {@code Kafka} resource.
-     * @return The address of the corresponding bootstrap {@code Service}.
-     * @see #tlsBootstrapAddress(String)
-     */
-    public static String namespacedPlainBootstrapAddress(String clusterName, String namespace) {
-        return bootstrapServiceName(clusterName) + "." + namespace + ".svc:9092";
-    }
-
-    /**
      * Returns the address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
      * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
@@ -148,18 +136,6 @@ public class KafkaResources {
      */
     public static String tlsBootstrapAddress(String clusterName) {
         return bootstrapServiceName(clusterName) + ":9093";
-    }
-
-    /**
-     * Returns the address (<em>&lt;host&gt;</em>.<em>&lt;namespace&gt;</em>.svc:<em>&lt;port&gt;</em>)
-     * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name and namespace.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @param namespace  The {@code metadata.namespace} of the {@code Kafka} resource.
-     * @return The address of the corresponding bootstrap {@code Service}.
-     * @see #plainBootstrapAddress(String)
-     */
-    public static String namespacedTlsBootstrapAddress(String clusterName, String namespace) {
-        return bootstrapServiceName(clusterName) + "." + namespace + ".svc:9093";
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -128,6 +128,17 @@ public class KafkaResources {
     }
 
     /**
+     * Returns the address (<em>&lt;host&gt;</em>.<em>&lt;namespace&gt;</em>.svc:<em>&lt;port&gt;</em>)
+     * of the internal plain bootstrap {@code Service} for a {@code Kafka} cluster of the given name and namespace.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The address of the corresponding bootstrap {@code Service}.
+     * @see #tlsBootstrapAddress(String)
+     */
+    public static String namespacedPlainBootstrapAddress(String clusterName, String namespace) {
+        return bootstrapServiceName(clusterName) + "." + namespace + ".svc:9092";
+    }
+
+    /**
      * Returns the address (<em>&lt;host&gt;</em>:<em>&lt;port&gt;</em>)
      * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
@@ -136,6 +147,18 @@ public class KafkaResources {
      */
     public static String tlsBootstrapAddress(String clusterName) {
         return bootstrapServiceName(clusterName) + ":9093";
+    }
+
+    /**
+     * Returns the address (<em>&lt;host&gt;</em>.<em>&lt;namespace&gt;</em>.svc:<em>&lt;port&gt;</em>)
+     * of the internal TLS bootstrap {@code Service} for a {@code Kafka} cluster of the given name and namespace.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @param namespace  The {@code metadata.namespace} of the {@code Kafka} resource.
+     * @return The address of the corresponding bootstrap {@code Service}.
+     * @see #plainBootstrapAddress(String)
+     */
+    public static String namespacedTlsBootstrapAddress(String clusterName, String namespace) {
+        return bootstrapServiceName(clusterName) + "." + namespace + ".svc:9093";
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -293,6 +293,8 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         return reconcileMirrorMaker2Connector(reconciliation, mirrorMaker2, apiClient, host, connectorName, connectorSpec, mirrorMaker2Status);
                     })
                     .collect(Collectors.toList()))
+                    .map((Void) null)
+                    .compose(i -> apiClient.updateConnectLoggers(reconciliation, host, KafkaConnectCluster.REST_API_PORT, desiredLogging, mirrorMaker2Cluster.getDefaultLogConfig()))
                     .compose(i -> {
                         boolean failedConnector = mirrorMaker2Status.getConnectors().stream()
                                 .anyMatch(connector -> {
@@ -305,8 +307,6 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                             return Future.succeededFuture();
                         }
                     })
-                    .map((Void) null)
-                    .compose(i -> apiClient.updateConnectLoggers(reconciliation, host, KafkaConnectCluster.REST_API_PORT, desiredLogging, mirrorMaker2Cluster.getDefaultLogConfig()))
                     .map((Void) null);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -10,7 +10,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -295,12 +294,12 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                     })
                     .collect(Collectors.toList()))
                     .compose(i -> {
-                        Optional<Map<String, Object>> failedOpt = mirrorMaker2Status.getConnectors().stream()
-                                .filter(connector -> {
+                        boolean failedConnector = mirrorMaker2Status.getConnectors().stream()
+                                .anyMatch(connector -> {
                                     Object state = ((Map) connector.getOrDefault("connector", emptyMap())).get("state");
                                     return "FAILED".equalsIgnoreCase(state.toString());
-                                }).findFirst();
-                        if (failedOpt.isPresent()) {
+                                });
+                        if (failedConnector) {
                             return Future.failedFuture("One or more connectors are in FAILED state");
                         } else {
                             return Future.succeededFuture();

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/StatusDiff.java
@@ -43,9 +43,11 @@ public class StatusDiff extends AbstractJsonDiff {
                 continue;
             }
 
-            LOGGER.debugOp("Status differs: {}", d);
-            LOGGER.debugOp("Current Status path {} has value {}", pathValue, lookupPath(source, pathValue));
-            LOGGER.debugOp("Desired Status path {} has value {}", pathValue, lookupPath(target, pathValue));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debugOp("Status differs: {}", d);
+                LOGGER.debugOp("Current Status path {} has value {}", pathValue, lookupPath(source, pathValue));
+                LOGGER.debugOp("Desired Status path {} has value {}", pathValue, lookupPath(target, pathValue));
+            }
 
             num++;
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -57,14 +57,14 @@ public class KafkaMirrorMaker2Templates {
     }
 
     private static KafkaMirrorMaker2Builder defaultKafkaMirrorMaker2(KafkaMirrorMaker2 kafkaMirrorMaker2, String name, String kafkaTargetClusterName, String kafkaSourceClusterName, int kafkaMirrorMaker2Replicas, boolean tlsListener) {
-        return defaultKafkaMirrorMaker2(kafkaMirrorMaker2, name, kafkaTargetClusterName, kafkaSourceClusterName, kafkaMirrorMaker2Replicas, tlsListener, kafkaMirrorMaker2.getMetadata().getNamespace(), kafkaMirrorMaker2.getMetadata().getNamespace());
+        return defaultKafkaMirrorMaker2(kafkaMirrorMaker2, name, kafkaTargetClusterName, kafkaSourceClusterName, kafkaMirrorMaker2Replicas, tlsListener, null, null);
     }
 
     private static KafkaMirrorMaker2Builder defaultKafkaMirrorMaker2(KafkaMirrorMaker2 kafkaMirrorMaker2, String name, String kafkaTargetClusterName, String kafkaSourceClusterName, int kafkaMirrorMaker2Replicas, boolean tlsListener, String sourceNs, String targetNs) {
 
         KafkaMirrorMaker2ClusterSpec targetClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(kafkaTargetClusterName)
-            .withBootstrapServers(KafkaResources.namespacedPlainBootstrapAddress(kafkaTargetClusterName, sourceNs))
+            .withBootstrapServers(targetNs == null ? KafkaResources.plainBootstrapAddress(kafkaTargetClusterName) : KafkaResources.namespacedPlainBootstrapAddress(kafkaTargetClusterName, targetNs))
             .addToConfig("config.storage.replication.factor", 1)
             .addToConfig("offset.storage.replication.factor", 1)
             .addToConfig("status.storage.replication.factor", 1)
@@ -72,19 +72,19 @@ public class KafkaMirrorMaker2Templates {
 
         KafkaMirrorMaker2ClusterSpec sourceClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(kafkaSourceClusterName)
-            .withBootstrapServers(KafkaResources.namespacedPlainBootstrapAddress(kafkaSourceClusterName, targetNs))
+            .withBootstrapServers(sourceNs == null ? KafkaResources.plainBootstrapAddress(kafkaSourceClusterName) : KafkaResources.namespacedPlainBootstrapAddress(kafkaSourceClusterName, sourceNs))
             .build();
 
         if (tlsListener) {
             targetClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder(targetClusterSpec)
-                .withBootstrapServers(KafkaResources.namespacedTlsBootstrapAddress(kafkaTargetClusterName, targetNs))
+                .withBootstrapServers(targetNs == null ? KafkaResources.tlsBootstrapAddress(kafkaTargetClusterName) : KafkaResources.namespacedTlsBootstrapAddress(kafkaTargetClusterName, targetNs))
                 .withNewTls()
                     .withTrustedCertificates(new CertSecretSourceBuilder().withSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaTargetClusterName)).withCertificate("ca.crt").build())
                 .endTls()
                 .build();
 
             sourceClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder(sourceClusterSpec)
-                .withBootstrapServers(KafkaResources.namespacedTlsBootstrapAddress(kafkaSourceClusterName, sourceNs))
+                .withBootstrapServers(sourceNs == null ? KafkaResources.tlsBootstrapAddress(kafkaSourceClusterName) : KafkaResources.namespacedTlsBootstrapAddress(kafkaSourceClusterName, sourceNs))
                 .withNewTls()
                     .withTrustedCertificates(new CertSecretSourceBuilder().withSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaSourceClusterName)).withCertificate("ca.crt").build())
                 .endTls()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 
@@ -60,23 +61,11 @@ public class KafkaMirrorMaker2Templates {
         return defaultKafkaMirrorMaker2(kafkaMirrorMaker2, name, kafkaTargetClusterName, kafkaSourceClusterName, kafkaMirrorMaker2Replicas, tlsListener, null, null);
     }
 
-    private static String namespacedPlainBootstrapAddress(String clusterName, String namespace) {
-        return namespacedBootstrapAddress(clusterName, namespace, 9092);
-    }
-
-    private static String namespacedTlsBootstrapAddress(String clusterName, String namespace) {
-        return namespacedBootstrapAddress(clusterName, namespace, 9093);
-    }
-
-    private static String namespacedBootstrapAddress(String clusterName, String namespace, int port) {
-        return KafkaResources.bootstrapServiceName(clusterName) + "." + namespace + ".svc:" + port;
-    }
-
     private static KafkaMirrorMaker2Builder defaultKafkaMirrorMaker2(KafkaMirrorMaker2 kafkaMirrorMaker2, String name, String kafkaTargetClusterName, String kafkaSourceClusterName, int kafkaMirrorMaker2Replicas, boolean tlsListener, String sourceNs, String targetNs) {
 
         KafkaMirrorMaker2ClusterSpec targetClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(kafkaTargetClusterName)
-            .withBootstrapServers(targetNs == null ? KafkaResources.plainBootstrapAddress(kafkaTargetClusterName) : namespacedPlainBootstrapAddress(kafkaTargetClusterName, targetNs))
+            .withBootstrapServers(targetNs == null ? KafkaResources.plainBootstrapAddress(kafkaTargetClusterName) : KafkaUtils.namespacedPlainBootstrapAddress(kafkaTargetClusterName, targetNs))
             .addToConfig("config.storage.replication.factor", 1)
             .addToConfig("offset.storage.replication.factor", 1)
             .addToConfig("status.storage.replication.factor", 1)
@@ -84,19 +73,19 @@ public class KafkaMirrorMaker2Templates {
 
         KafkaMirrorMaker2ClusterSpec sourceClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(kafkaSourceClusterName)
-            .withBootstrapServers(sourceNs == null ? KafkaResources.plainBootstrapAddress(kafkaSourceClusterName) : namespacedPlainBootstrapAddress(kafkaSourceClusterName, sourceNs))
+            .withBootstrapServers(sourceNs == null ? KafkaResources.plainBootstrapAddress(kafkaSourceClusterName) : KafkaUtils.namespacedPlainBootstrapAddress(kafkaSourceClusterName, sourceNs))
             .build();
 
         if (tlsListener) {
             targetClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder(targetClusterSpec)
-                .withBootstrapServers(targetNs == null ? KafkaResources.tlsBootstrapAddress(kafkaTargetClusterName) : namespacedTlsBootstrapAddress(kafkaTargetClusterName, targetNs))
+                .withBootstrapServers(targetNs == null ? KafkaResources.tlsBootstrapAddress(kafkaTargetClusterName) : KafkaUtils.namespacedTlsBootstrapAddress(kafkaTargetClusterName, targetNs))
                 .withNewTls()
                     .withTrustedCertificates(new CertSecretSourceBuilder().withSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaTargetClusterName)).withCertificate("ca.crt").build())
                 .endTls()
                 .build();
 
             sourceClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder(sourceClusterSpec)
-                .withBootstrapServers(sourceNs == null ? KafkaResources.tlsBootstrapAddress(kafkaSourceClusterName) : namespacedTlsBootstrapAddress(kafkaSourceClusterName, sourceNs))
+                .withBootstrapServers(sourceNs == null ? KafkaResources.tlsBootstrapAddress(kafkaSourceClusterName) : KafkaUtils.namespacedTlsBootstrapAddress(kafkaSourceClusterName, sourceNs))
                 .withNewTls()
                     .withTrustedCertificates(new CertSecretSourceBuilder().withSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaSourceClusterName)).withCertificate("ca.crt").build())
                 .endTls()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -457,4 +457,16 @@ public class KafkaUtils {
             throw new RuntimeException(e);
         }
     }
+
+    public static String namespacedPlainBootstrapAddress(String clusterName, String namespace) {
+        return namespacedBootstrapAddress(clusterName, namespace, 9092);
+    }
+
+    public static String namespacedTlsBootstrapAddress(String clusterName, String namespace) {
+        return namespacedBootstrapAddress(clusterName, namespace, 9093);
+    }
+
+    private static String namespacedBootstrapAddress(String clusterName, String namespace, int port) {
+        return KafkaResources.bootstrapServiceName(clusterName) + "." + namespace + ".svc:" + port;
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -683,7 +683,7 @@ public class MetricsST extends AbstractST {
             KafkaTemplates.kafkaWithMetrics(SECOND_CLUSTER, SECOND_NAMESPACE, 1, 1).build(),
             KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, firstKafkaClientsName).build(),
             KafkaClientsTemplates.kafkaClients(SECOND_NAMESPACE, false, secondKafkaClientsName).build(),
-            KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, INFRA_NAMESPACE, SECOND_NAMESPACE).build(),
+            KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, SECOND_NAMESPACE, INFRA_NAMESPACE).build(),
             KafkaBridgeTemplates.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).build()
         );
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -133,7 +133,7 @@ public class MetricsST extends AbstractST {
     void testKafkaTopicPartitions() {
         Pattern topicPartitions = Pattern.compile("kafka_server_replicamanager_partitioncount ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         ArrayList<Double> values = MetricsCollector.collectSpecificMetric(topicPartitions, kafkaMetricsData);
-        assertThat("Topic partitions count doesn't match expected value", values.stream().mapToDouble(i -> i).sum(), is(437.0));
+        assertThat("Topic partitions count doesn't match expected value", values.stream().mapToDouble(i -> i).sum(), is(438.0));
     }
 
     @ParallelTest
@@ -682,14 +682,14 @@ public class MetricsST extends AbstractST {
                 .build(),
             KafkaTemplates.kafkaWithMetrics(SECOND_CLUSTER, SECOND_NAMESPACE, 1, 1).build(),
             KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, firstKafkaClientsName).build(),
-            KafkaClientsTemplates.kafkaClients(SECOND_NAMESPACE, false, secondKafkaClientsName).build(),
-            KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, SECOND_NAMESPACE, INFRA_NAMESPACE).build(),
-            KafkaBridgeTemplates.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).build()
+            KafkaClientsTemplates.kafkaClients(SECOND_NAMESPACE, false, secondKafkaClientsName).build()
         );
 
         // sync resources
         resourceManager.synchronizeResources(extensionContext);
 
+        resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).build());
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, SECOND_NAMESPACE, INFRA_NAMESPACE).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(metricsClusterName, topicName, 7, 2).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(metricsClusterName, kafkaExporterTopic, 7, 2).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(metricsClusterName, bridgeTopic).build());
@@ -752,6 +752,7 @@ public class MetricsST extends AbstractST {
         list.add(CruiseControlUtils.CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC);
         list.add("strimzi-store-topic");
         list.add("strimzi-topic-operator-kstreams-topic-store-changelog");
+        list.add("__consumer-offsets---hash");
         return list;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -683,7 +683,7 @@ public class MetricsST extends AbstractST {
             KafkaTemplates.kafkaWithMetrics(SECOND_CLUSTER, SECOND_NAMESPACE, 1, 1).build(),
             KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, firstKafkaClientsName).build(),
             KafkaClientsTemplates.kafkaClients(SECOND_NAMESPACE, false, secondKafkaClientsName).build(),
-            KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1).build(),
+            KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, INFRA_NAMESPACE, SECOND_NAMESPACE).build(),
             KafkaBridgeTemplates.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).build()
         );
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
The KMM2 CR does have set the status as ready although some of its connectors are failed. Fixed by adding status (from API) check.
I think we need a ST for this. Could you please take a look @im-konge 

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/5715

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

