### PR TITLE
Admin client should use PEM format of secrets

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -878,32 +878,6 @@ public abstract class Ca {
         }
     }
 
-    /**
-     * Returns concatenated string of all public keys (all .crt records) from a secret
-     *
-     * @param secret    Kubernetes Secret with certificates
-     *
-     * @return          String secrets
-     */
-    public static String certsToString(Secret secret)  {
-        if (secret == null || secret.getData() == null) {
-            return "";
-        } else {
-            Base64.Decoder decoder = Base64.getDecoder();
-
-            return secret
-                    .getData()
-                    .entrySet()
-                    .stream()
-                    .filter(record -> record.getKey().endsWith(".crt"))
-                    .map(record -> {
-                        byte[] bytes = decoder.decode(record.getValue());
-                        return new String(bytes, StandardCharsets.UTF_8);
-                    })
-                    .collect(Collectors.joining("\n"));
-        }
-    }
-
     static X509Certificate x509Certificate(byte[] bytes) throws CertificateException {
         CertificateFactory factory = certificateFactory();
         return x509Certificate(factory, bytes);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -878,6 +878,32 @@ public abstract class Ca {
         }
     }
 
+    /**
+     * Returns concatenated string of all public keys (all .crt records) from a secret
+     *
+     * @param secret    Kubernetes Secret with certificates
+     *
+     * @return          String secrets
+     */
+    public static String certsToString(Secret secret)  {
+        if (secret == null || secret.getData() == null) {
+            return "";
+        } else {
+            Base64.Decoder decoder = Base64.getDecoder();
+
+            return secret
+                    .getData()
+                    .entrySet()
+                    .stream()
+                    .filter(record -> record.getKey().endsWith(".crt"))
+                    .map(record -> {
+                        byte[] bytes = decoder.decode(record.getValue());
+                        return new String(bytes, StandardCharsets.UTF_8);
+                    })
+                    .collect(Collectors.joining("\n"));
+        }
+    }
+
     static X509Certificate x509Certificate(byte[] bytes) throws CertificateException {
         CertificateFactory factory = certificateFactory();
         return x509Certificate(factory, bytes);

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -41,13 +41,13 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
      */
     @Override
     public Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
-        String publicKeys = null;
+        String trustedCertificates = null;
         String privateKey = null;
         String certificateChain = null;
 
         // provided Secret with cluster CA certificate for TLS encryption
         if (clusterCaCertSecret != null) {
-            publicKeys = Util.certsToString(clusterCaCertSecret);
+            trustedCertificates = Util.certsToPemString(clusterCaCertSecret);
         }
 
         // provided Secret and related key for getting the private key for TLS client authentication
@@ -60,10 +60,10 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
         p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
 
         // configuring TLS encryption if requested
-        if (publicKeys != null) {
+        if (trustedCertificates != null) {
             p.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
             p.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
-            p.setProperty(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, publicKeys);
+            p.setProperty(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, trustedCertificates);
         }
 
         // configuring TLS client authentication

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -12,7 +12,6 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
@@ -44,60 +43,45 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
     @Override
     public Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
         Admin ac;
-        String trustStorePassword = null;
-        File truststoreFile = null;
+        String sslTruststoreCertificates = null;
+        String sslKeystoreKey = null;
+        String sslKeystoreCertificateChain = null;
+
         // provided Secret with cluster CA certificate for TLS encryption
         if (clusterCaCertSecret != null) {
-            PasswordGenerator pg = new PasswordGenerator(12);
-            trustStorePassword = pg.generate();
-            truststoreFile = Util.createFileTrustStore(getClass().getName(), "ts", Ca.certs(clusterCaCertSecret), trustStorePassword.toCharArray());
+            sslTruststoreCertificates = Ca.certsToString(clusterCaCertSecret);
         }
 
-        try {
-            String keyStorePassword = null;
-            File keystoreFile = null;
-            // provided Secret and related key for getting the private key for TLS client authentication
-            if (keyCertSecret != null && keyCertName != null && !keyCertName.isEmpty()) {
-                keyStorePassword = new String(Util.decodeFromSecret(keyCertSecret, keyCertName + ".password"), StandardCharsets.US_ASCII);
-                keystoreFile = Util.createFileStore(getClass().getName(), "ts", Util.decodeFromSecret(keyCertSecret, keyCertName + ".p12"));
-            }
-
-            try {
-                Properties p = new Properties();
-                p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
-
-                // configuring TLS encryption if requested
-                if (truststoreFile != null && trustStorePassword != null) {
-                    p.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
-
-                    p.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreFile.getAbsolutePath());
-                    p.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
-                    p.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
-                }
-
-                // configuring TLS client authentication
-                if (keystoreFile != null && keyStorePassword != null) {
-                    p.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keystoreFile.getAbsolutePath());
-                    p.setProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
-                    p.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keyStorePassword);
-                }
-
-                p.setProperty(AdminClientConfig.METADATA_MAX_AGE_CONFIG, "30000");
-                p.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10000");
-                p.setProperty(AdminClientConfig.RETRIES_CONFIG, "3");
-                p.setProperty(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "40000");
-
-                ac = Admin.create(p);
-            } finally {
-                if (keystoreFile != null && !keystoreFile.delete()) {
-                    LOGGER.warn("Unable to delete keystore file {}", keystoreFile);
-                }
-            }
-        } finally {
-            if (truststoreFile != null && !truststoreFile.delete()) {
-                LOGGER.warn("Unable to delete truststore file {}", truststoreFile);
-            }
+        // provided Secret and related key for getting the private key for TLS client authentication
+        if (keyCertSecret != null && keyCertName != null && !keyCertName.isEmpty()) {
+            sslKeystoreKey = new String(Util.decodeFromSecret(keyCertSecret, keyCertName + ".key"), StandardCharsets.US_ASCII);
+            sslKeystoreCertificateChain = new String(Util.decodeFromSecret(keyCertSecret, keyCertName + ".crt"), StandardCharsets.US_ASCII);
         }
+
+        Properties p = new Properties();
+        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
+
+        // configuring TLS encryption if requested
+        if (sslTruststoreCertificates != null) {
+            p.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SSL");
+            p.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
+            p.setProperty(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, sslTruststoreCertificates);
+        }
+
+        // configuring TLS client authentication
+        if (sslKeystoreCertificateChain != null && sslKeystoreKey != null) {
+            p.setProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
+            p.setProperty(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, sslKeystoreCertificateChain);
+            p.setProperty(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, sslKeystoreKey);
+        }
+
+        p.setProperty(AdminClientConfig.METADATA_MAX_AGE_CONFIG, "30000");
+        p.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10000");
+        p.setProperty(AdminClientConfig.RETRIES_CONFIG, "3");
+        p.setProperty(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "40000");
+
+        ac = Admin.create(p);
+
         return ac;
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -669,4 +669,30 @@ public class Util {
             return Future.failedFuture("Auth type " + auth.getType() + " does not have a password property");
         }
     }
+
+    /**
+     * Returns concatenated string of all public keys (all .crt records) from a secret
+     *
+     * @param secret    Kubernetes Secret with certificates
+     *
+     * @return          String secrets
+     */
+    public static String certsToString(Secret secret)  {
+        if (secret == null || secret.getData() == null) {
+            return "";
+        } else {
+            Base64.Decoder decoder = Base64.getDecoder();
+
+            return secret
+                    .getData()
+                    .entrySet()
+                    .stream()
+                    .filter(record -> record.getKey().endsWith(".crt"))
+                    .map(record -> {
+                        byte[] bytes = decoder.decode(record.getValue());
+                        return new String(bytes, StandardCharsets.US_ASCII);
+                    })
+                    .collect(Collectors.joining("\n"));
+        }
+    }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -677,7 +677,7 @@ public class Util {
      *
      * @return          String secrets
      */
-    public static String certsToString(Secret secret)  {
+    public static String certsToPemString(Secret secret)  {
         if (secret == null || secret.getData() == null) {
             return "";
         } else {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Enhancement

### Description
Admin client should use PEM format of secrets for connecting to the kafka cluster

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

