### PR TITLE
Fix CC CPU utilization issue

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -93,7 +93,6 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_LOCATION + "=/tmp/kafka/cluster.truststore.p12");
             writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_PASSWORD + "=${CERTS_STORE_PASSWORD}");
             writer.println(CruiseControlConfigurationParameters.METRICS_TOPIC_AUTO_CREATE + "=true");
-            writer.println(CruiseControlConfigurationParameters.METRICS_REPORTER_KUBERNETES_MODE + "=true");
             if (numPartitions != null) {
                 writer.println(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS + "=" + numPartitions);
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -93,7 +93,6 @@ public class KafkaBrokerConfigurationBuilderTest {
                 CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_LOCATION + "=/tmp/kafka/cluster.truststore.p12\n" +
                 CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_PASSWORD + "=${CERTS_STORE_PASSWORD}\n" +
                 CruiseControlConfigurationParameters.METRICS_TOPIC_AUTO_CREATE + "=true\n" +
-                CruiseControlConfigurationParameters.METRICS_REPORTER_KUBERNETES_MODE + "=true\n" +
                 CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS + "=1\n" +
                 CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR + "=1\n" +
                 CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=1"));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Addresses rebalance issue raised in https://github.com/strimzi/strimzi-kafka-operator/issues/5951

Cruise Control relies on opendk's `getProcessCpuLoad()` method [1] for calculating broker CPU utilization. Prior to the`openjdk 11.0.13 2021-10-19 LTS` release, `getProcessCpuLoad()` was calculated with respect to the CPU resources available to the physical node it was run on. However, now `getProcessCpuLoad()` is calculated with respect to the CPU resources available to the operating environment it is run on (whether it be a physical node or container)

Before `getProcessCpuLoad()` was patched to be made "container aware" [2] Cruise Control needed a wrapper method [3] around  `getProcessCpuLoad()` to convert the node specific CPU utilization values to container specific CPU utilization values. This wrapper method is used when the Cruise Control Metric Reporters are configured with `cruise.control.metrics.reporter.kubernetes.mode` set to `true`.

Now that Strimzi uses a  openjdk version with the patched `getProcessCpuLoad()` method, `openjdk 11.0.13 2021-10-19 LTS`, we must disable Cruise Control's  wrapper method by setting `cruise.control.metrics.reporter.kubernetes.mode` to `false` or rely on Cruise Control's default configuration. Otherwise, the CPU utilization values reported by `getProcessCpuLoad()` will be incorrectly altered by the Cruise Control wrapper method [3] causing the broker CPU utilization to be grossly overestimated and prevent rebalances.

[1] https://github.com/linkedin/cruise-control/blob/4e5927b48bf2581ab76acbbecbf42b355b871b65/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java#L406
[2] https://bugs.openjdk.java.net/browse/JDK-8269851
[3] https://github.com/linkedin/cruise-control/blob/4e5927b48bf2581ab76acbbecbf42b355b871b65/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/ContainerMetricUtils.java#L90-L108

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards