### PR TITLE
[systemtest] Remove StatefulSet checks in methods where are not needed

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -357,6 +357,8 @@ public interface Constants {
     String CONSUMER_KEY = "CONSUMER_NAME";
     String KAFKA_CLIENTS_POD_KEY = "KAFKA_CLIENTS_POD_NAME";
     String KAFKA_TRACING_CLIENT_KEY = "KAFKA_TRACING_CLIENT";
+    String KAFKA_SELECTOR = "KAFKA_SELECTOR";
+    String ZOOKEEPER_SELECTOR = "ZOOKEEPER_SELECTOR";
 
     /**
      * Resource constants for Cluster Operator. In case we execute more than 5 test cases in parallel we at least these configuration

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -5,6 +5,8 @@
 package io.strimzi.systemtest.resources.crd;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
@@ -20,6 +22,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.platform.commons.util.Preconditions;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -101,5 +105,16 @@ public class KafkaResource implements ResourceType<Kafka> {
 
     public static KafkaStatus getKafkaStatus(String clusterName, String namespace) {
         return kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus();
+    }
+
+    public static LabelSelector getLabelSelector(String clusterName, String componentName) {
+        Map<String, String> matchLabels = new HashMap<>();
+        matchLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
+        matchLabels.put(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
+        matchLabels.put(Labels.STRIMZI_NAME_LABEL, componentName);
+
+        return new LabelSelectorBuilder()
+            .withMatchLabels(matchLabels)
+            .build();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -4,7 +4,10 @@
  */
 package io.strimzi.systemtest.storage;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -31,6 +34,8 @@ final public class TestStorage {
     private String kafkaClientsName;
     private String producerName;
     private String consumerName;
+    private LabelSelector kafkaSelector;
+    private LabelSelector zkSelector;
 
     public TestStorage(ExtensionContext extensionContext) {
         this(extensionContext, INFRA_NAMESPACE);
@@ -45,6 +50,8 @@ final public class TestStorage {
         this.kafkaClientsName = clusterName + "-" + Constants.KAFKA_CLIENTS;
         this.producerName = clusterName + "-" + PRODUCER;
         this.consumerName = clusterName  + "-" + CONSUMER;
+        this.kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
+        this.zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
 
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.NAMESPACE_KEY, this.namespaceName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.CLUSTER_KEY, this.clusterName);
@@ -53,6 +60,8 @@ final public class TestStorage {
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.KAFKA_CLIENTS_KEY, this.kafkaClientsName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PRODUCER_KEY, this.producerName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.CONSUMER_KEY, this.consumerName);
+        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.KAFKA_SELECTOR, this.kafkaSelector);
+        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.ZOOKEEPER_SELECTOR, this.zkSelector);
     }
 
     public void addToTestStorage(String key, Object value) {
@@ -70,6 +79,7 @@ final public class TestStorage {
     public String getClusterName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.CLUSTER_KEY).toString();
     }
+
     public String getTopicName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.TOPIC_KEY).toString();
     }
@@ -77,10 +87,20 @@ final public class TestStorage {
     public String getKafkaClientsName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.KAFKA_CLIENTS_KEY).toString();
     }
+
     public String getProducerName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.PRODUCER_KEY).toString();
     }
+
     public String getConsumerName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.CONSUMER_KEY).toString();
+    }
+
+    public LabelSelector getKafkaSelector() {
+        return (LabelSelector) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.KAFKA_SELECTOR);
+    }
+
+    public LabelSelector getZookeeperSelector() {
+        return (LabelSelector) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.ZOOKEEPER_SELECTOR);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
@@ -69,7 +69,10 @@ public class RollingUpdateUtils {
      */
     public static Map<String, String> waitTillComponentHasRolled(String namespaceName, LabelSelector selector, Map<String, String> snapshot) {
         String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+
         LOGGER.info("Waiting for component with name: {} rolling update", componentName);
+        LOGGER.debug("Waiting for rolling update of component matching LabelSelector: {}", selector);
+
         TestUtils.waitFor("component with name " + componentName + " rolling update",
             Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> {
                 try {
@@ -81,6 +84,7 @@ public class RollingUpdateUtils {
             });
 
         LOGGER.info("Component with name: {} has been successfully rolled", componentName);
+        LOGGER.debug("Component matching LabelSelector: {} successfully rolled", selector);
         return PodUtils.podSnapshot(namespaceName, selector);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.ResourceOperation;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
+public class RollingUpdateUtils {
+    private static final Logger LOGGER = LogManager.getLogger(RollingUpdateUtils.class);
+
+    /**
+     * Method to check that all pods for expected StatefulSet were rolled
+     * @param namespaceName Namespace name
+     * @param selector
+     * @param snapshot Snapshot of pods for StatefulSet before the rolling update
+     * @return true when the pods for StatefulSet are recreated
+     */
+    public static boolean componentHasRolled(String namespaceName, LabelSelector selector, Map<String, String> snapshot) {
+        LOGGER.debug("Existing snapshot: {}", new TreeMap<>(snapshot));
+
+        Map<String, String> currentSnapshot = PodUtils.podSnapshot(namespaceName, selector);
+
+        LOGGER.debug("Current snapshot: {}", new TreeMap<>(currentSnapshot));
+        // rolled when all the pods in snapshot have a different version in map
+
+        currentSnapshot.keySet().retainAll(snapshot.keySet());
+
+        LOGGER.debug("Pods in common: {}", new TreeMap<>(currentSnapshot));
+        for (Map.Entry<String, String> podSnapshot : currentSnapshot.entrySet()) {
+            String currentPodVersion = podSnapshot.getValue();
+            String podName = podSnapshot.getKey();
+            String oldPodVersion = snapshot.get(podName);
+            if (oldPodVersion.equals(currentPodVersion)) {
+                LOGGER.debug("At least {} hasn't rolled", podName);
+                return false;
+            }
+        }
+
+        LOGGER.debug("All pods seem to have rolled");
+        return true;
+    }
+
+    public static boolean componentHasRolled(LabelSelector selector, Map<String, String> snapshot) {
+        return componentHasRolled(kubeClient().getNamespace(), selector, snapshot);
+    }
+
+    /**
+     *  Method to wait when StatefulSet will be recreated after rolling update
+     * @param namespaceName Namespace name
+     * @param selector
+     * @param snapshot Snapshot of pods for StatefulSet before the rolling update
+     * @return The snapshot of the StatefulSet after rolling update with Uid for every pod
+     */
+    public static Map<String, String> waitTillComponentHasRolled(String namespaceName, LabelSelector selector, Map<String, String> snapshot) {
+        String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+        LOGGER.info("Waiting for component with name: {} rolling update", componentName);
+        TestUtils.waitFor("component with name " + componentName + " rolling update",
+            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> {
+                try {
+                    return componentHasRolled(namespaceName, selector, snapshot);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            });
+
+        LOGGER.info("Component with name: {} has been successfully rolled", componentName);
+        return PodUtils.podSnapshot(namespaceName, selector);
+    }
+
+    public static Map<String, String> waitTillComponentHasRolledAndPodsReady(LabelSelector selector, int expectedPods, Map<String, String> snapshot) {
+        return waitTillComponentHasRolledAndPodsReady(kubeClient().getNamespace(), selector, expectedPods, snapshot);
+    }
+
+    public static Map<String, String> waitTillComponentHasRolledAndPodsReady(String namespaceName, LabelSelector selector, int expectedPods, Map<String, String> snapshot) {
+        String clusterName = selector.getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+        String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+
+        waitTillComponentHasRolled(namespaceName, selector, snapshot);
+
+        LOGGER.info("Waiting for {} Pod(s) of {} to be ready", expectedPods, componentName);
+        PodUtils.waitForPodsReady(namespaceName, selector, expectedPods, true,
+            () -> ResourceManager.logCurrentResourceStatus(KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get()));
+
+        return PodUtils.podSnapshot(namespaceName, selector);
+    }
+
+    public static Map<String, String> waitTillComponentHasRolled(LabelSelector selector, int expectedPods, Map<String, String> snapshot) {
+        return waitTillComponentHasRolled(kubeClient().getNamespace(), selector, expectedPods, snapshot);
+    }
+
+    public static Map<String, String> waitTillComponentHasRolled(String namespaceName, LabelSelector selector, int expectedPods, Map<String, String> snapshot) {
+        waitTillComponentHasRolled(namespaceName, selector, snapshot);
+        waitForComponentAndPodsReady(namespaceName, selector, expectedPods);
+
+        return PodUtils.podSnapshot(namespaceName, selector);
+    }
+
+    public static void waitForComponentAndPodsReady(LabelSelector selector, int expectedPods) {
+        waitForComponentAndPodsReady(kubeClient().getNamespace(), selector, expectedPods);
+    }
+
+    public static void waitForComponentAndPodsReady(String namespaceName, LabelSelector selector, int expectedPods) {
+        String clusterName = selector.getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+        String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+
+        LOGGER.info("Waiting for {} Pod(s) of {} to be ready", expectedPods, componentName);
+        PodUtils.waitForPodsReady(namespaceName, selector, expectedPods, true,
+            () -> ResourceManager.logCurrentResourceStatus(KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get()));
+
+        KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
+        LOGGER.info("Kafka: {} is ready", clusterName);
+    }
+
+    public static void waitForNoRollingUpdate(String namespaceName, LabelSelector selector, Map<String, String> pods) {
+        // alternative to sync hassling AtomicInteger one could use an integer array instead
+        // not need to be final because reference to the array does not get another array assigned
+        int[] i = {0};
+
+        TestUtils.waitFor("Waiting for stability of rolling update will be not triggered", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> {
+                if (!componentHasRolled(namespaceName, selector, pods)) {
+                    LOGGER.info("{} pods didn't roll. Remaining seconds for stability: {}", pods.toString(),
+                        Constants.GLOBAL_RECONCILIATION_COUNT - i[0]);
+                    return i[0]++ == Constants.GLOBAL_RECONCILIATION_COUNT;
+                } else {
+                    throw new RuntimeException(pods.toString() + " pods are rolling!");
+                }
+            }
+        );
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.systemtest.utils.kubeUtils.controllers;
 
-import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -17,9 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
-import java.util.TreeMap;
 
-import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class StatefulSetUtils {
@@ -29,124 +25,6 @@ public class StatefulSetUtils {
     private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion(Constants.STATEFUL_SET);
 
     private StatefulSetUtils() { }
-
-    /**
-     * Returns a map of pod name to resource version for the pods currently in the given statefulset.
-     * @param namespaceName Namespace name
-     * @param name  The StatefulSet name
-     * @return A map of pod name to resource version for pods in the given StatefulSet.
-     */
-    public static Map<String, String> ssSnapshot(String namespaceName, String name) {
-        StatefulSet statefulSet = kubeClient(namespaceName).getStatefulSet(namespaceName, name);
-        LabelSelector selector = statefulSet.getSpec().getSelector();
-        return PodUtils.podSnapshot(namespaceName, selector);
-    }
-
-    public static Map<String, String> ssSnapshot(String name) {
-        return ssSnapshot(kubeClient().getNamespace(), name);
-    }
-
-    /**
-     * Method to check that all pods for expected StatefulSet were rolled
-     * @param namespaceName Namespace name
-     * @param name StatefulSet name
-     * @param snapshot Snapshot of pods for StatefulSet before the rolling update
-     * @return true when the pods for StatefulSet are recreated
-     */
-    public static boolean ssHasRolled(String namespaceName, String name, Map<String, String> snapshot) {
-        boolean log = true;
-        if (log) {
-            LOGGER.debug("Existing snapshot: {}", new TreeMap<>(snapshot));
-        }
-        LabelSelector selector = null;
-        int times = 60;
-        do {
-            selector = kubeClient(namespaceName).getStatefulSetSelectors(namespaceName, name);
-            if (selector == null) {
-                if (times-- == 0) {
-                    throw new RuntimeException("Retry failed");
-                }
-                try {
-                    Thread.sleep(1_000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        } while (selector == null);
-
-        Map<String, String> map = PodUtils.podSnapshot(namespaceName, selector);
-        if (log) {
-            LOGGER.debug("Current snapshot: {}", new TreeMap<>(map));
-        }
-        // rolled when all the pods in snapshot have a different version in map
-        map.keySet().retainAll(snapshot.keySet());
-        if (log) {
-            LOGGER.debug("Pods in common: {}", new TreeMap<>(map));
-        }
-        for (Map.Entry<String, String> e : map.entrySet()) {
-            String currentResourceVersion = e.getValue();
-            String resourceName = e.getKey();
-            String oldResourceVersion = snapshot.get(resourceName);
-            if (oldResourceVersion.equals(currentResourceVersion)) {
-                if (log) {
-                    LOGGER.debug("At least {} hasn't rolled", resourceName);
-                }
-                return false;
-            }
-        }
-        if (log) {
-            LOGGER.debug("All pods seem to have rolled");
-        }
-        return true;
-    }
-
-    public static boolean ssHasRolled(String name, Map<String, String> snapshot) {
-        return ssHasRolled(kubeClient().getNamespace(), name, snapshot);
-    }
-
-    /**
-     *  Method to wait when StatefulSet will be recreated after rolling update
-     * @param namespaceName Namespace name
-     * @param name StatefulSet name
-     * @param snapshot Snapshot of pods for StatefulSet before the rolling update
-     * @return The snapshot of the StatefulSet after rolling update with Uid for every pod
-     */
-    public static Map<String, String> waitTillSsHasRolled(String namespaceName, String name, Map<String, String> snapshot) {
-        LOGGER.info("Waiting for StatefulSet {} rolling update", name);
-        TestUtils.waitFor("StatefulSet " + name + " rolling update",
-            Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, ResourceOperation.timeoutForPodsOperation(snapshot.size()), () -> {
-                try {
-                    return ssHasRolled(namespaceName, name, snapshot);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    return false;
-                }
-            });
-        LOGGER.info("StatefulSet {} rolling update finished", name);
-        return ssSnapshot(namespaceName, name);
-    }
-
-    public static Map<String, String> waitTillSsHasRolled(String name, Map<String, String> snapshot) {
-        return waitTillSsHasRolled(kubeClient().getNamespace(), name, snapshot);
-    }
-
-    /**
-     *  Method to wait when StatefulSet will be recreated after rolling update with wait for all pods ready
-     * @param namespaceName Namespace name
-     * @param name StatefulSet name
-     * @param expectedPods Expected number of pods
-     * @param snapshot Snapshot of pods for StatefulSet before the rolling update
-     * @return The snapshot of the StatefulSet after rolling update with Uid for every pod
-     */
-    public static Map<String, String> waitTillSsHasRolled(String namespaceName, String name, int expectedPods, Map<String, String> snapshot) {
-        waitTillSsHasRolled(namespaceName, name, snapshot);
-        waitForAllStatefulSetPodsReady(namespaceName, name, expectedPods, READINESS_TIMEOUT);
-        return ssSnapshot(namespaceName, name);
-    }
-
-    public static Map<String, String> waitTillSsHasRolled(String name, int expectedPods, Map<String, String> snapshot) {
-        return waitTillSsHasRolled(kubeClient().getNamespace(), name, expectedPods, snapshot);
-    }
 
     /**
      * Wait until the STS is ready and all of its Pods are also ready with custom timeout.
@@ -184,26 +62,6 @@ public class StatefulSetUtils {
     }
 
     /**
-     * Wait until the given StatefulSet has been deleted.
-     * @param namespaceName Namespace name
-     * @param name The name of the StatefulSet.
-     */
-    public static void waitForStatefulSetDeletion(String namespaceName, String name) {
-        LOGGER.debug("Waiting for StatefulSet {} deletion", name);
-        TestUtils.waitFor("StatefulSet " + name + " to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT,
-            () -> {
-                if (kubeClient(namespaceName).getStatefulSet(namespaceName, name) == null) {
-                    return true;
-                } else {
-                    LOGGER.warn("StatefulSet {} is not deleted yet! Triggering force delete by cmd client!", name);
-                    cmdKubeClient(namespaceName).deleteByName("statefulset", name);
-                    return false;
-                }
-            });
-        LOGGER.debug("StatefulSet {} was deleted", name);
-    }
-
-    /**
      * Wait until the given StatefulSet has been recovered.
      * @param name The name of the StatefulSet.
      */
@@ -238,23 +96,5 @@ public class StatefulSetUtils {
             );
             LOGGER.info("StatefulSet label {} change to {}", labelKey, null);
         }
-    }
-
-    public static void waitForNoRollingUpdate(String namespaceName, String statefulSetName, Map<String, String> pods) {
-        // alternative to sync hassling AtomicInteger one could use an integer array instead
-        // not need to be final because reference to the array does not get another array assigned
-        int[] i = {0};
-
-        TestUtils.waitFor("Waiting for stability of rolling update will be not triggered", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> {
-                if (!StatefulSetUtils.ssHasRolled(namespaceName, statefulSetName, pods)) {
-                    LOGGER.info("{} pods didn't roll. Remaining seconds for stability: {}", pods.toString(),
-                            Constants.GLOBAL_RECONCILIATION_COUNT - i[0]);
-                    return i[0]++ == Constants.GLOBAL_RECONCILIATION_COUNT;
-                } else {
-                    throw new RuntimeException(pods.toString() + " pods are rolling!");
-                }
-            }
-        );
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceOperation;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +40,10 @@ public class PodUtils {
             .collect(
                 Collectors.toMap(pod -> pod.getMetadata().getName(),
                     pod -> pod.getMetadata().getUid()));
+    }
+
+    public static Map<String, String> podSnapshot(LabelSelector selector) {
+        return podSnapshot(kubeClient().getNamespace(), selector);
     }
 
     public static String getFirstContainerImageNameFromPod(String namespaceName, String podName) {
@@ -109,7 +112,9 @@ public class PodUtils {
 
     /**
      * The method to wait when all pods of specific prefix will be deleted
-     * To wait for the cluster to be updated, the following methods must be used: {@link StatefulSetUtils#ssHasRolled(String, Map)}, {@link StatefulSetUtils#waitTillSsHasRolled(String, int, Map)} )}
+     * To wait for the cluster to be updated, the following methods must be used:
+     * {@link io.strimzi.systemtest.utils.RollingUpdateUtils#componentHasRolled(String, LabelSelector, Map)},
+     * {@link io.strimzi.systemtest.utils.RollingUpdateUtils#waitTillComponentHasRolled(LabelSelector, int, Map)} )}
      * @param podsNamePrefix Cluster name where pods should be deleted
      */
     public static void waitForPodsWithPrefixDeletion(String podsNamePrefix) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.cruisecontrol;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
@@ -18,9 +19,9 @@ import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
 import io.strimzi.test.WaitException;
@@ -41,7 +42,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
-import static io.strimzi.api.kafka.model.KafkaResources.kafkaStatefulSetName;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -100,17 +100,18 @@ public class CruiseControlConfigurationST extends AbstractST {
     void testDeployAndUnDeployCruiseControl(ExtensionContext extensionContext) throws IOException {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
 
-        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             LOGGER.info("Removing Cruise Control to the classic Kafka.");
             kafka.getSpec().setCruiseControl(null);
         }, namespaceName);
 
-        StatefulSetUtils.waitTillSsHasRolled(namespaceName, kafkaStatefulSetName(clusterName), 3, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
 
         LOGGER.info("Verifying that in {} is not present in the Kafka cluster", Constants.CRUISE_CONTROL_NAME);
         assertThat(KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getCruiseControl(), nullValue());
@@ -124,14 +125,12 @@ public class CruiseControlConfigurationST extends AbstractST {
         LOGGER.info("Cruise Control topics will not be deleted and will stay in the Kafka cluster");
         CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(namespaceName);
 
-        kafkaPods = StatefulSetUtils.ssSnapshot(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
-
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             LOGGER.info("Adding Cruise Control to the classic Kafka.");
             kafka.getSpec().setCruiseControl(new CruiseControlSpec());
         }, namespaceName);
 
-        StatefulSetUtils.waitTillSsHasRolled(namespaceName, kafkaStatefulSetName(clusterName), 3, kafkaPods);
+        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
 
         LOGGER.info("Verifying that in Kafka config map there is configuration to cruise control metric reporter");
         CruiseControlUtils.verifyCruiseControlMetricReporterConfigurationInKafkaConfigMapIsPresent(CruiseControlUtils.getKafkaCruiseControlMetricsReporterConfiguration(namespaceName, clusterName));
@@ -145,10 +144,11 @@ public class CruiseControlConfigurationST extends AbstractST {
     void testConfigurationDiskChangeDoNotTriggersRollingUpdateOfKafkaPods(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
 
-        Map<String, String> kafkaSnapShot = StatefulSetUtils.ssSnapshot(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
+        Map<String, String> kafkaSnapShot = PodUtils.podSnapshot(namespaceName, kafkaSelector);
         Map<String, String> cruiseControlSnapShot = DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName));
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
@@ -168,7 +168,7 @@ public class CruiseControlConfigurationST extends AbstractST {
         DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, cruiseControlSnapShot);
 
         LOGGER.info("Verifying that Kafka pods did not roll");
-        StatefulSetUtils.waitForNoRollingUpdate(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName), kafkaSnapShot);
+        RollingUpdateUtils.waitForNoRollingUpdate(namespaceName, kafkaSelector, kafkaSnapShot);
 
         LOGGER.info("Verifying new configuration in the Kafka CR");
 
@@ -250,13 +250,14 @@ public class CruiseControlConfigurationST extends AbstractST {
     void testConfigurationPerformanceOptions(ExtensionContext extensionContext) throws IOException {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
 
         Container cruiseControlContainer;
         EnvVar cruiseControlConfiguration;
 
-        Map<String, String> kafkaSnapShot = StatefulSetUtils.ssSnapshot(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
+        Map<String, String> kafkaSnapShot = PodUtils.podSnapshot(namespaceName, kafkaSelector);
         Map<String, String> cruiseControlSnapShot = DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName));
         Map<String, Object> performanceTuningOpts = new HashMap<String, Object>() {{
                 put(CruiseControlConfigurationParameters.CONCURRENT_INTRA_PARTITION_MOVEMENTS.getValue(), 2);
@@ -276,7 +277,7 @@ public class CruiseControlConfigurationST extends AbstractST {
         DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, cruiseControlSnapShot);
 
         LOGGER.info("Verifying that Kafka pods did not roll");
-        StatefulSetUtils.waitForNoRollingUpdate(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName), kafkaSnapShot);
+        RollingUpdateUtils.waitForNoRollingUpdate(namespaceName, kafkaSelector, kafkaSnapShot);
 
         LOGGER.info("Verifying new configuration in the Kafka CR");
         Pod cruiseControlPod = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, clusterName + "-cruise-control-").get(0);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1990,7 +1990,7 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .build());
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, zkSelector, 1);
+        PodUtils.waitForPodsReady(namespaceName, zkSelector, 1, true);
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, namespaceName, ".*Secret " + nonExistingCertName + " with custom TLS certificate does not exist.*");
 
@@ -2027,7 +2027,7 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .build());
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, zkSelector, 1);
+        PodUtils.waitForPodsReady(namespaceName, zkSelector, 1, true);
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, namespaceName,
                 ".*Secret " + clusterCustomCertServer1 + " does not contain certificate under the key " + nonExistingCertName + ".*");
@@ -2065,7 +2065,7 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .build());
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, zkSelector, 1);
+        PodUtils.waitForPodsReady(namespaceName, zkSelector, 1, true);
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, namespaceName,
                 ".*Secret " + clusterCustomCertServer1 + " does not contain custom certificate private key under the key " + nonExistingCertKey + ".*");

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -497,12 +497,12 @@ class SecurityST extends AbstractST {
 
         if (zkShouldRoll) {
             LOGGER.info("Wait for zk to rolling restart (1)...");
-            zkPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, zkSelector, 3, zkPods);
+            zkPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, zkSelector, zkPods);
         }
 
         if (kafkaShouldRoll) {
             LOGGER.info("Wait for kafka to rolling restart (1)...");
-            kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, kafkaSelector, 3, kafkaPods);
+            kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
         }
 
         if (eoShouldRoll) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -340,7 +340,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         String teamBConsumerName = TEAM_B_CONSUMER_NAME + "-" + clusterName;
         // only write means that Team A can not create new topic 'x-.*'
         String topicXName = TOPIC_X + mapWithTestTopics.get(extensionContext.getDisplayName());
-        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
+        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(oauthClusterName, KafkaResources.kafkaStatefulSetName(oauthClusterName));
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicXName, INFRA_NAMESPACE).build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloak;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -21,9 +22,10 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.strimzi.test.WaitException;
 import io.vertx.core.cli.annotations.Description;
@@ -338,6 +340,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         String teamBConsumerName = TEAM_B_CONSUMER_NAME + "-" + clusterName;
         // only write means that Team A can not create new topic 'x-.*'
         String topicXName = TOPIC_X + mapWithTestTopics.get(extensionContext.getDisplayName());
+        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicXName, INFRA_NAMESPACE).build());
 
@@ -385,7 +388,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
         JobUtils.waitForJobFailure(teamAConsumerName, INFRA_NAMESPACE, 30_000);
         JobUtils.deleteJobWithWait(INFRA_NAMESPACE, teamAConsumerName);
 
-        Map<String, String> kafkaPods = StatefulSetUtils.ssSnapshot(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(oauthClusterName));
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(INFRA_NAMESPACE, kafkaSelector);
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(oauthClusterName, kafka -> {
 
@@ -396,7 +399,7 @@ public class OauthAuthorizationST extends OauthAbstractST {
             ((KafkaAuthorizationKeycloak) kafka.getSpec().getKafka().getAuthorization()).setSuperUsers(superUsers);
         }, INFRA_NAMESPACE);
 
-        StatefulSetUtils.waitTillSsHasRolled(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(oauthClusterName), 1, kafkaPods);
+        RollingUpdateUtils.waitTillComponentHasRolled(INFRA_NAMESPACE, kafkaSelector, 1, kafkaPods);
 
         LOGGER.info("Verifying that team B is able to write to topic starting with 'x-' and break authorization rule");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
@@ -186,7 +186,7 @@ public class OauthScopeST extends OauthAbstractST {
         final String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
         final String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
+        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(oauthClusterName, KafkaResources.kafkaStatefulSetName(oauthClusterName));
 
         KafkaBasicExampleClients oauthInternalClientChecksJob = new KafkaBasicExampleClients.Builder()
             .withNamespaceName(INFRA_NAMESPACE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeST.java
@@ -4,17 +4,16 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelTest;
-import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaBasicExampleClients;
 import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
@@ -22,9 +21,9 @@ import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -187,6 +186,7 @@ public class OauthScopeST extends OauthAbstractST {
         final String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
         final String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         KafkaBasicExampleClients oauthInternalClientChecksJob = new KafkaBasicExampleClients.Builder()
             .withNamespaceName(INFRA_NAMESPACE)
@@ -210,7 +210,7 @@ public class OauthScopeST extends OauthAbstractST {
             kafka.getSpec().getKafka().getListeners().set(0, scopeListeners.get(0));
         }, INFRA_NAMESPACE);
 
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(oauthClusterName), 1, ResourceOperation.getTimeoutForResourceReadiness(Constants.STATEFUL_SET));
+        RollingUpdateUtils.waitForComponentAndPodsReady(INFRA_NAMESPACE, kafkaSelector, 1);
 
         // verification phase client should fail here because clientScope is set to 'null'
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
@@ -234,7 +234,7 @@ public class OauthScopeST extends OauthAbstractST {
             kafka.getSpec().getKafka().getListeners().set(0, scopeListeners.get(0));
         }, INFRA_NAMESPACE);
 
-        StatefulSetUtils.waitForAllStatefulSetPodsReady(INFRA_NAMESPACE, KafkaResources.kafkaStatefulSetName(oauthClusterName), 1, ResourceOperation.getTimeoutForResourceReadiness(Constants.STATEFUL_SET));
+        RollingUpdateUtils.waitForComponentAndPodsReady(INFRA_NAMESPACE, kafkaSelector, 1);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -138,7 +138,6 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     void testUpgradeWithNoMessageAndProtocolVersionsSet(ExtensionContext testContext) {
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
-        String clusterName = mapWithClusterNames.get(testContext.getDisplayName());
         String producerName = clusterName + "-producer";
         String consumerName = clusterName + "-consumer";
 
@@ -263,7 +262,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
         LOGGER.info("1st Zookeeper roll (image change) is complete");
 
         // Wait for the kafka broker version change roll
-        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(INFRA_NAMESPACE, kafkaSelector, kafkaPods);
         LOGGER.info("1st Kafka roll (image change) is complete");
 
         Object currentLogMessageFormat = KafkaResource.kafkaClient().inNamespace(INFRA_NAMESPACE).withName(clusterName).get().getSpec().getKafka().getConfig().get("log.message.format.version");
@@ -273,7 +272,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             LOGGER.info("Kafka version is increased, two RUs remaining for increasing IBPV and LMFV");
 
             if (currentInterBrokerProtocol == null) {
-                kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
+                kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(INFRA_NAMESPACE, kafkaSelector, kafkaPods);
                 LOGGER.info("Kafka roll (inter.broker.protocol.version) is complete");
             }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -7,16 +7,15 @@ package io.strimzi.systemtest.upgrade;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.kafkaclients.KafkaBasicExampleClients;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 @Tag(UPGRADE)
 @IsolatedSuite
-public class KafkaUpgradeDowngradeST extends AbstractST {
+public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
 
@@ -219,7 +218,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
 
         } else {
             LOGGER.info("Initial Kafka version (" + initialVersion.version() + ") is already ready");
-            kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
+            kafkaPods = PodUtils.podSnapshot(INFRA_NAMESPACE, kafkaSelector);
 
             // Wait for log.message.format.version and inter.broker.protocol.version change
             if (!sameMinorVersion
@@ -236,7 +235,7 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
                     LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().getConfig().toString());
                 });
 
-                StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), kafkaReplicas, kafkaPods);
+                RollingUpdateUtils.waitTillComponentHasRolled(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
             }
         }
 
@@ -250,8 +249,8 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
         String kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0));
         LOGGER.info("Pre-change Kafka version query returned: " + kafkaVersionResult);
 
-        Map<String, String> zkPods = StatefulSetUtils.ssSnapshot(KafkaResources.zookeeperStatefulSetName(clusterName));
-        kafkaPods = StatefulSetUtils.ssSnapshot(KafkaResources.kafkaStatefulSetName(clusterName));
+        Map<String, String> zkPods = PodUtils.podSnapshot(INFRA_NAMESPACE, zkSelector);
+        kafkaPods = PodUtils.podSnapshot(INFRA_NAMESPACE, kafkaSelector);
         LOGGER.info("Updating Kafka CR version field to " + newVersion.version());
 
         // Change the version in Kafka CR
@@ -262,11 +261,11 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
         LOGGER.info("Waiting for readiness of new Kafka version (" + newVersion.version() + ") to complete");
 
         // Wait for the zk version change roll
-        zkPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.zookeeperStatefulSetName(clusterName), zkReplicas, zkPods);
+        zkPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, zkSelector, zkReplicas, zkPods);
         LOGGER.info("1st Zookeeper roll (image change) is complete");
 
         // Wait for the kafka broker version change roll
-        kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
         LOGGER.info("1st Kafka roll (image change) is complete");
 
         Object currentLogMessageFormat = KafkaResource.kafkaClient().inNamespace(INFRA_NAMESPACE).withName(clusterName).get().getSpec().getKafka().getConfig().get("log.message.format.version");
@@ -276,12 +275,12 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
             LOGGER.info("Kafka version is increased, two RUs remaining for increasing IBPV and LMFV");
 
             if (currentInterBrokerProtocol == null) {
-                kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), kafkaPods);
+                kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
                 LOGGER.info("Kafka roll (inter.broker.protocol.version) is complete");
             }
 
             if (currentLogMessageFormat == null) {
-                kafkaPods = StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), kafkaReplicas, kafkaPods);
+                kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
                 LOGGER.info("Kafka roll (log.message.format.version) is complete");
             }
         }
@@ -321,12 +320,12 @@ public class KafkaUpgradeDowngradeST extends AbstractST {
             if (currentLogMessageFormat != null || currentInterBrokerProtocol != null) {
                 LOGGER.info("Change of configuration is done manually - RollingUpdate");
                 // Wait for the kafka broker version of log.message.format.version change roll
-                StatefulSetUtils.waitTillSsHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), kafkaReplicas, kafkaPods);
+                RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
                 LOGGER.info("Kafka roll (log.message.format.version change) is complete");
             } else {
                 LOGGER.info("ClusterOperator already changed the configuration, there should be no RollingUpdate");
                 PodUtils.verifyThatRunningPodsAreStable(KafkaResources.kafkaStatefulSetName(clusterName));
-                assertFalse(StatefulSetUtils.ssHasRolled(KafkaResources.kafkaStatefulSetName(clusterName), kafkaPods));
+                assertFalse(RollingUpdateUtils.componentHasRolled(INFRA_NAMESPACE, kafkaSelector, kafkaPods));
             }
         }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -21,7 +21,6 @@ import io.strimzi.test.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.List;
