### PR TITLE
Add 'replicas' and 'config' to KT status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -12,6 +12,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.Map;
+
 /**
  * Represents a status of the KafkaTopic resource
  */
@@ -20,15 +22,15 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "topicName", "replicationFactor", "minISR" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "topicName", "replicas", "config" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {
     private static final long serialVersionUID = 1L;
 
     private String topicName;
-    private Integer replicationFactor;
-    private Integer minISR;
+    private Integer replicas;
+    private Map<String, Object> config;
 
     @Description("Topic name")
     public String getTopicName() {
@@ -40,20 +42,20 @@ public class KafkaTopicStatus extends Status {
     }
 
     @Description("Topic replication factor")
-    public Integer getReplicationFactor() {
-        return replicationFactor;
+    public Integer getReplicas() {
+        return replicas;
     }
 
-    public void setReplicationFactor(Integer replicationFactor) {
-        this.replicationFactor = replicationFactor;
+    public void setReplicas(Integer replicas) {
+        this.replicas = replicas;
     }
 
-    @Description("Topic minimum in sync replicas")
-    public Integer getMinISR() {
-        return minISR;
+    @Description("Topic configuration")
+    public Map<String, Object> getConfig() {
+        return config;
     }
 
-    public void setMinISR(Integer minISR) {
-        this.minISR = minISR;
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaTopicStatus.java
@@ -20,13 +20,15 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "topicName" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "topicName", "replicationFactor", "minISR" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {
     private static final long serialVersionUID = 1L;
 
     private String topicName;
+    private Integer replicationFactor;
+    private Integer minISR;
 
     @Description("Topic name")
     public String getTopicName() {
@@ -35,5 +37,23 @@ public class KafkaTopicStatus extends Status {
 
     public void setTopicName(String topicName) {
         this.topicName = topicName;
+    }
+
+    @Description("Topic replication factor")
+    public Integer getReplicationFactor() {
+        return replicationFactor;
+    }
+
+    public void setReplicationFactor(Integer replicationFactor) {
+        this.replicationFactor = replicationFactor;
+    }
+
+    @Description("Topic minimum in sync replicas")
+    public Integer getMinISR() {
+        return minISR;
+    }
+
+    public void setMinISR(Integer minISR) {
+        this.minISR = minISR;
     }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2194,6 +2194,10 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 |integer
 |topicName           1.2+<.<a|Topic name.
 |string
+|replicationFactor   1.2+<.<a|Topic replication factor.
+|integer
+|minISR              1.2+<.<a|Topic minimum in sync replicas.
+|integer
 |====
 
 [id='type-KafkaUser-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2194,10 +2194,10 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 |integer
 |topicName           1.2+<.<a|Topic name.
 |string
-|replicationFactor   1.2+<.<a|Topic replication factor.
+|replicas            1.2+<.<a|Topic replication factor.
 |integer
-|minISR              1.2+<.<a|Topic minimum in sync replicas.
-|integer
+|config              1.2+<.<a|Topic configuration.
+|map
 |====
 
 [id='type-KafkaUser-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -97,12 +97,13 @@ spec:
                 topicName:
                   type: string
                   description: Topic name.
-                replicationFactor:
+                replicas:
                   type: integer
                   description: Topic replication factor.
-                minISR:
-                  type: integer
-                  description: Topic minimum in sync replicas.
+                config:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                  description: Topic configuration.
               description: The status of the topic.
     - name: v1beta1
       served: true
@@ -180,12 +181,13 @@ spec:
                 topicName:
                   type: string
                   description: Topic name.
-                replicationFactor:
+                replicas:
                   type: integer
                   description: Topic replication factor.
-                minISR:
-                  type: integer
-                  description: Topic minimum in sync replicas.
+                config:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                  description: Topic configuration.
               description: The status of the topic.
     - name: v1alpha1
       served: true
@@ -263,10 +265,11 @@ spec:
                 topicName:
                   type: string
                   description: Topic name.
-                replicationFactor:
+                replicas:
                   type: integer
                   description: Topic replication factor.
-                minISR:
-                  type: integer
-                  description: Topic minimum in sync replicas.
+                config:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                  description: Topic configuration.
               description: The status of the topic.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -97,6 +97,12 @@ spec:
                 topicName:
                   type: string
                   description: Topic name.
+                replicationFactor:
+                  type: integer
+                  description: Topic replication factor.
+                minISR:
+                  type: integer
+                  description: Topic minimum in sync replicas.
               description: The status of the topic.
     - name: v1beta1
       served: true
@@ -174,6 +180,12 @@ spec:
                 topicName:
                   type: string
                   description: Topic name.
+                replicationFactor:
+                  type: integer
+                  description: Topic replication factor.
+                minISR:
+                  type: integer
+                  description: Topic minimum in sync replicas.
               description: The status of the topic.
     - name: v1alpha1
       served: true
@@ -251,4 +263,10 @@ spec:
                 topicName:
                   type: string
                   description: Topic name.
+                replicationFactor:
+                  type: integer
+                  description: Topic replication factor.
+                minISR:
+                  type: integer
+                  description: Topic minimum in sync replicas.
               description: The status of the topic.

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -110,12 +110,13 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
-              replicationFactor:
+              replicas:
                 type: integer
                 description: Topic replication factor.
-              minISR:
-                type: integer
-                description: Topic minimum in sync replicas.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: Topic configuration.
             description: The status of the topic.
   - name: v1beta1
     served: true
@@ -207,12 +208,13 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
-              replicationFactor:
+              replicas:
                 type: integer
                 description: Topic replication factor.
-              minISR:
-                type: integer
-                description: Topic minimum in sync replicas.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: Topic configuration.
             description: The status of the topic.
   - name: v1alpha1
     served: true
@@ -304,10 +306,11 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
-              replicationFactor:
+              replicas:
                 type: integer
                 description: Topic replication factor.
-              minISR:
-                type: integer
-                description: Topic minimum in sync replicas.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: Topic configuration.
             description: The status of the topic.

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -110,6 +110,12 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
+              replicationFactor:
+                type: integer
+                description: Topic replication factor.
+              minISR:
+                type: integer
+                description: Topic minimum in sync replicas.
             description: The status of the topic.
   - name: v1beta1
     served: true
@@ -201,6 +207,12 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
+              replicationFactor:
+                type: integer
+                description: Topic replication factor.
+              minISR:
+                type: integer
+                description: Topic minimum in sync replicas.
             description: The status of the topic.
   - name: v1alpha1
     served: true
@@ -292,4 +304,10 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
+              replicationFactor:
+                type: integer
+                description: Topic replication factor.
+              minISR:
+                type: integer
+                description: Topic minimum in sync replicas.
             description: The status of the topic.

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -110,12 +110,13 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
-              replicationFactor:
+              replicas:
                 type: integer
                 description: Topic replication factor.
-              minISR:
-                type: integer
-                description: Topic minimum in sync replicas.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: Topic configuration.
             description: The status of the topic.
   - name: v1beta1
     served: true
@@ -207,12 +208,13 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
-              replicationFactor:
+              replicas:
                 type: integer
                 description: Topic replication factor.
-              minISR:
-                type: integer
-                description: Topic minimum in sync replicas.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: Topic configuration.
             description: The status of the topic.
   - name: v1alpha1
     served: true
@@ -304,10 +306,11 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
-              replicationFactor:
+              replicas:
                 type: integer
                 description: Topic replication factor.
-              minISR:
-                type: integer
-                description: Topic minimum in sync replicas.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: Topic configuration.
             description: The status of the topic.

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -110,6 +110,12 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
+              replicationFactor:
+                type: integer
+                description: Topic replication factor.
+              minISR:
+                type: integer
+                description: Topic minimum in sync replicas.
             description: The status of the topic.
   - name: v1beta1
     served: true
@@ -201,6 +207,12 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
+              replicationFactor:
+                type: integer
+                description: Topic replication factor.
+              minISR:
+                type: integer
+                description: Topic minimum in sync replicas.
             description: The status of the topic.
   - name: v1alpha1
     served: true
@@ -292,4 +304,10 @@ spec:
               topicName:
                 type: string
                 description: Topic name.
+              replicationFactor:
+                type: integer
+                description: Topic replication factor.
+              minISR:
+                type: integer
+                description: Topic minimum in sync replicas.
             description: The status of the topic.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -1079,9 +1079,11 @@ class TopicOperator {
                     }
 
                     // we can do this because TO puts RF back to the k8s resource
-                    kts.setReplicationFactor(topic.getSpec().getReplicas());
-                    if (topicMetadata != null && topicMetadata.getConfig().get("min.insync.replicas") != null) {
-                        kts.setMinISR(Integer.parseInt(topicMetadata.getConfig().get("min.insync.replicas").value()));
+                    kts.setReplicas(topic.getSpec().getReplicas());
+                    if (topicMetadata != null) {
+                        Map<String, Object> cfg = new HashMap<>();
+                        cfg.putAll(topicMetadata.getConfig().entries().stream().filter(configEntry -> !configEntry.isDefault()).collect(Collectors.toMap(e -> e.name(), e -> e.value())));
+                        kts.setConfig(cfg);
                     }
 
                     StatusDiff ksDiff = new StatusDiff(topic.getStatus(), kts);


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
Add 'replicas' and 'config' to KT status. Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/5758

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

