### PR TITLE
[systemtest] OLM - let CO watch multiple namespaces

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -148,7 +148,7 @@ public class Environment {
     public static final String OLM_OPERATOR_DEPLOYMENT_NAME_DEFAULT = Constants.STRIMZI_DEPLOYMENT_NAME;
     public static final String OLM_SOURCE_NAME_DEFAULT = "community-operators";
     public static final String OLM_APP_BUNDLE_PREFIX_DEFAULT = "strimzi-cluster-operator";
-    public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.25.0";
+    public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.26.0";
     private static final boolean DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT = true;
     private static final ClusterOperatorInstallType CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT = ClusterOperatorInstallType.BUNDLE;
     private static final boolean LB_FINALIZERS_DEFAULT = false;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -119,7 +119,8 @@ public class SetupClusterOperator {
                     cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
                     extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
                 }
-                olmResource = new OlmResource(namespaceInstallTo);
+                applyBindings();
+                olmResource = new OlmResource(namespaceInstallTo, namespaceToWatch);
                 olmResource.create(extensionContext, operationTimeout, reconciliationInterval);
             }
         } else if (Environment.isHelmInstall()) {

--- a/systemtest/src/main/resources/olm/operator-group.yaml
+++ b/systemtest/src/main/resources/olm/operator-group.yaml
@@ -7,4 +7,4 @@ metadata:
     app: strimzi
 spec:
   targetNamespaces:
-  - ${OPERATOR_NAMESPACE}
+  - ${NAMESPACES_TO_WATCH}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes issue with deploying CO via OLM to watch multiple namespaces - which is used for example in `MetricsST`.

### Checklist

- [ ] Make sure all tests pass