@@ -52,7 +51,6 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     void testKafkaClusterUpgrade(ExtensionContext testContext) {
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
-        String clusterName = mapWithClusterNames.get(testContext.getDisplayName());
         String producerName = clusterName + "-producer";
         String consumerName = clusterName + "-consumer";
 
@@ -63,7 +61,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is an upgrade test we keep the message format as the lower version number
             String logMsgFormat = initialVersion.messageVersion();
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, clusterName, producerName, consumerName, logMsgFormat, interBrokerProtocol, 3, 3, testContext);
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, logMsgFormat, interBrokerProtocol, 3, 3, testContext);
         }
 
         // ##############################
@@ -88,7 +86,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is a downgrade then we make sure to use the lower version number for the message format
             String logMsgFormat = newVersion.messageVersion();
             String interBrokerProtocol = newVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, clusterName, producerName, consumerName, logMsgFormat, interBrokerProtocol, 3, 3, testContext);
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, logMsgFormat, interBrokerProtocol, 3, 3, testContext);
         }
 
         // ##############################
@@ -126,7 +124,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x - 1);
 
-            runVersionChange(initialVersion, newVersion, clusterName, producerName, consumerName, initLogMsgFormat, interBrokerProtocol, 3, 3, testContext);
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, initLogMsgFormat, interBrokerProtocol, 3, 3, testContext);
         }
 
         // ##############################
@@ -136,7 +134,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
         // ##############################
     }
 
-    @Test
+    @IsolatedTest
     void testUpgradeWithNoMessageAndProtocolVersionsSet(ExtensionContext testContext) {
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
@@ -148,7 +146,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x + 1);
 
-            runVersionChange(initialVersion, newVersion, clusterName, producerName, consumerName, null, null, 3, 3, testContext);
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, null, null, 3, 3, testContext);
         }
 
         // ##############################
@@ -159,7 +157,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String clusterName, String producerName, String consumerName, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas, ExtensionContext testContext) {
+    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String producerName, String consumerName, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas, ExtensionContext testContext) {
         boolean isUpgrade = initialVersion.isUpgrade(newVersion);
         Map<String, String> kafkaPods;
 

--- a/systemtest/src/test/resources/junit-platform.properties
+++ b/systemtest/src/test/resources/junit-platform.properties
@@ -1,9 +1,9 @@
 # These are default values if @ParallelTest or @ParallelSuite is not specified
 # junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
 # junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
-junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=1
+junit.jupiter.execution.parallel.config.fixed.parallelism=4
 junit.platform.output.capture.maxBuffer=true


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Refactoring

### Description

This PR removes checks for `StatefulSet`s from STs, which will allow us to execute tests with `StatefulSet` disabled. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

