### PR TITLE
Fix message when invalid log message or inter protocol version is provided

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -436,7 +436,8 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
                 return 1;
             }
         }
-        return components.length - otherComponents.length;
+        // mismatch was not found, but the versions are of different length, e.g. 2.8 and 2.8.0
+        return 0;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -90,6 +90,12 @@ public class KafkaVersionTest {
     }
 
     @ParallelTest
+    public void compareEqualVersionMMPTest() {
+        assertThat(KafkaVersion.compareDottedVersions("3.0", "3.0.0"), is(0));
+        assertThat(KafkaVersion.compareDottedVersions("3.0.0", "3.0"), is(0));
+    }
+
+    @ParallelTest
     public void compareEqualVersionTest() {
         assertThat(KafkaVersion.compareDottedVersions(KafkaVersionTestUtils.DEFAULT_KAFKA_VERSION, KafkaVersionTestUtils.DEFAULT_KAFKA_VERSION), is(0));
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/5767
the bug described in the issue ^

Fixed by considering `x.y.z` as an invalid format. The only format is `x.y` or `x.y-IVz`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

