### PR TITLE
[MO] - ClusterRole and ClusterRoleBinding fix operation namespace

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
@@ -199,7 +200,7 @@ public class ResourceManager {
         assertNotNull(resource.getMetadata().getName());
 
         // cluster role binding and custom resource definition does not need namespace...
-        if (!(resource instanceof ClusterRoleBinding || resource instanceof CustomResourceDefinition)) {
+        if (!(resource instanceof ClusterRoleBinding || resource instanceof CustomResourceDefinition || resource instanceof ClusterRole)) {
             assertNotNull(resource.getMetadata().getNamespace());
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
@@ -28,17 +28,16 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
     @Override
     public ClusterRoleBinding get(String namespace, String name) {
         // ClusterRoleBinding his operation namespace is only 'default'
-        return kubeClient().namespace(KubeClusterResource.getInstance().defaultNamespace()).getClusterRoleBinding(name);
+        return kubeClient(KubeClusterResource.getInstance().defaultNamespace()).getClusterRoleBinding(name);
     }
     @Override
     public void create(ClusterRoleBinding resource) {
-        kubeClient().createOrReplaceClusterRoleBinding(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrReplaceClusterRoleBinding(resource);
     }
     @Override
     public void delete(ClusterRoleBinding resource) {
         // ClusterRoleBinding his operation namespace is only 'default'
-        resource.getMetadata().setNamespace(KubeClusterResource.getInstance().defaultNamespace());
-        kubeClient().deleteClusterRoleBinding(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).deleteClusterRoleBinding(resource);
     }
     @Override
     public boolean waitForReadiness(ClusterRoleBinding resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
@@ -24,14 +24,12 @@ public class ClusterRoleResource implements ResourceType<ClusterRole> {
     @Override
     public void create(ClusterRole resource) {
         // ClusterRole his operation namespace is only 'default'
-        resource.getMetadata().setNamespace(KubeClusterResource.getInstance().defaultNamespace());
-        kubeClient().createOrReplaceClusterRoles(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrReplaceClusterRoles(resource);
     }
     @Override
     public void delete(ClusterRole resource) {
         // ClusterRole his operation namespace is only 'default'
-        resource.getMetadata().setNamespace(KubeClusterResource.getInstance().defaultNamespace());
-        kubeClient().deleteClusterRole(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).deleteClusterRole(resource);
     }
     @Override
     public boolean waitForReadiness(ClusterRole resource) {


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes the operation mismatch problem, which may occur when one does not have Kubernetes context pointed to the `default` namespace. I did not face this problem (in my parallelism PR) because I always use the `default` namespace...

### Checklist

- [x] Make sure all tests pass