### PR TITLE
Don't roll EO, KE and CC when Clients CA is replaced

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -208,7 +208,7 @@ class SecurityST extends AbstractST {
                 /* brokers need to trust client certs with new cert */
                 true,
                 /* eo needs to generate new client certs */
-                true,
+                false,
                 false);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -401,7 +401,7 @@ class SecurityST extends AbstractST {
             extensionContext,
                 false,
                 true,
-                true,
+                false,
                 false);
     }
 
@@ -507,12 +507,11 @@ class SecurityST extends AbstractST {
             eoPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPod);
         }
 
-//        TODO: Once issue with removal will be resolved (means RU CC and KE when cluster CA is changed) uncomment commented code - https://github.com/strimzi/strimzi-kafka-operator/issues/5810
-//        if (keAndCCShouldRoll) {
-        LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart (1)...");
-        kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
-        ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
-//        }
+        if (keAndCCShouldRoll) {
+            LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart (1)...");
+            kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
+            ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
+        }
 
         if (zkShouldRoll) {
             LOGGER.info("Wait for zk to rolling restart (2)...");
@@ -584,18 +583,16 @@ class SecurityST extends AbstractST {
 
         if (!kafkaShouldRoll) {
             assertThat("Kafka pods should not roll, but did.", StatefulSetUtils.ssSnapshot(namespaceName, kafkaStatefulSetName(clusterName)), is(kafkaPods));
-
         }
 
         if (!eoShouldRoll) {
             assertThat("EO pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName)), is(eoPod));
         }
 
-//        TODO: Once issue with removal will be resolved (means RU CC and KE when cluster CA is changed) uncomment commented code - https://github.com/strimzi/strimzi-kafka-operator/issues/5810
-//        if (!keAndCCShouldRoll) {
-//            assertThat("CC pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName)), is(ccPod));
-//            assertThat("KE pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaExporterResources.deploymentName(clusterName)), is(kePod));
-//        }
+        if (!keAndCCShouldRoll) {
+            assertThat("CC pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName)), is(ccPod));
+            assertThat("KE pod should not roll, but did.", DeploymentUtils.depSnapshot(namespaceName, KafkaExporterResources.deploymentName(clusterName)), is(kePod));
+        }
     }
 
     private void createKafkaCluster(ExtensionContext extensionContext) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka Exporter (KE) and Cruise Control (CC) do not use Clients CA. So they should not be rolled when the Clients CA is renewed. In Entity Operator (EO), the User Operator uses Clients CA. But it is not using it based on mounted volumes or environment variables. It is querying Kube API about it every reconciliation. So the EO does not need to roll in this case either. It also enabled the previously disabled parts of the related system tests.

This should close #5810.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging