### PR TITLE
[MO] - race conditions + complete clean-up

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/BeforeAllOnce.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/BeforeAllOnce.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest;
 import io.strimzi.systemtest.parallel.ParallelNamespacesSuitesNames;
 import io.strimzi.systemtest.parallel.ParallelSuiteController;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.utils.StUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -23,6 +24,7 @@ public class BeforeAllOnce implements BeforeAllCallback, ExtensionContext.Store.
     private static SetupClusterOperator install;
     private static final Logger LOGGER = LogManager.getLogger(BeforeAllOnce.class);
     private static boolean systemReady = false;
+    private static final String SYSTEM_RESOURCES = "SYSTEM_RESOURCES";
     private static ExtensionContext sharedExtensionContext;
 
     /**
@@ -60,8 +62,11 @@ public class BeforeAllOnce implements BeforeAllCallback, ExtensionContext.Store.
                     .createInstallation()
                     .runInstallation();
             }
-            // this is for correction because callback also count some randomly chosen class twice
-            ParallelSuiteController.decrementCounter();
+            // correction, because when @BeforeAllCallback is invoked firstly by @IsolatedSuite class it decrement counter which is not correct
+            if (StUtils.isParallelSuite(extensionContext)) {
+                ParallelSuiteController.decrementCounter();
+            }
+            sharedExtensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(SYSTEM_RESOURCES, new BeforeAllOnce());
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/ParallelNamespacesSuitesNames.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/ParallelNamespacesSuitesNames.java
@@ -23,7 +23,9 @@ public class ParallelNamespacesSuitesNames {
         Constants.BRIDGE_KAFKA_CORS_NAMESPACE,
         Constants.BRIDGE_KAFKA_EXTERNAL_LISTENER_NAMESPACE,
         Constants.BRIDGE_SCRAM_SHA_NAMESPACE,
-        Constants.BRIDGE_HTTP_TLS_NAMESPACE
+        Constants.BRIDGE_HTTP_TLS_NAMESPACE,
+        // metrics namespace
+        Constants.METRICS_SECOND_NAMESPACE
     );
 
     public static String getRbacNamespacesToWatch() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -147,7 +147,8 @@ public class SetupClusterOperator {
         return new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
             .withNamespace(Constants.INFRA_NAMESPACE)
-            .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES);
+            .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
+            .withBindingsNamespaces(ParallelNamespacesSuitesNames.getBindingNamespaces());
     }
 
     /**
@@ -311,9 +312,9 @@ public class SetupClusterOperator {
 
         public SetupClusterOperatorBuilder addToTheBindingsNamespaces(String bindingsNamespace) {
             if (this.bindingsNamespaces != null) {
-                this.bindingsNamespaces.add(bindingsNamespace);
+                this.bindingsNamespaces = new ArrayList<>(this.bindingsNamespaces);
             } else {
-                this.bindingsNamespaces = Arrays.asList(bindingsNamespace);
+                this.bindingsNamespaces = new ArrayList<>(Arrays.asList(bindingsNamespace));
             }
             return self();
         }
@@ -561,8 +562,7 @@ public class SetupClusterOperator {
                 e.printStackTrace();
             }
 
-            KubeClusterResource.getInstance().deleteNamespace(
-                CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo);
+            KubeClusterResource.getInstance().deleteAllSetNamespaces();
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -83,7 +83,11 @@ public abstract class AbstractST implements TestSeparator {
     protected KubeClusterResource cluster;
     protected static TimeMeasuringSystem timeMeasuringSystem = TimeMeasuringSystem.getInstance();
     private static final Logger LOGGER = LogManager.getLogger(AbstractST.class);
-    private final Object lock = new Object();
+
+    // {thread-safe} this lock ensures that no race-condition happen in @BeforeAll part
+    private static final Object BEFORE_ALL_LOCK = new Object();
+    // {thread-safe} this needs to be static because when more threads spawns diff. TestSuites it might produce race conditions
+    private static final Object LOCK = new Object();
 
     // maps for local variables {thread safe}
     protected static Map<String, String> mapWithClusterNames = new HashMap<>();
@@ -92,7 +96,8 @@ public abstract class AbstractST implements TestSeparator {
     protected static Map<String, String> mapWithKafkaClientNames = new HashMap<>();
     protected static ConcurrentHashMap<ExtensionContext, TestStorage> storageMap = new ConcurrentHashMap<>();
 
-    private AtomicInteger counterOfNamespaces = new AtomicInteger(0);
+    // we need to shared this number across all test suites
+    private static AtomicInteger counterOfNamespaces = new AtomicInteger(0);
 
     protected static final String CLUSTER_NAME_PREFIX = "my-cluster-";
     protected static final String KAFKA_IMAGE_MAP = "STRIMZI_KAFKA_IMAGES";
@@ -538,7 +543,7 @@ public abstract class AbstractST implements TestSeparator {
         }
     }
 
-    protected void afterAllMayOverride(ExtensionContext extensionContext) throws Exception {
+    protected synchronized void afterAllMayOverride(ExtensionContext extensionContext) throws Exception {
         if (!Environment.SKIP_TEARDOWN) {
             ResourceManager.getInstance().deleteResources(extensionContext);
         }
@@ -571,7 +576,7 @@ public abstract class AbstractST implements TestSeparator {
         // synchronization it can produce `data-race`
         String testName = null;
 
-        synchronized (lock) {
+        synchronized (LOCK) {
             if (extensionContext.getTestMethod().isPresent()) {
                 testName = extensionContext.getTestMethod().get().getName();
             }
@@ -619,12 +624,15 @@ public abstract class AbstractST implements TestSeparator {
         cluster = KubeClusterResource.getInstance();
         install = BeforeAllOnce.getInstall();
 
-        if (StUtils.isParallelSuite(extensionContext)) {
-            ParallelSuiteController.addParallelSuite(extensionContext);
-        }
-        if (StUtils.isIsolatedSuite(extensionContext)) {
-            cluster.setNamespace(Constants.INFRA_NAMESPACE);
-            ParallelSuiteController.waitUntilZeroParallelSuites();
+        // ensures that only one thread will modify @ParallelSuiteController and race-condition could not happen
+        synchronized (BEFORE_ALL_LOCK) {
+            if (StUtils.isParallelSuite(extensionContext)) {
+                ParallelSuiteController.addParallelSuite(extensionContext);
+            }
+            if (StUtils.isIsolatedSuite(extensionContext)) {
+                cluster.setNamespace(Constants.INFRA_NAMESPACE);
+                ParallelSuiteController.waitUntilZeroParallelSuites();
+            }
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -646,8 +646,6 @@ public class MetricsST extends AbstractST {
 
     @BeforeAll
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
-        super.beforeAllMayOverride(extensionContext);
-
         install.unInstall();
         install = SetupClusterOperator.defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -646,6 +646,8 @@ public class MetricsST extends AbstractST {
 
     @BeforeAll
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
+        super.beforeAllMayOverride(extensionContext);
+
         install.unInstall();
         install = SetupClusterOperator.defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -13,7 +13,6 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
@@ -188,6 +187,13 @@ public class MultipleClusterOperatorsST extends AbstractST {
             .editMetadata()
                 .withNamespace(DEFAULT_NAMESPACE)
             .endMetadata()
+            .editSpec()
+                .withGoals("DiskCapacityGoal", "CpuCapacityGoal",
+                    "NetworkInboundCapacityGoal", "MinTopicLeadersPerBrokerGoal",
+                    "NetworkOutboundCapacityGoal", "ReplicaCapacityGoal")
+                .withSkipHardGoalCheck(true)
+                // skip sanity check: because of removal 'RackAwareGoal'
+            .endSpec()
             .build());
 
         KafkaUtils.waitForClusterStability(DEFAULT_NAMESPACE, clusterName);
@@ -224,7 +230,7 @@ public class MultipleClusterOperatorsST extends AbstractST {
         envVarList.add(selectorEnv);
 
         install = new SetupClusterOperator.SetupClusterOperatorBuilder()
-            .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
+            .withExtensionContext(extensionContext)
             .withNamespace(coNamespace)
             .withClusterOperatorName(coName)
             .withWatchingNamespaces(namespace)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -70,6 +70,7 @@ public class OauthAbstractST extends AbstractST {
     static {
         connectorConfig = new HashMap<>();
         connectorConfig.put("config.storage.replication.factor", 1);
+        connectorConfig.put("config.topic.cleanup.policy", "compact");
         connectorConfig.put("offset.storage.replication.factor", 1);
         connectorConfig.put("status.storage.replication.factor", 1);
     }


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR fixes a few things:
- fix hidden bug of counterOfNamespaces variable that was instance variable instead of static one (this cause that something, when more test suites were invoked then TestSuite1, has TestCase1 with @ParallelNamespaceAnnotation created namespace-0 but also another suite (TestSuite2) created the same namespace...
- complete clean-up of all namespaces AfterSuite.

### Checklist

- [x] Make sure all tests pass