### PR TITLE
Set the base image in Kafka Connect Build properly when it is specified in the CR

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -57,7 +57,7 @@ public class KafkaConnectBuild extends AbstractModel {
     private SecurityContext templateBuildContainerSecurityContext;
     private Map<String, String> templateBuildConfigLabels;
     private Map<String, String> templateBuildConfigAnnotations;
-    private String baseImage;
+    /*test*/ String baseImage;
     private List<String> additionalKanikoOptions;
     private String pullSecret;
 
@@ -116,9 +116,7 @@ public class KafkaConnectBuild extends AbstractModel {
             }
         }
 
-        if (spec.getImage() == null) {
-            build.baseImage = versions.kafkaConnectVersion(spec.getImage(), spec.getVersion());
-        }
+        build.baseImage = versions.kafkaConnectVersion(spec.getImage(), spec.getVersion());
 
         if (spec.getTemplate() != null) {
             KafkaConnectTemplate template = spec.getTemplate();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -166,6 +166,7 @@ public class KafkaConnectBuildTest {
                     .withNamespace(namespace)
                 .endMetadata()
                 .withNewSpec()
+                    .withImage("my-source-image:latest")
                     .withBootstrapServers("my-kafka:9092")
                     .withNewBuild()
                         .withNewDockerOutput()
@@ -180,6 +181,8 @@ public class KafkaConnectBuildTest {
                 .build();
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS);
+
+        assertThat(build.baseImage, is("my-source-image:latest"));
 
         Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(cluster)));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When user specified `.spec.image` in `KafkaConnect` resource with Kafka Connect Build, the image should be used as a base image when building the new image. However, it isn't handled properly right now and it ends up with `FROM null`. This PR fixes this and sets it properly when specified by the user.

This should resolve #5793.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging