### PR TITLE
[ST] Flip the Control Plane Listener feature gate test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -59,7 +59,7 @@ public class FeatureGatesST extends AbstractST {
      * Control Plane Listener
      * https://github.com/strimzi/proposals/blob/main/025-control-plain-listener.md
      */
-    @IsolatedTest("Feature Gates test for ControlPlainListener")
+    @IsolatedTest("Feature Gates test for disabled ControlPlainListener")
     @Tag(INTERNAL_CLIENTS_USED)
     public void testControlPlaneListenerFeatureGate(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
@@ -72,7 +72,7 @@ public class FeatureGatesST extends AbstractST {
         List<EnvVar> testEnvVars = new ArrayList<>();
         int kafkaReplicas = 3;
 
-        testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+ControlPlaneListener", null));
+        testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "-ControlPlaneListener", null));
 
         install.unInstall();
         install = new SetupClusterOperator.SetupClusterOperatorBuilder()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `testControlPlaneListenerFeatureGate` in `FeatureGatesST` is supposed to test the `ControlPlaneListener` feature gate in regular regression runs. In 0.27, the `ControlPlaneListener` switches from being disabled by default to being enabled by default. We have to flip the feature gate in in this test as well since the enabled gate is tested in all the other tests.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally