### PR TITLE
Fix Grafana panels using filtered count queries

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -652,7 +652,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(strimzi_bridge_kafka_consumer_last_heartbeat_seconds_ago != -1)",
+          "expr": "sum(strimzi_bridge_kafka_consumer_last_heartbeat_seconds_ago != bool -1)",
           "format": "time_series",
           "instant": true,
           "interval": "",

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -679,7 +679,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kafka_topic_partition_leader_is_preferred{topic=~\"$topic\"}<1)",
+          "expr": "sum(kafka_topic_partition_leader_is_preferred{topic=~\"$topic\"} < bool 1)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes two Grafana panels that could show out-of-date data. Since Prometheus will return an empty vector rather than 0 with a query like `count(x < 1)` when all samples are filtered out, these Grafana panels would erroneously display the most recent non-zero value within the selected time range.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards