### PR TITLE
fix: Do not log zookeeper generated truststore passwords

### DIFF
--- a/docker-images/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka/scripts/zookeeper_run.sh
@@ -41,7 +41,7 @@ mkdir -p /tmp/zookeeper
 
 # Generate and print the config file
 echo "Starting Zookeeper with configuration:"
-./zookeeper_config_generator.sh | tee /tmp/zookeeper.properties
+./zookeeper_config_generator.sh | tee /tmp/zookeeper.properties | sed -e 's/password=.*/password=[hidden]/g'
 echo ""
 
 if [ -z "$KAFKA_LOG4J_OPTS" ]; then


### PR DESCRIPTION
This PR hides the Zookeeper config truststore passwords from the Zookeeper logs. This matches how truststore passwords are hidden when the Kafka configuration is printed out to the Kafka logs on startup (see https://github.com/strimzi/strimzi-kafka-operator/blob/main/docker-images/kafka/scripts/kafka_run.sh#L47).

Signed-off-by: Andrew Borley <borley@uk.ibm.com>
