### PR TITLE
docs: add drain cleaner image (0.26 branch)

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -288,7 +288,7 @@ If the `image` name is not defined in the Cluster Operator configuration, then t
 . Container image specified in the `STRIMZI_DEFAULT_JMXTRANS_IMAGE` environment variable from the Cluster Operator configuration.
 . `{DockerJmxtrans}` container image.
 
-.Example of container image configuration
+.Example container image configuration
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -123,6 +123,7 @@
 :DockerOrg: quay.io/strimzi
 :DockerTag: {ProductVersion}
 :BridgeDockerTag: {BridgeVersion}
+:DrainCleanerDockerTag: 0.1.0
 :DockerRepository: https://quay.io/organization/strimzi[Container Registry^]
 :DockerZookeeper: quay.io/strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaImageCurrent: quay.io/strimzi/kafka:{DockerTag}-kafka-{KafkaVersionHigher}
@@ -136,6 +137,7 @@
 :DockerUserOperator: quay.io/strimzi/operator:{DockerTag}
 :DockerEntityOperatorStunnel: quay.io/strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaBridge: quay.io/strimzi/kafka-bridge:{BridgeDockerTag}
+:DockerDrainCleaner: quay.io/strimzi/drain-cleaner:{DrainCleanerDockerTag}
 :DockerImageUser: 1001
 
 // API Versions current

--- a/documentation/snip-images.sh
+++ b/documentation/snip-images.sh
@@ -55,6 +55,12 @@ a|
 a|
 Strimzi image for running the Strimzi kafka Bridge
 
+|Strimzi Drain Cleaner
+a|
+* {DockerOrg}/drain-cleaner:{DrainCleanerDockerTag}
+a|
+Strimzi image for running the Strimzi Drain Cleaner
+
 |JmxTrans
 a|
 * {DockerOrg}/jmxtrans:{DockerTag}


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds drain cleaner image details to _Pushing container images to your own registry_ section in Deploying Strimzi

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

