### PR TITLE
Integrate client timeouts for `oauth` authentication and `keycloak` authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Intra-broker disk balancing using Cruise Control
 * Add connector context to the default logging configuration in Kafka Connect and Kafka Mirror Maker 2
 * Added the option `createBootstrapService` in the Kafka Spec to disable the creation of the bootstrap service for the Load Balancer Type Listener. It will save the cost of one load balancer resource, specially in the public cloud.
+* Added the `connectTimeoutSeconds` and `readTimeoutSeconds` options to OAuth authentication configuration. The default connect and read timeouts are set to 60 seconds (previously there was no timeout).
 * Add support for disabling the FIPS mode in OpenJDK
 * Fix renewing your own CA certificates [#5466](https://github.com/strimzi/strimzi-kafka-operator/issues/5466)
 * Update Strimzi Kafka Bridge to 0.21.4

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -25,7 +25,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "clientId", "tokenEndpointUri",
     "tlsTrustedCertificates", "disableTlsHostnameVerification",
-    "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize", "superUsers"})
+    "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize", "superUsers", "connectTimeoutSeconds", "readTimeoutSeconds"})
 @EqualsAndHashCode
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
@@ -41,6 +41,8 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     private boolean delegateToKafkaAcls = false;
     private Integer grantsRefreshPeriodSeconds;
     private Integer grantsRefreshPoolSize;
+    private Integer connectTimeoutSeconds;
+    private Integer readTimeoutSeconds;
     private List<String> superUsers;
 
     @Description("Must be `" + TYPE_KEYCLOAK + "`")
@@ -143,5 +145,27 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
 
     public void setSuperUsers(List<String> superUsers) {
         this.superUsers = superUsers;
+    }
+
+    @Description("The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.")
+    @Minimum(1)
+    @DefaultValue("60")
+    public Integer getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public void setConnectTimeoutSeconds(Integer connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    @Description("The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.")
+    @Minimum(1)
+    @DefaultValue("60")
+    public Integer getReadTimeoutSeconds() {
+        return readTimeoutSeconds;
+    }
+
+    public void setReadTimeoutSeconds(Integer readTimeoutSeconds) {
+        this.readTimeoutSeconds = readTimeoutSeconds;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/authentication/KafkaClientAuthenticationOAuth.java
@@ -34,6 +34,8 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
     private String scope;
     private String audience;
     private String tokenEndpointUri;
+    private Integer connectTimeoutSeconds;
+    private Integer readTimeoutSeconds;
     private GenericSecretSource clientSecret;
     private GenericSecretSource accessToken;
     private GenericSecretSource refreshToken;
@@ -89,6 +91,26 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
 
     public void setTokenEndpointUri(String tokenEndpointUri) {
         this.tokenEndpointUri = tokenEndpointUri;
+    }
+
+    @Description("The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public void setConnectTimeoutSeconds(Integer connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    @Description("The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getReadTimeoutSeconds() {
+        return readTimeoutSeconds;
+    }
+
+    public void setReadTimeoutSeconds(Integer readTimeoutSeconds) {
+        this.readTimeoutSeconds = readTimeoutSeconds;
     }
 
     @Description("Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate "

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -61,6 +61,8 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private String tokenEndpointUri;
     private boolean enableOauthBearer = true;
     private String customClaimCheck;
+    private Integer connectTimeoutSeconds;
+    private Integer readTimeoutSeconds;
     private String clientScope = null;
     private String clientAudience = null;
 
@@ -134,6 +136,26 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     public void setCustomClaimCheck(String customClaimCheck) {
         this.customClaimCheck = customClaimCheck;
+    }
+
+    @Description("The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public void setConnectTimeoutSeconds(Integer connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    @Description("The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getReadTimeoutSeconds() {
+        return readTimeoutSeconds;
+    }
+
+    public void setReadTimeoutSeconds(Integer readTimeoutSeconds) {
+        this.readTimeoutSeconds = readTimeoutSeconds;
     }
 
     @Description("The scope to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -450,6 +450,12 @@ public class KafkaBrokerConfigurationBuilder {
             addOption(options, ServerConfig.OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, "");
         }
 
+        if (oauth.getConnectTimeoutSeconds() != null && oauth.getConnectTimeoutSeconds() > 0) {
+            addOption(options, ServerConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, String.valueOf(oauth.getConnectTimeoutSeconds()));
+        }
+        if (oauth.getReadTimeoutSeconds() != null && oauth.getReadTimeoutSeconds() > 0) {
+            addOption(options, ServerConfig.OAUTH_READ_TIMEOUT_SECONDS, String.valueOf(oauth.getReadTimeoutSeconds()));
+        }
         return options;
     }
 
@@ -538,6 +544,8 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println("strimzi.authorization.delegate.to.kafka.acl=" + keycloakAuthz.isDelegateToKafkaAcls());
             addOption(writer, "strimzi.authorization.grants.refresh.period.seconds", keycloakAuthz.getGrantsRefreshPeriodSeconds());
             addOption(writer, "strimzi.authorization.grants.refresh.pool.size", keycloakAuthz.getGrantsRefreshPoolSize());
+            addOption(writer, "strimzi.authorization.connect.timeout.seconds", keycloakAuthz.getConnectTimeoutSeconds());
+            addOption(writer, "strimzi.authorization.read.timeout.seconds", keycloakAuthz.getReadTimeoutSeconds());
             writer.println("strimzi.authorization.kafka.cluster.name=" + clusterName);
 
             if (keycloakAuthz.getTlsTrustedCertificates() != null && keycloakAuthz.getTlsTrustedCertificates().size() > 0)    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -495,6 +495,14 @@ public class ListenersValidator {
                 errors.add("listener " + listenerName + ": Valid Issuer URI has to be specified or 'checkIssuer' set to 'false'");
             }
 
+            if (oAuth.getConnectTimeoutSeconds() != null && oAuth.getConnectTimeoutSeconds() <= 0) {
+                errors.add("listener " + listenerName + ": 'connectTimeoutSeconds' needs to be a positive integer (set to: " + oAuth.getConnectTimeoutSeconds() + ")");
+            }
+
+            if (oAuth.getReadTimeoutSeconds() != null && oAuth.getReadTimeoutSeconds() <= 0) {
+                errors.add("listener " + listenerName + ": 'readTimeoutSeconds' needs to be a positive integer (set to: " + oAuth.getReadTimeoutSeconds() + ")");
+            }
+
             if (oAuth.isCheckAudience() && oAuth.getClientId() == null) {
                 errors.add("listener " + listenerName + ": 'clientId' has to be configured when 'checkAudience' is 'true'");
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -973,13 +973,15 @@ public class KafkaBridgeClusterTest {
     }
 
     @ParallelTest
-    public void testGenerateDeploymentWithOAuthUsingOpaqueTokens() {
+    public void testGenerateDeploymentWithOAuthUsingOpaqueTokensAndTimeouts() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
                 .withAuthentication(
                         new KafkaClientAuthenticationOAuthBuilder()
                                 .withClientId("my-client-id")
                                 .withTokenEndpointUri("http://my-oauth-server")
+                                .withConnectTimeoutSeconds(15)
+                                .withReadTimeoutSeconds(15)
                                 .withNewClientSecret()
                                 .withSecretName("my-secret-secret")
                                 .withKey("my-secret-key")
@@ -998,7 +1000,9 @@ public class KafkaBridgeClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getName(), is("my-secret-secret"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-secret-key"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
-                is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server", ClientConfig.OAUTH_ACCESS_TOKEN_IS_JWT, "false", ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS, "600")));
+                is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server",
+                        ClientConfig.OAUTH_ACCESS_TOKEN_IS_JWT, "false", ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS, "600",
+                        ClientConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, "15", ClientConfig.OAUTH_READ_TIMEOUT_SECONDS, "15")));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -198,6 +198,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withTlsTrustedCertificates(cert)
                 .withDisableTlsHostnameVerification(true)
                 .addToSuperUsers("giada", "CN=paccu")
+                .withConnectTimeoutSeconds(30)
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
@@ -216,6 +217,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "strimzi.authorization.ssl.endpoint.identification.algorithm=\n" +
                 "strimzi.authorization.grants.refresh.period.seconds=120\n" +
                 "strimzi.authorization.grants.refresh.pool.size=10\n" +
+                "strimzi.authorization.connect.timeout.seconds=30\n" +
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:giada;User:CN=paccu"));
     }
 
@@ -230,6 +232,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withTokenEndpointUri("http://token-endpoint-uri")
                 .withClientId("my-client-id")
                 .withTlsTrustedCertificates(cert)
+                .withReadTimeoutSeconds(30)
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
@@ -246,6 +249,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "strimzi.authorization.ssl.truststore.type=PKCS12\n" +
                 "strimzi.authorization.ssl.secure.random.implementation=SHA1PRNG\n" +
                 "strimzi.authorization.ssl.endpoint.identification.algorithm=HTTPS\n" +
+                "strimzi.authorization.read.timeout.seconds=30\n" +
                 "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
@@ -1121,6 +1125,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                     .withJwksMinRefreshPauseSeconds(5)
                     .withEnablePlain(true)
                     .withTokenEndpointUri("http://token")
+                    .withConnectTimeoutSeconds(30)
+                    .withReadTimeoutSeconds(30)
                 .endKafkaListenerAuthenticationOAuth()
                 .build();
 
@@ -1151,9 +1157,9 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder",
                 "listener.name.plain-9092.oauthbearer.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
-                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\";",
+                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\";",
                 "listener.name.plain-9092.plain.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler",
-                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.token.endpoint.uri=\"http://token\";",
+                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.token.endpoint.uri=\"http://token\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=OAUTHBEARER,PLAIN",
                 "listener.name.plain-9092.connections.max.reauth.ms=3600000"));
     }
@@ -1176,6 +1182,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withTokenEndpointUri("http://token")
                 .withClientAudience("kafka")
                 .withClientScope("messaging")
+                .withConnectTimeoutSeconds(30)
                 .endKafkaListenerAuthenticationOAuth()
                 .build();
 
@@ -1206,7 +1213,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder",
                 "listener.name.plain-9092.plain.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler",
-                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.scope=\"messaging\" oauth.audience=\"kafka\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.token.endpoint.uri=\"http://token\";",
+                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.scope=\"messaging\" oauth.audience=\"kafka\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.connect.timeout.seconds=\"30\" oauth.token.endpoint.uri=\"http://token\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=PLAIN",
                 "listener.name.plain-9092.connections.max.reauth.ms=3600000"));
     }
@@ -1382,6 +1389,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withEnablePlain(true)
                 .withTokenEndpointUri("http://token")
                 .withCustomClaimCheck("@.aud && @.aud == 'something'")
+                .withConnectTimeoutSeconds(30)
+                .withReadTimeoutSeconds(60)
                 .withClientAudience("kafka")
                 .withClientScope("messaging")
                 .build();
@@ -1407,6 +1416,8 @@ public class KafkaBrokerConfigurationBuilderTest {
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_CHECK_ACCESS_TOKEN_TYPE, false));
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_VALID_TOKEN_TYPE, "access_token"));
         expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, ""));
+        expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, 30));
+        expectedOptions.add(String.format("%s=\"%s\"", ServerConfig.OAUTH_READ_TIMEOUT_SECONDS, 60));
 
         // enablePlain and tokenEndpointUri are handled separately from getOAuthOptions
         List<String> actualOptions = KafkaBrokerConfigurationBuilder.getOAuthOptions(auth);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -67,6 +67,8 @@ public class KafkaClusterOAuthValidationTest {
                         .withJwksRefreshSeconds(30)
                         .withJwksExpirySeconds(90)
                         .withJwksMinRefreshPauseSeconds(5)
+                        .withConnectTimeoutSeconds(20)
+                        .withReadTimeoutSeconds(20)
                         .withMaxSecondsWithoutReauthentication(1800)
                         .withNewClientSecret()
                             .withSecretName("my-secret-secret")
@@ -277,6 +279,42 @@ public class KafkaClusterOAuthValidationTest {
     public void testOAuthValidationNoUriSpecified() {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder().build();
+
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+        });
+    }
+
+    @ParallelTest
+    public void testOAuthValidationWithMinimumJWKS() {
+        KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
+                .withValidIssuerUri("http://valid-issuer")
+                .withJwksEndpointUri("http://jwks-endpoint")
+                .build();
+
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+    }
+
+    @ParallelTest
+    public void testOAuthValidationWithConnectTimeout() {
+        assertThrows(InvalidResourceException.class, () -> {
+            KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
+                    .withValidIssuerUri("http://valid-issuer")
+                    .withJwksEndpointUri("http://jwks-endpoint")
+                    .withConnectTimeoutSeconds(0)
+                    .build();
+
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+        });
+    }
+
+    @ParallelTest
+    public void testOAuthValidationWithReadTimeout() {
+        assertThrows(InvalidResourceException.class, () -> {
+            KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder()
+                    .withValidIssuerUri("http://valid-issuer")
+                    .withJwksEndpointUri("http://jwks-endpoint")
+                    .withReadTimeoutSeconds(0)
+                    .build();
 
             ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1395,6 +1395,8 @@ public class KafkaConnectClusterTest {
                         new KafkaClientAuthenticationOAuthBuilder()
                                 .withClientId("my-client-id")
                                 .withTokenEndpointUri("http://my-oauth-server")
+                                .withConnectTimeoutSeconds(15)
+                                .withReadTimeoutSeconds(15)
                                 .withNewRefreshToken()
                                     .withSecretName("my-token-secret")
                                     .withKey("my-token-key")
@@ -1411,7 +1413,8 @@ public class KafkaConnectClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_REFRESH_TOKEN.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getName(), is("my-token-secret"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_REFRESH_TOKEN.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-token-key"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
-                is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
+                is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server",
+                        ClientConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, "15", ClientConfig.OAUTH_READ_TIMEOUT_SECONDS, "15")));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1535,6 +1535,8 @@ public class KafkaMirrorMaker2ClusterTest {
                     new KafkaClientAuthenticationOAuthBuilder()
                             .withClientId("my-client-id")
                             .withTokenEndpointUri("http://my-oauth-server")
+                            .withConnectTimeoutSeconds(15)
+                            .withReadTimeoutSeconds(15)
                             .withNewRefreshToken()
                                 .withSecretName("my-token-secret")
                                 .withKey("my-token-key")
@@ -1556,7 +1558,8 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_REFRESH_TOKEN.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getName(), is("my-token-secret"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_REFRESH_TOKEN.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-token-key"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
-                is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
+                is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server",
+                        ClientConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, "15", ClientConfig.OAUTH_READ_TIMEOUT_SECONDS, "15")));
     }
 
     @ParallelTest

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.10.0-rc1-pre2</strimzi-oauth.version>
         <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
@@ -35,6 +35,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-pre</id>
+            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -38,7 +38,7 @@
         </repository>
         <repository>
             <id>oauth-pre</id>
-            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
+            <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.10.0-rc1-pre2</strimzi-oauth.version>
+        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
         <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
@@ -38,7 +38,7 @@
         </repository>
         <repository>
             <id>oauth-pre</id>
-            <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -36,10 +36,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>oauth-pre</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.10.0-rc1-pre2</strimzi-oauth.version>
         <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
@@ -35,6 +35,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>oauth-pre</id>
+            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -38,7 +38,7 @@
         </repository>
         <repository>
             <id>oauth-pre</id>
-            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
+            <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.10.0-rc1-pre2</strimzi-oauth.version>
+        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
         <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
@@ -38,7 +38,7 @@
         </repository>
         <repository>
             <id>oauth-pre</id>
-            <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -36,10 +36,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>oauth-pre</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -26,7 +26,7 @@
       </repository>
       <repository>
           <id>oauth-pre</id>
-          <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
+          <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
       </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -24,6 +24,10 @@
         <id>cruise-control</id>
           <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
       </repository>
+      <repository>
+          <id>oauth-pre</id>
+          <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
+      </repository>
     </repositories>
 
     <dependencies>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -24,10 +24,6 @@
         <id>cruise-control</id>
           <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
       </repository>
-      <repository>
-          <id>oauth-pre</id>
-          <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
-      </repository>
     </repositories>
 
     <dependencies>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -26,7 +26,7 @@
       </repository>
       <repository>
           <id>oauth-pre</id>
-          <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
+          <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
       </repository>
     </repositories>
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -195,6 +195,8 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |string
 |clientSecret                       1.2+<.<a|Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|connectTimeoutSeconds              1.2+<.<a|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
+|integer
 |customClaimCheck                   1.2+<.<a|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
 |string
 |disableTlsHostnameVerification     1.2+<.<a|Enable or disable TLS hostname verification. Default value is `false`.
@@ -220,6 +222,8 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |jwksRefreshSeconds                 1.2+<.<a|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
 |integer
 |maxSecondsWithoutReauthentication  1.2+<.<a|Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
+|integer
+|readTimeoutSeconds                 1.2+<.<a|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
 |integer
 |tlsTrustedCertificates             1.2+<.<a|Trusted certificates for TLS connection to the OAuth server.
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
@@ -597,6 +601,10 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |integer
 |superUsers                      1.2+<.<a|List of super users. Should contain list of user principals which should get unlimited access rights.
 |string array
+|connectTimeoutSeconds           1.2+<.<a|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
+|integer
+|readTimeoutSeconds              1.2+<.<a|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
+|integer
 |====
 
 [id='type-KafkaAuthorizationCustom-{context}']
@@ -1812,9 +1820,13 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 |string
 |clientSecret                    1.2+<.<a|Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|connectTimeoutSeconds           1.2+<.<a|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
+|integer
 |disableTlsHostnameVerification  1.2+<.<a|Enable or disable TLS hostname verification. Default value is `false`.
 |boolean
 |maxTokenExpirySeconds           1.2+<.<a|Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+|integer
+|readTimeoutSeconds              1.2+<.<a|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
 |integer
 |refreshToken                    1.2+<.<a|Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -126,6 +126,8 @@ Depending on how you apply OAuth 2.0 authentication, and the type of authorizati
     customClaimCheck: "@.custom == 'custom-value'" <10>
     clientAudience: __AUDIENCE__ <11>
     clientScope: __SCOPE__ <12>
+    connectTimeoutSeconds: 60 <13>
+    readTimeoutSeconds: 60 <14>
 ----
 <1> If your authorization server does not provide an `iss` claim, it is not possible to perform an issuer check. In this situation, set `checkIssuer` to `false` and do not specify a `validIssuerUri`. Default is `true`.
 <2> If your authorization server provides an `aud` (audience) claim, and you want to enforce an audience check, set `checkAudience` to `true`. Audience checks identify the intended recipients of tokens. As a result, the Kafka broker will reject tokens that do not have its `clientId` in their `aud` claim. Default is `false`.
@@ -139,6 +141,8 @@ Depending on how you apply OAuth 2.0 authentication, and the type of authorizati
 <10> Additional custom rules can be imposed on the JWT access token during validation by setting this to a JsonPath filter query. If the access token does not contain the necessary data, it is rejected. When using the `introspectionEndpointUri`, the custom check is applied to the introspection endpoint response JSON.
 <11> (Optional) An `audience` parameter passed to the token endpoint. An _audience_ is used  when obtaining an access token for inter-broker authentication. It is also used in the name of a client for OAuth 2.0 over PLAIN client authentication using a `clientId` and `secret`. This only affects the ability to obtain the token, and the content of the token, depending on the authorization server. It does not affect token validation rules by the listener.
 <12> (Optional) A `scope` parameter passed to the token endpoint. A _scope_ is used when obtaining an access token for inter-broker authentication. It is also used in the name of a client for OAuth 2.0 over PLAIN client authentication using a `clientId` and `secret`. This only affects the ability to obtain the token, and the content of the token, depending on the authorization server. It does not affect token validation rules by the listener.
+<13> (Optional) The connect timeout in seconds when connecting to the authorization server. The default value is 60.
+<14> (Optional) The read timeout in seconds when connecting to the authorization server. The default value is 60.
 
 . Save and exit the editor, then wait for rolling updates to complete.
 

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -65,6 +65,8 @@ spec:
         certificate: ca.crt
       grantsRefreshPeriodSeconds: 60 <8>
       grantsRefreshPoolSize: 5 <9>
+      connectTimeoutSeconds: 60 <10>
+      readTimeoutSeconds: 60 <11>
     #...
 ----
 <1> Type `keycloak` enables Keycloak authorization.
@@ -79,7 +81,8 @@ Default is `false`.
 <7> (Optional) Trusted certificates for TLS connection to the authorization server.
 <8> (Optional) The time between two consecutive grants refresh runs. That is the maximum time for active sessions to detect any permissions changes for the user on Keycloak. The default value is 60.
 <9> (Optional) The number of threads to use to refresh (in parallel) the grants for the active sessions. The default value is 5.
