### PR TITLE
Set `default.replication.factor` and `min.insync.replicas` in examples and generate warnings in `KafkaSpecChecker`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -31,6 +31,8 @@ public class KafkaConfiguration extends AbstractConfiguration {
 
     public static final String INTERBROKER_PROTOCOL_VERSION = "inter.broker.protocol.version";
     public static final String LOG_MESSAGE_FORMAT_VERSION = "log.message.format.version";
+    public static final String DEFAULT_REPLICATION_FACTOR = "default.replication.factor";
+    public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
 
     private static final List<String> FORBIDDEN_PREFIXES;
     private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecCheckerTest.java
@@ -48,7 +48,14 @@ public class KafkaSpecCheckerTest {
 
     @Test
     public void checkEmptyWarnings() {
-        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT);
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
         KafkaSpecChecker checker = generateChecker(kafka);
         assertThat(checker.run(), empty());
     }
@@ -64,6 +71,7 @@ public class KafkaSpecCheckerTest {
                     .endZookeeper()
                 .endSpec()
             .build();
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -86,6 +94,7 @@ public class KafkaSpecCheckerTest {
                     .endZookeeper()
                 .endSpec()
             .build();
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -97,8 +106,12 @@ public class KafkaSpecCheckerTest {
 
     @Test
     public void checkZookeeperStorage() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
         Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
-                null, emptyMap(), emptyMap(),
+                null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
                 .editSpec()
                     .editZookeeper()
@@ -106,6 +119,7 @@ public class KafkaSpecCheckerTest {
                     .endZookeeper()
                 .endSpec()
             .build();
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -117,7 +131,14 @@ public class KafkaSpecCheckerTest {
 
     @Test
     public void checkZookeeperReplicas() {
-        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 2, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT);
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 2);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 1);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 2, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -129,7 +150,14 @@ public class KafkaSpecCheckerTest {
 
     @Test
     public void checkZookeeperEvenReplicas() {
-        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 4, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT);
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 4, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -143,6 +171,9 @@ public class KafkaSpecCheckerTest {
     public void checkLogMessageFormatVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION);
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
         Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
@@ -152,6 +183,7 @@ public class KafkaSpecCheckerTest {
                     .endKafka()
                 .endSpec()
             .build();
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -165,10 +197,12 @@ public class KafkaSpecCheckerTest {
     public void checkLogMessageFormatWithoutVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION);
-        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
-            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
-                .build();
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
@@ -183,10 +217,12 @@ public class KafkaSpecCheckerTest {
     public void checkLogMessageFormatWithRightVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.LATEST_FORMAT_VERSION);
-        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
-            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
-                .build();
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
@@ -197,10 +233,12 @@ public class KafkaSpecCheckerTest {
     public void checkLogMessageFormatWithRightLongVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, KafkaVersionTestUtils.LATEST_FORMAT_VERSION + "-IV0");
-        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
-            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
-                .build();
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
@@ -211,6 +249,9 @@ public class KafkaSpecCheckerTest {
     public void checkInterBrokerProtocolVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION);
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
         Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
@@ -221,6 +262,7 @@ public class KafkaSpecCheckerTest {
                     .endKafka()
                 .endSpec()
             .build();
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(1));
@@ -234,10 +276,12 @@ public class KafkaSpecCheckerTest {
     public void checkInterBrokerProtocolWithoutVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION);
-        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
-            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
-                .build();
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
@@ -252,10 +296,12 @@ public class KafkaSpecCheckerTest {
     public void checkInterBrokerProtocolWithCorrectVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION);
-        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
-            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
-                .build();
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
@@ -266,10 +312,12 @@ public class KafkaSpecCheckerTest {
     public void checkInterBrokerProtocolWithCorrectLongVersion() {
         Map<String, Object> kafkaOptions = new HashMap<>();
         kafkaOptions.put(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION + "-IV0");
-        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, kafkaOptions, emptyMap(),
-            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null))
-                .build();
+            new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
@@ -278,11 +326,69 @@ public class KafkaSpecCheckerTest {
 
     @Test
     public void checkMultipleWarnings() {
-        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 1, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
                 null, emptyMap(), emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
         KafkaSpecChecker checker = generateChecker(kafka);
         List<Condition> warnings = checker.run();
         assertThat(warnings, hasSize(2));
+    }
+
+    @Test
+    public void checkReplicationFactorAndMinInsyncReplicasSet() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(0));
+    }
+
+    @Test
+    public void checkReplicationFactorAndMinInsyncReplicasSetToOne() {
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 1);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 1);
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(0));
+    }
+
+    @Test
+    public void checkReplicationFactorAndMinInsyncReplicasUnsetOnSingleNode() {
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 1, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, emptyMap(), emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        // Two warnings are generated, but they are not the ones we are testing here
+        assertThat(warnings, hasSize(2));
+        assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR)), is(false));
+        assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.MIN_INSYNC_REPLICAS)), is(false));
+    }
+
+    @Test
+    public void checkReplicationFactorAndMinInsyncReplicasNotSet() {
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, emptyMap(), emptyMap(),
+                new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+
+        KafkaSpecChecker checker = generateChecker(kafka);
+        List<Condition> warnings = checker.run();
+        assertThat(warnings, hasSize(2));
+        assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR)), is(true));
+        assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.MIN_INSYNC_REPLICAS)), is(true));
     }
 }

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -107,6 +107,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: {LogMsgVersHigher}
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <19>
       ssl.enabled.protocols: "TLSv1.2"

--- a/documentation/modules/quickstart/proc-creating-kafka-cluster.adoc
+++ b/documentation/modules/quickstart/proc-creating-kafka-cluster.adoc
@@ -60,6 +60,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
   zookeeper:
     replicas: 1
     storage:

--- a/packaging/examples/kafka/kafka-ephemeral-single.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral-single.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/kafka/kafka-ephemeral.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/kafka/kafka-persistent-single.yaml
+++ b/packaging/examples/kafka/kafka-persistent-single.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -25,6 +25,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As discussed on the Strimzi community call (11th November), this PR:
* Adds default values of `default.replication.factor` and `min.insync.replicas` to all our examples and docs
* Adds new check to the `KafkaSpecChecker` to warn if these options are not set. The warnings will be generated when:
    * One of the other option is not set
    * The Kafka cluster has more than 1 replica (with 1 replica, it does not seem to make sense to enforce this since the only possible value is `1` which is also the default)
    * The status looks possibly like this:
      ```yaml
        # ...
        status:
          conditions:
            - lastTransitionTime: "2021-11-19T00:20:11.961773Z"
              message: default.replication.factor option is not configured. It defaults to
                1 which does not guarantee reliability and availability. You should configure
                this option in .spec.kafka-config.
              reason: KafkaDefaultReplicationFactor
              status: "True"
              type: Warning
            - lastTransitionTime: "2021-11-19T00:20:11.961815Z"
              message: min.insync.replicas option is not configured. It defaults to 1 which
                does not guarantee reliability and availability. You should configure this
                option in .spec.kafka-config.
              reason: KafkaMinInsyncReplicas
              status: "True"
              type: Warning
            - lastTransitionTime: "2021-11-19T00:22:14.941Z"
              status: "True"
              type: Ready
          # ...
      ```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally