### PR TITLE
Fixed date command to rename CA cert with date/time

### DIFF
--- a/documentation/modules/security/proc-renewing-your-own-ca-certificates.adoc
+++ b/documentation/modules/security/proc-renewing-your-own-ca-certificates.adoc
@@ -53,7 +53,7 @@ where _DATE_ is the certificate expiry date in the format _YEAR-MONTH-DAYTHOUR-M
 For example `ca-2018-09-27T17-32-00Z.crt`.
 +
 [source,shell,subs="+quotes"]
-mv ca.crt ca-$(date -u -d$(openssl x509 -enddate -noout -in ca.crt | sed 's/.*=//') +'%Y-%m-%dT%H-%M-%SZ').crt
+mv ca.crt ca-$(date -u -d"$(openssl x509 -enddate -noout -in ca.crt | sed 's/.*=//')" +'%Y-%m-%dT%H-%M-%SZ').crt
 
 . Copy your new CA certificate into the directory, naming it `ca.crt`:
 +


### PR DESCRIPTION
While running the procedure to renew my own CA cert, the command to rename the old certificate with expiration date/time failed with this error:

```shell
date: extra operand ‘15:38:23’
```

It seems that the output produced by the openssl command is something like this:

```shell
Thu  2 Dec 15:38:23 UTC 2021
```

and the subsequent date command consider that time as an extra operand so the need for double quotes.

This PR should addresses the problem.
Running this on Fedora 33.