-
+<10> (Optional) The connect timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
+<11> (Optional) The read timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
 . Save and exit the editor, then wait for rolling updates to complete.
 
 . Check the update in the logs or by watching the pod state transitions:

--- a/documentation/modules/oauth/proc-oauth-kafka-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-kafka-config.adoc
@@ -97,6 +97,8 @@ spec:
     accessTokenIsJwt: false <3>
     scope: any <4>
     audience: kafka <5>
+    connectTimeoutSeconds: 60 <6>
+    readTimeoutSeconds: 60 <7>
 ----
 <1> (Optional) Disable TLS hostname verification. Default is `false`.
 <2> If the authorization server does not return a `typ` (type) claim inside the JWT token, you can apply `checkAccessTokenType: false` to skip the token type check. Default is `true`.
@@ -107,6 +109,8 @@ In this case it is `any`.
 <5> (Optional) The `audience` for requesting the token from the token endpoint.
 An authorization server may require a client to specify the audience.
 In this case it is `kafka`.
+<6> (Optional) The connect timeout in seconds when connecting to the authorization server. The default value is 60.
+<7> (Optional) The read timeout in seconds when connecting to the authorization server. The default value is 60.
 
 . Apply the changes to the deployment of your Kafka resource.
 +

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -52,7 +52,7 @@
 :keycloak-server-install-doc: link:https://www.keycloak.org/docs/latest/server_installation/index.html#_operator[Installing the Keycloak Operator^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]
-:OAuthVersion: 0.9.0
+:OAuthVersion: 0.10.0
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples[Using Keycloak as the OAuth 2.0 authorization server^]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples/docker#running-with-hydra-using-ssl-and-opaque-tokens[Using Hydra as the OAuth 2.0 authorization server^]
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -126,6 +126,9 @@ spec:
                                   - key
                                   - secretName
                                 description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+                              connectTimeoutSeconds:
+                                type: integer
+                                description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                               customClaimCheck:
                                 type: string
                                 description: JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
@@ -172,6 +175,9 @@ spec:
                               maxSecondsWithoutReauthentication:
                                 type: integer
                                 description: Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
+                              readTimeoutSeconds:
+                                type: integer
+                                description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                               sasl:
                                 type: boolean
                                 description: Enable or disable SASL on this listener.
@@ -544,6 +550,10 @@ spec:
                         clientId:
                           type: string
                           description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                        connectTimeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                         delegateToKafkaAcls:
                           type: boolean
                           description: Whether authorization decision should be delegated to the 'Simple' authorizer if DENIED by Keycloak Authorization Services policies. Default value is `false`.
@@ -570,6 +580,10 @@ spec:
                         maximumCacheSize:
                           type: integer
                           description: Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
+                        readTimeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                         superUsers:
                           type: array
                           items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -132,6 +132,9 @@ spec:
                         - key
                         - secretName
                       description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                    connectTimeoutSeconds:
+                      type: integer
+                      description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                     disableTlsHostnameVerification:
                       type: boolean
                       description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -151,6 +154,9 @@ spec:
                         - password
                         - secretName
                       description: Reference to the `Secret` which holds the password.
+                    readTimeoutSeconds:
+                      type: integer
+                      description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                     refreshToken:
                       type: object
                       properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -137,6 +137,9 @@ spec:
                             - key
                             - secretName
                           description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                        connectTimeoutSeconds:
+                          type: integer
+                          description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                         disableTlsHostnameVerification:
                           type: boolean
                           description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -156,6 +159,9 @@ spec:
                             - password
                             - secretName
                           description: Reference to the `Secret` which holds the password.
+                        readTimeoutSeconds:
+                          type: integer
+                          description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                         refreshToken:
                           type: object
                           properties:
@@ -296,6 +302,9 @@ spec:
                             - key
                             - secretName
                           description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                        connectTimeoutSeconds:
+                          type: integer
+                          description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                         disableTlsHostnameVerification:
                           type: boolean
                           description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -315,6 +324,9 @@ spec:
                             - password
                             - secretName
                           description: Reference to the `Secret` which holds the password.
