### PR TITLE
Fix NPE when secret does not exist

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -585,7 +585,7 @@ public class Util {
     private static Future<Integer> addSecretHash(SecretOperator secretOperations, String namespace, GenericSecretSource genericSecretSource) {
         if (genericSecretSource != null) {
             return secretOperations.getAsync(namespace, genericSecretSource.getSecretName())
-                    .compose(secret -> Future.succeededFuture(secret.getData().get(genericSecretSource.getKey()).hashCode()));
+                    .compose(secret -> secret == null ? Future.failedFuture("Secret " + genericSecretSource.getSecretName() + " not found") : Future.succeededFuture(secret.getData().get(genericSecretSource.getKey()).hashCode()));
         }
         return Future.succeededFuture(0);
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -574,7 +574,8 @@ public class Util {
                 futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getAccessToken()));
                 futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getClientSecret()));
                 futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getRefreshToken()));
-                return CompositeFuture.join(futureList).compose(hashes -> Future.succeededFuture(hashes.list().stream().collect(Collectors.summingInt(e -> (int) e))));
+                return CompositeFuture.join(futureList)
+                        .compose(hashes -> Future.succeededFuture(hashes.list().stream().collect(Collectors.summingInt(e -> (int) e))));
             } else {
                 // unknown Auth type
                 return tlsFuture;
@@ -585,7 +586,13 @@ public class Util {
     private static Future<Integer> addSecretHash(SecretOperator secretOperations, String namespace, GenericSecretSource genericSecretSource) {
         if (genericSecretSource != null) {
             return secretOperations.getAsync(namespace, genericSecretSource.getSecretName())
-                    .compose(secret -> secret == null ? Future.failedFuture("Secret " + genericSecretSource.getSecretName() + " not found") : Future.succeededFuture(secret.getData().get(genericSecretSource.getKey()).hashCode()));
+                    .compose(secret -> {
+                        if (secret == null) {
+                            return Future.failedFuture("Secret " + genericSecretSource.getSecretName() + " not found");
+                        } else {
+                            return Future.succeededFuture(secret.getData().get(genericSecretSource.getKey()).hashCode());
+                        }
+                    });
         }
         return Future.succeededFuture(0);
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/5897
While working on https://github.com/strimzi/strimzi-kafka-operator/pull/5549 I forgot to add a null check.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

