### PR TITLE
docs: updates to `additional resources` sections in doc assemblies

### DIFF
--- a/documentation/assemblies/assembly-securing-external-listeners.adoc
+++ b/documentation/assemblies/assembly-securing-external-listeners.adoc
@@ -5,6 +5,7 @@
 [id='assembly-accessing-kafka-outside-cluster-{context}']
 = Accessing Kafka outside of the Kubernetes cluster
 
+[role="_abstract"]
 Use an external listener to expose your Strimzi Kafka cluster to a client outside a Kubernetes environment.
 
 Specify the connection `type` to expose Kafka in the external listener configuration.
@@ -16,11 +17,9 @@ Specify the connection `type` to expose Kafka in the external listener configura
 
 For more information on listener configuration, see xref:type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference].
 
+If you want to know more about the pros and cons of each connection type, refer to {Externallisteners}.
+
 NOTE: `route` is only supported on OpenShift
-
-.Additional resources
-
-* {Externallisteners}
 
 include::../modules/proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]
 include::../modules/proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-securing-kafka-clients.adoc
+++ b/documentation/assemblies/assembly-securing-kafka-clients.adoc
@@ -16,8 +16,8 @@ You can also create _super users_ that have unconstrained access to Kafka broker
 
 The authentication and authorization mechanisms must match the xref:proc-securing-kafka-{context}[specification for the listener used to access the Kafka brokers].
 
-[role="_additional-resources"]
-.Additional resources
+.Configuring users for secure access to Kafka brokers
+For more information on configuring a `KafkaUser` resource to access Kafka brokers securely, see the following sections:
 
 * xref:proc-configuring-kafka-user-str[Securing user access to Kafka]
 * link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^]

--- a/documentation/assemblies/assembly-securing-kafka.adoc
+++ b/documentation/assemblies/assembly-securing-kafka.adoc
@@ -5,6 +5,7 @@
 [id='assembly-securing-kafka-{context}']
 = Securing access to Kafka brokers
 
+[role="_abstract"]
 To establish secure access to Kafka brokers, you configure and apply:
 
 * A `Kafka` resource to:
@@ -38,12 +39,11 @@ Configure the `KafkaUser` resource to set up:
 
 The User Operator creates the user representing the client and the security credentials used for client authentication, based on the chosen authentication type.
 
-.Additional resources
+Refer to the schema reference for more information on access configuration properties:
 
-For more information about the schema for:
-
-* `Kafka`, see the xref:type-Kafka-reference[`Kafka` schema reference].
-* `KafkaUser`, see the xref:type-KafkaUser-reference[`KafkaUser` schema reference].
+* xref:type-Kafka-reference[`Kafka` schema reference]
+* xref:type-KafkaUser-reference[`KafkaUser` schema reference]
+* xref:type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference]
 
 //steps to secure the brokers
 include::../modules/proc-securing-kafka.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -5,6 +5,7 @@
 [id='assembly-kafka-connect-{context}']
 = Kafka Connect cluster configuration
 
+[role="_abstract"]
 This section describes how to configure a Kafka Connect deployment in your Strimzi cluster.
 
 Kafka Connect is an integration toolkit for streaming data between Kafka brokers and other systems using connector plugins.
@@ -12,13 +13,7 @@ Kafka Connect provides a framework for integrating Kafka with an external data s
 Connectors are plugins that provide the connection configuration needed.
 The full schema of the `KafkaConnect` resource is described in xref:type-KafkaConnect-reference[].
 
-.Additional resources
-
-* link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^]
-* link:{BookURLDeploying}#proc-deploying-kafkaconnector-str[Deploying a KafkaConnector resource to Kafka Connect^]
-* link:{BookURLDeploying}#proc-manual-restart-connector-str[Restart a Kafka connector by annotating a KafkaConnector resource^]
-* link:{BookURLDeploying}#proc-manual-restart-connector-task-str[Restart a Kafka connector task by annotating a KafkaConnector resource^]
-
+For more information on deploying connector plugins, see link:{BookURLDeploying}#using-kafka-connect-with-plug-ins-str[Extending Kafka Connect with connector plug-ins^].
 
 //procedure to configure Kafka Connect
 include::../../modules/configuring/proc-config-kafka-connect.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-config-kafka.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka.adoc
@@ -5,6 +5,7 @@
 [id='assembly-config-kafka-{context}']
 = Kafka cluster configuration
 
+[role="_abstract"]
 This section describes how to configure a Kafka deployment in your Strimzi cluster.
 A Kafka cluster is deployed with a ZooKeeper cluster. The deployment can also include the Topic Operator and User Operator, which manage Kafka topics and users.
 
@@ -13,6 +14,7 @@ Configuration options are also available for ZooKeeper and the Entity Operator w
 The Entity Operator comprises the Topic Operator and User Operator.
 
 The full schema of the `Kafka` resource is described in the xref:type-Kafka-reference[].
+For more information about Apache Kafka, see the {kafkaDoc}.
 
 .Listener configuration
 You configure listeners for connecting clients to Kafka brokers.
@@ -20,17 +22,13 @@ For more information on configuring listeners for connecting brokers, see xref:c
 
 .Authorizing access to Kafka
 You can configure your Kafka cluster to allow or decline actions executed by users.
-For more information on securing access to Kafka brokers, see xref:assembly-securing-kafka-str[Managing access to Kafka].
+For more information, see xref:assembly-securing-kafka-str[Securing access to Kafka brokers].
 
 .Managing TLS certificates
 When deploying Kafka, the Cluster Operator automatically sets up and renews TLS certificates to enable encryption and authentication within your cluster.
 If required, you can manually renew the cluster and client CA certificates before their renewal period ends.
 You can also replace the keys used by the cluster and client CA certificates.
 For more information, see xref:proc-renewing-ca-certs-manually-{context}[Renewing CA certificates manually] and xref:proc-replacing-private-keys-{context}[Replacing private keys].
-
-.Additional resources
-
-* For more information about Apache Kafka, see the http://kafka.apache.org[Apache Kafka website^].
 
 //procedure to configure Kafka
 include::../../modules/configuring/proc-config-kafka.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
@@ -18,6 +18,12 @@ This chapter describes how to configure different aspects of the supported deplo
 NOTE: Labels applied to a custom resource are also applied to the Kubernetes resources making up its cluster.
 This provides a convenient mechanism for resources to be labeled as required.
 
+Strimzi provides link:{BookURLDeploying}#deploy-examples-{context}[example configuration files^], which can serve as a starting point when building your own Kafka component configuration for deployment.
+
+.Monitoring a Strimzi deployment
+You can use Prometheus and Grafana to monitor your Strimzi deployment.
+For more information, see link:{BookURLDeploying}#assembly-metrics-str[Introducing metrics to Kafka^].
+
 include::assembly-config-kafka.adoc[leveloffset=+1]
 
 include::assembly-config-kafka-connect.adoc[leveloffset=+1]
@@ -36,9 +42,3 @@ include::assembly-logging-configuration.adoc[leveloffset=+1]
 
 //Procedure to load configuration from external sources for all Kafka components
 include::../../modules/configuring/proc-loading-config-with-provider.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]
-* link:{BookURLDeploying}#assembly-metrics-str[Introduce metrics to monitor your Strimzi deployment^]

--- a/documentation/assemblies/configuring/assembly-jmxtrans.adoc
+++ b/documentation/assemblies/configuring/assembly-jmxtrans.adoc
@@ -13,8 +13,6 @@ Strimzi supports using JmxTrans to read JMX metrics from Kafka brokers.
 JmxTrans reads JMX metrics data from secure or insecure Kafka brokers and pushes the data to remote sinks in various data formats.
 For example, JmxTrans can obtain JMX metrics about the request rate of each Kafka broker's network and then push the data to a Logstash database outside the Kubernetes cluster.
 
+For more information about JmxTrans, see the link:https://github.com/jmxtrans/jmxtrans[JmxTrans GitHub^].
+
 include::../../modules/configuring/proc-jmxtrans-deployment.adoc[leveloffset=+1]
-
-== Additional resources
-
-For more information about JmxTrans, see the link:https://github.com/jmxtrans/jmxtrans[JmxTrans github^].

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -47,10 +47,11 @@ spec:
 Values for the `name` and `key` of the ConfigMap are mandatory.
 Default logging is used if the `name` or `key` is not set.
 
-[role="_additional-resources"]
-.Additional resources
+== Logging options for Kafka components and operators
 
-*Kafka component logging*
+For more information on configuring logging for specific Kafka components or operators, see the following sections.
+
+.Kafka component logging
 
 * xref:property-kafka-logging-reference[Kafka logging]
 * xref:property-zookeeper-logging-reference[Zookeeper logging]
@@ -59,9 +60,9 @@ Default logging is used if the `name` or `key` is not set.
 * xref:property-kafka-bridge-logging-reference[Kafka Bridge logging]
 * xref:ref-cruise-control-configuration-str[Cruise Control logging]
 
-*Operator logging*
+.Operator logging
 
-* xref:logging_configuration_by_configmap[Cluster Operatror logging]
+* xref:logging_configuration_by_configmap[Cluster Operator logging]
 * xref:property-topic-operator-logging-reference[Topic Operator logging]
 * xref:property-user-operator-logging-reference[User Operator logging]
 

--- a/documentation/assemblies/configuring/assembly-storage.adoc
+++ b/documentation/assemblies/configuring/assembly-storage.adoc
@@ -5,6 +5,7 @@
 [id='assembly-storage-{context}']
 = Kafka and ZooKeeper storage types
 
+[role="_abstract"]
 As stateful applications, Kafka and ZooKeeper need to store data on disk. Strimzi supports three storage types for this data:
 
 * Ephemeral
@@ -20,14 +21,13 @@ When configuring a `Kafka` resource, you can specify the type of storage used by
 
 The storage type is configured in the `type` field.
 
+Refer to the schema reference for more information on storage configuration properties:
+
+* xref:type-EphemeralStorage-reference[`EphemeralStorage` schema reference]
+* xref:type-PersistentClaimStorage-reference[`PersistentClaimStorage` schema reference]
+* xref:type-JbodStorage-reference[`JbodStorage` schema reference]
+
 WARNING: The storage type cannot be changed after a Kafka cluster is deployed.
-
-.Additional resources
-
-* For more information about ephemeral storage, see xref:type-EphemeralStorage-reference[ephemeral storage schema reference].
-* For more information about persistent storage, see xref:type-PersistentClaimStorage-reference[persistent storage schema reference].
-* For more information about JBOD storage, see xref:type-JbodStorage-reference[JBOD schema reference].
-* For more information about the schema for `Kafka`, see xref:type-Kafka-reference[`Kafka` schema reference].
 
 include::../../modules/configuring/con-considerations-for-data-storage.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/deploying/assembly-deploy-intro-custom-resources.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-intro-custom-resources.adoc
@@ -10,10 +10,5 @@
 [role="_abstract"]
 include::modules/snip-intro-custom-resources.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* {K8sCRDs}
-* link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]
-
 //Example custom resource showing configuration options
 include::modules/con-deploy-custom-resources-example.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-tuning-config.adoc
+++ b/documentation/assemblies/managing/assembly-tuning-config.adoc
@@ -14,9 +14,7 @@ For example, you can tune latency and throughput of messages so that clients can
 You might start by analyzing metrics to gauge where to make your initial configurations,
 then make incremental changes and further comparisons of metrics until you have the configuration you need.
 
-[role="_additional-resources"]
-.Additional resources
-* {kafkaDoc}
+For more information about Apache Kafka configuration properties, see the {kafkaDoc}.
 
 //Tips to optimize the performance of brokers, and producer and consumer clients
 include::modules/con-broker-config-properties.adoc[leveloffset=+1]

--- a/documentation/assemblies/metrics/assembly-metrics.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics.adoc
@@ -22,12 +22,13 @@ NOTE: Strimzi provides example installation files for Prometheus and Grafana.
 You can use these files as a starting point when trying out monitoring of Strimzi.
 For further support, try engaging with the Prometheus and Grafana developer communities.
 
-[role="_additional-resources"]
-.Additional resources
-* link:https://prometheus.io/docs/introduction/overview/[Prometheus documentation]
+.Supporting documentation for metrics and monitoring tools
+For more information on the metrics and monitoring tools, refer to the supporting documentation:
+
+* {PrometheusHome}
 * {PrometheusConfig}
-* link:https://grafana.com/docs/guides/getting_started/[Grafana documentation]
 * {kafka-exporter-project}
+* {GrafanaHome}
 * link:http://kafka.apache.org/documentation/#monitoring[Apache Kafka Monitoring] describes JMX metrics exposed by Apache Kafka
 * link:https://zookeeper.apache.org/doc/current/zookeeperJMX.html[ZooKeeper JMX] describes JMX metrics exposed by Apache ZooKeeper
 

--- a/documentation/assemblies/oauth/assembly-oauth-authentication.adoc
+++ b/documentation/assemblies/oauth/assembly-oauth-authentication.adoc
@@ -5,16 +5,17 @@
 [id='assembly-oauth-authentication_{context}']
 = Using OAuth 2.0 token-based authentication
 
-Strimzi supports the use of OAuth 2.0 authentication using the _OAUTHBEARER_ and _PLAIN_ mechanisms.
+[role="_abstract"]
+Strimzi supports the use of link:https://oauth.net/2/[OAuth 2.0 authentication^] using the _OAUTHBEARER_ and _PLAIN_ mechanisms.
 
 OAuth 2.0 enables standardized token-based authentication and authorization between applications, using a central authorization server to issue tokens that grant limited access to resources.
 
-Kafka brokers and clients both need to be configured to use OAuth 2.0. 
+Kafka brokers and clients both need to be configured to use OAuth 2.0.
 You can configure OAuth 2.0 authentication, then xref:assembly-oauth-authorization_{context}[OAuth 2.0 authorization].
 
 [NOTE]
 ====
-OAuth 2.0 authentication can be used in conjunction with xref:con-securing-kafka-authorization-str[Kafka authorization]. 
+OAuth 2.0 authentication can be used in conjunction with xref:con-securing-kafka-authorization-str[Kafka authorization].
 ====
 
 Using OAuth 2.0 authentication, application clients can access resources on application servers (called _resource servers_) without exposing account credentials.
@@ -34,10 +35,6 @@ For a deployment of Strimzi, OAuth 2.0 integration provides:
 
 * Server-side OAuth 2.0 support for Kafka brokers
 * Client-side OAuth 2.0 support for Kafka MirrorMaker, Kafka Connect and the Kafka Bridge
-
-.Additional resources
-
-* link:https://oauth.net/2/[OAuth 2.0 site^]
 
 include::modules/con-oauth-authentication-flow.adoc[leveloffset=+1]
 include::modules/con-oauth-authentication-broker.adoc[leveloffset=+1]

--- a/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
@@ -9,12 +9,7 @@
 [role="_abstract"]
 The Cluster Operator is used to deploy a Kafka cluster and other Kafka components.
 
-The Cluster Operator is deployed using YAML installation files.
-
-[role="_additional-resources"]
-.Additional resources
-* link:{BookURLDeploying}#cluster-operator-str[Deploying the Cluster Operator^] in the _Deploying and Upgrading Strimzi_ guide.
-* xref:assembly-config-kafka-str[Kafka Cluster configuration].
+For information on deploying the Cluster Operator, see link:{BookURLDeploying}#cluster-operator-str[Deploying the Cluster Operator^].
 
 include::../../modules/operators/ref-operator-cluster.adoc[leveloffset=+1]
 //Passing proxy configuration variables from Cluster Operator

--- a/documentation/assemblies/overview/assembly-configuration-points.adoc
+++ b/documentation/assemblies/overview/assembly-configuration-points.adoc
@@ -8,12 +8,9 @@
 [role="_abstract"]
 include::../../shared/snip-intro-custom-resources.adoc[leveloffset=+1]
 
-In this chapter we look at how Kafka components are configured through custom resources, starting with common configuration points and then important configuration considerations specific to components.
+In this section we look at how Kafka components are configured through custom resources, starting with common configuration points and then important configuration considerations specific to components.
 
-[role="_additional-resources"]
-.Additional resources
-* {K8sCRDs}
-* link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]
+Strimzi provides link:{BookURLDeploying}#deploy-examples-{context}[example configuration files^], which can serve as a starting point when building your own Kafka component configuration for deployment.
 
 //Intro to custom resources
 include::modules/con-configuration-points-resources.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-kafka-concepts.adoc
+++ b/documentation/assemblies/overview/assembly-kafka-concepts.adoc
@@ -7,9 +7,7 @@
 
 Apache Kafka is an open-source distributed publish-subscribe messaging system for fault-tolerant real-time data feeds.
 
-.Additional resources
-
-* For more information about Apache Kafka, see the http://kafka.apache.org[Apache Kafka website^].
+For more information about Apache Kafka, see the {kafkaDoc}.
 
 include::modules/con-kafka-concepts-key.adoc[leveloffset=+1]
 include::modules/con-kafka-concepts-producers-consumers.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-key-features.adoc
+++ b/documentation/assemblies/overview/assembly-key-features.adoc
@@ -12,13 +12,9 @@ include::../../shared/snip-intro-text.adoc[leveloffset=+1]
 This guide is intended as a starting point for building an understanding of Strimzi.
 The guide introduces some of the key concepts behind Kafka, which is central to Strimzi, explaining briefly the purpose of Kafka components.
 Configuration points are outlined, including options to secure and monitor Kafka.
-A distribution of Strimzi provides the files to deploy and manage a Kafka cluster, as well as example files for configuration and monitoring of your deployment.
+A distribution of Strimzi provides the files to deploy and manage a Kafka cluster, as well as link:{BookURLDeploying}#deploy-examples-{context}[example files for configuration and monitoring of your deployment^].
 
 A typical Kafka deployment is described, as well as the tools used to deploy and manage Kafka.
-
-[role="_additional-resources"]
-.Additional resources
-link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]
 
 //description of Kafka features and concepts
 include::modules/con-key-features-kafka.adoc[leveloffset=+1]

--- a/documentation/assemblies/overview/assembly-metrics-overview.adoc
+++ b/documentation/assemblies/overview/assembly-metrics-overview.adoc
@@ -16,7 +16,7 @@ Example metrics configuration files are provided with Strimzi.
 
 Distributed tracing complements the gathering of metrics data by providing a facility for end-to-end tracking of messages through Strimzi.
 
-Cruise Control provides support for rebalancing of Kafka clusters, based on workload data. 
+Cruise Control provides support for rebalancing of Kafka clusters, based on workload data.
 
 .Metrics and monitoring tools
 Strimzi can employ the following tools for metrics and monitoring:
@@ -27,7 +27,8 @@ Strimzi can employ the following tools for metrics and monitoring:
 * *Jaeger* provides distributed tracing support to track transactions between applications
 * *Cruise Control* balances data across a Kafka cluster
 
-.Additional resources
+.Supporting documentation for metrics and monitoring tools
+For more information on the metrics and monitoring tools, refer to the supporting documentation:
 
 * {PrometheusHome}
 * {kafka-exporter-project}

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -6,6 +6,7 @@
 
 = Upgrading Kafka
 
+[role="_abstract"]
 After you have upgraded your Cluster Operator to {ProductVersion}, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.
 
 Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers.
@@ -34,11 +35,6 @@ As part of the Kafka upgrade, the Cluster Operator initiates rolling updates for
 
 * A single rolling update occurs even if the ZooKeeper version is unchanged.
 * Additional rolling updates occur if the new version of Kafka requires a new ZooKeeper version.
-
-.Additional resources
-
-* xref:proc-upgrading-the-co-{context}[]
-* xref:ref-kafka-versions-{context}[]
 
 include::modules/ref-upgrade-kafka-versions.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka.adoc
@@ -22,7 +22,7 @@ endif::StrimziUpgrades[]
 * xref:con-upgrade-cluster-{context}[]
 --
 
-. When upgrading from {ConvertAfterProductVersion} or earlier, update existing custom resources to support the `v1beta2` API version.
+. When upgrading Strimzi from {ConvertAfterProductVersion} or earlier, update existing custom resources to support the `v1beta2` API version.
 +
 --
 * xref:assembly-upgrade-resources-{context}[]

--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -112,10 +112,6 @@ For more information, see xref:ref-operator-cluster-{context}[Cluster Operator c
 
 NOTE: Your configuration of Kubernetes must support ingress `NetworkPolicies` in order to use network policies in Strimzi.
 
-.Additional resources
-
-* xref:configuration-listener-network-policy-reference[`networkPolicyPeers`]
-
 == Additional listener configuration options
 
 You can use the properties of the xref:type-GenericKafkaListenerConfiguration-reference[GenericKafkaListenerConfiguration schema] to add further configuration to listeners.

--- a/documentation/modules/configuring/proc-loading-config-with-provider.adoc
+++ b/documentation/modules/configuring/proc-loading-config-with-provider.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// assembly-config-kafka-connect.adoc
+// assembly-deployment-configuration.adoc
 
 [id='proc-loading-config-with-provider-{context}']
 = Loading configuration values from external sources
@@ -151,8 +151,3 @@ spec:
 Placeholders for the property values in the ConfigMap are referenced in the connector configuration.
 The placeholder structure is `configmaps:__PATH-AND-FILE-NAME__:__PROPERTY__`.
 `KubernetesConfigMapConfigProvider` reads and extracts the _option1_ property value from the external ConfigMap.
-
-
-[role="_additional-resources"]
-.Additional resources
-* xref:type-ExternalConfiguration-reference[External configuration for Kafka Connect connectors]

--- a/documentation/modules/configuring/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-connector-task.adoc
@@ -28,7 +28,7 @@ Task IDs are non-negative integers, starting from 0.
 kubectl describe KafkaConnector _KAFKACONNECTOR-NAME_
 ----
 
-. To restart the connector task, annotate the `KafkaConnector` resource in Kubernetes. 
+. To restart the connector task, annotate the `KafkaConnector` resource in Kubernetes.
 For example, using `kubectl annotate` to restart task 0:
 +
 [source,shell,subs="+quotes"]
@@ -38,9 +38,5 @@ kubectl annotate KafkaConnector _KAFKACONNECTOR-NAME_ strimzi.io/restart-task=0
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 +
-The Kafka connector task is restarted, as long as the annotation was detected by the reconciliation process. 
+The Kafka connector task is restarted, as long as the annotation was detected by the reconciliation process.
 When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.
-
-.Additional resources
-
-* link:{BookURLDeploying}#con-creating-managing-connectors-{context}[Creating and managing connectors^] in the _Deploying and Upgrading_ guide.

--- a/documentation/modules/configuring/proc-manual-restart-connector.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-connector.adoc
@@ -20,7 +20,7 @@ This procedure describes how to manually trigger a restart of a Kafka connector 
 kubectl get KafkaConnector
 ----
 
-. To restart the connector, annotate the `KafkaConnector` resource in Kubernetes. 
+. To restart the connector, annotate the `KafkaConnector` resource in Kubernetes.
 For example, using `kubectl annotate`:
 +
 [source,shell,subs="+quotes"]
@@ -30,9 +30,5 @@ kubectl annotate KafkaConnector _KAFKACONNECTOR-NAME_ strimzi.io/restart=true
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 +
-The Kafka connector is restarted, as long as the annotation was detected by the reconciliation process. 
+The Kafka connector is restarted, as long as the annotation was detected by the reconciliation process.
 When Kafka Connect accepts the restart request, the annotation is removed from the `KafkaConnector` custom resource.
-
-.Additional resources
-
-* link:{BookURLDeploying}#con-creating-managing-connectors-{context}[Creating and managing connectors^] in the _Deploying and Upgrading_ guide.

--- a/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
@@ -5,6 +5,7 @@
 [id='proc-resizing-persistent-volumes-{context}']
 = Resizing persistent volumes
 
+[role="_abstract"]
 You can provision increased storage capacity by increasing the size of the persistent volumes used by an existing Strimzi cluster.
 Resizing persistent volumes is supported in clusters that use either a single persistent volume or multiple persistent volumes in a JBOD storage configuration.
 
@@ -53,6 +54,7 @@ Kubernetes increases the capacity of the selected persistent volumes in response
 When the resizing is complete, the Cluster Operator restarts all pods that use the resized persistent volumes.
 This happens automatically.
 
+[role="_additional-resources"]
 .Additional resources
 
-For more information about resizing persistent volumes in Kubernetes, see {K8sResizingPersistentVolumesUsingKubernetes}.
+* For more information about resizing persistent volumes in Kubernetes, see {K8sResizingPersistentVolumesUsingKubernetes}.

--- a/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
+++ b/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
@@ -12,7 +12,7 @@ After a new custom resource type is added to your cluster by installing a CRD, y
 Depending on the cluster setup, installation typically requires cluster admin privileges.
 
 NOTE: Access to manage custom resources is limited to Strimzi administrators.
-For more information, see link:{BookURLDeploying}#adding-users-the-strimzi-admin-role-str[Designating Strimzi administrators^] in the _Deploying and Upgrading Strimzi_ guide.
+For more information, see link:{BookURLDeploying}#adding-users-the-strimzi-admin-role-str[Designating Strimzi administrators^].
 
 A CRD defines a new `kind` of resource, such as `kind:Kafka`, within a Kubernetes cluster.
 
@@ -109,3 +109,9 @@ Custom resources can be applied to a cluster through the platform CLI.
 When the custom resource is created, it uses the same validation as the built-in resources of the Kubernetes API.
 
 After a `KafkaTopic` custom resource is created, the Topic Operator is notified and corresponding Kafka topics are created in Strimzi.
+
+[role="_additional-resources"]
+.Additional resources
+
+* {K8sCRDs}
+* link:{BookURLDeploying}#deploy-examples-{context}[Example configuration files provided with Strimzi^]

--- a/documentation/modules/kafka-bridge/con-requests-kafka-bridge.adoc
+++ b/documentation/modules/kafka-bridge/con-requests-kafka-bridge.adoc
@@ -5,6 +5,7 @@
 [id='con-requests-kafka-bridge-{context}']
 = Requests to the Kafka Bridge
 
+[role="_abstract"]
 Specify data formats and HTTP headers to ensure valid requests are submitted to the Kafka Bridge.
 
 == Content Type headers
@@ -237,6 +238,7 @@ HTTP/1.1 200 OK
 Access-Control-Allow-Origin: https://strimzi.io
 ----
 
+[role="_additional-resources"]
 .Additional resources
 
-link:{external-cors-link}[Fetch^] CORS specification
+* link:{external-cors-link}[Fetch CORS specification^]

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -24,7 +24,7 @@ see the link:{BookURLUsing}#type-GenericKafkaListener-reference[`GenericKafkaLis
 
 .Configuring listeners to secure access to Kafka brokers
 You can configure listeners for secure connection using authentication.
-For more information on securing access to Kafka brokers, see xref:assembly-securing-kafka-str[Managing access to Kafka].
+For more information, see xref:assembly-securing-kafka-str[Securing access to Kafka brokers].
 
 .Configuring external listeners for client access outside Kubernetes
 You can configure external listeners for client access outside a Kubernetes environment using a specified connection mechanism, such as a loadbalancer.

--- a/documentation/modules/overview/con-configuration-points-resources.adoc
+++ b/documentation/modules/overview/con-configuration-points-resources.adoc
@@ -29,3 +29,8 @@ spec:
 ----
 
 There are many additional configuration options that can be incorporated into a YAML definition, some common and some specific to a particular component.
+
+[role="_additional-resources"]
+.Additional resources
+
+* {K8sCRDs}

--- a/documentation/modules/proc-restricting-access-to-listeners-using-network-policies.adoc
+++ b/documentation/modules/proc-restricting-access-to-listeners-using-network-policies.adoc
@@ -5,6 +5,7 @@
 [id='proc-restricting-access-to-listeners-using-network-policies-{context}']
 = Restricting access to Kafka listeners using network policies
 
+[role="_abstract"]
 You can restrict access to a listener to only selected applications by using the `networkPolicyPeers` property.
 
 .Prerequisites
@@ -49,5 +50,8 @@ Use `kubectl apply`:
 [source,shell,subs=+quotes]
 kubectl apply -f _your-file_
 
+[role="_additional-resources"]
 .Additional resources
-* For more information about the schema, see the {K8sNetworkPolicyPeerAPI} and the xref:type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference].
+
+* xref:configuration-listener-network-policy-reference[`networkPolicyPeers` configuration]
+* {K8sNetworkPolicyPeerAPI}


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates **_Additional resources_** sections in the Strimzi guides.
When using an additional resources section in an assembly, the content can sit next to another additional resources section in sub-section. 

This PR updates all instances of using additional resources in assembly files.
Related links are either moved or absorbed into the main intro for the assembly.
Some additional resources links have either been removed or updated.    

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

