### PR TITLE
[systemtest] Change back settings for running STs in parallel

### DIFF
--- a/systemtest/src/test/resources/junit-platform.properties
+++ b/systemtest/src/test/resources/junit-platform.properties
@@ -1,9 +1,9 @@
 # These are default values if @ParallelTest or @ParallelSuite is not specified
 # junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
 # junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
-junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.enabled=false
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.fixed.parallelism=1
 junit.platform.output.capture.maxBuffer=true


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In #5840 I accidentally added settings to `junit-platform.properties`, so we always ran STs in parallel. This PR changes the settings back.

### Checklist

