### PR TITLE
[systemtest] - SecurityST - disable checks for KE and CC in renewal tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -507,7 +507,7 @@ class SecurityST extends AbstractST {
             eoPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPod);
         }
 
-//        TODO: Once issue with removal will be resolved (means RU CC and KE when cluster CA is changed) uncomment commented code
+//        TODO: Once issue with removal will be resolved (means RU CC and KE when cluster CA is changed) uncomment commented code - https://github.com/strimzi/strimzi-kafka-operator/issues/5810
 //        if (keAndCCShouldRoll) {
         LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart (1)...");
         kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
@@ -591,6 +591,7 @@ class SecurityST extends AbstractST {
             assertThat("EO pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName)), is(eoPod));
         }
 
+//        TODO: Once issue with removal will be resolved (means RU CC and KE when cluster CA is changed) uncomment commented code - https://github.com/strimzi/strimzi-kafka-operator/issues/5810
 //        if (!keAndCCShouldRoll) {
 //            assertThat("CC pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName)), is(ccPod));
 //            assertThat("KE pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaExporterResources.deploymentName(clusterName)), is(kePod));

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -315,8 +315,8 @@ class SecurityST extends AbstractST {
         }
         if (keAndCCShouldRoll) {
             LOGGER.info("Wait for CC and KE to rolling restart ...");
-            kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, kePod);
-            ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, ccPod);
+            kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
+            ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
         }
 
         LOGGER.info("Checking the certificates have been replaced");
@@ -507,11 +507,12 @@ class SecurityST extends AbstractST {
             eoPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPod);
         }
 
-        if (keAndCCShouldRoll) {
-            LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart (1)...");
-            kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, kePod);
-            ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, ccPod);
-        }
+//        TODO: Once issue with removal will be resolved (means RU CC and KE when cluster CA is changed) uncomment commented code
+//        if (keAndCCShouldRoll) {
+        LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart (1)...");
+        kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
+        ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
+//        }
 
         if (zkShouldRoll) {
             LOGGER.info("Wait for zk to rolling restart (2)...");
@@ -530,8 +531,8 @@ class SecurityST extends AbstractST {
 
         if (keAndCCShouldRoll) {
             LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart (2)...");
-            kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, kePod);
-            ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, ccPod);
+            kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
+            ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
         }
 
         LOGGER.info("Checking the certificates have been replaced");
@@ -590,10 +591,10 @@ class SecurityST extends AbstractST {
             assertThat("EO pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName)), is(eoPod));
         }
 
-        if (!keAndCCShouldRoll) {
-            assertThat("CC pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName)), is(ccPod));
-            assertThat("KE pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaExporterResources.deploymentName(clusterName)), is(kePod));
-        }
+//        if (!keAndCCShouldRoll) {
+//            assertThat("CC pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName)), is(ccPod));
+//            assertThat("KE pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaExporterResources.deploymentName(clusterName)), is(kePod));
+//        }
     }
 
     private void createKafkaCluster(ExtensionContext extensionContext) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Disable test checks

### Description

It seems that there is some issue, which causing `KafkaExporter`, `CruiseControl` and maybe `EntityOperator` roll even on clients CA renewal - this PR disables test checks, verifying if `KE` and `CC` pods were rolled, even they shouldn't - after the issue will be fixed, we will enable it again.

### Checklist

- [ ] Make sure all tests pass

