### PR TITLE
Run Strimzi tests on Ubuntu 20.04

### DIFF
--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -12,7 +12,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: Ubuntu-18.04
+      vmImage: Ubuntu-20.04
     # Pipeline steps
     steps:
       # Get cached files

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -19,8 +19,8 @@ public class ConnectCluster {
 
     private int numNodes;
     private String brokerList;
-    private List<Connect> connectInstances = new ArrayList<>();
-    private List<String> pluginPath = new ArrayList<>();
+    private final List<Connect> connectInstances = new ArrayList<>();
+    private final List<String> pluginPath = new ArrayList<>();
 
     ConnectCluster addConnectNodes(int numNodes) {
         this.numNodes = numNodes;
@@ -35,7 +35,7 @@ public class ConnectCluster {
     public void startup() throws InterruptedException {
         for (int i = 0; i < numNodes; i++) {
             Map<String, String> workerProps = new HashMap<>();
-            workerProps.put("listeners", "http://localhost:" + (STARTING_PORT + i));
+            workerProps.put("listeners", "http://localhost:" + getPort(i));
             workerProps.put("plugin.path", String.join(",", pluginPath));
             workerProps.put("group.id", toString());
             workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
@@ -75,7 +75,14 @@ public class ConnectCluster {
         }
     }
 
-    public int getPort() {
-        return STARTING_PORT;
+    /**
+     * Gets the port used for given Connect node. The nudes start from 0.
+     *
+     * @param node  ID of the node for which we want to get the port number (node numbers start with 0)
+     *
+     * @return      Port which can be used to connect to given Connect node
+     */
+    public int getPort(int node) {
+        return STARTING_PORT + node * 10_000;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -154,7 +154,7 @@ public class KafkaConnectorIT {
                         null, null, connectCrdOperator, null, null, null, null, null, null, metrics, null, null),
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),
             connect -> new KafkaConnectApiImpl(vertx),
-            connectCluster.getPort() + 2
+            connectCluster.getPort(2)
         ) { };
 
         Checkpoint async = context.checkpoint();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, most of the build pipeline runs on Ubuntu 20.04. Only the unit and integration tests run on Ubuntu 18.04 because `KafkaConnectorIT` fails on 20.04. The problem is that the second and third Kafka Connect server seems to fail to start:

```
2021-12-07 15:54:33 INFO  AppInfoParser:119 - Kafka version: 3.0.0
2021-12-07 15:54:33 INFO  AppInfoParser:120 - Kafka commitId: 8cb0a5e9d3441962
2021-12-07 15:54:33 INFO  AppInfoParser:121 - Kafka startTimeMs: 1638892473896
2021-12-07 15:54:33 INFO  ConnectUtils:65 - Kafka cluster ID: c3HNKYzfSe6u4pEXg8JOiQ
2021-12-07 15:54:33 INFO  AppInfoParser:83 - App info kafka.admin.client for adminclient-9 unregistered
2021-12-07 15:54:33 INFO  Metrics:659 - Metrics scheduler closed
2021-12-07 15:54:33 INFO  Metrics:663 - Closing reporter org.apache.kafka.common.metrics.JmxReporter
2021-12-07 15:54:33 INFO  Metrics:669 - Metrics reporters closed
2021-12-07 15:54:33 INFO  RestServer:117 - Added connector for http://localhost:8084
2021-12-07 15:54:33 INFO  RestServer:188 - Initializing REST server
2021-12-07 15:54:33 INFO  Server:375 - jetty-9.4.43.v20210629; built: 2021-06-30T11:07:22.254Z; git: 526006ecfa3af7f1a27ef3a288e2bef7ea9dd7e8; jvm 11.0.11+9-Ubuntu-0ubuntu2.20.04
```

The above is where it gets stuck forever (well, until Azure kills the job). Instead, it should normally continue with something like this:

```
2021-12-07T15:54:23.6601011Z 2021-12-07 15:54:23 INFO  AppInfoParser:119 - Kafka version: 3.0.0
2021-12-07T15:54:23.6605144Z 2021-12-07 15:54:23 INFO  AppInfoParser:120 - Kafka commitId: 8cb0a5e9d3441962
2021-12-07T15:54:23.6609732Z 2021-12-07 15:54:23 INFO  AppInfoParser:121 - Kafka startTimeMs: 1638892463659
2021-12-07T15:54:23.8044231Z 2021-12-07 15:54:23 INFO  ConnectUtils:65 - Kafka cluster ID: c3HNKYzfSe6u4pEXg8JOiQ
2021-12-07T15:54:23.8069767Z 2021-12-07 15:54:23 INFO  AppInfoParser:83 - App info kafka.admin.client for adminclient-1 unregistered
2021-12-07T15:54:23.8154488Z 2021-12-07 15:54:23 INFO  Metrics:659 - Metrics scheduler closed
2021-12-07T15:54:23.8155747Z 2021-12-07 15:54:23 INFO  Metrics:663 - Closing reporter org.apache.kafka.common.metrics.JmxReporter
2021-12-07T15:54:23.8156749Z 2021-12-07 15:54:23 INFO  Metrics:669 - Metrics reporters closed
2021-12-07T15:54:23.8710308Z 2021-12-07 15:54:23 INFO  log:170 - Logging initialized @2861237ms to org.eclipse.jetty.util.log.Slf4jLog
2021-12-07T15:54:24.0155841Z 2021-12-07 15:54:24 INFO  RestServer:117 - Added connector for http://localhost:8083
2021-12-07T15:54:24.0164284Z 2021-12-07 15:54:24 INFO  RestServer:188 - Initializing REST server
2021-12-07T15:54:24.0286046Z 2021-12-07 15:54:24 INFO  Server:375 - jetty-9.4.43.v20210629; built: 2021-06-30T11:07:22.254Z; git: 526006ecfa3af7f1a27ef3a288e2bef7ea9dd7e8; jvm 11.0.11+9-Ubuntu-0ubuntu2.20.04
2021-12-07T15:54:24.0794134Z 2021-12-07 15:54:24 INFO  AbstractConnector:331 - Started http_localhost8083@7c4c58ed{HTTP/1.1, (http/1.1)}{localhost:8083}
2021-12-07T15:54:24.0796644Z 2021-12-07 15:54:24 INFO  Server:415 - Started @2861459ms
```

It looks like for some reason, the port 8084 doesn't work on Ubuntu 20.04 (used by something else?). This PR changes the logic from using port 8083, 8084 d 8085 to use 8083, 18083 and 28083 which seems to work fine.

### Checklist

- [x] Make sure all tests pass