### PR TITLE
Remove the `ps` dependency from system tests

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 USER root
 
 RUN microdnf update \
-    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl procps shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-11

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -141,7 +141,7 @@ public abstract class AbstractST implements TestSeparator {
     private List<List<String>> commandLines(String namespaceName, String podName, String containerName) {
         List<List<String>> result = new ArrayList<>();
         String output = cmdKubeClient().namespace(namespaceName).execInPodContainer(podName, containerName, "/bin/bash", "-c",
-            "for pid in $(ps -C java -o pid h); do cat /proc/$pid/cmdline; done"
+                "for proc in $(ls -1 /proc/ | grep [0-9]); do if echo \"$(ls -lh /proc/$proc/exe 2>/dev/null || true)\" | grep -q java; then cat /proc/$proc/cmdline; fi; done"
         ).out();
         for (String cmdLine : output.split("\n")) {
             result.add(asList(cmdLine.split("\0")));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR removes the `ps` utility from system tests and the `procps` package from our base image.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally