### PR TITLE
docs: link fixes for pvc sections

### DIFF
--- a/documentation/modules/configuring/ref-storage-jbod.adoc
+++ b/documentation/modules/configuring/ref-storage-jbod.adoc
@@ -5,6 +5,7 @@
 [id='ref-jbod-storage-{context}']
 = JBOD storage overview
 
+[role="_abstract"]
 You can configure Strimzi to use JBOD, a data storage configuration of multiple disks or volumes. JBOD is one approach to providing increased data storage for Kafka brokers. It can also improve performance.
 
 A JBOD configuration is described by one or more volumes, each of which can be either xref:ref-ephemeral-storage-{context}[ephemeral] or xref:ref-persistent-storage-{context}[persistent]. The rules and constraints for JBOD volume declarations are the same as those for ephemeral and persistent storage. For example, you cannot decrease the size of a persistent storage volume after it has been provisioned, or you cannot change the value of `sizeLimit` when type=ephemeral.
@@ -34,7 +35,7 @@ The ids cannot be changed once the JBOD volumes are created.
 
 Users can add or remove volumes from the JBOD configuration.
 
-[[jbod-pvc]]
+[id='ref-jbod-storage-pvc-{context}']
 == JBOD and Persistent Volume Claims
 
 When persistent storage is used to declare JBOD volumes, the naming scheme of the resulting Persistent Volume Claims is as follows:

--- a/documentation/modules/configuring/ref-storage-persistent.adoc
+++ b/documentation/modules/configuring/ref-storage-persistent.adoc
@@ -136,7 +136,7 @@ As a result of the configured `overrides` property, the volumes use the followin
 The `overrides` property is currently used only to override storage class configurations. Overriding other storage configuration fields is not currently supported.
 Other fields from the storage configuration are currently not supported.
 
-[[pvc-naming]]
+[id='ref-persistent-storage-pvc-{context}']
 == Persistent Volume Claim naming
 
 When persistent storage is used, it creates Persistent Volume Claims with the following names:

--- a/documentation/modules/managing/proc-cluster-recovery-volume.adoc
+++ b/documentation/modules/managing/proc-cluster-recovery-volume.adoc
@@ -5,6 +5,7 @@
 [id="cluster-recovery-volume_{context}"]
 = Recovering a deleted cluster from persistent volumes
 
+[role="_abstract"]
 This procedure describes how to recover a deleted cluster from persistent volumes (PVs).
 
 In this situation, the Topic Operator identifies that topics exist in Kafka, but the `KafkaTopic` resources do not exist.
@@ -28,8 +29,8 @@ A `volumeName` is specified for the PVC and this must match the name of the PV.
 
 For more information, see:
 
-* xref:ref-persistent-storage-{context}#pvc-naming[Persistent Volume Claim naming]
-* xref:ref-jbod-storage-{context}#jbod-pvc[JBOD and Persistent Volume Claims]
+* xref:ref-persistent-storage-pvc-{context}[Persistent Volume Claim naming]
+* xref:ref-jbod-storage-pvc-{context}[JBOD and Persistent Volume Claims]
 
 NOTE: The procedure does not include recovery of `KafkaUser` resources, which must be recreated manually.
 If passwords and certificates need to be retained, secrets must be recreated before creating the `KafkaUser` resources.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Fixes a couple of broken links related to persistent volumes
The references used a file id and tag, which have been replaced with a new id

Checked to see if there were any other links in the format: none
Some links use anchors like `[[name]]`, but these are all fine

This PR fixes #5939 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

