### PR TITLE
[MO] - [system test] -> KafkaConnect (SASL_PLAINTEXT) and KafkaOauth plain

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -689,7 +689,7 @@ public class OauthPlainST extends OauthAbstractST {
             .build());
 
         // verify that KafkaConnect is able to connect to Oauth Kafka configured as plain
-        KafkaConnectUtils.waitForConnectReady(testStorage.getClusterName());
+        KafkaConnectUtils.waitForConnectReady(testStorage.getNamespaceName(), testStorage.getClusterName());
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR adds a system test for verification that KafkaConnect with SASL_PLAINTEXT authentification configured is able to connect to KafkaOauth cluster using plain communication.


### Checklist

- [x] Write tests
- [ ] Make sure all tests pass

