### PR TITLE
Try to fix disabled CRD tests for extra properties

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -55,7 +55,7 @@ public abstract class AbstractCrdIT implements TestSeparator {
         RuntimeException deletionException = null;
         try {
             try {
-                cmdKubeClient().create(resourceFile, false);
+                cmdKubeClient().create(resourceFile, true);
             } catch (RuntimeException t) {
                 creationException = t;
             }
@@ -116,7 +116,8 @@ public abstract class AbstractCrdIT implements TestSeparator {
             assertThat("Could not find" + requiredProperty + " in message: " + message, message, anyOf(
                     containsStringIgnoringCase(requiredProperty + " in body is required"),
                     containsStringIgnoringCase(requiredProperty + ": Required value"),
-                    containsStringIgnoringCase("missing required field \"" + requiredProperty + "\"")
+                    containsStringIgnoringCase("missing required field \"" + requiredProperty + "\""),
+                    containsStringIgnoringCase("missing required field \"" + requiredProperty.substring(requiredProperty.lastIndexOf(".") + 1) + "\"")
             ));
         }
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -108,9 +107,8 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
                 containsStringIgnoringCase("spec.tracing.type: Unsupported value: \"wrongtype\": supported values: \"jaeger\"")));
     }
 
-    @Disabled("See https://github.com/strimzi/strimzi-kafka-operator/issues/4606")
     @Test
-    void testCreateKafkaBridgeWithExtraProperty() {
+    void testKafkaBridgeWithExtraProperty() {
         Throwable exception = assertThrows(
             KubeClusterException.class,
             () -> createDeleteCustomResource("KafkaBridge-with-extra-property.yaml"));
@@ -134,9 +132,15 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() throws InterruptedException {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_BRIDGE);
         cluster.waitForCustomResourceDefinition("kafkabridges.kafka.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
+
+        try {
+            Thread.sleep(1_000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaConnectorCrdIT.java
@@ -30,9 +30,15 @@ public class KafkaConnectorCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_CONNECTOR);
         cluster.waitForCustomResourceDefinition("kafkaconnectors.kafka.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
+
+        try {
+            Thread.sleep(1_000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -8,7 +8,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -36,9 +35,8 @@ public class KafkaCrdIT extends AbstractCrdIT {
         createDeleteCustomResource("Kafka-minimal.yaml");
     }
 
-    @Disabled("See https://github.com/strimzi/strimzi-kafka-operator/issues/4606")
     @Test
-    void testCreateKafkaWithExtraProperty() {
+    void testKafkaWithExtraProperty() {
         Throwable exception = assertThrows(
             KubeClusterException.class,
             () -> createDeleteCustomResource("Kafka-with-extra-property.yaml"));
@@ -74,7 +72,10 @@ public class KafkaCrdIT extends AbstractCrdIT {
             });
 
         assertThat(exception.getMessage(),
-                containsStringIgnoringCase("invalid: spec.maintenanceTimeWindows: Invalid value: \"null\": spec.maintenanceTimeWindows in body must be of type string: \"null\""));
+                anyOf(
+                        containsStringIgnoringCase("invalid: spec.maintenanceTimeWindows: Invalid value: \"null\": spec.maintenanceTimeWindows in body must be of type string: \"null\""),
+                        containsStringIgnoringCase("unknown object type \"nil\" in Kafka.spec.maintenanceTimeWindows[0]")
+                ));
     }
 
     @Test

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerCrdIT.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,9 +34,8 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
         createDeleteCustomResource("KafkaMirrorMaker-minimal.yaml");
     }
 
-    @Disabled("See https://github.com/strimzi/strimzi-kafka-operator/issues/4606")
     @Test
-    void testCreateKafkaMirrorMakerWithExtraProperty() {
+    void testKafkaMirrorMakerWithExtraProperty() {
         Throwable exception = assertThrows(
             KubeClusterException.class,
             () -> createDeleteCustomResource("KafkaMirrorMaker-with-extra-property.yaml"));
@@ -96,9 +94,15 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_MIRROR_MAKER);
         cluster.waitForCustomResourceDefinition("kafkamirrormakers.kafka.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
+
+        try {
+            Thread.sleep(1_000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaRebalanceCrdIT.java
@@ -54,9 +54,15 @@ public class KafkaRebalanceCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_REBALANCE);
         cluster.waitForCustomResourceDefinition("kafkarebalances.kafka.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
+
+        try {
+            Thread.sleep(1_000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTopicCrdIT.java
@@ -8,7 +8,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,7 +44,6 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
         createDeleteCustomResource("KafkaTopic-minimal.yaml");
     }
 
-    @Disabled("See https://github.com/strimzi/strimzi-kafka-operator/issues/4606")
     @Test
     void testCreateKafkaTopicWithExtraProperty() {
         Throwable exception = assertThrows(
@@ -57,9 +55,15 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_TOPIC);
         cluster.waitForCustomResourceDefinition("kafkatopics.kafka.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
+
+        try {
+            Thread.sleep(1_000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -8,7 +8,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,9 +43,8 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
         createDeleteCustomResource("KafkaUser-minimal.yaml");
     }
 
-    @Disabled("See https://github.com/strimzi/strimzi-kafka-operator/issues/4606")
     @Test
-    void testCreateKafkaUserWithExtraProperty() {
+    void testKafkaUserWithExtraProperty() {
         Throwable exception = assertThrows(
             KubeClusterException.class,
             () -> createDeleteCustomResource("KafkaUser-with-extra-property.yaml"));
@@ -56,9 +54,15 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_KAFKA_USER);
         cluster.waitForCustomResourceDefinition("kafkausers.kafka.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
+
+        try {
+            Thread.sleep(1_000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @AfterAll

--- a/api/src/test/java/io/strimzi/api/kafka/model/StrimziPodSetCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/StrimziPodSetCrdIT.java
@@ -37,9 +37,9 @@ public class StrimziPodSetCrdIT extends AbstractCrdIT {
 
     @BeforeAll
     void setupEnvironment() throws InterruptedException {
-        cluster.createNamespace(NAMESPACE);
         cluster.createCustomResources(TestUtils.CRD_STRIMZI_POD_SET);
         cluster.waitForCustomResourceDefinition("strimzipodsets.core.strimzi.io");
+        cluster.createNamespace(NAMESPACE);
     }
 
     @AfterAll

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker-with-extra-property.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaMirrorMaker
 metadata:
-  name: test-kafka-mirror-maker
+  name: test-kafka-mirror-maker-with-extra-property
 spec:
   replicas: 1
   consumer:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-extra-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-extra-property.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaMirrorMaker2
 metadata:
-  name: test-kafka-mirror-maker-2
+  name: test-kafka-mirror-maker-2-with-extra-prop
 spec:
   image: foo
   replicas: 6
@@ -19,6 +19,5 @@ spec:
   - sourceCluster: source
     targetCluster: target
     sourceConnector: {}
-    topics: my-topic
   extra: true
 extra: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-invalid-replicas.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-invalid-replicas.yaml
@@ -16,5 +16,3 @@ spec:
     targetCluster: target
     sourceConnector: {}
     topicsPattern: my-topic
-  config:
-    name: bar


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#4606 disabled several integration tests for our CRDs. These tests tested the CRD validation for extra fields. This Pr re-enables them and fixes the things which changed since. Out of the box, these tests are flaky, because it seems that even through the CRD is established, the validation is not always in place. 

The fix adds 1_000 sleep to the before-all methods in the IT tests. That seems to make it stable locally as well as in Azure. It is not a nice solution. But I guess the alternative is to either give up on these tests and delete them or keep the issue opened and try again in a year or two. I would probably go with this PR, but id anyone has strong opinions, I'm fine to close this.

### Checklist

- [x] Make sure all tests pass