### PR TITLE
Adjust the size of the init container volumes to work also on platforms with bigger page size

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1411,7 +1411,7 @@ public class KafkaCluster extends AbstractModel {
         List<Volume> volumeList = new ArrayList<>(dataVolumes);
 
         if (rack != null || isExposedWithNodePort()) {
-            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "100Ki", "Memory"));
+            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
         }
 
         volumeList.add(createTempDirVolume());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -346,7 +346,7 @@ public class KafkaConnectCluster extends AbstractModel {
         volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigMapName));
 
         if (rack != null) {
-            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "10Ki", "Memory"));
+            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
         }
 
         if (tls != null) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Some platforms tend to use bigger page size (I hope this is the right term) which defines the increments in which the file size grows. PPC64LE seems to often default to 64kB and in that case, the current sizes for the volumes used to share data between init containers and main containers when rack awareness or node ports are used is not sufficient. While on x86 with the usual size 4kB the files fit, they do not fit on PPC64LE anymore.

This PR increases the sizes of the volumes to 1Mi => that should give us some overhead for situations similar to this and should be still negligible given the usual overal size of the Kafka broker or Connect pod.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally