### PR TITLE
Fix bullet points in additional resources in the docs section _Configuring a Strimzi deployment_

### DIFF
--- a/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
@@ -39,5 +39,6 @@ include::../../modules/configuring/proc-loading-config-with-provider.adoc[levelo
 
 [role="_additional-resources"]
 .Additional resources
-link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]
-link:{BookURLDeploying}#assembly-metrics-str[Introduce metrics to monitor your Strimzi deployment^]
+
+* link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]
+* link:{BookURLDeploying}#assembly-metrics-str[Introduce metrics to monitor your Strimzi deployment^]


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The _Additional Resources_ part of the _Configuring a Strimzi deployment_ section of our docs is missing bullet points. As a result all the resources are mixed on a single line:

![Screenshot 2021-10-29 at 16 59 35](https://user-images.githubusercontent.com/5658439/139458164-1a6b5c0e-1e75-469e-a1b6-575daa95f852.png)

This PR fixes it so that it looks better:

![Screenshot 2021-10-29 at 17 00 53](https://user-images.githubusercontent.com/5658439/139458208-892287d9-e35d-44de-9fb9-e0b5afb69608.png)