### PR TITLE
Update `default.replication.factor` and `min.insync.replicas` in system tests based on number of nodes

### DIFF
--- a/packaging/examples/cruise-control/kafka-cruise-control.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control.yaml
@@ -19,6 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
       log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -66,9 +66,9 @@ public class KafkaMirrorMaker2Templates {
         KafkaMirrorMaker2ClusterSpec targetClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(kafkaTargetClusterName)
             .withBootstrapServers(targetNs == null ? KafkaResources.plainBootstrapAddress(kafkaTargetClusterName) : KafkaUtils.namespacedPlainBootstrapAddress(kafkaTargetClusterName, targetNs))
-            .addToConfig("config.storage.replication.factor", 1)
-            .addToConfig("offset.storage.replication.factor", 1)
-            .addToConfig("status.storage.replication.factor", 1)
+            .addToConfig("config.storage.replication.factor", -1)
+            .addToConfig("offset.storage.replication.factor", -1)
+            .addToConfig("status.storage.replication.factor", -1)
             .build();
 
         KafkaMirrorMaker2ClusterSpec sourceClusterSpec = new KafkaMirrorMaker2ClusterSpecBuilder()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -187,6 +187,8 @@ public class KafkaTemplates {
                     .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))
+                    .addToConfig("default.replication.factor", Math.min(kafkaReplicas, 3))
+                    .addToConfig("min.insync.replicas", Math.min(kafkaReplicas - 1, 2))
                     .withListeners(new GenericKafkaListenerBuilder()
                                 .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
                                 .withPort(9092)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -188,7 +188,7 @@ public class KafkaTemplates {
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("default.replication.factor", Math.min(kafkaReplicas, 3))
-                    .addToConfig("min.insync.replicas", Math.min(kafkaReplicas - 1, 2))
+                    .addToConfig("min.insync.replicas", Math.min(Math.max(kafkaReplicas - 1, 1), 2))
                     .withListeners(new GenericKafkaListenerBuilder()
                                 .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
                                 .withPort(9092)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -119,7 +119,7 @@ public class CruiseControlUtils {
 
     public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(String namespaceName, long timeout) {
         final int numberOfPartitionsMetricTopic = 1;
-        final int numberOfReplicasMetricTopic = 1;
+        final int numberOfReplicasMetricTopic = 3;
 
         TestUtils.waitFor("Verify that kafka contains cruise control topics with related configuration.",
             Constants.GLOBAL_POLL_INTERVAL, timeout, () -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -628,9 +628,9 @@ class ConnectST extends AbstractST {
         envVarUpdated.put("TEST_ENV_3", "test.env.three");
 
         Map<String, Object> connectConfig = new HashMap<>();
-        connectConfig.put("config.storage.replication.factor", "1");
-        connectConfig.put("offset.storage.replication.factor", "1");
-        connectConfig.put("status.storage.replication.factor", "1");
+        connectConfig.put("config.storage.replication.factor", "-1");
+        connectConfig.put("offset.storage.replication.factor", "-1");
+        connectConfig.put("status.storage.replication.factor", "-1");
 
         final int initialDelaySeconds = 30;
         final int timeoutSeconds = 10;

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -89,7 +89,7 @@ public class CruiseControlST extends AbstractST {
 
         LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_METRICS_TOPIC);
         assertThat(metricsTopic.getPartitions(), is(1));
-        assertThat(metricsTopic.getReplicas(), is(1));
+        assertThat(metricsTopic.getReplicas(), is(3));
 
         LOGGER.info("Checking partitions and replicas for {}", CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC);
         assertThat(modelTrainingTopic.getPartitions(), is(32));

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -133,7 +133,7 @@ public class MetricsST extends AbstractST {
     void testKafkaTopicPartitions() {
         Pattern topicPartitions = Pattern.compile("kafka_server_replicamanager_partitioncount ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         ArrayList<Double> values = MetricsCollector.collectSpecificMetric(topicPartitions, kafkaMetricsData);
-        assertThat("Topic partitions count doesn't match expected value", values.stream().mapToDouble(i -> i).sum(), is(438.0));
+        assertThat("Topic partitions count doesn't match expected value", values.stream().mapToDouble(i -> i).sum(), is(504.0));
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -110,9 +110,9 @@ class MirrorMaker2ST extends AbstractST {
                 "config.storage.topic=mirrormaker2-cluster-configs\n" +
                 "status.storage.topic=mirrormaker2-cluster-status\n" +
                 "offset.storage.topic=mirrormaker2-cluster-offsets\n" +
-                "config.storage.replication.factor=1\n" +
-                "status.storage.replication.factor=1\n" +
-                "offset.storage.replication.factor=1\n" + 
+                "config.storage.replication.factor=-1\n" +
+                "status.storage.replication.factor=-1\n" +
+                "offset.storage.replication.factor=-1\n" +
                 "config.providers=file\n" + 
                 "config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider\n");
 
@@ -370,9 +370,9 @@ class MirrorMaker2ST extends AbstractST {
                 .withNewTls()
                     .withTrustedCertificates(certSecretTarget)
                 .endTls()
-                .addToConfig("config.storage.replication.factor", 1)
-                .addToConfig("offset.storage.replication.factor", 1)
-                .addToConfig("status.storage.replication.factor", 1)
+                .addToConfig("config.storage.replication.factor", -1)
+                .addToConfig("offset.storage.replication.factor", -1)
+                .addToConfig("status.storage.replication.factor", -1)
                 .build();
 
         resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
@@ -571,9 +571,9 @@ class MirrorMaker2ST extends AbstractST {
                 .withNewTls()
                     .withTrustedCertificates(certSecretTarget)
                 .endTls()
-                .addToConfig("config.storage.replication.factor", 1)
-                .addToConfig("offset.storage.replication.factor", 1)
-                .addToConfig("status.storage.replication.factor", 1)
+                .addToConfig("config.storage.replication.factor", -1)
+                .addToConfig("offset.storage.replication.factor", -1)
+                .addToConfig("status.storage.replication.factor", -1)
                 .build();
 
         resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -69,10 +69,10 @@ public class OauthAbstractST extends AbstractST {
     public static Map<String, Object> connectorConfig;
     static {
         connectorConfig = new HashMap<>();
-        connectorConfig.put("config.storage.replication.factor", 1);
+        connectorConfig.put("config.storage.replication.factor", -1);
         connectorConfig.put("config.topic.cleanup.policy", "compact");
-        connectorConfig.put("offset.storage.replication.factor", 1);
-        connectorConfig.put("status.storage.replication.factor", 1);
+        connectorConfig.put("offset.storage.replication.factor", -1);
+        connectorConfig.put("status.storage.replication.factor", -1);
     }
 
     protected static final Function<KeycloakInstance, GenericKafkaListener> BUILD_OAUTH_TLS_LISTENER = (keycloakInstance) -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -341,9 +341,9 @@ public class TracingST extends AbstractST {
             .build());
 
         Map<String, Object> configOfKafkaConnect = new HashMap<>();
-        configOfKafkaConnect.put("config.storage.replication.factor", "1");
-        configOfKafkaConnect.put("offset.storage.replication.factor", "1");
-        configOfKafkaConnect.put("status.storage.replication.factor", "1");
+        configOfKafkaConnect.put("config.storage.replication.factor", "-1");
+        configOfKafkaConnect.put("offset.storage.replication.factor", "-1");
+        configOfKafkaConnect.put("status.storage.replication.factor", "-1");
         configOfKafkaConnect.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
         configOfKafkaConnect.put("value.converter", "org.apache.kafka.connect.storage.StringConverter");
         configOfKafkaConnect.put("key.converter.schemas.enable", "false");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The #5916 added the `default.replication.factor` and `min.insync.replicas` fields to the example files. The example files are being used by the system tests and now system tests are failing, because they do not adapt the numbers for these options but they change the number of replicas.

This PR changes the `default.replication.factor` and `min.insync.replicas` values in the same way as they are changed to the other configuration options included in the example YAMLs. That should help to fix the system tests.

### Checklist

- [x] Make sure all tests pass