### PR TITLE
Release lock and cancel timer regardless of callable's outcome

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -379,6 +379,21 @@ public abstract class AbstractOperator<
         return handler.future();
     }
 
+    /**
+     * Safely executes <code>callable</code>, always returning a
+     * <code>Future</code>. In the context of this method the term "safely"
+     * indicates that exceptions thrown by <code>callable</code> will result in the
+     * return of a failed <code>Future</code>.
+     *
+     * @param <C>            result type of the <code>Future</code> returned by the
+     *                       provided <code>callable</code>
+     * @param reconciliation the reconciliation being processed by
+     *                       <code>callable</code>
+     * @param callable       callable routine for processing the reconciliation
+     *
+     * @return the result of <code>callable</code> or a failed <code>Future</code>
+     *         when an exception is thrown
+     */
     private <C> Future<C> callSafely(Reconciliation reconciliation, Callable<Future<C>> callable) {
         try {
             return callable.call();
@@ -388,6 +403,21 @@ public abstract class AbstractOperator<
         }
     }
 
+    /**
+     * Provides a proxy <code>Handler</code> that will safely execute the given
+     * <code>handler</code>. In the context of this method the term "safely"
+     * indicates that exceptions thrown by <code>handler</code> will be caught and
+     * logged, not to be thrown to the caller.
+     *
+     * @param <H>            argument type of the <code>Handler</code>
+     * @param reconciliation the reconciliation being processed, the context of the
+     *                       operation
+     * @param handler        handler, for either success or failure
+     *
+     * @return a proxy <code>Handler</code> that, when executed, will execute the
+     *         provided handler, ensuring that unhandled exceptions are caught and
+     *         logged.
+     */
     private <H> Handler<H> handleSafely(Reconciliation reconciliation, Handler<H> handler) {
         return result -> {
             try {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -381,7 +381,7 @@ public abstract class AbstractOperator<
 
     /**
      * Safely executes <code>callable</code>, always returning a
-     * <code>Future</code>. In the context of this method the term "safely"
+     * <code>Future</code>. In the context of this method, the term "safely"
      * indicates that exceptions thrown by <code>callable</code> will result in the
      * return of a failed <code>Future</code>.
      *
@@ -405,9 +405,9 @@ public abstract class AbstractOperator<
 
     /**
      * Provides a proxy <code>Handler</code> that will safely execute the given
-     * <code>handler</code>. In the context of this method the term "safely"
+     * <code>handler</code>. In the context of this method, the term "safely"
      * indicates that exceptions thrown by <code>handler</code> will be caught and
-     * logged, not to be thrown to the caller.
+     * logged, and not thrown to the caller.
      *
      * @param <H>            argument type of the <code>Handler</code>
      * @param reconciliation the reconciliation being processed, the context of the

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -55,7 +55,7 @@ import static io.strimzi.operator.common.Util.async;
  * <li>uses the Fabric8 kubernetes API and implements
  * {@link #reconcile(Reconciliation)} by delegating to abstract {@link #createOrUpdate(Reconciliation, CustomResource)}
  * and {@link #delete(Reconciliation)} methods for subclasses to implement.
- * 
+ *
  * <li>add support for operator-side {@linkplain #validate(Reconciliation, CustomResource) validation}.
  *     This can be used to automatically log warnings about source resources which used deprecated part of the CR API.
  *ą
@@ -268,8 +268,11 @@ public abstract class AbstractOperator<
 
         Promise<Void> result = Promise.promise();
         handler.onComplete(reconcileResult -> {
-            handleResult(reconciliation, reconcileResult, reconciliationTimerSample);
-            result.handle(reconcileResult);
+            try {
+                handleResult(reconciliation, reconcileResult, reconciliationTimerSample);
+            } finally {
+                result.handle(reconcileResult);
+            }
         });
 
         return result.future();

--- a/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.strimzi.api.kafka.model.Spec;
+import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.shareddata.Lock;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(VertxExtension.class)
+@Group("strimzi")
+@Version("v1")
+class AbstractOperatorTest {
+    private static Vertx vertx;
+    private static final String EXPECTED_MESSAGE = "Exception is expected";
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx(new VertxOptions()
+                .setBlockedThreadCheckInterval(60)
+                .setBlockedThreadCheckIntervalUnit(TimeUnit.SECONDS)
+                .setMetricsOptions(new MicrometerMetricsOptions()
+                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setEnabled(true)
+        ));
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    /**
+     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
+     * with `eventually` after a normal/successful execution of the `Callable`
+     */
+    void testWithLockCallableSuccessfulReleasesLock(VertxTestContext context) throws Exception {
+        var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
+        String lockName = target.getLockName(reconciliation);
+
+        Checkpoint callableSucceeded = context.checkpoint();
+        Checkpoint lockObtained  = context.checkpoint();
+        @SuppressWarnings("unchecked")
+        Future<String> result = target.withLockTest(reconciliation, () -> Future.succeededFuture("OK"));
+        Promise<Void> successHandlerCalled = Promise.promise();
+
+        result.onComplete(context.succeeding(v -> context.verify(() -> {
+            assertThat(v, is("OK"));
+            successHandlerCalled.complete();
+            callableSucceeded.flag();
+        })));
+
+        successHandlerCalled.future()
+            .compose(v -> vertx.sharedData().getLockWithTimeout(lockName, 10000L))
+            .onComplete(context.succeeding(lock -> context.verify(() -> {
+                assertThat(lock, instanceOf(Lock.class));
+                lock.release();
+                lockObtained.flag();
+            })));
+    }
+
+    @Test
+    /**
+     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
+     * with `eventually` after a failed execution via a handled exception in the `Callable`
+     */
+    void testWithLockCallableHandledExceptionReleasesLock(VertxTestContext context) throws Exception {
+        var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
+        String lockName = target.getLockName(reconciliation);
+
+        Checkpoint callableFailed = context.checkpoint();
+        Checkpoint lockObtained  = context.checkpoint();
+        @SuppressWarnings("unchecked")
+        Future<String> result = target.withLockTest(reconciliation,
+                () -> Future.failedFuture(new UnsupportedOperationException(EXPECTED_MESSAGE)));
+
+        Promise<Void> failHandlerCalled = Promise.promise();
+
+        result.onComplete(context.failing(e -> context.verify(() -> {
+            assertThat(e.getMessage(), is(EXPECTED_MESSAGE));
+            failHandlerCalled.complete();
+            callableFailed.flag();
+        })));
+
+        failHandlerCalled.future()
+            .compose(nothing -> vertx.sharedData().getLockWithTimeout(lockName, 10000L))
+            .onComplete(context.succeeding(lock -> context.verify(() -> {
+                assertThat(lock, instanceOf(Lock.class));
+                lock.release();
+                lockObtained.flag();
+            })));
+    }
+
+    @Test
+    /**
+     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
+     * with `eventually` after a failed execution via an unhandled exception in the `Callable`
+     */
+    void testWithLockCallableUnhandledExceptionReleasesLock(VertxTestContext context) throws Exception {
+        var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
+        String lockName = target.getLockName(reconciliation);
+
+        Checkpoint callableFailed = context.checkpoint();
+        Checkpoint lockObtained  = context.checkpoint();
+        @SuppressWarnings("unchecked")
+        Future<String> result = target.withLockTest(reconciliation,
+                () -> {
+                    throw new UnsupportedOperationException(EXPECTED_MESSAGE);
+                });
+
+        Promise<Void> failHandlerCalled = Promise.promise();
+
+        result.onComplete(context.failing(e -> context.verify(() -> {
+            assertThat(e.getMessage(), is(EXPECTED_MESSAGE));
+            failHandlerCalled.complete();
+            callableFailed.flag();
+        })));
+
+        failHandlerCalled.future()
+            .compose(nothing -> vertx.sharedData().getLockWithTimeout(lockName, 10000L))
+            .onComplete(context.succeeding(lock -> context.verify(() -> {
+                assertThat(lock, instanceOf(Lock.class));
+                lock.release();
+                lockObtained.flag();
+            })));
+    }
+
+    @Test
+    /**
+     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
+     * with `eventually` after a failed execution via an unhandled exception in the `Callable` followed
+     * by an unhandled exception occurring in the onFailure handler.
+     */
+    void testWithLockFailHandlerUnhandledExceptionReleasesLock(VertxTestContext context) throws Exception {
+        var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
+        String lockName = target.getLockName(reconciliation);
+
+        Promise<Void> handlersRegistered = Promise.promise();
+        Promise<Void> failHandlerCalled = Promise.promise();
+
+        @SuppressWarnings("unchecked")
+        Future<String> result = target.withLockTest(reconciliation,
+                // TEST SETUP: Do not throw the exception until all handlers registered
+                () -> handlersRegistered.future().compose(nothing -> {
+                    throw new UnsupportedOperationException(EXPECTED_MESSAGE);
+                }));
+
+        Checkpoint callableFailed = context.checkpoint();
+        Checkpoint lockObtained  = context.checkpoint();
+
+        result.onComplete(ar -> {
+            assertThat(ar.failed(), is(true));
+            Throwable e = ar.cause();
+            context.verify(() -> {
+                assertThat(e.getMessage(), is(EXPECTED_MESSAGE));
+                callableFailed.flag();
+            });
+            try {
+                throw new RuntimeException(e);
+            } finally {
+                // Enables the subsequent lock retrieval to verify it has been unlocked.
+                failHandlerCalled.complete();
+            }
+        });
+
+        failHandlerCalled.future()
+            .compose(nothing ->
+                vertx.sharedData().getLockWithTimeout(lockName, 10000L))
+            .onComplete(context.succeeding(lock -> context.verify(() -> {
+                assertThat(lock, instanceOf(Lock.class));
+                lock.release();
+                lockObtained.flag();
+            })));
+
+        handlersRegistered.complete();
+    }
+
+    private static class DefaultOperator<
+            T extends CustomResource<P, S>,
+            P extends Spec,
+            S extends Status,
+            O extends AbstractWatchableStatusedResourceOperator<?, T, ?, ?>>
+                extends AbstractOperator<T, P, S, O> {
+
+        public DefaultOperator(Vertx vertx, String kind, O resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
+            super(vertx, kind, resourceOperator, metrics, selectorLabels);
+        }
+
+        @Override
+        protected Future<S> createOrUpdate(Reconciliation reconciliation, T resource) {
+            return null;
+        }
+
+        @Override
+        protected Future<Boolean> delete(Reconciliation reconciliation) {
+            return null;
+        }
+
+        @Override
+        protected S createStatus() {
+            return null;
+        }
+
+        public String getLockName(Reconciliation reconciliation) {
+            return getLockName(reconciliation.namespace(), reconciliation.name());
+        }
+
+        public <C> Future<C> withLockTest(Reconciliation reconciliation, Callable<Future<C>> callable) {
+            return withLock(reconciliation, LOCK_TIMEOUT_MS, callable);
+        }
+    }
+
+    private static class DefaultWatchableStatusedResourceOperator<
+            C extends KubernetesClient,
+            T extends HasMetadata,
+            L extends KubernetesResourceList<T>,
+            R extends Resource<T>>
+                extends AbstractWatchableStatusedResourceOperator<C, T, L, R> {
+
+        public DefaultWatchableStatusedResourceOperator(Vertx vertx, C client, String resourceKind) {
+            super(vertx, client, resourceKind);
+        }
+
+        @Override
+        public Future<T> updateStatusAsync(Reconciliation reconciliation, T resource) {
+            return null;
+        }
+
+        @Override
+        protected MixedOperation<T, L, R> operation() {
+            return null;
+        }
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
@@ -59,8 +59,8 @@ class AbstractOperatorTest {
 
     @Test
     /**
-     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
-     * with `eventually` after a normal/successful execution of the `Callable`
+     * Verifies that the lock is released by a call to `releaseLockAndTimer`. 
+     * The call is made through a chain of futures ending with `eventually` after a normal/successful execution of the `Callable`
      */
     void testWithLockCallableSuccessfulReleasesLock(VertxTestContext context) throws Exception {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
@@ -92,8 +92,8 @@ class AbstractOperatorTest {
 
     @Test
     /**
-     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
-     * with `eventually` after a failed execution via a handled exception in the `Callable`
+     * Verifies that the lock is released by a call to `releaseLockAndTimer`. 
+     * The call is made through a chain of futures ending with `eventually` after a failed execution via a handled exception in the `Callable`.
      */
     void testWithLockCallableHandledExceptionReleasesLock(VertxTestContext context) throws Exception {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
@@ -127,8 +127,8 @@ class AbstractOperatorTest {
 
     @Test
     /**
-     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
-     * with `eventually` after a failed execution via an unhandled exception in the `Callable`
+     * Verifies that the lock is released by a call to `releaseLockAndTimer`.
+     * The call is made through a chain of futures ending with `eventually` after a failed execution via an unhandled exception in the `Callable`.
      */
     void testWithLockCallableUnhandledExceptionReleasesLock(VertxTestContext context) throws Exception {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
@@ -164,9 +164,9 @@ class AbstractOperatorTest {
 
     @Test
     /**
-     * Verifies that lock is released by call to `releaseLockAndTimer` via chain of futures ending
-     * with `eventually` after a failed execution via an unhandled exception in the `Callable` followed
-     * by an unhandled exception occurring in the onFailure handler.
+     * Verifies that lock is released by call to `releaseLockAndTimer`. 
+     * The call is made through a chain of futures ending with `eventually` after a failed execution via an unhandled exception in the `Callable`, 
+     * followed by an unhandled exception occurring in the `onFailure` handler.
      */
     void testWithLockFailHandlerUnhandledExceptionReleasesLock(VertxTestContext context) throws Exception {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");

--- a/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
@@ -10,8 +10,6 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.model.annotation.Group;
-import io.fabric8.kubernetes.model.annotation.Version;
 import io.strimzi.api.kafka.model.Spec;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.common.model.Labels;
@@ -39,8 +37,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(VertxExtension.class)
-@Group("strimzi")
-@Version("v1")
 class AbstractOperatorTest {
     private static Vertx vertx;
     private static final String EXPECTED_MESSAGE = "Exception is expected";

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -7,12 +7,14 @@ package io.strimzi.operator.common;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.search.RequiredSearch;
 import io.strimzi.api.kafka.model.Spec;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.Status;
@@ -35,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -296,6 +299,61 @@ public class OperatorMetricsTest {
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").meter().getId().getTags().get(2), is(selectorTag));
                     assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "TestResource").counter().count(), is(1.0));
+                    async.flag();
+                })));
+    }
+
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void testFailingReconcileWithClientExceptionNotBlocked(VertxTestContext context)  {
+        MetricsProvider metrics = createCleanMetricsProvider();
+
+        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithKubernetesClientException();
+
+        AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metrics, null) {
+            @Override
+            protected Future createOrUpdate(Reconciliation reconciliation, CustomResource resource) {
+                throw new IllegalStateException("Unexpected call to createOrUpdate");
+            }
+
+            @Override
+            public Set<Condition> validate(Reconciliation reconciliation, CustomResource resource) {
+                throw new IllegalStateException("Unexpected call to validate");
+            }
+
+            @Override
+            protected Future<Boolean> delete(Reconciliation reconciliation) {
+                throw new IllegalStateException("Unexpected call to delete");
+            }
+
+            @Override
+            protected Status createStatus() {
+                throw new IllegalStateException("Unexpected call to createStatus");
+            }
+        };
+
+        Checkpoint async = context.checkpoint();
+        operator.reconcile(new Reconciliation("test", "TestResource", "my-namespace", "my-resource"))
+                .onComplete(context.failing(v -> context.verify(() -> {
+                    assertThat(v.getClass(), is(KubernetesClientException.class));
+
+                    MeterRegistry registry = metrics.meterRegistry();
+                    Tag selectorTag = Tag.of("selector", "");
+
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").meter().getId().getTags().get(2), is(selectorTag));
+                    // General counter incremented
+                    assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations").tag("kind", "TestResource").counter().count(), is(1.0));
+
+                    // Final counters not incremented before exception occurs
+                    for (String type : List.of("successful", "failed", "locked")) {
+                        RequiredSearch search = registry.get(AbstractOperator.METRICS_PREFIX + "reconciliations." + type);
+                        assertThrows(MeterNotFoundException.class, () -> search.meter());
+
+                        RequiredSearch tagSearch = search.tag("kind", "TestResource");
+                        assertThrows(MeterNotFoundException.class, () -> tagSearch.counter());
+                    }
+
                     async.flag();
                 })));
     }
@@ -660,6 +718,26 @@ public class OperatorMetricsTest {
                     }
                 }
                 return Future.succeededFuture(new Foo());
+            }
+        };
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private AbstractWatchableStatusedResourceOperator resourceOperatorWithKubernetesClientException() {
+        return new AbstractWatchableStatusedResourceOperator(vertx, null, "TestResource") {
+            @Override
+            public Future updateStatusAsync(Reconciliation reconciliation, HasMetadata resource) {
+                return null;
+            }
+
+            @Override
+            protected MixedOperation operation() {
+                return null;
+            }
+
+            @Override
+            public CustomResource get(String namespace, String name) {
+                throw new KubernetesClientException("Error");
             }
         };
     }


### PR DESCRIPTION
Fixes #5927

Signed-off-by: Michael Edgar <medgar@redhat.com>

### Type of change
- Bugfix

### Description
- Safely execute `callable.call`, `handler.success` and `handler.fail` within `withLock`. Ensure release of `lock` and `timer` are completed regardless of any exceptions thrown.
- Ensure `result.handled` is called at end of reconcile. There seems to be a potential need for changes in `handleResult` to ensure metrics are captured in situations where an exception is thrown, but I have not made those changes here.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

