### PR TITLE
[systemtest] Add option to specify custom pull-secret for test-clients

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaAdminClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaAdminClient.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
@@ -15,7 +17,9 @@ import org.apache.logging.log4j.Logger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -144,6 +148,13 @@ public class KafkaAdminClient {
         adminLabels.put("app", adminName);
         adminLabels.put(Constants.KAFKA_ADMIN_CLIENT_LABEL_KEY, Constants.KAFKA_ADMIN_CLIENT_LABEL_VALUE);
 
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
+
         return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(namespaceName)
@@ -158,7 +169,7 @@ public class KafkaAdminClient {
                         .withNamespace(namespaceName)
                         .withLabels(adminLabels)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withRestartPolicy("Never")
                             .withContainers()
                                 .addNewContainer()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBasicExampleClients.java
@@ -6,6 +6,8 @@ package io.strimzi.systemtest.resources.crd.kafkaclients;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
@@ -19,7 +21,9 @@ import org.apache.logging.log4j.Logger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaBasicExampleClients {
@@ -277,6 +281,13 @@ public class KafkaBasicExampleClients {
         producerLabels.put("app", producerName);
         producerLabels.put(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE);
 
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
+
         return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(namespaceName)
@@ -291,7 +302,7 @@ public class KafkaBasicExampleClients {
                         .withNamespace(namespaceName)
                         .withLabels(producerLabels)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withRestartPolicy("Never")
                         .withContainers()
                             .addNewContainer()
@@ -351,6 +362,13 @@ public class KafkaBasicExampleClients {
         consumerLabels.put("app", consumerName);
         consumerLabels.put(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE);
 
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
+
         return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(namespaceName)
@@ -365,7 +383,7 @@ public class KafkaBasicExampleClients {
                         .withNamespace(namespaceName)
                         .withName(consumerName)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withRestartPolicy("Never")
                             .withContainers()
                                 .addNewContainer()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBridgeExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaBridgeExampleClients.java
@@ -4,11 +4,15 @@
  */
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 // HTTP Bridge clients
@@ -122,6 +126,13 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
         producerLabels.put("app", producerName);
         producerLabels.put(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_BRIDGE_CLIENTS_LABEL_VALUE);
 
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
+
         return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(namespaceName)
@@ -134,7 +145,7 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
                     .withNewMetadata()
                         .withLabels(producerLabels)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withRestartPolicy("OnFailure")
                         .withContainers()
                             .addNewContainer()
@@ -172,6 +183,13 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
         consumerLabels.put("app", consumerName);
         consumerLabels.put(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_BRIDGE_CLIENTS_LABEL_VALUE);
 
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
+
         return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(namespaceName)
@@ -184,7 +202,7 @@ public class KafkaBridgeExampleClients extends KafkaBasicExampleClients {
                     .withNewMetadata()
                         .withLabels(consumerLabels)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withRestartPolicy("OnFailure")
                         .withContainers()
                             .addNewContainer()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaTracingExampleClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/kafkaclients/KafkaTracingExampleClients.java
@@ -4,11 +4,15 @@
  */
 package io.strimzi.systemtest.resources.crd.kafkaclients;
 
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
@@ -214,6 +218,13 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
         Map<String, String> kafkaStreamLabels = new HashMap<>();
         kafkaStreamLabels.put("app", kafkaStreamsName);
 
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
+
         return new JobBuilder()
             .withNewMetadata()
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
@@ -226,7 +237,7 @@ public class KafkaTracingExampleClients extends KafkaBasicExampleClients {
                     .withNewMetadata()
                         .withLabels(kafkaStreamLabels)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withRestartPolicy("Never")
                         .withContainers()
                         .addNewContainer()


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR adds option for specifying custom pull-secret for all `test-clients` - in case someone has images pushed in private repository and wants to use them in STs.

### Checklist

- [x] Make sure all tests pass
