### PR TITLE
chore: bump cruise control to 2.5.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * The `ControlPlaneListener` feature gate is now enabled by default.
   When upgrading from Strimzi 0.22 or earlier, you have to disable the `ControlPlaneListener` feature gate when upgrading the cluster operator to make sure the Kafka cluster stays available during the upgrade.
   When downgrading to Strimzi 0.22 or earlier, you have to disable the `ControlPlaneListener` feature gate before downgrading the cluster operator to make sure the Kafka cluster stays available during the downgrade.
+* Update to Cruise Control version 2.5.74
 
 ## 0.26.0
 

--- a/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.73</cruise-control.version>
+        <cruise-control.version>2.5.74</cruise-control.version>
         <opa-authorizer.version>1.1.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/kafka/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.73</cruise-control.version>
+        <cruise-control.version>2.5.74</cruise-control.version>
         <opa-authorizer.version>1.2.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.73</cruise-control.version>
+        <cruise-control.version>2.5.74</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Type of change

Dependencies

### Description

Update cruise control to 2.5.74

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

