### PR TITLE
Update the upgrade procedure to reflect changes in Kafka 3.0.0

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -277,7 +277,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             }
 
             // Only Kafka versions before 3.0.0 require the second roll
-            if (currentLogMessageFormat == null && TestKafkaVersion.compareDottedVersions(newVersion.protocolVersion(), "3.0") >= 0) {
+            if (currentLogMessageFormat == null && TestKafkaVersion.compareDottedVersions(newVersion.protocolVersion(), "3.0") < 0) {
                 kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
                 LOGGER.info("Kafka roll (log.message.format.version) is complete");
             }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -276,7 +276,8 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 LOGGER.info("Kafka roll (inter.broker.protocol.version) is complete");
             }
 
-            if (currentLogMessageFormat == null) {
+            // Only Kafka versions before 3.0.0 require the second roll
+            if (currentLogMessageFormat == null && TestKafkaVersion.compareDottedVersions(newVersion.protocolVersion(), "3.0") >= 0) {
                 kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(INFRA_NAMESPACE, kafkaSelector, kafkaReplicas, kafkaPods);
                 LOGGER.info("Kafka roll (log.message.format.version) is complete");
             }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

From Kafka 3.0.0, the `log.message.format.version` field is deprecated and ignored when the `inter.broker.protocol.version` is set to 3.0 or newer. 

Currently, when `log.message.format.version` and `inter.broker.protocol.version` are not specified, Strimzi updates these in a separate rolling updates. But that does not seem to be needed anymore with Kafka 3.0.0. That allows us to avoid one additional rolling update which is not needed anymore:
* First rolling update to roll out new software (container images) but keep old IBPV and LMFV
* Second rolling update to update IBPV and LMFV (for the time being, LMFV is still kept around. It can be removed after we drop 2.8.x support)

For older Kafka versions (for example when upgrading from 2.7 to 2.8), it still works as before:
* First rolling update to roll out new software (container images) but keep old IBPV and LMFV
* Second rolling update to update IBPV but keep old LMFV
* Third rolling update to update LMFV

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally