### PR TITLE
Reduce the fanout of the parametrized `KafkaAssemblyOperator` tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -146,6 +146,8 @@ public class KafkaAssemblyOperatorMockTest {
 
     public static Iterable<KafkaAssemblyOperatorMockTest.Params> data() {
         int[] replicas = {1, 3};
+
+        int[] storageOptions = {0, 1, 2};
         Storage[] kafkaStorageConfigs = {
             new EphemeralStorage(),
             new PersistentClaimStorageBuilder()
@@ -172,6 +174,7 @@ public class KafkaAssemblyOperatorMockTest {
                     .withDeleteClaim(false)
                     .build()
         };
+
         ResourceRequirements[] resources = {
             new ResourceRequirementsBuilder()
                 .addToLimits("cpu", new Quantity("5000m"))
@@ -180,18 +183,15 @@ public class KafkaAssemblyOperatorMockTest {
                 .addToRequests("memory", new Quantity("5000m"))
                 .build()
         };
+
         List<KafkaAssemblyOperatorMockTest.Params> result = new ArrayList();
 
-        for (int zkReplica : replicas) {
-            for (SingleVolumeStorage zkStorage : zkStorageConfigs) {
-                for (int kafkaReplica : replicas) {
-                    for (Storage kafkaStorage : kafkaStorageConfigs) {
-                        for (ResourceRequirements resource : resources) {
-                            result.add(new KafkaAssemblyOperatorMockTest.Params(
-                                    zkReplica, zkStorage,
-                                    kafkaReplica, kafkaStorage, resource));
-                        }
-                    }
+        for (int replicaCount : replicas) {
+            for (int storage : storageOptions) {
+                for (ResourceRequirements resource : resources) {
+                    result.add(new KafkaAssemblyOperatorMockTest.Params(
+                            replicaCount, zkStorageConfigs[storage],
+                            replicaCount, kafkaStorageConfigs[storage], resource));
                 }
             }
         }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We have two classes which use parametrized tests to test the `KafkaAsssemblyOperator` class:
* `KafkaAssemblyOperatorTest` runs over 4 minutes and executes over 4600 tests
* ` KafkaAssemblyOperatorMockTest` runs around 462 tests and takes over 9 minutes

The parameters in these tests often combine options which in my opinion do not really improve the coverage because they do not combine any relevant areas of the `KafkaAssemblyOperator` class. Here are some examples:
* Different combinations of storage used in ZooKeeper and Kafka cluster do not seem to affect each other. Plus combinations such as ephemeral ZooKeeper storage with persistent Kafka storage do not seem to follow the best practice. => I don't think we really need to test all the different storage combinations, so these parameters do not need to mix.
* Different combinations of Kafka and ZooKeeper configuration are independent. It should not really matter to Kafka whether ZooKeeper `config` section is null, empty map or has some values. And the same the other way around. => I don't think we need to re-combine these options.
* It should not really matter to Kafka (from the Kubernetes resources perspective) whether ZooKeeper has 1 or 3 nodes. And the other way around. => I don't think we need to re-combine these options.
* The same applies to some of the other options => Kafka Exporter, Entity Operator or Route-type listener do not affect each other. => So I do not think we need to recombine them.

_(Keep in mind that these tests are mock tests testing the Kubernetes resources management. Some of the above examples might seem significant for actual Kafka or ZooKeeper cluster. But these tests do not run actual Kafka and ZooKeeper clusters. They just mock the Kube APIs and test the resulting resources.)_

This PR rearranges how the different parameters are combined in these two test classes. After my PR, these tests are much faster:
* `KafkaAssemblyOperatorTest` runs over around 20 seconds and executes 192 tests
* ` KafkaAssemblyOperatorMockTest` runs around 77 tests and takes over 1 and half minutes

I believe it keeps most of the value and doesn't significantly affect the real test coverage which saving more than 10 minutes when running the unit tests.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass