### PR TITLE
[systemtest] Add tags for STs in `*NamespacesST`

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/AllNamespacesST.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import static io.strimzi.systemtest.Constants.BRIDGE;
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -42,24 +46,28 @@ public class AllNamespacesST extends OlmAbstractST {
 
     @Test
     @Order(4)
+    @Tag(CONNECT)
     void testDeployExampleKafkaConnect() {
         doTestDeployExampleKafkaConnect();
     }
 
     @Test
     @Order(5)
+    @Tag(BRIDGE)
     void testDeployExampleKafkaBridge() {
         doTestDeployExampleKafkaBridge();
     }
 
     @Test
     @Order(6)
+    @Tag(MIRROR_MAKER)
     void testDeployExampleKafkaMirrorMaker() {
         doTestDeployExampleKafkaMirrorMaker();
     }
 
     @Test
     @Order(7)
+    @Tag(MIRROR_MAKER2)
     void testDeployExampleKafkaMirrorMaker2() {
         doTestDeployExampleKafkaMirrorMaker2();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceST.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import static io.strimzi.systemtest.Constants.BRIDGE;
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -41,24 +45,28 @@ public class SingleNamespaceST extends OlmAbstractST {
 
     @Test
     @Order(4)
+    @Tag(CONNECT)
     void testDeployExampleKafkaConnect() {
         doTestDeployExampleKafkaConnect();
     }
 
     @Test
     @Order(5)
+    @Tag(BRIDGE)
     void testDeployExampleKafkaBridge() {
         doTestDeployExampleKafkaBridge();
     }
 
     @Test
     @Order(6)
+    @Tag(MIRROR_MAKER)
     void testDeployExampleKafkaMirrorMaker() {
         doTestDeployExampleKafkaMirrorMaker();
     }
 
     @Test
     @Order(7)
+    @Tag(MIRROR_MAKER2)
     void testDeployExampleKafkaMirrorMaker2() {
         doTestDeployExampleKafkaMirrorMaker2();
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR adds tags into the `*NamespaceST` tests for `olm` install type, so we will be able to run STs for specific component

### Checklist

- [ ] Make sure all tests pass

