### PR TITLE
Add s390x support to multi-arch images on Azure CI

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -53,7 +53,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
 
   # Push Strimzi containers -> run only on main branch
   - stage: push_containers
@@ -73,7 +73,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
 
   # Publish Strimzi docs to the website -> run only on main branch
   - stage: public_docs

--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -37,7 +37,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn:
@@ -52,7 +52,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: manual_validation
     displayName: Validate container before pushing container as ${{ parameters.releaseVersion }}
     dependsOn:
@@ -87,4 +87,4 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -48,7 +48,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
@@ -63,4 +63,4 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']


### PR DESCRIPTION
Signed-off-by: Kun-Lu <kun.lu@ibm.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR is to add s390x support to Operator images on Azure CI.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

