### PR TITLE
Added SCRAM-SHA-256 authentication for Kafka clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the option to configure the Cluster Operator's Zookeeper admin client session timeout via an new env var: `STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS`
 * The `ControlPlaneListener` and `ServiceAccountPatching` feature gates are now in the _beta_ phase and are enabled by default.
 * Allow setting any extra environment variables for the Cluster Operator container through Helm using a new `extraEnvs` value.
+* Added SCRAM-SHA-256 authentication for Kafka clients
 * Update OPA Authorizer to 1.3.0
 
 ### Changes, deprecations and removals

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
@@ -23,6 +23,7 @@ import java.util.Map;
         property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = KafkaClientAuthenticationTls.TYPE_TLS, value = KafkaClientAuthenticationTls.class),
+    @JsonSubTypes.Type(name = KafkaClientAuthenticationScramSha256.TYPE_SCRAM_SHA_256, value = KafkaClientAuthenticationScramSha256.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaClientAuthenticationScramSha512.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationPlain.TYPE_PLAIN, value = KafkaClientAuthenticationPlain.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationOAuth.TYPE_OAUTH, value = KafkaClientAuthenticationOAuth.class),

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthentication.java
@@ -36,8 +36,8 @@ public abstract class KafkaClientAuthentication implements UnknownPropertyPreser
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +
-            "Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. " +
-            "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
+            "Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. " +
+            "`scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. " +
             "`plain` type uses SASL PLAIN Authentication. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
             "The `tls` type uses TLS Client Authentication. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScram.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScram.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.authentication;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.api.kafka.model.PasswordSecretSource;
+import io.strimzi.crdgenerator.annotations.Description;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Configures the Kafka client authentication using one of the possible SASL SCRAM_SHA_* methods in client based
+ * components
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+public abstract class KafkaClientAuthenticationScram extends KafkaClientAuthentication {
+    private static final long serialVersionUID = 1L;
+
+    private String username;
+    private PasswordSecretSource passwordSecret;
+
+    @Description("Reference to the `Secret` which holds the password.")
+    public PasswordSecretSource getPasswordSecret() {
+        return passwordSecret;
+    }
+
+    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
+        this.passwordSecret = passwordSecret;
+    }
+
+    @Description("Username used for the authentication.")
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScram.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScram.java
@@ -18,24 +18,13 @@ import lombok.EqualsAndHashCode;
 public abstract class KafkaClientAuthenticationScram extends KafkaClientAuthentication {
     private static final long serialVersionUID = 1L;
 
-    private String username;
-    private PasswordSecretSource passwordSecret;
-
     @Description("Reference to the `Secret` which holds the password.")
-    public PasswordSecretSource getPasswordSecret() {
-        return passwordSecret;
-    }
+    public abstract PasswordSecretSource getPasswordSecret();
 
-    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
-        this.passwordSecret = passwordSecret;
-    }
+    public abstract void setPasswordSecret(PasswordSecretSource passwordSecret);
 
     @Description("Username used for the authentication.")
-    public String getUsername() {
-        return username;
-    }
+    public abstract String getUsername();
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
+    public abstract void setUsername(String username);
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha256.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.authentication;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Configures the Kafka client authentication using SASL SCRAM_SHA_256 in client based components
+ */
+@DescriptionFile
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticationScram {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_SCRAM_SHA_256 = "scram-sha-256";
+
+    @Description("Must be `" + TYPE_SCRAM_SHA_256 + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Override
+    public String getType() {
+       return TYPE_SCRAM_SHA_256;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha256.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
@@ -26,10 +27,33 @@ public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticat
 
     public static final String TYPE_SCRAM_SHA_256 = "scram-sha-256";
 
+    private String username;
+    private PasswordSecretSource passwordSecret;
+
     @Description("Must be `" + TYPE_SCRAM_SHA_256 + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
-       return TYPE_SCRAM_SHA_256;
+        return TYPE_SCRAM_SHA_256;
+    }
+
+    @Description("Reference to the `Secret` which holds the password.")
+    @Override
+    public PasswordSecretSource getPasswordSecret() {
+        return passwordSecret;
+    }
+
+    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
+        this.passwordSecret = passwordSecret;
+    }
+
+    @Description("Username used for the authentication.")
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 /**
- * Configures the Kafka client authentication usign SASL SCRAM_SHA_512 in client based components
+ * Configures the Kafka client authentication using SASL SCRAM_SHA_512 in client based components
  */
 @DescriptionFile
 @Buildable(
@@ -21,37 +21,16 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
-public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthentication {
+@EqualsAndHashCode(callSuper = true)
+public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticationScram {
     private static final long serialVersionUID = 1L;
 
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
-
-    private String username;
-    private PasswordSecretSource passwordSecret;
 
     @Description("Must be `" + TYPE_SCRAM_SHA_512 + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_SCRAM_SHA_512;
-    }
-
-    @Description("Reference to the `Secret` which holds the password.")
-    public PasswordSecretSource getPasswordSecret() {
-        return passwordSecret;
-    }
-
-    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
-        this.passwordSecret = passwordSecret;
-    }
-
-    @Description("Username used for the authentication.")
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationScramSha512.java
@@ -27,10 +27,33 @@ public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticat
 
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
 
+    private String username;
+    private PasswordSecretSource passwordSecret;
+
     @Description("Must be `" + TYPE_SCRAM_SHA_512 + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
         return TYPE_SCRAM_SHA_512;
+    }
+
+    @Description("Reference to the `Secret` which holds the password.")
+    @Override
+    public PasswordSecretSource getPasswordSecret() {
+        return passwordSecret;
+    }
+
+    public void setPasswordSecret(PasswordSecretSource passwordSecret) {
+        this.passwordSecret = passwordSecret;
+    }
+
+    @Description("Username used for the authentication.")
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -112,8 +112,8 @@ public class AuthenticationUtils {
                 KafkaClientAuthenticationPlain passwordAuth = (KafkaClientAuthenticationPlain) authentication;
                 addNewVolume(volumeList, volumeNamePrefix, passwordAuth.getPasswordSecret().getSecretName(), isOpenShift);
             } else if (authentication instanceof KafkaClientAuthenticationScram) {
-                KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
-                addNewVolume(volumeList, volumeNamePrefix, passwordAuth.getPasswordSecret().getSecretName(), isOpenShift);
+                KafkaClientAuthenticationScram scramAuth = (KafkaClientAuthenticationScram) authentication;
+                addNewVolume(volumeList, volumeNamePrefix, scramAuth.getPasswordSecret().getSecretName(), isOpenShift);
             } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                 KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
                 volumeList.addAll(configureOauthCertificateVolumes(oauthVolumeNamePrefix, oauth.getTlsTrustedCertificates(), isOpenShift));
@@ -183,8 +183,8 @@ public class AuthenticationUtils {
                 KafkaClientAuthenticationPlain passwordAuth = (KafkaClientAuthenticationPlain) authentication;
                 volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + passwordAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + passwordAuth.getPasswordSecret().getSecretName()));
             } else if (authentication instanceof KafkaClientAuthenticationScram) {
-                KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
-                volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + passwordAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + passwordAuth.getPasswordSecret().getSecretName()));
+                KafkaClientAuthenticationScram scramAuth = (KafkaClientAuthenticationScram) authentication;
+                volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + scramAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + scramAuth.getPasswordSecret().getSecretName()));
             } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                 KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
                 volumeMountList.addAll(configureOauthCertificateVolumeMounts(oauthVolumeNamePrefix, oauth.getTlsTrustedCertificates(), oauthCertsVolumeMount));
@@ -256,10 +256,10 @@ public class AuthenticationUtils {
                 properties.put(SASL_PASSWORD_FILE, String.format("%s/%s", passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword()));
                 properties.put(SASL_MECHANISM, KafkaClientAuthenticationPlain.TYPE_PLAIN);
             } else if (authentication instanceof KafkaClientAuthenticationScram) {
-                KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
-                properties.put(SASL_USERNAME, passwordAuth.getUsername());
-                properties.put(SASL_PASSWORD_FILE, String.format("%s/%s", passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword()));
-                properties.put(SASL_MECHANISM, passwordAuth.getType());
+                KafkaClientAuthenticationScram scramAuth = (KafkaClientAuthenticationScram) authentication;
+                properties.put(SASL_USERNAME, scramAuth.getUsername());
+                properties.put(SASL_PASSWORD_FILE, String.format("%s/%s", scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword()));
+                properties.put(SASL_MECHANISM, scramAuth.getType());
             } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                 KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
                 properties.put(SASL_MECHANISM, KafkaClientAuthenticationOAuth.TYPE_OAUTH);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -13,7 +13,7 @@ import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPassword;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha512;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScram;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
@@ -55,10 +55,10 @@ public class AuthenticationUtils {
                 } else {
                     throw new InvalidResourceException("TLS Client authentication selected, but no certificate and key configured.");
                 }
-            } else if (authentication instanceof KafkaClientAuthenticationScramSha512)    {
-                KafkaClientAuthenticationScramSha512 auth = (KafkaClientAuthenticationScramSha512) authentication;
+            } else if (authentication instanceof KafkaClientAuthenticationScram)    {
+                KafkaClientAuthenticationScram auth = (KafkaClientAuthenticationScram) authentication;
                 if (auth.getUsername() == null || auth.getPasswordSecret() == null) {
-                    throw new InvalidResourceException("SCRAM-SHA-512 authentication selected, but username or password configuration is missing.");
+                    throw new InvalidResourceException(String.format("%s authentication selected, but username or password configuration is missing.", auth.getType().toUpperCase()));
                 }
             } else if (authentication instanceof KafkaClientAuthenticationPlain) {
                 KafkaClientAuthenticationPlain auth = (KafkaClientAuthenticationPlain) authentication;
@@ -110,8 +110,8 @@ public class AuthenticationUtils {
             } else if (authentication instanceof KafkaClientAuthenticationPlain) {
                 KafkaClientAuthenticationPlain passwordAuth = (KafkaClientAuthenticationPlain) authentication;
                 addNewVolume(volumeList, volumeNamePrefix, passwordAuth.getPasswordSecret().getSecretName(), isOpenShift);
-            } else if (authentication instanceof KafkaClientAuthenticationScramSha512) {
-                KafkaClientAuthenticationScramSha512 passwordAuth = (KafkaClientAuthenticationScramSha512) authentication;
+            } else if (authentication instanceof KafkaClientAuthenticationScram) {
+                KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
                 addNewVolume(volumeList, volumeNamePrefix, passwordAuth.getPasswordSecret().getSecretName(), isOpenShift);
             } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                 KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
@@ -181,8 +181,8 @@ public class AuthenticationUtils {
             } else if (authentication instanceof KafkaClientAuthenticationPlain) {
                 KafkaClientAuthenticationPlain passwordAuth = (KafkaClientAuthenticationPlain) authentication;
                 volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + passwordAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + passwordAuth.getPasswordSecret().getSecretName()));
-            } else if (authentication instanceof KafkaClientAuthenticationScramSha512) {
-                KafkaClientAuthenticationScramSha512 passwordAuth = (KafkaClientAuthenticationScramSha512) authentication;
+            } else if (authentication instanceof KafkaClientAuthenticationScram) {
+                KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
                 volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + passwordAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + passwordAuth.getPasswordSecret().getSecretName()));
             } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                 KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
@@ -254,11 +254,11 @@ public class AuthenticationUtils {
                 properties.put(SASL_USERNAME, passwordAuth.getUsername());
                 properties.put(SASL_PASSWORD_FILE, String.format("%s/%s", passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword()));
                 properties.put(SASL_MECHANISM, KafkaClientAuthenticationPlain.TYPE_PLAIN);
-            } else if (authentication instanceof KafkaClientAuthenticationScramSha512) {
-                KafkaClientAuthenticationScramSha512 passwordAuth = (KafkaClientAuthenticationScramSha512) authentication;
+            } else if (authentication instanceof KafkaClientAuthenticationScram) {
+                KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
                 properties.put(SASL_USERNAME, passwordAuth.getUsername());
                 properties.put(SASL_PASSWORD_FILE, String.format("%s/%s", passwordAuth.getPasswordSecret().getSecretName(), passwordAuth.getPasswordSecret().getPassword()));
-                properties.put(SASL_MECHANISM, KafkaClientAuthenticationScramSha512.TYPE_SCRAM_SHA_512);
+                properties.put(SASL_MECHANISM, passwordAuth.getType());
             } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                 KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
                 properties.put(SASL_MECHANISM, KafkaClientAuthenticationOAuth.TYPE_OAUTH);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -58,7 +59,7 @@ public class AuthenticationUtils {
             } else if (authentication instanceof KafkaClientAuthenticationScram)    {
                 KafkaClientAuthenticationScram auth = (KafkaClientAuthenticationScram) authentication;
                 if (auth.getUsername() == null || auth.getPasswordSecret() == null) {
-                    throw new InvalidResourceException(String.format("%s authentication selected, but username or password configuration is missing.", auth.getType().toUpperCase()));
+                    throw new InvalidResourceException(String.format("%s authentication selected, but username or password configuration is missing.", auth.getType().toUpperCase(Locale.ENGLISH)));
                 }
             } else if (authentication instanceof KafkaClientAuthenticationPlain) {
                 KafkaClientAuthenticationPlain auth = (KafkaClientAuthenticationPlain) authentication;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -22,7 +22,7 @@ import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha512;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScram;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
@@ -239,8 +239,8 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                 } else if (authentication instanceof KafkaClientAuthenticationPlain) {
                     KafkaClientAuthenticationPlain passwordAuth = (KafkaClientAuthenticationPlain) authentication;
                     appendClusterPasswordSecretSource(clustersSaslPasswordFiles, clusterAlias, passwordAuth.getPasswordSecret());
-                } else if (authentication instanceof KafkaClientAuthenticationScramSha512) {
-                    KafkaClientAuthenticationScramSha512 passwordAuth = (KafkaClientAuthenticationScramSha512) authentication;
+                } else if (authentication instanceof KafkaClientAuthenticationScram) {
+                    KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
                     appendClusterPasswordSecretSource(clustersSaslPasswordFiles, clusterAlias, passwordAuth.getPasswordSecret());
                 } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
                     KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Spec;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha256;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.common.Annotations;
@@ -380,6 +381,9 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
             if (KafkaClientAuthenticationPlain.TYPE_PLAIN.equals(clientAuthType)) {
                 saslMechanism = "PLAIN";
                 jaasConfig = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + authProperties.get(AuthenticationUtils.SASL_USERNAME) + "\" password=\"${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}\";";        
+            } else if (KafkaClientAuthenticationScramSha256.TYPE_SCRAM_SHA_256.equals(clientAuthType)) {
+                saslMechanism = "SCRAM-SHA-256";
+                jaasConfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + authProperties.get(AuthenticationUtils.SASL_USERNAME) + "\" password=\"${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}\";";
             } else if (KafkaClientAuthenticationScramSha512.TYPE_SCRAM_SHA_512.equals(clientAuthType)) {
                 saslMechanism = "SCRAM-SHA-512";
                 jaasConfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + authProperties.get(AuthenticationUtils.SASL_USERNAME) + "\" password=\"${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}\";";

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
@@ -62,6 +62,10 @@ if [ -n "$KAFKA_CONNECT_SASL_MECHANISM" ]; then
         PASSWORD=$(cat "/opt/kafka/connect-password/$KAFKA_CONNECT_SASL_PASSWORD_FILE")
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_CONNECT_SASL_USERNAME}\" password=\"${PASSWORD}\";"
+    elif [ "$KAFKA_CONNECT_SASL_MECHANISM" = "scram-sha-256" ]; then
+        PASSWORD=$(cat "/opt/kafka/connect-password/$KAFKA_CONNECT_SASL_PASSWORD_FILE")
+        SASL_MECHANISM="SCRAM-SHA-256"
+        JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_CONNECT_SASL_USERNAME}\" password=\"${PASSWORD}\";"
     elif [ "$KAFKA_CONNECT_SASL_MECHANISM" = "oauth" ]; then
         if [ -n "$KAFKA_CONNECT_OAUTH_ACCESS_TOKEN" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_CONNECT_OAUTH_ACCESS_TOKEN\""

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_consumer_config_generator.sh
@@ -41,6 +41,10 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" ]; then
         PASSWORD=$(cat "/opt/kafka/consumer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER")
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER}\" password=\"${PASSWORD}\";"
+    elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "scram-sha-256" ]; then
+        PASSWORD=$(cat "/opt/kafka/consumer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER")
+        SASL_MECHANISM="SCRAM-SHA-256"
+        JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER}\" password=\"${PASSWORD}\";"
     elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER" = "oauth" ]; then
         if [ -n "$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_CONSUMER" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_CONSUMER\""

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_producer_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_producer_config_generator.sh
@@ -41,6 +41,10 @@ if [ -n "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" ]; then
         PASSWORD=$(cat "/opt/kafka/producer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER")
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER}\" password=\"${PASSWORD}\";"
+    elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "scram-sha-256" ]; then
+        PASSWORD=$(cat "/opt/kafka/producer-password/$KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_PRODUCER")
+        SASL_MECHANISM="SCRAM-SHA-256"
+        JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_MIRRORMAKER_SASL_USERNAME_PRODUCER}\" password=\"${PASSWORD}\";"
     elif [ "$KAFKA_MIRRORMAKER_SASL_MECHANISM_PRODUCER" = "oauth" ]; then
         if [ -n "$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_PRODUCER" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_MIRRORMAKER_OAUTH_ACCESS_TOKEN_PRODUCER\""

--- a/documentation/api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha256.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha256.adoc
@@ -1,0 +1,47 @@
+To configure SASL-based SCRAM-SHA-256 authentication, set the `type` property to `scram-sha-256`.
+The SCRAM-SHA-256 authentication mechanism requires a username and password.
+
+=== `username`
+Specify the username in the `username` property.
+
+=== `passwordSecret`
+In the `passwordSecret` property, specify a link to a `Secret` containing the password.
+
+You can use the secrets created by the User Operator.
+
+If required, you can create a text file that contains the password, in cleartext, to use for authentication:
+
+[source,shell,subs="+quotes"]
+echo -n _PASSWORD_ > _MY-PASSWORD_.txt
+
+You can then create a `Secret` from the text file, setting your own field name (key) for the password:
+
+[source,shell,subs="+quotes"]
+kubectl create secret generic _MY-CONNECT-SECRET-NAME_ --from-file=_MY-PASSWORD-FIELD-NAME_=./_MY-PASSWORD_.txt
+
+.Example Secret for SCRAM-SHA-256 client authentication for Kafka Connect
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-connect-secret-name
+type: Opaque
+data:
+  my-connect-password-field: LFTIyFRFlMmU2N2Tm
+----
+
+The `secretName` property contains the name of the `Secret`, and the `password` property contains the name of the key under which the password is stored inside the `Secret`.
+
+IMPORTANT: Do not specify the actual password in the `password` property.
+
+.Example SASL-based SCRAM-SHA-256 client authentication configuration for Kafka Connect
+[source,yaml,subs=attributes+]
+----
+authentication:
+  type: scram-sha-256
+  username: my-connect-username
+  passwordSecret:
+    secretName: my-connect-secret-name
+    password: my-connect-password-field
+----

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1579,8 +1579,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |string
 |tls                    1.2+<.<a|TLS configuration.
 |xref:type-ClientTls-{context}[`ClientTls`]
-|authentication         1.2+<.<a|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|authentication         1.2+<.<a|Authentication configuration for Kafka Connect. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |config                 1.2+<.<a|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
@@ -1646,7 +1646,7 @@ include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticat
 ==== `KafkaClientAuthenticationTls` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationTls` type from xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
+The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationTls` type from xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
 It must have the value `tls` for the type `KafkaClientAuthenticationTls`.
 [options="header"]
 |====
@@ -1654,6 +1654,45 @@ It must have the value `tls` for the type `KafkaClientAuthenticationTls`.
 |certificateAndKey  1.2+<.<a|Reference to the `Secret` which holds the certificate and private key pair.
 |xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
 |type               1.2+<.<a|Must be `tls`.
+|string
+|====
+
+[id='type-KafkaClientAuthenticationScramSha256-{context}']
+### `KafkaClientAuthenticationScramSha256` schema reference
+
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+
+xref:type-KafkaClientAuthenticationScramSha256-schema-{context}[Full list of `KafkaClientAuthenticationScramSha256` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha256.adoc[leveloffset=+1]
+
+[id='type-KafkaClientAuthenticationScramSha256-schema-{context}']
+==== `KafkaClientAuthenticationScramSha256` schema properties
+
+
+[options="header"]
+|====
+|Property               |Description
+|passwordSecret  1.2+<.<a|Reference to the `Secret` which holds the password.
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|type            1.2+<.<a|Must be `scram-sha-256`.
+|string
+|username        1.2+<.<a|Username used for the authentication.
+|string
+|====
+
+[id='type-PasswordSecretSource-{context}']
+### `PasswordSecretSource` schema reference
+
+Used in: xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`]
+
+
+[options="header"]
+|====
+|Property           |Description
+|password    1.2+<.<a|The name of the key in the Secret under which the password is stored.
+|string
+|secretName  1.2+<.<a|The name of the Secret containing the password.
 |string
 |====
 
@@ -1670,8 +1709,6 @@ include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticat
 ==== `KafkaClientAuthenticationScramSha512` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationScramSha512` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
-It must have the value `scram-sha-512` for the type `KafkaClientAuthenticationScramSha512`.
 [options="header"]
 |====
 |Property               |Description
@@ -1680,21 +1717,6 @@ It must have the value `scram-sha-512` for the type `KafkaClientAuthenticationSc
 |type            1.2+<.<a|Must be `scram-sha-512`.
 |string
 |username        1.2+<.<a|Username used for the authentication.
-|string
-|====
-
-[id='type-PasswordSecretSource-{context}']
-### `PasswordSecretSource` schema reference
-
-Used in: xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`]
-
-
-[options="header"]
-|====
-|Property           |Description
-|password    1.2+<.<a|The name of the key in the Secret under which the password is stored.
-|string
-|secretName  1.2+<.<a|The name of the Secret containing the password.
 |string
 |====
 
@@ -1711,7 +1733,7 @@ include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticat
 ==== `KafkaClientAuthenticationPlain` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationPlain` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
+The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationPlain` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
 It must have the value `plain` for the type `KafkaClientAuthenticationPlain`.
 [options="header"]
 |====
@@ -1737,7 +1759,7 @@ include::../api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticat
 ==== `KafkaClientAuthenticationOAuth` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationOAuth` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`].
+The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationOAuth` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`].
 It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 [options="header"]
 |====
@@ -2580,8 +2602,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc[lev
 |string
 |groupId               1.2+<.<a|A unique string that identifies the consumer group this consumer belongs to.
 |string
-|authentication        1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|authentication        1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |config                1.2+<.<a|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |tls                   1.2+<.<a|TLS configuration for connecting MirrorMaker to the cluster.
@@ -2608,8 +2630,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc[lev
 |string
 |abortOnSendFailure  1.2+<.<a|Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
 |boolean
-|authentication      1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|authentication      1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |config              1.2+<.<a|The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |tls                 1.2+<.<a|TLS configuration for connecting MirrorMaker to the cluster.
@@ -2693,8 +2715,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 |string
 |tls               1.2+<.<a|TLS configuration for connecting Kafka Bridge to the cluster.
 |xref:type-ClientTls-{context}[`ClientTls`]
-|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |http              1.2+<.<a|The HTTP related configuration.
 |xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
 |adminClient       1.2+<.<a|Kafka AdminClient related configuration.
@@ -2990,8 +3012,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec.adoc[lev
 |string
 |tls               1.2+<.<a|TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
 |xref:type-ClientTls-{context}[`ClientTls`]
-|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-512, plain, oauth].
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |config            1.2+<.<a|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====

--- a/documentation/modules/configuring/proc-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-bridge.adoc
@@ -110,7 +110,7 @@ spec:
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes].
 <2> xref:con-common-configuration-bootstrap-reference[Bootstrap server] for connection to the target Kafka cluster.
 <3> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for the source Kafka cluster. If certificates are stored in the same secret, it can be listed multiple times.
-<4> Authentication for the Kafka Bridge cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
+<4> Authentication for the Kafka Bridge cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha256-reference[SCRAM-SHA-256]/xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 By default, the Kafka Bridge connects to Kafka brokers without authentication.
 <5> xref:type-KafkaBridgeHttpConfig-reference[HTTP access] to Kafka brokers.
 <6> xref:type-KafkaBridgeHttpConfig-reference[CORS access] specifying selected resources and access methods. Additional HTTP headers in requests xref:con-requests-kafka-bridge-cors-kafka-bridge-overview[describe the origins that are permitted access to the Kafka cluster].

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -158,7 +158,7 @@ spec:
 <1> Use `KafkaConnect`.
 <2> Enables KafkaConnectors for the Kafka Connect cluster.
 <3> xref:con-common-configuration-replicas-reference[The number of replica nodes].
-<4> Authentication for the Kafka Connect cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
+<4> Authentication for the Kafka Connect cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha256-reference[SCRAM-SHA-256]/xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 By default, Kafka Connect connects to Kafka brokers using a plain text connection.
 <5> xref:con-common-configuration-bootstrap-reference[Bootstrap server] for connection to the Kafka Connect cluster.
 <6> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for the cluster. If certificates are stored in the same secret, it can be listed multiple times.

--- a/documentation/modules/configuring/proc-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker.adoc
@@ -131,7 +131,7 @@ spec:
 <4> xref:property-consumer-streams-reference[The number of consumer streams].
 <5> xref:property-consumer-offset-autocommit-reference[The offset auto-commit interval in milliseconds].
 <6> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for consumer or producer. If certificates are stored in the same secret, it can be listed multiple times.
-<7> Authentication for consumer or producer, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
+<7> Authentication for consumer or producer, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha256-reference[SCRAM-SHA-256]/xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 <8> Kafka configuration options for xref:property-consumer-config-reference[consumer] and xref:property-producer-config-reference[producer].
 <9> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
 <10> xref:type-KafkaMirrorMakerConsumerSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -190,7 +190,7 @@ spec:
 <3> xref:type-KafkaMirrorMaker2Spec-reference[Kafka cluster alias] for Kafka Connect, which must specify the *target* Kafka cluster. The Kafka cluster is used by Kafka Connect for its internal topics.
 <4> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Specification] for the Kafka clusters being synchronized.
 <5> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Cluster alias] for the source Kafka cluster.
-<6> Authentication for the source cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
+<6> Authentication for the source cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha256-reference[SCRAM-SHA-256]/xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 <7> xref:con-common-configuration-bootstrap-reference[Bootstrap server] for connection to the source Kafka cluster.
 <8> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for the source Kafka cluster. If certificates are stored in the same secret, it can be listed multiple times.
 <9> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Cluster alias] for the target Kafka cluster.

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -17,7 +17,7 @@ import io.strimzi.api.kafka.model.MetricsConfig;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha512;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScram;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
@@ -552,7 +552,7 @@ public class Util {
             return tlsFuture;
         } else {
             // compute hash from Auth
-            if (auth instanceof KafkaClientAuthenticationScramSha512) {
+            if (auth instanceof KafkaClientAuthenticationScram) {
                 // only passwordSecret can be changed
                 return tlsFuture.compose(tlsHash -> getPasswordAsync(secretOperations, namespace, auth)
                         .compose(password -> Future.succeededFuture(password.hashCode() + tlsHash)));
@@ -678,15 +678,15 @@ public class Util {
                 }   
             });
         }
-        if (auth instanceof KafkaClientAuthenticationScramSha512) {
-            return secretOperator.getAsync(namespace, ((KafkaClientAuthenticationScramSha512) auth).getPasswordSecret().getSecretName())
+        if (auth instanceof KafkaClientAuthenticationScram) {
+            return secretOperator.getAsync(namespace, ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getSecretName())
             .compose(secret -> {
                 if (secret == null) {
-                    return Future.failedFuture("Secret " + ((KafkaClientAuthenticationScramSha512) auth).getPasswordSecret().getSecretName() + " not found");
+                    return Future.failedFuture("Secret " + ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getSecretName() + " not found");
                 } else {
-                    String passwordKey = ((KafkaClientAuthenticationScramSha512) auth).getPasswordSecret().getPassword();
+                    String passwordKey = ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getPassword();
                     if (!secret.getData().containsKey(passwordKey)) {
-                        return Future.failedFuture(String.format("Secret %s does not contain key %s", ((KafkaClientAuthenticationScramSha512) auth).getPasswordSecret().getSecretName(), passwordKey));
+                        return Future.failedFuture(String.format("Secret %s does not contain key %s", ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getSecretName(), passwordKey));
                     }
                     return Future.succeededFuture(secret.getData().get(passwordKey));
                 }

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -193,7 +193,7 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -189,6 +189,7 @@ spec:
                       type: string
                       enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -198,7 +198,7 @@ spec:
                             - scram-sha-512
                             - plain
                             - oauth
-                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                         username:
                           type: string
                           description: Username used for the authentication.
@@ -357,7 +357,7 @@ spec:
                             - scram-sha-512
                             - plain
                             - oauth
-                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -194,6 +194,7 @@ spec:
                           type: string
                           enum:
                             - tls
+                            - scram-sha-256
                             - scram-sha-512
                             - plain
                             - oauth
@@ -352,6 +353,7 @@ spec:
                           type: string
                           enum:
                             - tls
+                            - scram-sha-256
                             - scram-sha-512
                             - plain
                             - oauth

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -192,6 +192,7 @@ spec:
                       type: string
                       enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -196,7 +196,7 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -205,7 +205,7 @@ spec:
                               - scram-sha-512
                               - plain
                               - oauth
-                            description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                            description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                           username:
                             type: string
                             description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -201,6 +201,7 @@ spec:
                             type: string
                             enum:
                               - tls
+                              - scram-sha-256
                               - scram-sha-512
                               - plain
                               - oauth

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -220,6 +220,7 @@ spec:
                     type: string
                     enum:
                     - tls
+                    - scram-sha-256
                     - scram-sha-512
                     - plain
                     - oauth

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -225,10 +225,11 @@ spec:
                     - plain
                     - oauth
                     description: Authentication type. Currently the only supported
-                      types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                      type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses
-                      SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                      Authentication. The `tls` type uses TLS Client Authentication.
+                      types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                      `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                      and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                      type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                      OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication.
                       The `tls` type is supported only over TLS connections.
                   username:
                     type: string

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -230,6 +230,7 @@ spec:
                         type: string
                         enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth
@@ -433,6 +434,7 @@ spec:
                         type: string
                         enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -235,11 +235,13 @@ spec:
                         - plain
                         - oauth
                         description: Authentication type. Currently the only supported
-                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                          Authentication. The `tls` type uses TLS Client Authentication.
-                          The `tls` type is supported only over TLS connections.
+                          types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                          `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                          and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                          type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                          OAUTHBEARER Authentication. The `tls` type uses TLS Client
+                          Authentication. The `tls` type is supported only over TLS
+                          connections.
                       username:
                         type: string
                         description: Username used for the authentication.
@@ -439,11 +441,13 @@ spec:
                         - plain
                         - oauth
                         description: Authentication type. Currently the only supported
-                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                          Authentication. The `tls` type uses TLS Client Authentication.
-                          The `tls` type is supported only over TLS connections.
+                          types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                          `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                          and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                          type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                          OAUTHBEARER Authentication. The `tls` type uses TLS Client
+                          Authentication. The `tls` type is supported only over TLS
+                          connections.
                       username:
                         type: string
                         description: Username used for the authentication.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -222,6 +222,7 @@ spec:
                     type: string
                     enum:
                     - tls
+                    - scram-sha-256
                     - scram-sha-512
                     - plain
                     - oauth

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -227,10 +227,11 @@ spec:
                     - plain
                     - oauth
                     description: Authentication type. Currently the only supported
-                      types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                      type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses
-                      SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                      Authentication. The `tls` type uses TLS Client Authentication.
+                      types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                      `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                      and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                      type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                      OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication.
                       The `tls` type is supported only over TLS connections.
                   username:
                     type: string

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -240,6 +240,7 @@ spec:
                           type: string
                           enum:
                           - tls
+                          - scram-sha-256
                           - scram-sha-512
                           - plain
                           - oauth

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -245,12 +245,13 @@ spec:
                           - plain
                           - oauth
                           description: Authentication type. Currently the only supported
-                            types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                            type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                            uses SASL PLAIN Authentication. `oauth` type uses SASL
-                            OAUTHBEARER Authentication. The `tls` type uses TLS Client
-                            Authentication. The `tls` type is supported only over
-                            TLS connections.
+                            types are `tls`, `scram-sha-256`, `scram-sha-512`, and
+                            `plain`. `scram-sha-256` and `scram-sha-512` types use
+                            SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication,
+                            respectively. `plain` type uses SASL PLAIN Authentication.
+                            `oauth` type uses SASL OAUTHBEARER Authentication. The
+                            `tls` type uses TLS Client Authentication. The `tls` type
+                            is supported only over TLS connections.
                         username:
                           type: string
                           description: Username used for the authentication.


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

This modification adds SCRAM-SHA-256 authentication support for Kafka clients. See discussion https://github.com/strimzi/strimzi-kafka-operator/discussions/5855

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests - not done (see thread)
- [ ] Make sure all tests pass - we had problems running the integration tests against a local minikube, but the same tests fail in the main branch, so it is unlikely this change is responsible
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles - does not apply
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging - issue does not exist (yet)
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards - does not apply

