### PR TITLE
Add ZIP artifacts to the Kafka Connect Build docs

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -196,8 +196,8 @@ spec:
 .Using ZIP artifacts
 
 ZIP artifacts are used to download ZIP compressed archives.
-ZIP artifacts can be used in the same way as the TGZ artifacts described in the previous section.
-The only difference is that instead of `type: tgz`, `type: zip` is used.
+Use ZIP artifacts in the same way as the TGZ artifacts described in the previous section.
+The only difference is you specify `type: zip` instead of  `type: tgz`.
 
 .Using Maven artifacts
 

--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -117,6 +117,7 @@ Strimzi supports the following types of artifacts:
 --
 * JAR files, which are downloaded and used directly
 * TGZ archives, which are downloaded and unpacked
+* ZIP archives, which are downloaded and unpacked
 * Maven artifacts, which uses Maven coordinates
 * Other artifacts, which are downloaded and used directly
 --
@@ -191,6 +192,12 @@ spec:
 <1> (Required) Type of artifact.
 <2> (Required) URL from which the archive is downloaded.
 <3> (Optional) SHA-512 checksum to verify the artifact.
+
+.Using ZIP artifacts
+
+ZIP artifacts are used to download ZIP compressed archives.
+ZIP artifacts can be used in the same way as the TGZ artifacts described in the previous section.
+The only difference is that instead of `type: tgz`, `type: zip` is used.
 
 .Using Maven artifacts
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

As noticed in #5915, we have fairly extensive docs (https://strimzi.io/docs/operators/latest/using.html#plugins) covering the different artifact types supported in Kafka Connect Build. But somehow, the ZIP artifacts are missing there. This PR adds them. For simplicity, it mostly refers to the TGZ section instead of copying everything and just changing `tgz` => `zip`.

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging