### PR TITLE
KMM2 should roll when certificates or user credentials are updated

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.security.CertAndKeyFiles;
 import io.strimzi.test.TestUtils;
@@ -167,5 +168,13 @@ public class SecretUtils {
         TestUtils.waitFor(String.format("user password will be changed to: %s in secret: %s", expectedEncodedPassword, secretName),
             Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> kubeClient().namespace(namespaceName).getSecret(secretName).getData().get("password").equals(expectedEncodedPassword));
+    }
+
+    public static String annotateSecret(String namespaceName, String resourceName, String annotationKey, String annotationValue) {
+        LOGGER.info("Annotating Secret:{} with annotation {}={}", resourceName, annotationKey, annotationValue);
+        return ResourceManager.cmdKubeClient().namespace(namespaceName)
+                .execInCurrentNamespace("annotate", "secret", resourceName, annotationKey + "=" + annotationValue)
+                .out()
+                .trim();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -1306,7 +1306,7 @@ class ConnectST extends AbstractST {
 
         Secret passwordSecret = new SecretBuilder()
                 .withNewMetadata()
-                .withName("custom-pwd-secret")
+                    .withName("custom-pwd-secret")
                 .endMetadata()
                 .addToData("pwd", "MTIzNDU2Nzg5")
                 .build();
@@ -1364,7 +1364,7 @@ class ConnectST extends AbstractST {
 
         kubeClient(namespaceName).createSecret(newPasswordSecret);
 
-        kafkaUser =  KafkaUserTemplates.scramShaUser(clusterName, userName)
+        kafkaUser = KafkaUserTemplates.scramShaUser(clusterName, userName)
                 .editSpec()
                     .withNewKafkaUserScramSha512ClientAuthentication()
                         .withNewPassword()


### PR DESCRIPTION
New Test for KMM2 when scram password, CA cluster and clients certs are changed on both sides of source and target clusters.

- [x] Write tests
- [x] Make sure all tests pass