### PR TITLE
[MO] - @ParallelSuites -> CruiseControl support 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/BeforeAllOnce.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/BeforeAllOnce.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest;
 import io.strimzi.systemtest.parallel.ParallelNamespacesSuitesNames;
 import io.strimzi.systemtest.parallel.ParallelSuiteController;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.utils.StUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -62,8 +63,10 @@ public class BeforeAllOnce implements BeforeAllCallback, ExtensionContext.Store.
                     .createInstallation()
                     .runInstallation();
             }
-            // this is for correction because callback also count some randomly chosen class twice
-            ParallelSuiteController.decrementCounter();
+            // correction, because when @BeforeAllCallback is invoked firstly by @IsolatedSuite class it decrement counter which is not correct
+            if (StUtils.isParallelSuite(extensionContext)) {
+                ParallelSuiteController.decrementCounter();
+            }
             sharedExtensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(SYSTEM_RESOURCES, new BeforeAllOnce());
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/BeforeAllOnce.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/BeforeAllOnce.java
@@ -23,6 +23,7 @@ public class BeforeAllOnce implements BeforeAllCallback, ExtensionContext.Store.
     private static SetupClusterOperator install;
     private static final Logger LOGGER = LogManager.getLogger(BeforeAllOnce.class);
     private static boolean systemReady = false;
+    private static final String SYSTEM_RESOURCES = "SYSTEM_RESOURCES";
     private static ExtensionContext sharedExtensionContext;
 
     /**
@@ -34,6 +35,7 @@ public class BeforeAllOnce implements BeforeAllCallback, ExtensionContext.Store.
         if (!systemReady) {
             // get root extension context to be different from others context (BeforeAll)
             sharedExtensionContext = extensionContext.getRoot();
+
             systemReady = true;
             LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
             LOGGER.debug("[BEFORE SUITE] - Going to setup testing system");
@@ -62,6 +64,7 @@ public class BeforeAllOnce implements BeforeAllCallback, ExtensionContext.Store.
             }
             // this is for correction because callback also count some randomly chosen class twice
             ParallelSuiteController.decrementCounter();
+            sharedExtensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(SYSTEM_RESOURCES, new BeforeAllOnce());
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -336,6 +336,10 @@ public interface Constants {
     String BRIDGE_SCRAM_SHA_NAMESPACE = "bridge-scram-sha-namespace";
     String BRIDGE_HTTP_TLS_NAMESPACE = "http-bridge-tls-namespace";
     String METRICS_SECOND_NAMESPACE = "second-metrics-cluster-test";
+    // cruise control package
+    String CRUISE_CONTROL_NAMESPACE = "cruise-control-namespace";
+    String CRUISE_CONTROL_CONFIGURATION_NAMESPACE = "cruise-control-configuration-namespace";
+    String CRUISE_CONTROL_API_NAMESPACE = "cruise-control-api-namespace";
 
     /**
      * Auxiliary variables for storing data across our tests

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/ParallelNamespacesSuitesNames.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/ParallelNamespacesSuitesNames.java
@@ -20,10 +20,15 @@ public class ParallelNamespacesSuitesNames {
     private static final List<String> PARALLEL_NAMESPACE_SUITE_NAMES = Arrays.asList(
         // default namespace for cluster operator
         Constants.INFRA_NAMESPACE,
+        // bridge package
         Constants.BRIDGE_KAFKA_CORS_NAMESPACE,
         Constants.BRIDGE_KAFKA_EXTERNAL_LISTENER_NAMESPACE,
         Constants.BRIDGE_SCRAM_SHA_NAMESPACE,
-        Constants.BRIDGE_HTTP_TLS_NAMESPACE
+        Constants.BRIDGE_HTTP_TLS_NAMESPACE,
+        // cruise control package
+        Constants.CRUISE_CONTROL_NAMESPACE,
+        Constants.CRUISE_CONTROL_CONFIGURATION_NAMESPACE,
+        Constants.CRUISE_CONTROL_API_NAMESPACE
     );
 
     public static String getRbacNamespacesToWatch() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -312,9 +312,10 @@ public class SetupClusterOperator {
 
         public SetupClusterOperatorBuilder addToTheBindingsNamespaces(String bindingsNamespace) {
             if (this.bindingsNamespaces != null) {
+                this.bindingsNamespaces = new ArrayList<>(this.bindingsNamespaces);
                 this.bindingsNamespaces.add(bindingsNamespace);
             } else {
-                this.bindingsNamespaces = Arrays.asList(bindingsNamespace);
+                this.bindingsNamespaces = new ArrayList<>(Arrays.asList(bindingsNamespace));
             }
             return self();
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -147,7 +147,8 @@ public class SetupClusterOperator {
         return new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
             .withNamespace(Constants.INFRA_NAMESPACE)
-            .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES);
+            .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
+            .withBindingsNamespaces(ParallelNamespacesSuitesNames.getBindingNamespaces());
     }
 
     /**
@@ -561,8 +562,7 @@ public class SetupClusterOperator {
                 e.printStackTrace();
             }
 
-            KubeClusterResource.getInstance().deleteNamespace(
-                CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo);
+            KubeClusterResource.getInstance().deleteAllSetNamespaces();
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -62,8 +62,8 @@ public class ClientUtils {
         LOGGER.info("Waiting for producer/consumer:{} to finished", jobName);
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
             () -> {
-                LOGGER.debug("Job {} in namespace {}, has status {}", jobName, namespace, kubeClient().namespace(namespace).getJobStatus(jobName));
-                return kubeClient().namespace(namespace).checkSucceededJobStatus(jobName);
+                LOGGER.debug("Job {} in namespace {}, has status {}", jobName, namespace, kubeClient().namespace(namespace).getJobStatus(namespace, jobName));
+                return kubeClient().namespace(namespace).checkSucceededJobStatus(namespace, jobName, 1);
             });
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -568,7 +568,7 @@ public abstract class AbstractST implements TestSeparator {
      * you your implementation in sub-class as you want.
      * @param extensionContext
      */
-    protected synchronized void beforeEachMayOverride(ExtensionContext extensionContext) {
+    protected void beforeEachMayOverride(ExtensionContext extensionContext) {
         // this is because we need to have different clusterName and kafkaClientsName in each test case without
         // synchronization it can produce `data-race`
         String testName = null;

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -193,7 +193,7 @@ class HttpBridgeScramShaST extends AbstractST {
             .withTopicName(TOPIC_NAME)
             .withMessageCount(MESSAGE_COUNT)
             .withPort(Constants.HTTP_BRIDGE_DEFAULT_PORT)
-            .withDelayMs(1000)
+            .withDelayMs(100)
             .withPollInterval(1000)
             .withNamespaceName(NAMESPACE)
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -6,9 +6,11 @@ package io.strimzi.systemtest.cruisecontrol;
 
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlUserTaskStatus;
-import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.annotations.ParallelSuite;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
 import org.apache.logging.log4j.LogManager;
@@ -20,7 +22,6 @@ import java.util.HashMap;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
-import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -29,31 +30,29 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
-@IsolatedSuite
+@ParallelSuite
 public class CruiseControlApiST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlApiST.class);
     private static final String CRUISE_CONTROL_NAME = "Cruise Control";
-    private final String cruiseControlApiClusterName = "cruise-control-api-cluster-name";
+    private static final String NAMESPACE = Constants.CRUISE_CONTROL_API_NAMESPACE;
 
     @Tag(ACCEPTANCE)
-    @ParallelTest
+    @ParallelNamespaceTest
     void testCruiseControlBasicAPIRequests(ExtensionContext extensionContext)  {
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(cruiseControlApiClusterName, 3, 3)
-            .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
-            .endMetadata()
-            .build());
+        TestStorage testStorage = new TestStorage(extensionContext);
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(testStorage.getClusterName(), 3, 3).build());
 
         LOGGER.info("----> CRUISE CONTROL DEPLOYMENT STATE ENDPOINT <----");
 
-        String response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        String response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/state'\n" +
             "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, " +
                 "RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION, RIGHTSIZE]\n"));
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         LOGGER.info("Verifying that {} REST API is available", CRUISE_CONTROL_NAME);
 
@@ -61,19 +60,19 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(response, containsString("RUNNING"));
         assertThat(response, containsString("NO_TASK_IN_PROGRESS"));
 
-        CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(INFRA_NAMESPACE);
+        CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(testStorage.getNamespaceName());
 
         LOGGER.info("----> KAFKA REBALANCE <----");
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REBALANCE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REBALANCE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/rebalance'\n" +
             "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
 
         LOGGER.info("Waiting for CC will have for enough metrics to be recorded to make a proposal ");
-        CruiseControlUtils.waitForRebalanceEndpointIsReady(INFRA_NAMESPACE);
+        CruiseControlUtils.waitForRebalanceEndpointIsReady(testStorage.getNamespaceName());
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.REBALANCE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.REBALANCE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         // all goals stats that contains
         assertThat(response, containsString("RackAwareGoal"));
@@ -96,24 +95,24 @@ public class CruiseControlApiST extends AbstractST {
 
         LOGGER.info("----> EXECUTION OF STOP PROPOSAL <----");
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STOP, CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STOP, CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/stop_proposal_execution'\n" +
             "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STOP, CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STOP, CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, containsString("Proposal execution stopped."));
 
         LOGGER.info("----> USER TASKS <----");
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.USER_TASKS, CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.USER_TASKS, CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/user_tasks'\n" +
             "Supported POST endpoints: [ADD_BROKER, REMOVE_BROKER, FIX_OFFLINE_REPLICAS, REBALANCE, STOP_PROPOSAL_EXECUTION, PAUSE_SAMPLING, " +
                 "RESUME_SAMPLING, DEMOTE_BROKER, ADMIN, REVIEW, TOPIC_CONFIGURATION, RIGHTSIZE]\n"));
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.USER_TASKS,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.USER_TASKS,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, containsString("GET"));
         assertThat(response, containsString(CruiseControlEndpoints.STATE.toString()));
@@ -125,23 +124,22 @@ public class CruiseControlApiST extends AbstractST {
 
         LOGGER.info("Verifying that {} REST API doesn't allow HTTP requests", CRUISE_CONTROL_NAME);
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTP, false);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTP, false);
         assertThat(response, not(containsString("RUNNING")));
         assertThat(response, not(containsString("NO_TASK_IN_PROGRESS")));
 
         LOGGER.info("Verifying that {} REST API doesn't allow unauthenticated requests", CRUISE_CONTROL_NAME);
 
-        response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, false);
+        response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE,  CruiseControlUtils.SupportedSchemes.HTTPS, false);
         assertThat(response, containsString("401 Unauthorized"));
     }
 
     @Tag(ACCEPTANCE)
-    @ParallelTest
+    @ParallelNamespaceTest
     void testCruiseControlBasicAPIRequestsWithSecurityDisabled(ExtensionContext extensionContext) {
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(cruiseControlApiClusterName, 3, 3)
-            .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
-            .endMetadata()
+        TestStorage testStorage = new TestStorage(extensionContext);
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(testStorage.getClusterName(), 3, 3)
             .editOrNewSpec()
                 .withNewCruiseControl().withConfig(
                         new HashMap<String, Object>() {{
@@ -154,10 +152,11 @@ public class CruiseControlApiST extends AbstractST {
 
         LOGGER.info("----> CRUISE CONTROL DEPLOYMENT STATE ENDPOINT <----");
 
-        String response = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE, CruiseControlUtils.SupportedSchemes.HTTP, false);
+        String response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STATE, CruiseControlUtils.SupportedSchemes.HTTP, false);
 
         LOGGER.info("Verifying that {} REST API is available using HTTP request without credentials", CRUISE_CONTROL_NAME);
 
+        LOGGER.debug("=========================================\n\n\n\n\n\n{}", response);
         assertThat(response, not(containsString("404")));
         assertThat(response, containsString("RUNNING"));
         assertThat(response, containsString("NO_TASK_IN_PROGRESS"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -156,7 +156,6 @@ public class CruiseControlApiST extends AbstractST {
 
         LOGGER.info("Verifying that {} REST API is available using HTTP request without credentials", CRUISE_CONTROL_NAME);
 
-        LOGGER.debug("=========================================\n\n\n\n\n\n{}", response);
         assertThat(response, not(containsString("404")));
         assertThat(response, containsString("RUNNING"));
         assertThat(response, containsString("NO_TASK_IN_PROGRESS"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -14,8 +14,8 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.StUtils;
@@ -43,7 +43,6 @@ import java.util.Properties;
 
 import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
-import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -57,14 +56,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
-@IsolatedSuite
+@ParallelSuite
 public class CruiseControlConfigurationST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlConfigurationST.class);
+    private static final String NAMESPACE = Constants.CRUISE_CONTROL_CONFIGURATION_NAMESPACE;
 
     @ParallelNamespaceTest
     void testCapacityFile(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
@@ -98,7 +98,7 @@ public class CruiseControlConfigurationST extends AbstractST {
 
     @ParallelNamespaceTest
     void testDeployAndUnDeployCruiseControl(ExtensionContext extensionContext) throws IOException {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
@@ -143,7 +143,7 @@ public class CruiseControlConfigurationST extends AbstractST {
 
     @ParallelNamespaceTest
     void testConfigurationDiskChangeDoNotTriggersRollingUpdateOfKafkaPods(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
@@ -180,7 +180,7 @@ public class CruiseControlConfigurationST extends AbstractST {
 
     @ParallelNamespaceTest
     void testConfigurationReflection(ExtensionContext extensionContext) throws IOException {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
@@ -234,7 +234,7 @@ public class CruiseControlConfigurationST extends AbstractST {
 
     @ParallelNamespaceTest
     void testConfigurationFileIsCreated(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
@@ -248,7 +248,7 @@ public class CruiseControlConfigurationST extends AbstractST {
 
     @ParallelNamespaceTest
     void testConfigurationPerformanceOptions(ExtensionContext extensionContext) throws IOException {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -646,6 +646,8 @@ public class MetricsST extends AbstractST {
 
     @BeforeAll
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
+        super.beforeAllMayOverride(extensionContext);
+
         install.unInstall();
         install = SetupClusterOperator.defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -50,6 +50,7 @@ import java.util.stream.Stream;
 
 import static io.strimzi.systemtest.Constants.GLOBAL_POLL_INTERVAL;
 import static io.strimzi.systemtest.Constants.GLOBAL_TIMEOUT;
+import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.PATH_TO_KAFKA_TOPIC_CONFIG;
 import static io.strimzi.systemtest.Constants.PATH_TO_PACKAGING_EXAMPLES;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -223,7 +224,7 @@ public class AbstractUpgradeST extends AbstractST {
                 LOGGER.info("Going to set Kafka version to " + kafkaVersionFromProcedure);
                 cmdKubeClient().patchResource(getResourceApiVersion(Kafka.RESOURCE_PLURAL, operatorVersion), clusterName, "/spec/kafka/version", kafkaVersionFromProcedure);
                 LOGGER.info("Wait until kafka rolling update is finished");
-                kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
+                kafkaPods = StatefulSetUtils.waitTillSsHasRolled(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
             }
 
             String logMessageVersion = procedures.getString("logMessageVersion");
@@ -243,7 +244,7 @@ public class AbstractUpgradeST extends AbstractST {
                 if ((currentInterBrokerProtocol != null && !currentInterBrokerProtocol.equals(interBrokerProtocolVersion)) ||
                         (currentLogMessageFormat != null) && !currentLogMessageFormat.equals(logMessageVersion)) {
                     LOGGER.info("Wait until kafka rolling update is finished");
-                    kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
+                    kafkaPods = StatefulSetUtils.waitTillSsHasRolled(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
                 }
                 makeSnapshots(clusterName);
             }
@@ -252,7 +253,7 @@ public class AbstractUpgradeST extends AbstractST {
                 LOGGER.info("Going to set Kafka version to " + kafkaVersionFromProcedure);
                 cmdKubeClient().patchResource(getResourceApiVersion(Kafka.RESOURCE_PLURAL, operatorVersion), clusterName, "/spec/kafka/version", kafkaVersionFromProcedure);
                 LOGGER.info("Wait until kafka rolling update is finished");
-                kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
+                kafkaPods = StatefulSetUtils.waitTillSsHasRolled(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(clusterName), 3, kafkaPods);
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -22,7 +22,6 @@ import io.strimzi.test.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.List;
@@ -137,7 +136,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
         // ##############################
     }
 
-    @Test
+    @IsolatedTest
     void testUpgradeWithNoMessageAndProtocolVersionsSet(ExtensionContext testContext) {
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
@@ -204,6 +203,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
             KafkaBasicExampleClients kafkaBasicClientJob = new KafkaBasicExampleClients.Builder()
+                .withNamespaceName(INFRA_NAMESPACE)
                 .withProducerName(producerName)
                 .withConsumerName(consumerName)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -137,7 +137,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, producerName, consumerName, continuousTopicName, continuousConsumerGroup, acrossUpgradeData.getString("startingKafkaVersion"), INFRA_NAMESPACE);
         convertCRDs(conversionTool, INFRA_NAMESPACE);
         // Make snapshots of all pods
-        makeSnapshots(clusterName);
+        makeSnapshots(INFRA_NAMESPACE, clusterName);
 
         // Upgrade CO
         changeClusterOperator(acrossUpgradeData, INFRA_NAMESPACE, extensionContext);

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -221,15 +221,14 @@ public class KubeClusterResource {
         LOGGER.info("Deleting these namespaces:\n{}", MAP_WITH_SUITE_NAMESPACES::toString);
         LOGGER.info(String.join("", Collections.nCopies(76, "=")));
 
-        for (CollectorElement element : MAP_WITH_SUITE_NAMESPACES.keySet()) {
-            Set<String> namespacesNames = MAP_WITH_SUITE_NAMESPACES.get(element);
-
-            for (String namespaceName : namespacesNames) {
-                LOGGER.debug("Deleting {} namespace", namespaceName);
-                kubeClient().deleteNamespace(namespaceName);
-                cmdKubeClient().waitForResourceDeletion("Namespace", namespaceName);
-            }
-        }
+        MAP_WITH_SUITE_NAMESPACES.values()
+            .forEach(setOfNamespaces ->
+                setOfNamespaces
+                    .forEach(namespaceName -> {
+                        LOGGER.debug("Deleting {} namespace", namespaceName);
+                        kubeClient().deleteNamespace(namespaceName);
+                        cmdKubeClient().waitForResourceDeletion("Namespace", namespaceName);
+                    }));
     }
 
     /**

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Junit resource which discovers the running cluster and provides an appropriate KubeClient for it,
@@ -223,11 +224,12 @@ public class KubeClusterResource {
 
         MAP_WITH_SUITE_NAMESPACES.values()
             .forEach(setOfNamespaces ->
-                setOfNamespaces
+                setOfNamespaces.parallelStream()
                     .forEach(namespaceName -> {
                         LOGGER.debug("Deleting {} namespace", namespaceName);
                         kubeClient().deleteNamespace(namespaceName);
-                        cmdKubeClient().waitForResourceDeletion("Namespace", namespaceName);
+                        client.getClient().namespaces().withName(namespaceName).waitUntilCondition(
+                            namespace -> client.getClient().namespaces().withName(namespaceName).get() == null, 4, TimeUnit.MINUTES);
                     }));
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -216,6 +216,22 @@ public class KubeClusterResource {
         }
     }
 
+    public void deleteAllSetNamespaces() {
+        LOGGER.info(String.join("", Collections.nCopies(76, "=")));
+        LOGGER.info("Deleting these namespaces:\n{}", MAP_WITH_SUITE_NAMESPACES::toString);
+        LOGGER.info(String.join("", Collections.nCopies(76, "=")));
+
+        for (CollectorElement element : MAP_WITH_SUITE_NAMESPACES.keySet()) {
+            Set<String> namespacesNames = MAP_WITH_SUITE_NAMESPACES.get(element);
+
+            for (String namespaceName : namespacesNames) {
+                LOGGER.debug("Deleting {} namespace", namespaceName);
+                kubeClient().deleteNamespace(namespaceName);
+                cmdKubeClient().waitForResourceDeletion("Namespace", namespaceName);
+            }
+        }
+    }
+
     /**
      * Replaces custom resources for CO such as templates. Deletion is up to caller and can be managed
      * by calling {@link #deleteCustomResources()}


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR adds a few things:

1. @ParallelSuite (support to run cruise control package in parallel mode with other suites)
2. fixing bad usage of @ParallelTest annotation (In `CruiseControlApiST` one created Kafka cluster in `INFRA_NAMESPACE` and does not use @ParalllelNamespaceTest as we do in all cases)

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass