### PR TITLE
Listener in status reporting name as type of listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Update Open Policy Agent authorizer to 1.4.0 and add support for enabling metrics 
 * Added the option `createBootstrapService` in the Kafka Spec to disable the creation of the bootstrap service for the Load Balancer Type Listener. It will save the cost of one load balancer resource, specially in the public cloud.
 
+### Changes, deprecations and removals
+
+* The `type` field in `ListenerStatus` has been deprecated and will be removed in the future.
+
 ## 0.27.0
 
 * Multi-arch container images with support for x86_64 / AMD64 and AArch64 / ARM64 platforms

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -28,25 +29,36 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "type", "addresses", "bootstrapServers", "certificates" })
+@JsonPropertyOrder({ "type", "name", "addresses", "bootstrapServers", "certificates" })
 @EqualsAndHashCode
 public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String type;
+    private String name;
     private List<ListenerAddress> addresses;
     private String bootstrapServers;
     private List<String> certificates;
     private Map<String, Object> additionalProperties;
 
-    @Description("The type of the listener. " +
-            "Can be one of the following three types: `plain`, `tls`, and `external`.")
+    @Description("The name of the listener.")
+    @DeprecatedProperty(movedToPath = "name")
+    @Deprecated
     public String getType() {
-        return type;
+        return name;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    @Deprecated
+    public void setType(String name) {
+        this.name = name;
+    }
+
+    @Description("The name of the listener.")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Description("A list of the addresses for this listener.")

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-listener-name-and-status.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-listener-name-and-status.yaml
@@ -1,0 +1,38 @@
+---
+kind: "Kafka"
+metadata:
+  generation: 2
+  name: "my-cluster"
+  namespace: "my-namespace"
+spec:
+  kafka:
+    replicas: 3
+    listeners:
+    - name: "plain"
+      port: 9092
+      type: "internal"
+      tls: false
+    storage:
+      type: "ephemeral"
+  zookeeper:
+    replicas: 3
+    storage:
+      type: "ephemeral"
+status:
+  conditions:
+  - type: "Ready"
+    status: "True"
+  observedGeneration: 1
+  listeners:
+  - type: "plain"
+    name: "plain"
+    addresses:
+    - host: "my-service.my-namespace.svc"
+      port: 9092
+    bootstrapServers: "my-service.my-namespace.svc:9092"
+  - type: "external"
+    name: "external"
+    addresses:
+    - host: "my-route-address.domain.tld"
+      port: 443
+    bootstrapServers: "my-route-address.domain.tld:443"

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2111,7 +2111,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 String bootstrapAddress = getInternalServiceHostname(ListenersUtils.backwardsCompatibleBootstrapServiceName(name, listener), useServiceDnsDomain);
 
                 ListenerStatus ls = new ListenerStatusBuilder()
-                        .withType(listener.getName())
+                        .withName(listener.getName())
                         .withAddresses(new ListenerAddressBuilder()
                                 .withHost(bootstrapAddress)
                                 .withPort(listener.getPort())
@@ -2233,7 +2233,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     return CompositeFuture.join(perPodFutures);
                 }).compose(res -> {
                     ListenerStatus ls = new ListenerStatusBuilder()
-                        .withType(listener.getName())
+                        .withName(listener.getName())
                         .withAddresses(bootstrapListenerAddressList.stream()
                                 .map(listenerAddress -> new ListenerAddressBuilder().withHost(listenerAddress)
                                         .withPort(listener.getPort())
@@ -2399,7 +2399,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 }
 
                                 ListenerStatus ls = new ListenerStatusBuilder()
-                                        .withType(listener.getName())
+                                        .withName(listener.getName())
                                         .withAddresses(new ArrayList<>(statusAddresses))
                                         .build();
                                 addListenerStatus(ls);
@@ -2438,7 +2438,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             kafkaBootstrapDnsName.add(bootstrapAddress);
 
                             ListenerStatus ls = new ListenerStatusBuilder()
-                                    .withType(listener.getName())
+                                    .withName(listener.getName())
                                     .withAddresses(new ListenerAddressBuilder()
                                             .withHost(bootstrapAddress)
                                             .withPort(kafkaCluster.getRoutePort())
@@ -2523,7 +2523,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             kafkaBootstrapDnsName.add(bootstrapAddress);
 
                             ListenerStatus ls = new ListenerStatusBuilder()
-                                    .withType(listener.getName())
+                                    .withName(listener.getName())
                                     .withAddresses(new ListenerAddressBuilder()
                                             .withHost(bootstrapAddress)
                                             .withPort(kafkaCluster.getRoutePort())
@@ -2601,7 +2601,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             kafkaBootstrapDnsName.add(bootstrapAddress);
 
                             ListenerStatus ls = new ListenerStatusBuilder()
-                                    .withType(listener.getName())
+                                    .withName(listener.getName())
                                     .withAddresses(new ListenerAddressBuilder()
                                             .withHost(bootstrapAddress)
                                             .withPort(kafkaCluster.getRoutePort())
@@ -4150,7 +4150,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             List<ListenerStatus> listeners = kafkaStatus.getListeners();
 
             if (listeners != null) {
-                ListenerStatus listener = listeners.stream().filter(listenerType -> type.equals(listenerType.getType())).findFirst().orElse(null);
+                ListenerStatus listener = listeners.stream().filter(listenerType -> type.equals(listenerType.getName())).findFirst().orElse(null);
 
                 if (listener != null) {
                     listener.setCertificates(singletonList(certificate));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StatusDiffTest.java
@@ -27,7 +27,7 @@ public class StatusDiffTest {
     @ParallelTest
     public void testStatusDiff()    {
         ListenerStatus ls1 = new ListenerStatusBuilder()
-                .withType("plain")
+                .withName("plain")
                 .withAddresses(new ListenerAddressBuilder()
                         .withHost("my-service.my-namespace.svc")
                         .withPort(9092)
@@ -35,7 +35,7 @@ public class StatusDiffTest {
                 .build();
 
         ListenerStatus ls2 = new ListenerStatusBuilder()
-                .withType("tls")
+                .withName("tls")
                 .withAddresses(new ListenerAddressBuilder()
                         .withHost("my-service.my-namespace.svc")
                         .withPort(9093)
@@ -43,7 +43,7 @@ public class StatusDiffTest {
                 .build();
 
         ListenerStatus ls3 = new ListenerStatusBuilder()
-                .withType("tls")
+                .withName("tls")
                 .withAddresses(new ListenerAddressBuilder()
                         .withHost("my-service.my-namespace.svc")
                         .withPort(9094)
@@ -114,7 +114,7 @@ public class StatusDiffTest {
     @ParallelTest
     public void testTimestampDiff() throws ParseException {
         ListenerStatus ls1 = new ListenerStatusBuilder()
-                .withType("plain")
+                .withName("plain")
                 .withAddresses(new ListenerAddressBuilder()
                         .withHost("my-service.my-namespace.svc")
                         .withPort(9092)
@@ -122,7 +122,7 @@ public class StatusDiffTest {
                 .build();
 
         ListenerStatus ls2 = new ListenerStatusBuilder()
-                .withType("tls")
+                .withName("tls")
                 .withAddresses(new ListenerAddressBuilder()
                         .withHost("my-service.my-namespace.svc")
                         .withPort(9093)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -164,10 +164,12 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(2));
             assertThat(status.getListeners().get(0).getType(), is("plain"));
+            assertThat(status.getListeners().get(0).getName(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(Integer.valueOf(9092)));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
             assertThat(status.getListeners().get(1).getType(), is("external"));
+            assertThat(status.getListeners().get(1).getName(), is("external"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getHost(), is("my-route-address.domain.tld"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getPort(), is(Integer.valueOf(443)));
             assertThat(status.getListeners().get(1).getBootstrapServers(), is("my-route-address.domain.tld:443"));
@@ -234,14 +236,14 @@ public class KafkaStatusTest {
                         .withType("Ready")
                     .endCondition()
                     .withListeners(new ListenerStatusBuilder()
-                            .withType("plain")
+                            .withName("plain")
                             .withAddresses(new ListenerAddressBuilder()
                                     .withHost("my-service.my-namespace.svc")
                                     .withPort(9092)
                                     .build())
                             .build(),
                             new ListenerStatusBuilder()
-                                    .withType("external")
+                                    .withName("external")
                                     .withAddresses(new ListenerAddressBuilder()
                                             .withHost("my-route-address.domain.tld")
                                             .withPort(443)
@@ -312,6 +314,7 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("plain"));
+            assertThat(status.getListeners().get(0).getName(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(Integer.valueOf(9092)));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
@@ -343,14 +346,14 @@ public class KafkaStatusTest {
                         .withType("Ready")
                     .endCondition()
                     .withListeners(new ListenerStatusBuilder()
-                                    .withType("plain")
+                                    .withName("plain")
                                     .withAddresses(new ListenerAddressBuilder()
                                             .withHost("my-service.my-namespace.svc")
                                             .withPort(9092)
                                             .build())
                                     .build(),
                             new ListenerStatusBuilder()
-                                    .withType("external")
+                                    .withName("external")
                                     .withAddresses(new ListenerAddressBuilder()
                                             .withHost("my-route-address.domain.tld")
                                             .withPort(443)
@@ -383,11 +386,12 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("plain"));
+            assertThat(status.getListeners().get(0).getName(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(Integer.valueOf(9092)));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
 
-            assertThat(status.getConditions().size(), is(1));
+            assertThat(status.getConditions().size(), is(2));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
             assertThat(status.getConditions().get(0).getStatus(), is("True"));
             assertThat(status.getConditions().get(0).getReason(), is("RuntimeException"));
@@ -552,6 +556,7 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("external"));
+            assertThat(status.getListeners().get(0).getName(), is("external"));
 
             List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
             assertThat(addresses.size(), is(3));
@@ -673,6 +678,7 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("external"));
+            assertThat(status.getListeners().get(0).getName(), is("external"));
 
             List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
             assertThat(addresses.size(), is(3));
@@ -784,6 +790,7 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("external"));
+            assertThat(status.getListeners().get(0).getName(), is("external"));
 
             List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
             assertThat(addresses.size(), is(3));
@@ -892,6 +899,7 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("external"));
+            assertThat(status.getListeners().get(0).getName(), is("external"));
 
             List<ListenerAddress> addresses = status.getListeners().get(0).getAddresses();
             assertThat(addresses.size(), is(1));
@@ -979,6 +987,7 @@ public class KafkaStatusTest {
 
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getType(), is("external"));
+            assertThat(status.getListeners().get(0).getName(), is("external"));
 
             assertThat(status.getListeners().get(0).getAddresses(), is(emptyList()));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is(nullValue()));
@@ -1168,7 +1177,7 @@ public class KafkaStatusTest {
         @Override
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             ListenerStatus ls = new ListenerStatusBuilder()
-                    .withType("plain")
+                    .withName("plain")
                     .withAddresses(new ListenerAddressBuilder()
                             .withHost("my-service.my-namespace.svc")
                             .withPort(9092)
@@ -1176,7 +1185,7 @@ public class KafkaStatusTest {
                     .build();
 
             ListenerStatus ls2 = new ListenerStatusBuilder()
-                    .withType("external")
+                    .withName("external")
                     .withAddresses(new ListenerAddressBuilder()
                             .withHost("my-route-address.domain.tld")
                             .withPort(443)
@@ -1205,7 +1214,7 @@ public class KafkaStatusTest {
         @Override
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             ListenerStatus ls = new ListenerStatusBuilder()
-                    .withType("plain")
+                    .withName("plain")
                     .withAddresses(new ListenerAddressBuilder()
                             .withHost("my-service.my-namespace.svc")
                             .withPort(9092)

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1540,7 +1540,9 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 [options="header"]
 |====
 |Property                 |Description
-|type              1.2+<.<a|The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.
+|type              1.2+<.<a|*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener.
+|string
+|name              1.2+<.<a|The name of the listener.
 |string
 |addresses         1.2+<.<a|A list of the addresses for this listener.
 |xref:type-ListenerAddress-{context}[`ListenerAddress`] array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5956,7 +5956,10 @@ spec:
                     properties:
                       type:
                         type: string
-                        description: 'The type of the listener. Can be one of the following three types: `plain`, `tls`, and `external`.'
+                        description: The name of the listener.
+                      name:
+                        type: string
+                        description: The name of the listener.
                       addresses:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6975,8 +6975,10 @@ spec:
                   properties:
                     type:
                       type: string
-                      description: 'The type of the listener. Can be one of the following
-                        three types: `plain`, `tls`, and `external`.'
+                      description: The name of the listener.
+                    name:
+                      type: string
+                      description: The name of the listener.
                     addresses:
                       type: array
                       items:

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/AbstractKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/AbstractKafkaClient.java
@@ -214,7 +214,7 @@ public abstract class AbstractKafkaClient<C extends AbstractKafkaClient.Builder<
             return listenerStatusList.get(0).getBootstrapServers();
         }
 
-        return listenerStatusList.stream().filter(listener -> listener.getType().equals(listenerName))
+        return listenerStatusList.stream().filter(listener -> listener.getName().equals(listenerName))
             .findFirst()
             .orElseThrow(RuntimeException::new)
             .getBootstrapServers();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -150,7 +150,7 @@ public class KafkaUtils {
         List<ListenerStatus> kafkaListeners = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getListeners();
 
         for (ListenerStatus listener : kafkaListeners) {
-            if (listener.getType().equals(listenerType))
+            if (listener.getName().equals(listenerType))
                 certs = listener.getCertificates().toString();
         }
         certs = certs.substring(1, certs.length() - 1);


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Enhancement 

### Description

This PR addresses the issue mentioned in #5757. This PR adds the `name` field in the listener status which have the same as the field `type`.

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

