### PR TITLE
Get rid of source errors docung docs builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 
 include ./Makefile.os
 
+SHELL = /usr/bin/env bash
 GITHUB_VERSION ?= main
 OAUTH_VERSION = $(shell source ./tools/strimzi-oauth-version.sh && get_strimzi_oauth_version)
 RELEASE_VERSION ?= latest

--- a/documentation/snip-images.sh
+++ b/documentation/snip-images.sh
@@ -5,7 +5,7 @@ source $(dirname $(realpath $0))/../tools/kafka-versions-tools.sh
 # Generates documentation/book/snip-images.adoc
 # according to the values in kafka-versions
 
-. $(dirname $0)/../tools/multi-platform-support.sh
+source $(dirname $(realpath $0))/../tools/multi-platform-support.sh
 
 # Parse the Kafka versions file and get a list of version strings in an array
 # called "versions"

--- a/documentation/snip-kafka-versions.sh
+++ b/documentation/snip-kafka-versions.sh
@@ -5,7 +5,7 @@ source $(dirname $(realpath $0))/../tools/kafka-versions-tools.sh
 # Generates documentation/book/ref-kafka-versions.adoc
 # according to the values in kafka-versions
 
-. $(dirname $0)/../tools/multi-platform-support.sh
+source $(dirname $(realpath $0))/../tools/multi-platform-support.sh
 
 # Parse the Kafka versions file and get a list of version strings in an array
 # called "versions" and likewise for protocols, formats and zookeeper versions

--- a/documentation/version-dependent-attrs.sh
+++ b/documentation/version-dependent-attrs.sh
@@ -5,7 +5,7 @@ source $(dirname $(realpath $0))/../tools/kafka-versions-tools.sh
 # Generates documentation/book/shared/version-dependent-attrs.adoc
 # according to the values in kafka-versions
 
-. $(dirname $0)/../tools/multi-platform-support.sh
+source $(dirname $(realpath $0))/../tools/multi-platform-support.sh
 
 get_default_kafka_version
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the build pipelines, during the docs build, we are regularly seeing errors like this:
```
/bin/sh: 1: source: not found
/bin/sh: 1: source: not found
/bin/sh: 1: source: not found
/bin/sh: 1: source: not found
/bin/sh: 1: source: not found
```

This is caused by the shell call in the `Makefile `which is used to get the used OAuth release version:
```
OAUTH_VERSION = $(shell source ./tools/strimzi-oauth-version.sh && get_strimzi_oauth_version)
```

It seems that on Azure this executes on `/bin/sh` which does not support `source` command and causes the error. The `SHELL` definition in the `Makefile` makes sure it will be executed in `bash` and gets rid of the error.

This PR also changes how sourcing is done in the documentation tooling scrips -> it now uses the `source` command as all our other shell scripts instead and uses the same mechanism to determine the directory. This is changed in the PR to do the same as the other `source`  command used few lines above in the same script. It looked a bit weird to use two different ways in the same scripts. (I originally suspected this to be the issue causing the error somehow, but it wasn't -> if desired, it can be removed from the PR)