### PR TITLE
shellcheck 0.8.0 - disable Expansions inside of ${...} 

### DIFF
--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -8,6 +8,7 @@ set -e
 function get_option_for_broker {
   for OPTION in $3 ; do
     if [[ $OPTION == "$1_$2"://* ]] ; then
+      # shellcheck disable=SC2295
       echo "${OPTION#$1_$2://}"
       break
     fi


### PR DESCRIPTION
### Type of change

- Bugfix

Build fails with:
```
./.azure/scripts/shellcheck.sh

In docker-images/kafka/scripts/kafka_config_generator.sh line 11:
      echo "${OPTION#$1_$2://}"
                     ^-- SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.
                        ^-- SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean: 
      echo "${OPTION#"$1"_"$2"://}"

For more information:
 https://www.shellcheck.net/wiki/SC2295 -- Expansions inside ${..} need to b...
make: *** [Makefile:135: shellcheck] Error 1
Build step 'Execute shell' marked build as failure
```

### Description

shellcheck version 0.8.0 has changed the checks for "Expansions inside ${..} need to be quoted separately, otherwise they match as patterns."

disabling that check for the one line
   echo "${OPTION#$1_$2://}"

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards