### PR TITLE
Make ZooKeeper rolling independent on StatefulSets

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -165,6 +165,24 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     /**
+     * Generates the DNS name of the pod including the cluster suffix
+     * (i.e. usually with the cluster.local - but can be different on different clusters)
+     * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc.cluster.local
+     *
+     * @param namespace     Namespace of the pod
+     * @param cluster       Name of the cluster
+     * @param podName       Name of the pod
+     *
+     * @return              DNS name of the pod
+     */
+    public static String podDnsName(String namespace, String cluster, String podName) {
+        return DnsNameGenerator.podDnsName(
+                namespace,
+                ZookeeperCluster.headlessServiceName(cluster),
+                podName);
+    }
+
+    /**
      * Generates the full DNS name of the pod without the cluster suffix
      * (i.e. usually without the cluster.local - but can be different on different clusters)
      * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperator.java
@@ -4,17 +4,10 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import java.util.List;
-import java.util.function.Function;
-
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 /**
@@ -63,16 +56,5 @@ public class KafkaSetOperator extends StatefulSetOperator {
             return false;
         }
         return false;
-    }
-
-    @Override
-    public Future<Void> maybeRollingUpdate(Reconciliation reconciliation, StatefulSet sts, Function<Pod, List<String>> podNeedsRestart) {
-        return maybeRollingUpdate(reconciliation, sts, podNeedsRestart, null, null);
-    }
-
-    @Override
-    public Future<Void> maybeRollingUpdate(Reconciliation reconciliation, StatefulSet sts, Function<Pod, List<String>> podNeedsRestart,
-                                           Secret clusterCaCertSecret, Secret coKeySecret) {
-        throw new UnsupportedOperationException();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -83,11 +83,12 @@ public class ResourceOperatorSupplier {
     public final NodeOperator nodeOperator;
     public final ZookeeperScalerProvider zkScalerProvider;
     public final MetricsProvider metricsProvider;
-    public AdminClientProvider adminClientProvider;
+    public final AdminClientProvider adminClientProvider;
+    public final ZookeeperLeaderFinder zookeeperLeaderFinder;
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, FeatureGates gates, long operationTimeoutMs) {
         this(vertx, client,
-            new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
+            new ZookeeperLeaderFinder(vertx,
             // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
                 () -> new BackOff(5_000, 2, 4)),
                     new DefaultAdminClientProvider(),
@@ -129,7 +130,8 @@ public class ResourceOperatorSupplier {
                 new NodeOperator(vertx, client),
                 zkScalerProvider,
                 metricsProvider,
-                adminClientProvider);
+                adminClientProvider,
+                zlf);
     }
 
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
@@ -162,7 +164,8 @@ public class ResourceOperatorSupplier {
                                     NodeOperator nodeOperator,
                                     ZookeeperScalerProvider zkScalerProvider,
                                     MetricsProvider metricsProvider,
-                                    AdminClientProvider adminClientProvider) {
+                                    AdminClientProvider adminClientProvider,
+                                    ZookeeperLeaderFinder zookeeperLeaderFinder) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
         this.zkSetOperations = zkSetOperations;
@@ -194,5 +197,6 @@ public class ResourceOperatorSupplier {
         this.zkScalerProvider = zkScalerProvider;
         this.metricsProvider = metricsProvider;
         this.adminClientProvider = adminClientProvider;
+        this.zookeeperLeaderFinder = zookeeperLeaderFinder;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -98,7 +98,7 @@ public class ZooKeeperRoller {
                                 }
                             }
 
-                            // Check if we have a leader and if it needs tolling
+                            // Check if we have a leader and if it needs rolling
                             if (ZookeeperLeaderFinder.UNKNOWN_LEADER.equals(leader) || podsToRoll.get(leader) == null || podsToRoll.get(leader).isEmpty()) {
                                 return fut;
                             } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * ZooKeeperRoller helps to roll ZooKeeper cluster. It uses the ZooKeeperLeaderFinder to find the leader which is
+ * rolled first.
+ */
+public class ZooKeeperRoller {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ZooKeeperRoller.class.getName());
+
+    private final PodOperator podOperator;
+    private final ZookeeperLeaderFinder leaderFinder;
+    private final long operationTimeoutMs;
+
+    public ZooKeeperRoller(PodOperator podOperator, ZookeeperLeaderFinder leaderFinder, long operationTimeoutMs) {
+        this.podOperator = podOperator;
+        this.leaderFinder = leaderFinder;
+        this.operationTimeoutMs = operationTimeoutMs;
+    }
+
+    /**
+     * Asynchronously perform a rolling update of all the pods belonging to the ZooKeeper cluster and returns a future
+     * which completes when all required pods are rolled and ready again. It uses the ZooKeeperLeaderFinder to find the
+     * leader node and roll it last.
+     *
+     * @param reconciliation    The reconciliation
+     * @param selectorLabels    The selector labels to find the pods
+     * @param podRestart        Function that returns a list is reasons why the given pod needs to be restarted, or an empty list if the pod does not need to be restarted.
+     * @param clusterCaSecret   Secret with cluster CA certificates
+     * @param coKeySecret       Secret with the Cluster operator certificates
+     *
+     * @return A future that completes when any necessary rolling has been completed.
+     */
+    public Future<Void> maybeRollingUpdate(Reconciliation reconciliation, Labels selectorLabels, Function<Pod, List<String>> podRestart, Secret clusterCaSecret, Secret coKeySecret) {
+        String namespace = reconciliation.namespace();
+
+        return podOperator.listAsync(namespace, selectorLabels)
+                .compose(pods -> {
+                    Map<String, List<String>> podsToRoll = new HashMap<>(pods.size());
+                    boolean needsRolling = false;
+
+                    for (Pod pod : pods)    {
+                        List<String> restartReasons = podRestart.apply(pod);
+                        String podName = pod.getMetadata().getName();
+
+                        if (restartReasons != null && !restartReasons.isEmpty())    {
+                            LOGGER.debugCr(reconciliation, "Pod {} should be rolled due to {}", podName, restartReasons);
+                            podsToRoll.put(podName, restartReasons);
+                            needsRolling = true;
+                        } else {
+                            LOGGER.debugCr(reconciliation, "Pod {} does not need to be rolled", podName);
+                            podsToRoll.put(podName, null);
+                        }
+                    }
+
+                    if (needsRolling)   {
+                        return Future.succeededFuture(podsToRoll);
+                    } else {
+                        return Future.succeededFuture(null);
+                    }
+                }).compose(podsToRoll -> {
+                    if (podsToRoll != null)  {
+                        Promise<Void> promise = Promise.promise();
+                        Future<String> leaderFuture = leaderFinder.findZookeeperLeader(reconciliation, podsToRoll.keySet(), clusterCaSecret, coKeySecret);
+
+                        leaderFuture.compose(leader -> {
+                            LOGGER.debugCr(reconciliation, "Zookeeper leader is " + (ZookeeperLeaderFinder.UNKNOWN_LEADER.equals(leader) ? "unknown" : "pod " + leader));
+                            Future<Void> fut = Future.succeededFuture();
+
+                            // Then roll each non-leader pod => the leader is rolled last
+                            for (Map.Entry<String, List<String>> podEntry : podsToRoll.entrySet())  {
+                                if (podEntry.getValue() != null && !podEntry.getValue().isEmpty()) {
+                                    if (!podEntry.getKey().equals(leader)) {
+                                        LOGGER.debugCr(reconciliation, "Restarting non-leader pod {}", podEntry.getKey());
+                                        // roll the pod and wait until it is ready
+                                        // this prevents rolling into faulty state (note: this applies just for ZK pods)
+                                        fut = fut.compose(ignore -> restartPod(reconciliation, podEntry.getKey(), podEntry.getValue()));
+                                    } else {
+                                        LOGGER.debugCr(reconciliation, "Deferring restart of leader {}", podEntry.getKey());
+                                    }
+                                }
+                            }
+
+                            // Check if we have a leader and if it needs tolling
+                            if (ZookeeperLeaderFinder.UNKNOWN_LEADER.equals(leader) || podsToRoll.get(leader) == null || podsToRoll.get(leader).isEmpty()) {
+                                return fut;
+                            } else {
+                                // Roll the leader pod
+                                return fut.compose(ar -> {
+                                    // the leader is rolled as the last
+                                    LOGGER.debugCr(reconciliation, "Restarting leader pod (previously deferred) {}", leader);
+                                    return restartPod(reconciliation, leader, podsToRoll.get(leader));
+                                });
+                            }
+                        }).onComplete(promise);
+
+                        return promise.future();
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                });
+    }
+
+    /**
+     * Restarts the Pod => deletes it, waits until it is really deleted and until the new pod starts and gets ready.
+     *
+     * @param reconciliation Reconciliation object
+     * @param podName The name of the Pod to possibly restart.
+     * @param reasons Reasons for the restart
+     *
+     * @return a Future which completes when the given (possibly recreated) pod is ready.
+     */
+    Future<Void> restartPod(Reconciliation reconciliation, String podName, List<String> reasons) {
+        long pollingIntervalMs = 1_000;
+
+        LOGGER.infoCr(reconciliation, "Rolling pod {} due to {}", podName, reasons);
+        return podOperator.getAsync(reconciliation.namespace(), podName)
+                .compose(pod -> podOperator.restart(reconciliation, pod, operationTimeoutMs))
+                .compose(ignore -> {
+                    LOGGER.debugCr(reconciliation, "Waiting for readiness of pod {}", podName);
+                    return podOperator.readiness(reconciliation, reconciliation.namespace(), podName, pollingIntervalMs, operationTimeoutMs);
+                });
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperator.java
@@ -4,22 +4,10 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.model.Labels;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
 
 /**
  * Specialization of {@link StatefulSetOperator} for StatefulSets of Zookeeper nodes
@@ -66,60 +54,4 @@ public class ZookeeperSetOperator extends StatefulSetOperator {
         }
         return false;
     }
-
-    @Override
-    public Future<Void> maybeRollingUpdate(Reconciliation reconciliation, StatefulSet sts, Function<Pod, List<String>> podRestart, Secret clusterCaSecret, Secret coKeySecret) {
-        String namespace = sts.getMetadata().getNamespace();
-        String name = sts.getMetadata().getName();
-        final int replicas = sts.getSpec().getReplicas();
-        LOGGER.debugCr(reconciliation, "Considering rolling update of {}/{}", namespace, name);
-
-        boolean zkRoll = false;
-        ArrayList<Pod> pods = new ArrayList<>(replicas);
-        String cluster = sts.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
-        for (int i = 0; i < replicas; i++) {
-            Pod pod = podOperations.get(sts.getMetadata().getNamespace(), KafkaResources.zookeeperPodName(cluster, i));
-            List<String> zkPodRestart = podRestart.apply(pod);
-            zkRoll |= zkPodRestart != null && !zkPodRestart.isEmpty();
-            pods.add(pod);
-        }
-
-        final Future<Void> rollFuture;
-        if (zkRoll) {
-            // Find the leader
-            Promise<Void> promise = Promise.promise();
-            rollFuture = promise.future();
-            Future<Integer> leaderFuture = leaderFinder.findZookeeperLeader(reconciliation, cluster, namespace, pods, coKeySecret);
-            leaderFuture.compose(leader -> {
-                LOGGER.debugCr(reconciliation, "Zookeeper leader is " + (leader == ZookeeperLeaderFinder.UNKNOWN_LEADER ? "unknown" : "pod " + leader));
-                Future<Void> fut = Future.succeededFuture();
-                // Then roll each non-leader pod
-                for (int i = 0; i < replicas; i++) {
-                    String podName = KafkaResources.zookeeperPodName(cluster, i);
-                    if (i != leader) {
-                        LOGGER.debugCr(reconciliation, "Possibly restarting non-leader pod {}", podName);
-                        // roll the pod and wait until it is ready
-                        // this prevents rolling into faulty state (note: this applies just for ZK pods)
-                        fut = fut.compose(ignore -> maybeRestartPod(reconciliation, sts, podName, podRestart));
-                    } else {
-                        LOGGER.debugCr(reconciliation, "Deferring restart of leader {}", podName);
-                    }
-                }
-                if (leader == ZookeeperLeaderFinder.UNKNOWN_LEADER) {
-                    return fut;
-                } else {
-                    // Finally roll the leader pod
-                    return fut.compose(ar -> {
-                        // the leader is rolled as the last
-                        LOGGER.debugCr(reconciliation, "Possibly restarting leader pod (previously deferred) {}", leader);
-                        return maybeRestartPod(reconciliation, sts, KafkaResources.zookeeperPodName(cluster, leader), podRestart);
-                    });
-                }
-            }).onComplete(promise);
-        } else {
-            rollFuture = Future.succeededFuture();
-        }
-        return rollFuture;
-    }
-
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LoadBalancerIngressBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
@@ -557,10 +556,9 @@ public class ResourceUtils {
     }
 
     public static ZookeeperLeaderFinder zookeeperLeaderFinder(Vertx vertx, KubernetesClient client) {
-        return new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
-            () -> new BackOff(5_000, 2, 4)) {
+        return new ZookeeperLeaderFinder(vertx, () -> new BackOff(5_000, 2, 4)) {
                 @Override
-                protected Future<Boolean> isLeader(Reconciliation reconciliation, Pod pod, NetClientOptions options) {
+                protected Future<Boolean> isLeader(Reconciliation reconciliation, String podName, NetClientOptions options) {
                     return Future.succeededFuture(true);
                 }
 
@@ -706,7 +704,8 @@ public class ResourceUtils {
                 mock(NodeOperator.class),
                 zookeeperScalerProvider(),
                 metricsProvider(),
-                adminClientProvider());
+                adminClientProvider(),
+                mock(ZookeeperLeaderFinder.class));
 
         when(supplier.secretOperations.getAsync(any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.serviceAccountOperations.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -36,7 +36,6 @@ import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
@@ -144,7 +143,7 @@ public class ConnectorMockTest {
         setupMockConnectAPI();
 
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
-                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, client),
+                new ZookeeperLeaderFinder(vertx,
                     // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
                     () -> new BackOff(5_000, 2, 4)),
                 new DefaultAdminClientProvider(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -112,7 +112,6 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.strimzi.test.TestUtils.set;
@@ -460,7 +459,6 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<StatefulSet> ssCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockZsOps.reconcile(any(), anyString(), anyString(), ssCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new StatefulSet())));
         when(mockZsOps.scaleDown(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(null));
-        when(mockZsOps.maybeRollingUpdate(any(), any(), any(Function.class))).thenReturn(Future.succeededFuture());
         when(mockZsOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         AtomicReference<StatefulSet> ref = new AtomicReference<>();
         when(mockKsOps.reconcile(any(), anyString(), anyString(), ssCaptor.capture())).thenAnswer(i -> {
@@ -475,7 +473,6 @@ public class KafkaAssemblyOperatorTest {
             return Future.succeededFuture(ReconcileResult.created(sts));
         });
         when(mockKsOps.scaleDown(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(null));
-        when(mockKsOps.maybeRollingUpdate(any(), any(), any(Function.class))).thenReturn(Future.succeededFuture());
         when(mockKsOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
         when(mockPolicyOps.reconcile(any(), anyString(), anyString(), policyCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
         when(mockZsOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture());
@@ -1235,8 +1232,6 @@ public class KafkaAssemblyOperatorTest {
             StatefulSet sts = invocation.getArgument(3);
             return Future.succeededFuture(ReconcileResult.patched(sts));
         });
-        when(mockZsOps.maybeRollingUpdate(any(), any(), any(Function.class))).thenReturn(Future.succeededFuture());
-        when(mockKsOps.maybeRollingUpdate(any(), any(), any(Function.class))).thenReturn(Future.succeededFuture());
 
         when(mockZsOps.getAsync(clusterNamespace, ZookeeperCluster.zookeeperClusterName(clusterName))).thenReturn(
                 Future.succeededFuture(originalZookeeperCluster.generateStatefulSet(openShift, null, null))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -28,7 +28,6 @@ import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
@@ -113,7 +112,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
     private Future<Void> createConnectCluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi, boolean reconciliationPaused) {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_16);
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, this.mockClient,
-                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, this.mockClient),
+                new ZookeeperLeaderFinder(vertx,
                     // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
                     () -> new BackOff(5_000, 2, 4)),
                 new DefaultAdminClientProvider(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -151,7 +151,7 @@ public class KafkaConnectorIT {
                 new ResourceOperatorSupplier(
                         null, null, null, null, null, null, null, null, null, null, null, null,
                         null, null, null, null, null, null, null, null, null,
-                        null, null, connectCrdOperator, null, null, null, null, null, metrics, null),
+                        null, null, connectCrdOperator, null, null, null, null, null, metrics, null, null),
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),
             connect -> new KafkaConnectApiImpl(vertx),
             connectCluster.getPort() + 2

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -27,7 +27,6 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
@@ -113,7 +112,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
     private Future<Void> createMirrorMaker2Cluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi, boolean reconciliationPaused) {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(true, KubernetesVersion.V1_16);
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, this.mockClient,
-                new ZookeeperLeaderFinder(vertx, new SecretOperator(vertx, this.mockClient),
+                new ZookeeperLeaderFinder(vertx,
                     // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
                     () -> new BackOff(5_000, 2, 4)),
                 new DefaultAdminClientProvider(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.vertx.core.Future;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class ZooKeeperRollerTest {
+    private final static Labels DUMMY_SELECTOR = Labels.fromMap(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, "my-cluster", Labels.STRIMZI_NAME_LABEL, "my-cluster-zookeeper"));
+    private final static List<Pod> PODS = List.of(
+            new PodBuilder()
+                    .withNewMetadata()
+                        .withName("my-cluster-zookeeper-0")
+                    .endMetadata()
+                    .withNewSpec()
+                    .endSpec()
+                    .build(),
+            new PodBuilder()
+                    .withNewMetadata()
+                    .withName("my-cluster-zookeeper-1")
+                    .endMetadata()
+                    .withNewSpec()
+                    .endSpec()
+                    .build(),
+            new PodBuilder()
+                    .withNewMetadata()
+                    .withName("my-cluster-zookeeper-2")
+                    .endMetadata()
+                    .withNewSpec()
+                    .endSpec()
+                    .build()
+    );
+
+    @Test
+    public void testAllPodsAreRolled(VertxTestContext context)  {
+        PodOperator podOperator = mock(PodOperator.class);
+        when(podOperator.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(PODS));
+
+        ZookeeperLeaderFinder leaderFinder = mock(ZookeeperLeaderFinder.class);
+        when(leaderFinder.findZookeeperLeader(any(), any(), any(), any())).thenReturn(Future.succeededFuture(ZookeeperLeaderFinder.UNKNOWN_LEADER));
+
+        MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, pod -> List.of("Should restart"), new Secret(), new Secret())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(roller.podRestarts.size(), is(3));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-0"), is(true));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-1"), is(true));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-2"), is(true));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testNoPodsAreRolled(VertxTestContext context)  {
+        PodOperator podOperator = mock(PodOperator.class);
+        when(podOperator.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(PODS));
+
+        ZookeeperLeaderFinder leaderFinder = mock(ZookeeperLeaderFinder.class);
+        when(leaderFinder.findZookeeperLeader(any(), any(), any(), any())).thenReturn(Future.succeededFuture(ZookeeperLeaderFinder.UNKNOWN_LEADER));
+
+        MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, pod -> null, new Secret(), new Secret())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(roller.podRestarts.size(), is(0));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testLeaderIsLast(VertxTestContext context)  {
+        PodOperator podOperator = mock(PodOperator.class);
+        when(podOperator.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(PODS));
+
+        ZookeeperLeaderFinder leaderFinder = mock(ZookeeperLeaderFinder.class);
+        when(leaderFinder.findZookeeperLeader(any(), any(), any(), any())).thenReturn(Future.succeededFuture("my-cluster-zookeeper-1"));
+
+        MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, pod -> List.of("Should restart"), new Secret(), new Secret())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(roller.podRestarts.size(), is(3));
+                    assertThat(roller.podRestarts.removeLast(), is("my-cluster-zookeeper-1"));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-2"), is(true));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-0"), is(true));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testOnlySomePodsAreRolled(VertxTestContext context)  {
+        PodOperator podOperator = mock(PodOperator.class);
+        when(podOperator.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(PODS));
+
+        ZookeeperLeaderFinder leaderFinder = mock(ZookeeperLeaderFinder.class);
+        when(leaderFinder.findZookeeperLeader(any(), any(), any(), any())).thenReturn(Future.succeededFuture(ZookeeperLeaderFinder.UNKNOWN_LEADER));
+
+        MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
+
+        Function<Pod, List<String>> shouldRoll = pod -> {
+            if (!"my-cluster-zookeeper-1".equals(pod.getMetadata().getName()))  {
+                return List.of("Should restart");
+            } else {
+                return List.of();
+            }
+        };
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, shouldRoll, new Secret(), new Secret())
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(roller.podRestarts.size(), is(2));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-0"), is(true));
+                    assertThat(roller.podRestarts.contains("my-cluster-zookeeper-2"), is(true));
+
+                    async.flag();
+                })));
+    }
+
+    static class MockZooKeeperRoller extends ZooKeeperRoller   {
+        Deque<String> podRestarts = new ArrayDeque<>();
+
+        public MockZooKeeperRoller(PodOperator podOperator, ZookeeperLeaderFinder leaderFinder, long operationTimeoutMs) {
+            super(podOperator, leaderFinder, operationTimeoutMs);
+        }
+
+        @Override
+        Future<Void> restartPod(Reconciliation reconciliation, String podName, List<String> reasons) {
+            podRestarts.add(podName);
+            return Future.succeededFuture();
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, rolling of ZooKeeper clusters is tightly coupled with StatefulSets. That is something what needs to be dealt with as part of the ZooKeeper removal work. In order to avoid too big PRs, this PR refactors the ZooKeeper rolling update to not depend on the stateful set. It adds a new `ZooKeeperRoller` class which uses the same logic as we used so far but instead of depending on stateful sets it uses pod selector to find the pods and roll if needed. It also removed the rolling update logic from the StatefulSet operator and its Kafka and Zoo version since neither one uses it anymore.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally