### PR TITLE
Upgrade fabric8 to 5.10.1

### DIFF
--- a/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube/MockBuilder.java
@@ -194,7 +194,7 @@ class MockBuilder<T extends HasMetadata,
             String value = i.getArgument(1);
             return mockWithLabels(singletonMap(label, value));
         });
-        when(mixed.withLabelSelector(any())).thenAnswer(i -> {
+        when(mixed.withLabelSelector(any(LabelSelector.class))).thenAnswer(i -> {
             LabelSelector labelSelector = i.getArgument(0);
             Map<String, String> matchLabels = labelSelector.getMatchLabels();
             List<LabelSelectorRequirement> matchExpressions = labelSelector.getMatchExpressions();

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.9.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.9.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.9.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.10.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.10.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.10.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.10.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.10.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.10.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.10.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.10.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.10.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Chores

### Description
Upgrade fabric8 dependency to https://github.com/fabric8io/kubernetes-client/releases/tag/v5.10.1

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

