### PR TITLE
Remove `watch()` method from `PodOperator`

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
@@ -8,8 +8,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.strimzi.operator.common.Reconciliation;
@@ -19,8 +17,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 /**
- * Operations for {@code Pod}s, which support {@link #isReady(String, String)} and
- * {@link #watch(String, String, Watcher)} in addition to the usual operations.
+ * Operations for {@code Pod}s, which support {@link #isReady(String, String)}.
  */
 public class PodOperator extends AbstractReadyResourceOperator<KubernetesClient, Pod, PodList, PodResource<Pod>> {
 
@@ -39,17 +36,6 @@ public class PodOperator extends AbstractReadyResourceOperator<KubernetesClient,
     @Override
     protected MixedOperation<Pod, PodList, PodResource<Pod>> operation() {
         return client.pods();
-    }
-
-    /**
-     * Watch the pod identified by the given {@code namespace} and {@code name} using the given {@code watcher}.
-     * @param namespace The namespace
-     * @param name The name
-     * @param watcher The watcher
-     * @return The watch
-     */
-    public Watch watch(String namespace, String name, Watcher<Pod> watcher) {
-        return operation().inNamespace(namespace).withName(name).watch(watcher);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `PodOperator` class currently has a `watch(...)` method which does not seem to be used. It also seems to be a bit _out of place_ => should we need such method, it would be better to have it in one of the abstract operators and share it also with the CRDs etc. where watching is actually used. The PR removes it as a cleanup of unnecessary code.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally