### PR TITLE
docs: adds information on exposing the kafka connect api

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -25,5 +25,7 @@ include::../../modules/configuring/proc-config-kafka-connect-user-authorization.
 include::../../modules/configuring/proc-manual-restart-connector.adoc[leveloffset=+1]
 //Procedure to restart a Kafka connector task
 include::../../modules/configuring/proc-manual-restart-connector-task.adoc[leveloffset=+1]
+//Tips to expose the Kafka Connect API
+include::../../modules/configuring/con-exposing-kafka-connect-api.adoc[leveloffset=+1]
 //Resources created for Kafka Connect
 include::../../modules/configuring/ref-config-list-of-kafka-connect-resources.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
+++ b/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
@@ -1,0 +1,66 @@
+// This assembly is included in the following assemblies:
+//
+//assembly-config-kafka-connect.adoc
+
+[id='con-exposing-kafka-connect-api-{context}']
+
+= Exposing the Kafka Connect API
+
+[role="_abstract"]
+Use the Kafka Connect REST API as an alternative to using `KafkaConnector` resources to manage connectors.
+The Kafka Connect REST API is available as a service running on `_<connect_cluster_name>_-connect-api:8083`, where _<connect_cluster_name>_ is the name of your Kafka Connect cluster.
+The service is created when you create a Kafka Connect instance.
+
+You can add connector configuration as a JSON object.
+
+.Example curl request to add connector configuration
+[source,curl,subs=attributes+]
+----
+curl -X POST \
+  http://my-connect-cluster-connect-api:8083/connectors \
+  -H 'Content-Type: application/json' \
+  -d '{ "name": "my-source-connector",
+    "config": [
+    {
+      "class":"org.apache.kafka.connect.file.FileStreamSourceConnector",
+      "file": "/opt/kafka/LICENSE",
+      "topic":"my-topic",
+      "tasksMax": "4",
+      # ...
+    }
+  ]
+}'
+----
+
+The API is only accessible within the cluster.
+If you want to make the Kafka Connect API accessible to applications running outside of the Kubernetes cluster, you can expose it manually by using one of the following features:
+
+* Services of types KafkaConnect or KafkaConnector
+
+* Ingress resources
+
+* OpenShift Routes
+
+NOTE: The connection is insecure, so allow external access advisedly.
+
+If you decide to create services, use the service labels in the `selector` of the `_<connect_cluster_name>_-connect-api` service to configure the pods to which the service will route the traffic:
+
+.Selector configuration for the service
+[source,yaml,subs=attributes+]
+----
+  # ...
+  selector:
+    strimzi.io/cluster: my-connect-cluster <1>
+    strimzi.io/kind: KafkaConnect
+    strimzi.io/name: my-connect-cluster-connect
+  #...
+----
+<1> Name of the Kafka Connect custom resource in your Kubernetes cluster.
+
+You must also create a `NetworkPolicy` that allows HTTP requests from external clients.
+
+To add connector configuration outside the cluster, use the URL of the resource that exposes the API in the curl command.
+
+.Additional resources
+
+* The operations supported by the REST API are described in the http://kafka.apache.org[Apache Kafka documentation^].

--- a/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
+++ b/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
@@ -15,7 +15,7 @@ NOTE: The `strimzi.io/use-connector-resources` annotation enables KafkaConnector
 If you applied the annotation to your `KafkaConnect` resource configuration, you need to remove it to use the Kafka Connect API.
 Otherwise, manual changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
 
-You can add connector configuration as a JSON object.
+You can add the connector configuration as a JSON object.
 
 .Example curl request to add connector configuration
 [source,curl,subs=attributes+]
@@ -89,7 +89,7 @@ spec:
 ----
 <1> The label of the pod that is allowed to connect to the API.
 
-To add connector configuration outside the cluster, use the URL of the resource that exposes the API in the curl command.
+To add the connector configuration outside the cluster, use the URL of the resource that exposes the API in the curl command.
 
 .Additional resources
 

--- a/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
+++ b/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
@@ -35,7 +35,7 @@ curl -X POST \
 }'
 ----
 
-The API is only accessible within the cluster.
+The API is only accessible within the Kubernetes cluster.
 If you want to make the Kafka Connect API accessible to applications running outside of the Kubernetes cluster, you can expose it manually by creating one of the following features:
 
 * `LoadBalancer` or `NodePort` type services
@@ -87,7 +87,7 @@ spec:
   policyTypes:
   - Ingress
 ----
-<1> The name of the pod that is allowed to connect to the API.
+<1> The label of the pod that is allowed to connect to the API.
 
 To add connector configuration outside the cluster, use the URL of the resource that exposes the API in the curl command.
 

--- a/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
+++ b/documentation/modules/configuring/con-exposing-kafka-connect-api.adoc
@@ -11,6 +11,10 @@ Use the Kafka Connect REST API as an alternative to using `KafkaConnector` resou
 The Kafka Connect REST API is available as a service running on `_<connect_cluster_name>_-connect-api:8083`, where _<connect_cluster_name>_ is the name of your Kafka Connect cluster.
 The service is created when you create a Kafka Connect instance.
 
+NOTE: The `strimzi.io/use-connector-resources` annotation enables KafkaConnectors.
+If you applied the annotation to your `KafkaConnect` resource configuration, you need to remove it to use the Kafka Connect API.
+Otherwise, manual changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
+
 You can add connector configuration as a JSON object.
 
 .Example curl request to add connector configuration
@@ -20,7 +24,7 @@ curl -X POST \
   http://my-connect-cluster-connect-api:8083/connectors \
   -H 'Content-Type: application/json' \
   -d '{ "name": "my-source-connector",
-    "config": [
+    "config":
     {
       "class":"org.apache.kafka.connect.file.FileStreamSourceConnector",
       "file": "/opt/kafka/LICENSE",
@@ -28,36 +32,62 @@ curl -X POST \
       "tasksMax": "4",
       # ...
     }
-  ]
 }'
 ----
 
 The API is only accessible within the cluster.
-If you want to make the Kafka Connect API accessible to applications running outside of the Kubernetes cluster, you can expose it manually by using one of the following features:
+If you want to make the Kafka Connect API accessible to applications running outside of the Kubernetes cluster, you can expose it manually by creating one of the following features:
 
-* Services of types KafkaConnect or KafkaConnector
+* `LoadBalancer` or `NodePort` type services
 
-* Ingress resources
+* `Ingress` resources
 
-* OpenShift Routes
+* OpenShift routes
 
 NOTE: The connection is insecure, so allow external access advisedly.
 
-If you decide to create services, use the service labels in the `selector` of the `_<connect_cluster_name>_-connect-api` service to configure the pods to which the service will route the traffic:
+If you decide to create services, use the labels from the `selector` of the `_<connect_cluster_name>_-connect-api` service to configure the pods to which the service will route the traffic:
 
 .Selector configuration for the service
 [source,yaml,subs=attributes+]
 ----
-  # ...
-  selector:
-    strimzi.io/cluster: my-connect-cluster <1>
-    strimzi.io/kind: KafkaConnect
-    strimzi.io/name: my-connect-cluster-connect
-  #...
+# ...
+selector:
+  strimzi.io/cluster: my-connect-cluster <1>
+  strimzi.io/kind: KafkaConnect
+  strimzi.io/name: my-connect-cluster-connect <2>
+#...
 ----
 <1> Name of the Kafka Connect custom resource in your Kubernetes cluster.
+<2> Name of the Kafka Connect deployment created by the Cluster Operator.
 
 You must also create a `NetworkPolicy` that allows HTTP requests from external clients.
+
+.NetworkPolicy to allow requests to the Kafka Connect API
+[source,yaml,subs=attributes+]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: my-custom-connect-network-policy
+spec:
+  ingress:
+  - from:
+    - podSelector: <1>
+        matchLabels:
+          app: my-connector-manager
+    ports:
+    - port: 8083
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: my-connect-cluster
+      strimzi.io/kind: KafkaConnect
+      strimzi.io/name: my-connect-cluster-connect
+  policyTypes:
+  - Ingress
+----
+<1> The name of the pod that is allowed to connect to the API.
 
 To add connector configuration outside the cluster, use the URL of the resource that exposes the API in the curl command.
 

--- a/documentation/modules/kafka-bridge/con-accessing-kafka-bridge-from-outside.adoc
+++ b/documentation/modules/kafka-bridge/con-accessing-kafka-bridge-from-outside.adoc
@@ -6,17 +6,18 @@
 
 = Accessing the Kafka Bridge outside of Kubernetes
 
-After deployment, the Strimzi Kafka Bridge can only be accessed by applications running in the same Kubernetes cluster. These applications use the `_kafka-bridge-name_-bridge-service` Service to access the API.
+After deployment, the Strimzi Kafka Bridge can only be accessed by applications running in the same Kubernetes cluster.
+These applications use the `_<kafka_bridge_name>_-bridge-service` service to access the API.
 
-If you want to make the Kafka Bridge accessible to applications running outside of the Kubernetes cluster, you can expose it manually by using one of the following features:
+If you want to make the Kafka Bridge accessible to applications running outside of the Kubernetes cluster, you can expose it manually by creating one of the following features:
 
-* Services of types LoadBalancer or NodePort
+* `LoadBalancer` or `NodePort` type services
 
-* Ingress resources
+* `Ingress` resources
 
-* OpenShift Routes
+* OpenShift routes
 
-If you decide to create Services, use the following labels in the `selector` to configure the pods to which the service will route the traffic:
+If you decide to create Services, use the labels from the `selector` of the `_<kafka_bridge_name>_-bridge-service` service to configure the pods to which the service will route the traffic:
 
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -225,7 +225,7 @@ curl -X POST \
   http://my-connect-cluster-connect-api:8083/connectors \
   -H 'Content-Type: application/json' \
   -d '{ "name": "my-source-connector",
-    "config": [
+    "config":
     {
       "class":"org.apache.kafka.connect.file.FileStreamSourceConnector",
       "file": "/opt/kafka/LICENSE",
@@ -233,7 +233,6 @@ curl -X POST \
       "tasksMax": "4",
       # ...
     }
-  ]
 }'
 ----
 

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -214,7 +214,7 @@ NOTE: You can link:{BookURLUsing}#proc-loading-config-with-provider-str[load con
 == Kafka Connect API
 
 Use the Kafka Connect REST API as an alternative to using `KafkaConnector` resources to manage connectors.
-The Kafka Connect REST API is available as a service running on `_<connect-cluster-name>_-connect-api:8083`, where _<connect-cluster-name>_ is the name of your Kafka Connect cluster.
+The Kafka Connect REST API is available as a service running on `_<connect_cluster_name>_-connect-api:8083`, where _<connect_cluster_name>_ is the name of your Kafka Connect cluster.
 
 You add the connector configuration as a JSON object.
 
@@ -225,7 +225,7 @@ curl -X POST \
   http://my-connect-cluster-connect-api:8083/connectors \
   -H 'Content-Type: application/json' \
   -d '{ "name": "my-source-connector",
-    "config":
+    "config": [
     {
       "class":"org.apache.kafka.connect.file.FileStreamSourceConnector",
       "file": "/opt/kafka/LICENSE",
@@ -233,6 +233,7 @@ curl -X POST \
       "tasksMax": "4",
       # ...
     }
+  ]
 }'
 ----
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds a new section to the _Using Strimzi_ guide.
The section describes how to use the Kafka Connect API to add connector configuration and how the API can be exposed outside the cluster.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

