### PR TITLE
[doc] Fix maven coords yaml inside the connect build documentation

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -222,10 +222,10 @@ spec:
       - name: my-plugin
         artifacts:
           - type: maven <1>
-          - repository: https://mvnrepository.com <2>
-          - group: org.apache.camel.kafkaconnector <3>
-          - artifact: camel-kafka-connector <4>
-          - version: 0.11.0 <5>
+            repository: https://mvnrepository.com <2>
+            group: org.apache.camel.kafkaconnector <3>
+            artifact: camel-kafka-connector <4>
+            version: 0.11.0 <5>
   #...
 ----
 <1> (Required) Type of artifact.


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes wrongly formatted yaml of Maven artifact type inside documentation about KafkaConnect build.

### Checklist

- [x] Update documentation

