### PR TITLE
Update the packaging folder with the Drain Cleaner 0.2.0 release

### DIFF
--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.1.0
+          image: quay.io/strimzi/drain-cleaner:0.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.1.0
+          image: quay.io/strimzi/drain-cleaner:0.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.1.0
+          image: quay.io/strimzi/drain-cleaner:0.2.0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
### Type of change

- Task

### Description

Now after Drain cleaner 0.2.0 was released, this PR updates the `packaging/install/drain-cleaner` folder with the updated installation files.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally