### PR TITLE
Remove unicode control characters from the CRDs and API docs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectSpec.java
@@ -73,7 +73,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
         this.rack = rack;
     }
 
-    @Description("Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:\u200D_<port>_ pairs.")
+    @Description("Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.")
     @JsonProperty(required = true)
     public String getBootstrapServers() {
         return bootstrapServers;

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1575,7 +1575,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |integer
 |image                  1.2+<.<a|The docker image for the pods.
 |string
-|bootstrapServers       1.2+<.<a|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+|bootstrapServers       1.2+<.<a|Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
 |string
 |tls                    1.2+<.<a|TLS configuration.
 |xref:type-ClientTls-{context}[`ClientTls`]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -57,7 +57,7 @@ spec:
                   description: The docker image for the pods.
                 bootstrapServers:
                   type: string
-                  description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
                 tls:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -59,7 +59,7 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given
-                  as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  as a comma separated list of _<hostname>_:_<port>_ pairs.
               tls:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `KafkaConnectSpec` class is using a unicode control character `\u200D` in its description. This is used to generate the CRDs and the API reference. It looks like this cause some security tools such as https://access.redhat.com/security/vulnerabilities/RHSB-2021-007 to trigger some false alerts. It is not obvious if it was originally used by mistake or to help with formatting (it is _Zero-width_joiner_ so it might help to avoid line breaks at the `:`). But since we do seem to use it only in this particular place of all the documentation, it seems to be not something we really need. So I think we can remove it to avoid the false alerts.