### PR TITLE
chore: bump topic-operator resource requests/limits

### DIFF
--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -55,10 +55,10 @@ spec:
             periodSeconds: 30
           resources:
             limits:
-              memory: 96Mi
-              cpu: 100m
+              memory: 512Mi
+              cpu: 500m
             requests:
-              memory: 96Mi
+              memory: 256Mi
               cpu: 100m
   strategy:
     type: Recreate


### PR DESCRIPTION
### Type of change

Bugfix

### Description

The standalone topic-operator chokes when it starts up with a fairly obscure error. 

```
2021-12-02 22:14:51 INFO  KafkaStreamsTopicStoreService:52 - Starting ...
2021-12-02 22:14:52 WARN  BlockedThreadChecker: - Thread Thread[vert.x-eventloop-thread-0,5,main] has been blocked for 2299 ms, time limit is 2000 ms
2021-12-02 22:14:53 WARN  BlockedThreadChecker: - Thread Thread[vert.x-eventloop-thread-0,5,main] has been blocked for 3299 ms, time limit is 2000 ms
2021-12-02 22:14:54 WARN  BlockedThreadChecker: - Thread Thread[vert.x-eventloop-thread-0,5,main] has been blocked for 4299 ms, time limit is 2000 ms
```

This issue brought to light that the resource limits might be too tight, and it was correct.
https://github.com/strimzi/strimzi-kafka-operator/issues/1050

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

