### PR TITLE
resource leak due to Files.walk

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -80,7 +80,7 @@ public class OpenSslCertManager implements CertManager {
     }
 
     static void delete(Path fileOrDir) throws IOException {
-        if (fileOrDir != null) {
+        if (fileOrDir != null)
             if (Files.isDirectory(fileOrDir)) {
                 try (Stream<Path> stream = Files.walk(fileOrDir)) {
                     stream.sorted(Comparator.reverseOrder())
@@ -92,10 +92,11 @@ public class OpenSslCertManager implements CertManager {
                             }
                         });
                 }
-            } 
-        } else if (!Files.deleteIfExists(fileOrDir)) {
-            LOGGER.debug("File not deleted, because it did not exist: {}", fileOrDir);
-        }
+            } else {
+                if (!Files.deleteIfExists(fileOrDir)) {
+                    LOGGER.debug("File not deleted, because it did not exist: {}", fileOrDir);
+                }
+            }
     }
 
     private Path createDefaultConfig() throws IOException {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Stream opened by Files.walk should be closed.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