+                        readTimeoutSeconds:
+                          type: integer
+                          description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                         refreshToken:
                           type: object
                           properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -135,6 +135,9 @@ spec:
                         - key
                         - secretName
                       description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                    connectTimeoutSeconds:
+                      type: integer
+                      description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                     disableTlsHostnameVerification:
                       type: boolean
                       description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -154,6 +157,9 @@ spec:
                         - password
                         - secretName
                       description: Reference to the `Secret` which holds the password.
+                    readTimeoutSeconds:
+                      type: integer
+                      description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                     refreshToken:
                       type: object
                       properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -144,6 +144,9 @@ spec:
                               - key
                               - secretName
                             description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                          connectTimeoutSeconds:
+                            type: integer
+                            description: The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
                           disableTlsHostnameVerification:
                             type: boolean
                             description: Enable or disable TLS hostname verification. Default value is `false`.
@@ -163,6 +166,9 @@ spec:
                               - password
                               - secretName
                             description: Reference to the `Secret` which holds the password.
+                          readTimeoutSeconds:
+                            type: integer
+                            description: The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
                           refreshToken:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -174,6 +174,11 @@ spec:
                                 OAuth client secret which the Kafka broker can use
                                 to authenticate against the authorization server and
                                 use the introspect endpoint URI.
+                            connectTimeoutSeconds:
+                              type: integer
+                              description: The connect timeout in seconds when connecting
+                                to authorization server. If not set, the effective
+                                connect timeout is 60 seconds.
                             customClaimCheck:
                               type: string
                               description: JsonPath filter query to be applied to
@@ -263,6 +268,11 @@ spec:
                                 expire when the access token expires. This option
                                 only applies to SASL_OAUTHBEARER authentication mechanism
                                 (when `enableOauthBearer` is `true`).
+                            readTimeoutSeconds:
+                              type: integer
+                              description: The read timeout in seconds when connecting
+                                to authorization server. If not set, the effective
+                                read timeout is 60 seconds.
                             sasl:
                               type: boolean
                               description: Enable or disable SASL on this listener.
@@ -822,6 +832,12 @@ spec:
                         description: OAuth Client ID which the Kafka client can use
                           to authenticate against the OAuth server and use the token
                           endpoint URI.
+                      connectTimeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The connect timeout in seconds when connecting
+                          to authorization server. If not set, the effective connect
+                          timeout is 60 seconds.
                       delegateToKafkaAcls:
                         type: boolean
                         description: Whether authorization decision should be delegated
@@ -865,6 +881,12 @@ spec:
                         description: Maximum capacity of the local cache used by the
                           authorizer to avoid querying the Open Policy Agent for every
                           request. Defaults to `50000`.
+                      readTimeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The read timeout in seconds when connecting to
+                          authorization server. If not set, the effective read timeout
+                          is 60 seconds.
                       superUsers:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -150,6 +150,11 @@ spec:
                     description: Link to Kubernetes Secret containing the OAuth client
                       secret which the Kafka client can use to authenticate against
                       the OAuth server and use the token endpoint URI.
+                  connectTimeoutSeconds:
+                    type: integer
+                    description: The connect timeout in seconds when connecting to
+                      authorization server. If not set, the effective connect timeout
+                      is 60 seconds.
                   disableTlsHostnameVerification:
                     type: boolean
                     description: Enable or disable TLS hostname verification. Default
@@ -173,6 +178,10 @@ spec:
                     - password
                     - secretName
                     description: Reference to the `Secret` which holds the password.
+                  readTimeoutSeconds:
+                    type: integer
+                    description: The read timeout in seconds when connecting to authorization
+                      server. If not set, the effective read timeout is 60 seconds.
                   refreshToken:
                     type: object
                     properties:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -159,6 +159,11 @@ spec:
                         description: Link to Kubernetes Secret containing the OAuth
                           client secret which the Kafka client can use to authenticate
                           against the OAuth server and use the token endpoint URI.
+                      connectTimeoutSeconds:
+                        type: integer
+                        description: The connect timeout in seconds when connecting
+                          to authorization server. If not set, the effective connect
+                          timeout is 60 seconds.
                       disableTlsHostnameVerification:
                         type: boolean
                         description: Enable or disable TLS hostname verification.
@@ -182,6 +187,11 @@ spec:
                         - password
                         - secretName
                         description: Reference to the `Secret` which holds the password.
+                      readTimeoutSeconds:
+                        type: integer
+                        description: The read timeout in seconds when connecting to
+                          authorization server. If not set, the effective read timeout
+                          is 60 seconds.
                       refreshToken:
                         type: object
                         properties:
@@ -365,6 +375,11 @@ spec:
                         description: Link to Kubernetes Secret containing the OAuth
                           client secret which the Kafka client can use to authenticate
                           against the OAuth server and use the token endpoint URI.
+                      connectTimeoutSeconds:
+                        type: integer
+                        description: The connect timeout in seconds when connecting
+                          to authorization server. If not set, the effective connect
+                          timeout is 60 seconds.
                       disableTlsHostnameVerification:
                         type: boolean
                         description: Enable or disable TLS hostname verification.
@@ -388,6 +403,11 @@ spec:
                         - password
                         - secretName
                         description: Reference to the `Secret` which holds the password.
+                      readTimeoutSeconds:
+                        type: integer
+                        description: The read timeout in seconds when connecting to
+                          authorization server. If not set, the effective read timeout
+                          is 60 seconds.
                       refreshToken:
                         type: object
                         properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -152,6 +152,11 @@ spec:
                     description: Link to Kubernetes Secret containing the OAuth client
                       secret which the Kafka client can use to authenticate against
                       the OAuth server and use the token endpoint URI.
+                  connectTimeoutSeconds:
+                    type: integer
+                    description: The connect timeout in seconds when connecting to
+                      authorization server. If not set, the effective connect timeout
+                      is 60 seconds.
                   disableTlsHostnameVerification:
                     type: boolean
                     description: Enable or disable TLS hostname verification. Default
@@ -175,6 +180,10 @@ spec:
                     - password
                     - secretName
                     description: Reference to the `Secret` which holds the password.
+                  readTimeoutSeconds:
+                    type: integer
+                    description: The read timeout in seconds when connecting to authorization
+                      server. If not set, the effective read timeout is 60 seconds.
                   refreshToken:
                     type: object
                     properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -168,6 +168,11 @@ spec:
                           description: Link to Kubernetes Secret containing the OAuth
                             client secret which the Kafka client can use to authenticate
                             against the OAuth server and use the token endpoint URI.
+                        connectTimeoutSeconds:
+                          type: integer
+                          description: The connect timeout in seconds when connecting
+                            to authorization server. If not set, the effective connect
+                            timeout is 60 seconds.
                         disableTlsHostnameVerification:
                           type: boolean
                           description: Enable or disable TLS hostname verification.
@@ -191,6 +196,11 @@ spec:
                           - password
                           - secretName
                           description: Reference to the `Secret` which holds the password.
+                        readTimeoutSeconds:
+                          type: integer
+                          description: The read timeout in seconds when connecting
+                            to authorization server. If not set, the effective read
+                            timeout is 60 seconds.
                         refreshToken:
                           type: object
                           properties:

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <jaeger.version>1.6.0</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
+        <strimzi-oauth.version>0.10.0-rc1-pre</strimzi-oauth.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.2.Final</registry.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
@@ -148,6 +148,13 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>oauth-pre</id>
+            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
+        </repository>
+    </repositories>
 
     <modules>
         <module>kafka-agent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <jaeger.version>1.6.0</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <strimzi-oauth.version>0.10.0-rc1-pre</strimzi-oauth.version>
+        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.2.Final</registry.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
@@ -152,7 +152,7 @@
     <repositories>
         <repository>
             <id>oauth-pre</id>
-            <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,13 +149,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>oauth-pre</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1161</url>
-        </repository>
-    </repositories>
-
     <modules>
         <module>kafka-agent</module>
         <module>mirror-maker-agent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <repositories>
         <repository>
             <id>oauth-pre</id>
-            <url>https://raw.githubusercontent.com/mstruk/strimzi-kafka-oauth/m2repo/m2repo</url>
+            <url>https://github.com/mstruk/strimzi-kafka-oauth/raw/m2repo/m2repo</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

### Type of change

- Enhancement / new feature
- Documentation

### Description

Integrate client timeouts when connecting to authorization server introduced in strimzi-kafka-oauth 0.10.0

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

