### PR TITLE
docs: standalone operator connection to cluster

### DIFF
--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -11,8 +11,9 @@ You can use a standalone Topic Operator with a Kafka cluster that is not managed
 
 A standalone deployment can operate with any Kafka cluster.
 
-Standalone deployment files are provided.
-Edit the `05-Deployment-strimzi-topic-operator.yaml` deployment file to add the environment variables that enable the Topic Operator to connect to a Kafka cluster.
+Standalone deployment files are provided with Strimzi.
+Use the `05-Deployment-strimzi-topic-operator.yaml` deployment file to deploy the Topic Operator.
+Add or set the environment variables needed to make a connection to a Kafka cluster.
 
 .Prerequisites
 

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -12,11 +12,14 @@ You can use a standalone Topic Operator with a Kafka cluster that is not managed
 A standalone deployment can operate with any Kafka cluster.
 
 Standalone deployment files are provided.
-Configure the `05-Deployment-strimzi-topic-operator.yaml` deployment file to add the environment variables that enable the Topic Operator to connect to a Kafka cluster.
+Edit the `05-Deployment-strimzi-topic-operator.yaml` deployment file to add the environment variables that enable the Topic Operator to connect to a Kafka cluster.
 
 .Prerequisites
 
 * You are running a Kafka cluster for the Topic Operator to connect to.
++
+As long as the standalone Topic Operator is correctly configured for connection,
+the Kafka cluster can be running on a bare-metal environment, a virtual machine, or as a managed cloud application service.
 
 .Procedure
 

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -17,6 +17,9 @@ Edit the `05-Deployment-strimzi-user-operator.yaml` deployment file to add the e
 .Prerequisites
 
 * You are running a Kafka cluster for the User Operator to connect to.
++
+As long as the standalone User Operator is correctly configured for connection,
+the Kafka cluster can be running on a bare-metal environment, a virtual machine, or as a managed cloud application service.
 
 .Procedure
 

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -11,8 +11,9 @@ You can use a standalone User Operator with a Kafka cluster that is not managed 
 
 A standalone deployment can operate with any Kafka cluster.
 
-Standalone deployment files are provided.
-Edit the `05-Deployment-strimzi-user-operator.yaml` deployment file to add the environment variables that enable the User Operator to connect to a Kafka cluster.
+Standalone deployment files are provided with Strimzi.
+Use the `05-Deployment-strimzi-user-operator.yaml` deployment file to deploy the User Operator.
+Add or set the environment variables needed to make a connection to a Kafka cluster.  
 
 .Prerequisites
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updates the topic operator and user operator standalone operator deployment procedures in the _Deploying Strimzi_ guide.

Expands the prereqs of each procedure to describe the types of Kafka cluster environments that the operators can connect to.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

