### PR TITLE
docs: upgrade and message format version handling for Kafka 3.0 and later

### DIFF
--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -30,7 +30,7 @@ Changing each will trigger a further rolling update.
 
 |===
 
-IMPORTANT: From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+IMPORTANT: From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 The `log.message.format.version` property for brokers and the `message.format.version` property for topics are deprecated and will be removed in a future release of Kafka.
 
 As part of the Kafka upgrade, the Cluster Operator initiates rolling updates for ZooKeeper.

--- a/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-kafka-versions.adoc
@@ -30,6 +30,9 @@ Changing each will trigger a further rolling update.
 
 |===
 
+IMPORTANT: From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+The `log.message.format.version` property for brokers and the `message.format.version` property for topics are deprecated and will be removed in a future release of Kafka.
+
 As part of the Kafka upgrade, the Cluster Operator initiates rolling updates for ZooKeeper.
 
 * A single rolling update occurs even if the ZooKeeper version is unchanged.

--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -22,7 +22,7 @@ Upgrading Strimzi from the previous minor version to version {ProductVersion}.
 Multi-version::
 Upgrading Strimzi from an old version to version {ProductVersion} within a single upgrade (skipping one or more intermediate versions).
 +
-For example, upgrading from Strimzi 0.20.0 directly to Strimzi {ConvertAfterProductVersion}.
+For example, upgrading from Strimzi 0.23.0 directly to Strimzi {ProductVersion}.
 
 .Upgrading from a version earlier than {ConvertAfterProductVersion}
 The `v1beta2` API version for all custom resources was introduced with Strimzi {ConvertAfterProductVersion}.

--- a/documentation/modules/con-kafka-downgrades-using-cluster-operator.adoc
+++ b/documentation/modules/con-kafka-downgrades-using-cluster-operator.adoc
@@ -12,8 +12,11 @@ Whether and how the Cluster Operator will perform a downgrade depends on the dif
 * The version of ZooKeeper used by the two Kafka versions
 
 If the downgraded version of Kafka has the same log message format version then downgrading is always possible.
-In this case the Cluster Operator will be able to downgrade by performing a single rolling restart of the brokers.
+In this case, the Cluster Operator performs a downgrade with a single rolling restart of the brokers.
 
-If the downgraded version of Kafka has a different log message format version, then downgrading is only possible if the running cluster has _always_ had `log.message.format.version` set to the version used by the downgraded version. 
+From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+
+If the downgraded version of Kafka has a different log message format version, then downgrading is only possible if
+the running cluster has _always_ had `log.message.format.version` set to the version used by the downgraded version.
 This is typically only the case if the upgrade procedure was aborted before the `log.message.format.version` was changed.
 In this case the downgrade will require two rolling restarts of the brokers if the interbroker protocol of the two versions is different, or a single rolling restart if they are the same.

--- a/documentation/modules/con-kafka-downgrades-using-cluster-operator.adoc
+++ b/documentation/modules/con-kafka-downgrades-using-cluster-operator.adoc
@@ -14,7 +14,7 @@ Whether and how the Cluster Operator will perform a downgrade depends on the dif
 If the downgraded version of Kafka has the same log message format version then downgrading is always possible.
 In this case, the Cluster Operator performs a downgrade with a single rolling restart of the brokers.
 
-From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 
 If the downgraded version of Kafka has a different log message format version, then downgrading is only possible if
 the running cluster has _always_ had `log.message.format.version` set to the version used by the downgraded version.

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -23,10 +23,13 @@ This procedure shows only some of the possible configuration options, but those 
 
 .Kafka versions
 
-The `log.message.format.version` and `inter.broker.protocol.version` properties for the Kafka `config` must be the versions supported by the specified Kafka version (`spec.kafka.version`).
-The properties represent the log format version appended to messages and the version of Kafka protocol used in a Kafka cluster.
-Updates to these properties are required when upgrading your Kafka version.
-For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versions-str[Upgrading Kafka] in the _Deploying and Upgrading Strimzi_ guide.
+The `inter.broker.protocol.version` property for the Kafka `config` must be the version supported by the specified Kafka version (`spec.kafka.version`).
+The property represents the version of Kafka protocol used in a Kafka cluster.
+
+From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+
+An update to the `inter.broker.protocol.version` is required when upgrading your Kafka version.
+For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versions-str[Upgrading Kafka].
 
 .Prerequisites
 
@@ -104,7 +107,6 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: {LogMsgVersHigher}
       inter.broker.protocol.version: {LogMsgVersHigher}
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <19>
       ssl.enabled.protocols: "TLSv1.2"

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -26,7 +26,7 @@ This procedure shows only some of the possible configuration options, but those 
 The `inter.broker.protocol.version` property for the Kafka `config` must be the version supported by the specified Kafka version (`spec.kafka.version`).
 The property represents the version of Kafka protocol used in a Kafka cluster.
 
-From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 
 An update to the `inter.broker.protocol.version` is required when upgrading your Kafka version.
 For more information, see link:{BookURLDeploying}#assembly-upgrading-kafka-versions-str[Upgrading Kafka].

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
@@ -28,7 +28,12 @@ ifdef::Kubernetes[HostPath volumes on Minikube or]
 Amazon EBS volumes in Amazon AWS deployments without any changes in the YAML files. The `PersistentVolumeClaim` can use a `StorageClass` to trigger automatic volume provisioning.
 
 The example YAML files specify the latest supported Kafka version, and configuration for its supported log message format version and inter-broker protocol version.
-Updates to these properties are required when xref:assembly-upgrading-kafka-versions-str[upgrading Kafka].
+The `inter.broker.protocol.version` property for the Kafka `config` must be the version supported by the specified Kafka version (`spec.kafka.version`).
+The property represents the version of Kafka protocol used in a Kafka cluster.
+
+From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+
+An update to the `inter.broker.protocol.version` is required when xref:assembly-upgrading-kafka-versions-str[upgrading Kafka].
 
 The example clusters are named `my-cluster` by default.
 The cluster name is defined by the name of the resource and cannot be changed after the cluster has been deployed.

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
@@ -31,7 +31,7 @@ The example YAML files specify the latest supported Kafka version, and configura
 The `inter.broker.protocol.version` property for the Kafka `config` must be the version supported by the specified Kafka version (`spec.kafka.version`).
 The property represents the version of Kafka protocol used in a Kafka cluster.
 
-From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 
 An update to the `inter.broker.protocol.version` is required when xref:assembly-upgrading-kafka-versions-str[upgrading Kafka].
 

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -42,7 +42,7 @@ You can create a custom Kafka Connect image that includes your choice of plugins
 You can create the image in two ways:
 
 * link:{BookURLDeploying}#creating-new-image-using-kafka-connect-build-str[Automatically using Kafka Connect configuration^]
-* link:{BookURLDeploying}#creating-new-image-from-base-str[Manually using a Dockerfile and a Kafka container image from {DockerRepository} as a base image^]
+* link:{BookURLDeploying}#creating-new-image-from-base-str[Manually using a Dockerfile and a Kafka container image as a base image^]
 
 To create the container image automatically, you specify the plugins to add to your Kafka Connect cluster using the `build` property of the `KafkaConnect` resource.
 Strimzi automatically downloads and adds the plugin artifacts to a new container image.

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -13,7 +13,7 @@ You cannot revert to the previous Kafka version if that version does not support
 or messages have been added to message logs that use a newer `log.message.format.version`.
 
 The `inter.broker.protocol.version` determines the schemas used for persistent metadata stored by the broker, such as the schema for messages written to `__consumer_offsets`.
-If you downgrade to a version of Kafka that does not understand an `inter.broker.protocol.version` that has (ever) been previously used in the cluster the broker will encounter data it cannot understand.
+If you downgrade to a version of Kafka that does not understand an `inter.broker.protocol.version` that has ever been previously used in the cluster the broker will encounter data it cannot understand.
 
 If the target downgrade version of Kafka has:
 
@@ -40,4 +40,6 @@ spec:
       # ...
 ----
 
-The downgrade would not be possible if the `log.message.format.version` was set at `"{LogMsgVersHigher}"` or a value was absent (so that the parameter took the default value for a {KafkaVersionHigher} broker of {LogMsgVersHigher}).
+The downgrade would not be possible if the `log.message.format.version` was set at `"{LogMsgVersHigher}"` or a value was absent, so that the parameter took the default value for a {KafkaVersionHigher} broker of {LogMsgVersHigher}.
+
+IMPORTANT: From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.

--- a/documentation/modules/upgrading/con-downgrade-target-version.adoc
+++ b/documentation/modules/upgrading/con-downgrade-target-version.adoc
@@ -42,4 +42,4 @@ spec:
 
 The downgrade would not be possible if the `log.message.format.version` was set at `"{LogMsgVersHigher}"` or a value was absent, so that the parameter took the default value for a {KafkaVersionHigher} broker of {LogMsgVersHigher}.
 
-IMPORTANT: From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+IMPORTANT: From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.

--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -27,8 +27,8 @@ Messages published to a topic in a new-version format will be visible to consume
 Common strategies you can use to upgrade your clients are described as follows.
 Other strategies for upgrading client applications are also possible.
 
-IMPORTANT: The steps outlined in each strategy change slightly when upgrading to Kafka {DefaultKafkaVersion} or later.
-From Kafka {DefaultKafkaVersion}, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
+IMPORTANT: The steps outlined in each strategy change slightly when upgrading to Kafka 3.0.0 or later.
+From Kafka 3.0.0, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
 
 .Broker-level consumers first strategy
 

--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -24,39 +24,45 @@ Broker down-conversion is configured in two ways:
 
 Messages published to a topic in a new-version format will be visible to consumers, because brokers perform down-conversion when they receive messages from producers, not when they are sent to consumers.
 
-There are a number of strategies you can use to upgrade your clients:
+Common strategies you can use to upgrade your clients are described as follows.
+Other strategies for upgrading client applications are also possible.
 
-Consumers first::
+IMPORTANT: The steps outlined in each strategy change slightly when upgrading to Kafka {DefaultKafkaVersion} or later.
+From Kafka {DefaultKafkaVersion}, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
+
+.Broker-level consumers first strategy
+
 . Upgrade all the consuming applications.
 . Change the broker-level `log.message.format.version` to the new version.
 . Upgrade all the producing applications.
-+
+
 This strategy is straightforward, and avoids any broker down-conversion.
 However, it assumes that all consumers in your organization can be upgraded in a coordinated way, and it does not work for applications that are both consumers and producers.
 There is also a risk that, if there is a problem with the upgraded clients, new-format messages might get added to the message log so that you cannot revert to the previous consumer version.
 
-Per-topic consumers first::
+.Topic-level consumers first strategy
+
 For each topic:
+
 . Upgrade all the consuming applications.
 . Change the topic-level `message.format.version` to the new version.
 . Upgrade all the producing applications.
-+
+
 This strategy avoids any broker down-conversion, and means you can proceed on a topic-by-topic basis. It does not work for applications that are both consumers and producers of the same topic. Again, it has the risk that, if there is a problem with the upgraded clients, new-format messages might get added to the message log.
 
-Per-topic consumers first, with down conversion::
+.Topic-level consumers first strategy with down conversion
+
 For each topic:
-+
+
 . Change the topic-level `message.format.version` to the old version
 (or rely on the topic defaulting to the broker-level `log.message.format.version`).
 . Upgrade all the consuming and producing applications.
 . Verify that the upgraded applications function correctly.
 . Change the topic-level `message.format.version` to the new version.
-+
-This strategy requires broker down-conversion, but the load on the brokers is minimized because it is only required for a single topic (or small group of topics) at a time. It also works for applications that are both consumers and producers of the same topic. This approach ensures that the upgraded producers and consumers are working correctly before you commit to using the new message format version.
-+
-The main drawback of this approach is that it can be complicated to manage in a cluster with many topics and applications.
 
-Other strategies for upgrading client applications are also possible.
+This strategy requires broker down-conversion, but the load on the brokers is minimized because it is only required for a single topic (or small group of topics) at a time. It also works for applications that are both consumers and producers of the same topic. This approach ensures that the upgraded producers and consumers are working correctly before you commit to using the new message format version.
+
+The main drawback of this approach is that it can be complicated to manage in a cluster with many topics and applications.
 
 NOTE: It is also possible to apply multiple strategies.
 For example, for the first few applications and topics the

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -79,7 +79,7 @@ Reconciliation #_NUM_(watch) Kafka(_NAMESPACE_/_NAME_): Kafka version downgrade 
 +
 The Kafka cluster and clients are now using the previous Kafka version.
 
-. If you are reverting back to a version of Strimzi earlier than 0.22, which uses ZooKeeper for the storage of topic metadata, delete the internal topic store topics from the Kafka cluster.
+. If you are reverting back to a version of Strimzi earlier than {ConvertAfterProductVersion}, which uses ZooKeeper for the storage of topic metadata, delete the internal topic store topics from the Kafka cluster.
 +
 [source,shell,subs=attributes+]
 ----

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -11,12 +11,14 @@ This procedure describes how you can downgrade a Strimzi Kafka cluster to a lowe
 
 .Prerequisites
 
-For the `Kafka` resource to be downgraded, check:
+Before you downgrade the Strimzi Kafka cluster, check the following for the `Kafka` resource:
 
 * IMPORTANT: xref:con-target-downgrade-version-{context}[Compatibility of Kafka versions].
 * The Cluster Operator, which supports both versions of Kafka, is up and running.
 * The `Kafka.spec.kafka.config` does not contain options that are not supported by the Kafka version being downgraded to.
 * The `Kafka.spec.kafka.config` has a `log.message.format.version` and `inter.broker.protocol.version` that is supported by the Kafka version being downgraded to.
++
+From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
 
 .Procedure
 
@@ -46,7 +48,7 @@ spec:
 <2> Message format version is unchanged.
 <3> Inter-broker protocol version is unchanged.
 +
-NOTE: You must format the value of `log.message.format.version` and `inter.broker.protocol.version` as a string to prevent it from being interpreted as a floating point number.
+NOTE: The value of `log.message.format.version` and `inter.broker.protocol.version` must be strings to prevent them from being interpreted as floating point numbers.
 
 . If the image for the Kafka version is different from the image defined in `STRIMZI_KAFKA_IMAGES` for the Cluster Operator, update `Kafka.spec.kafka.image`.
 +

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -18,7 +18,7 @@ Before you downgrade the Strimzi Kafka cluster, check the following for the `Kaf
 * The `Kafka.spec.kafka.config` does not contain options that are not supported by the Kafka version being downgraded to.
 * The `Kafka.spec.kafka.config` has a `log.message.format.version` and `inter.broker.protocol.version` that is supported by the Kafka version being downgraded to.
 +
-From Kafka {DefaultKafkaVersion}, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 
 .Procedure
 

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -144,7 +144,7 @@ spec:
       # ...
 ----
 +
-IMPORTANT: If upgrading to Kafka {DefaultKafkaVersion} or later, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
+IMPORTANT: From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 
 . Wait for the Cluster Operator to update the cluster.
 +

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -143,6 +143,8 @@ spec:
       inter.broker.protocol.version: "{InterBrokVersHigher}"
       # ...
 ----
++
+IMPORTANT: If upgrading to Kafka {DefaultKafkaVersion} or later, the `log.message.format.version` is assumed to match the `inter.broker.protocol.version` and doesn't need to be set.
 
 . Wait for the Cluster Operator to update the cluster.
 +

--- a/documentation/modules/upgrading/ref-upgrade-kafka-versions.adoc
+++ b/documentation/modules/upgrading/ref-upgrade-kafka-versions.adoc
@@ -6,7 +6,7 @@
 
 = Kafka versions
 
-Kafka's log message format version and inter-broker protocol version specify, respectively, the log format version appended to messages and the version of the Kafka protocol used in a cluster. 
+Kafka's log message format version and inter-broker protocol version specify, respectively, the log format version appended to messages and the version of the Kafka protocol used in a cluster.
 To ensure the correct versions are used, the upgrade process involves making configuration changes to existing Kafka brokers and code changes to client applications (consumers and producers).
 
 The following table shows the differences between Kafka versions:
@@ -15,23 +15,30 @@ include::snip-kafka-versions.adoc[leveloffset=+1]
 
 .Inter-broker protocol version
 
-In Kafka, the network protocol used for inter-broker communication is called the _inter-broker protocol_. 
-Each version of Kafka has a compatible version of the inter-broker protocol. 
+In Kafka, the network protocol used for inter-broker communication is called the _inter-broker protocol_.
+Each version of Kafka has a compatible version of the inter-broker protocol.
 The minor version of the protocol typically increases to match the minor version of Kafka, as shown in the preceding table.
 
-The inter-broker protocol version is set cluster wide in the `Kafka` resource.  
+The inter-broker protocol version is set cluster wide in the `Kafka` resource.
 To change it, you edit the `inter.broker.protocol.version` property in `Kafka.spec.kafka.config`.
 
 .Log message format version
 
 When a producer sends a message to a Kafka broker, the message is encoded using a specific format.
-The format can change between Kafka releases, so messages specify which version of the format they were encoded with. You can configure a Kafka broker to convert messages from newer format versions to a given older format version before the broker appends the message to the log.
+The format can change between Kafka releases, so messages specify which version of the message format they were encoded with.
 
-In Kafka, there are two different methods for setting the message format version:
+The properties used to set a specific message format version are as follows:
 
-* The `message.format.version` property is set on topics.
-* The `log.message.format.version` property is set on Kafka brokers.
+* `message.format.version` property for topics
+* `log.message.format.version` property for Kafka brokers
 
-The default value of `message.format.version` for a topic is defined by the `log.message.format.version` that is set on the Kafka broker. You can manually set the `message.format.version` of a topic by modifying its topic configuration.
+From Kafka {DefaultKafkaVersion}, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
+The values reflect the Kafka version used.
 
-The upgrade tasks in this section assume that the message format version is defined by the `log.message.format.version`.
+When upgrading to Kafka {DefaultKafkaVersion} or higher, you can remove these settings when you update the `inter.broker.protocol.version`.
+Otherwise, set the message format version version based on the Kafka version you are upgrading to.
+
+The default value of `message.format.version` for a topic is defined by the `log.message.format.version` that is set on the Kafka broker.
+You can manually set the `message.format.version` of a topic by modifying its topic configuration.
+
+The properties can be used for down-conversion to an earlier format depending on your chosen xref:con-strategies-for-upgrading-clients-str[strategy for upgrading clients].

--- a/documentation/modules/upgrading/ref-upgrade-kafka-versions.adoc
+++ b/documentation/modules/upgrading/ref-upgrade-kafka-versions.adoc
@@ -32,10 +32,10 @@ The properties used to set a specific message format version are as follows:
 * `message.format.version` property for topics
 * `log.message.format.version` property for Kafka brokers
 
-From Kafka {DefaultKafkaVersion}, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
+From Kafka 3.0.0, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
 The values reflect the Kafka version used.
 
-When upgrading to Kafka {DefaultKafkaVersion} or higher, you can remove these settings when you update the `inter.broker.protocol.version`.
+When upgrading to Kafka 3.0.0 or higher, you can remove these settings when you update the `inter.broker.protocol.version`.
 Otherwise, set the message format version version based on the Kafka version you are upgrading to.
 
 The default value of `message.format.version` for a topic is defined by the `log.message.format.version` that is set on the Kafka broker.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates the Upgrading and Downgrading Kafka sections in the _Deploying Strimzi_ guide
Describes new handling for `log.message.format.version` property for brokers and the `message.format.version` property for topics.  From Kafka 3.0 and later, the version is assumed to match the `inter.broker.protocol.version` (see [KIP-724](https://cwiki.apache.org/confluence/display/KAFKA/KIP-724%3A+Drop+support+for+message+formats+v0+and+v1)).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

