### PR TITLE
Move `ANY_NAMESPACE` constant to `AbstractResourceOperator`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -13,7 +13,7 @@ import io.strimzi.operator.cluster.model.UnsupportedVersionException;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.AbstractWatchableResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractResourceOperator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -224,16 +224,16 @@ public class ClusterOperatorConfig {
     private static Set<String> parseNamespaceList(String namespacesList)   {
         Set<String> namespaces;
         if (namespacesList == null || namespacesList.isEmpty()) {
-            namespaces = Collections.singleton(AbstractWatchableResourceOperator.ANY_NAMESPACE);
+            namespaces = Collections.singleton(AbstractResourceOperator.ANY_NAMESPACE);
         } else {
-            if (namespacesList.trim().equals(AbstractWatchableResourceOperator.ANY_NAMESPACE)) {
-                namespaces = Collections.singleton(AbstractWatchableResourceOperator.ANY_NAMESPACE);
+            if (namespacesList.trim().equals(AbstractResourceOperator.ANY_NAMESPACE)) {
+                namespaces = Collections.singleton(AbstractResourceOperator.ANY_NAMESPACE);
             } else if (namespacesList.matches("(\\s*[a-z0-9.-]+\\s*,)*\\s*[a-z0-9.-]+\\s*")) {
                 namespaces = new HashSet<>(asList(namespacesList.trim().split("\\s*,+\\s*")));
             } else {
                 throw new InvalidConfigurationException(STRIMZI_NAMESPACE
                         + " is not a valid list of namespaces nor the 'any namespace' wildcard "
-                        + AbstractWatchableResourceOperator.ANY_NAMESPACE);
+                        + AbstractResourceOperator.ANY_NAMESPACE);
             }
         }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -44,6 +44,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
         T extends HasMetadata,
         L extends KubernetesResourceList<T>,
         R extends Resource<T>> {
+    public final static String ANY_NAMESPACE = "*";
 
     protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
@@ -312,7 +313,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      * @return A list of matching resources.
      */
     public List<T> list(String namespace, Labels selector) {
-        if (AbstractWatchableResourceOperator.ANY_NAMESPACE.equals(namespace))  {
+        if (ANY_NAMESPACE.equals(namespace))  {
             return listInAnyNamespace(selector);
         } else {
             return listInNamespace(namespace, selector);
@@ -361,7 +362,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
     public Future<List<T>> listAsync(String namespace, Labels selector) {
         FilterWatchListDeletable<T, L> x;
 
-        if (AbstractWatchableResourceOperator.ANY_NAMESPACE.equals(namespace))  {
+        if (ANY_NAMESPACE.equals(namespace))  {
             x = operation().inAnyNamespace();
         } else {
             x = operation().inNamespace(namespace);
@@ -376,7 +377,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
     public Future<List<T>> listAsync(String namespace, Optional<LabelSelector> selector) {
         FilterWatchListDeletable<T, L> x;
 
-        if (AbstractWatchableResourceOperator.ANY_NAMESPACE.equals(namespace))  {
+        if (ANY_NAMESPACE.equals(namespace))  {
             x = operation().inAnyNamespace();
         } else {
             x = operation().inNamespace(namespace);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableResourceOperator.java
@@ -22,9 +22,6 @@ public abstract class AbstractWatchableResourceOperator<
         L extends KubernetesResourceList<T>,
         R extends Resource<T>>
         extends AbstractResourceOperator<C, T, L, R> {
-
-    public final static String ANY_NAMESPACE = "*";
-
     /**
      * Constructor.
      *


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `AbstractWatchableResourceOperator` class has currently a public constant `ANY_NAMESPACE` which is used to indicate in  various operations that they should be done cluster wide across all namespaces. This method is used in `AbstractWatchableResourceOperator` but also in other classes. Among them also in the `AbstractResourceOperator` class which  is one of the parent classes of `AbstractWatchableResourceOperator`. 

This arrangement seems a bit weird. This PR moves the `ANY_NAMESPACE` constant to `AbstractResourceOperator` and makes the code a bit cleaner.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally