### PR TITLE
[Issue 5791] Use separate certificates for the topic operator and user operator.

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -61,6 +61,17 @@ public class KafkaResources {
     }
 
     /**
+     * Returns the name of the Entity Operator {@code Secret} for a {@code Kafka} cluster of the given name.
+     * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator} is configured in the
+     * {@code Kafka} resource with the given name.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Entity Operator {@code Secret}.
+     */
+    public static String entityOperatorSecretName(String clusterName) {
+        return entityOperatorDeploymentName(clusterName) + "-certs";
+    }
+
+    /**
      * Returns the name of the Entity Topic Operator {@code Secret} for a {@code Kafka} cluster of the given name.
      * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator.topicOperator} is configured in the
      * {@code Kafka} resource with the given name.

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -61,14 +61,26 @@ public class KafkaResources {
     }
 
     /**
-     * Returns the name of the Entity Operator {@code Secret} for a {@code Kafka} cluster of the given name.
+     * Returns the name of the Entity Topic Operator {@code Secret} for a {@code Kafka} cluster of the given name.
      * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator} is configured in the
+     * {@code Kafka} resource with the given name.
+     * Note: This secret is used by both EntityTopicOperator and the TLS sidecar in the same EntityOperator.
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     * @return The name of the corresponding Entity Topic Operator {@code Secret}.
+     */
+    public static String entityTopicOperatorSecretName(String clusterName) {
+        return clusterName + "-entity-topic-operator-certs";
+    }
+
+    /**
+     * Returns the name of the Entity User Operator {@code Secret} for a {@code Kafka} cluster of the given name.
+     * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator.userOperator} is configured in the
      * {@code Kafka} resource with the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
      * @return The name of the corresponding Entity Operator {@code Secret}.
      */
-    public static String entityOperatorSecretName(String clusterName) {
-        return entityOperatorDeploymentName(clusterName) + "-certs";
+    public static String entityUserOperatorSecretName(String clusterName) {
+        return clusterName + "-entity-user-operator-certs";
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -62,7 +62,7 @@ public class KafkaResources {
 
     /**
      * Returns the name of the Entity Topic Operator {@code Secret} for a {@code Kafka} cluster of the given name.
-     * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator} is configured in the
+     * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator.topicOperator} is configured in the
      * {@code Kafka} resource with the given name.
      * Note: This secret is used by both EntityTopicOperator and the TLS sidecar in the same EntityOperator.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -24,7 +24,8 @@ import io.strimzi.operator.common.Reconciliation;
 public class ClusterCa extends Ca {
 
     private final String clusterName;
-    private Secret entityOperatorSecret;
+    private Secret entityTopicOperatorSecret;
+    private Secret entityUserOperatorSecret;
     private Secret clusterOperatorSecret;
     private Secret kafkaExporterSecret;
     private Secret cruiseControlSecret;
@@ -84,8 +85,10 @@ public class ClusterCa extends Ca {
             String name = secret.getMetadata().getName();
             if (KafkaCluster.brokersSecretName(clusterName).equals(name)) {
                 brokersSecret = secret;
-            } else if (EntityOperator.secretName(clusterName).equals(name)) {
-                entityOperatorSecret = secret;
+            } else if (EntityTopicOperator.secretName(clusterName).equals(name)) {
+                entityTopicOperatorSecret = secret;
+            } else if (EntityUserOperator.secretName(clusterName).equals(name)) {
+                entityUserOperatorSecret = secret;
             } else if (ZookeeperCluster.nodesSecretName(clusterName).equals(name)) {
                 zkNodesSecret = secret;
             } else if (ClusterOperator.secretName(clusterName).equals(name)) {
@@ -98,8 +101,12 @@ public class ClusterCa extends Ca {
         }
     }
 
-    public Secret entityOperatorSecret() {
-        return entityOperatorSecret;
+    public Secret entityTopicOperatorSecret() {
+        return entityTopicOperatorSecret;
+    }
+
+    public Secret entityUserOperatorSecret() {
+        return entityUserOperatorSecret;
     }
 
     public Secret clusterOperatorSecret() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -54,10 +53,14 @@ import static io.strimzi.operator.cluster.model.EntityUserOperator.USER_OPERATOR
 @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
 public class EntityOperator extends AbstractModel {
     protected static final String APPLICATION_NAME = "entity-operator";
+    // Certificates for the Entity Topic Operator
+    protected static final String ETO_CERTS_VOLUME_NAME = "eto-certs";
+    protected static final String ETO_CERTS_VOLUME_MOUNT = "/etc/eto-certs/";
+    // Certificates for the Entity User Operator
+    protected static final String EUO_CERTS_VOLUME_NAME = "euo-certs";
+    protected static final String EUO_CERTS_VOLUME_MOUNT = "/etc/euo-certs/";
 
     protected static final String TLS_SIDECAR_NAME = "tls-sidecar";
-    protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_NAME = "eo-certs";
-    protected static final String TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/eo-certs/";
     protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_NAME = "cluster-ca-certs";
     protected static final String TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT = "/etc/tls-sidecar/cluster-ca-certs/";
 
@@ -134,10 +137,6 @@ public class EntityOperator extends AbstractModel {
 
     public String getZookeeperConnect() {
         return zookeeperConnect;
-    }
-
-    public static String secretName(String cluster) {
-        return KafkaResources.entityOperatorSecretName(cluster);
     }
 
     public void setDeployed(boolean isDeployed) {
@@ -278,7 +277,7 @@ public class EntityOperator extends AbstractModel {
                 .withResources(tlsSidecar != null ? tlsSidecar.getResources() : null)
                 .withEnv(getTlsSidecarEnvVars())
                 .withVolumeMounts(createTempDirVolumeMount(TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
-                        VolumeUtils.createVolumeMount(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
+                        VolumeUtils.createVolumeMount(ETO_CERTS_VOLUME_NAME, ETO_CERTS_VOLUME_MOUNT),
                         VolumeUtils.createVolumeMount(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT))
                 .withLifecycle(new LifecycleBuilder().withNewPreStop().withNewExec()
                             .withCommand("/opt/stunnel/entity_operator_stunnel_pre_stop.sh")
@@ -306,7 +305,7 @@ public class EntityOperator extends AbstractModel {
     }
 
     private List<Volume> getVolumes(boolean isOpenShift) {
-        List<Volume> volumeList = new ArrayList<>(7);
+        List<Volume> volumeList = new ArrayList<>(8);
 
         if (topicOperator != null) {
             volumeList.addAll(topicOperator.getVolumes());
@@ -316,31 +315,13 @@ public class EntityOperator extends AbstractModel {
         if (userOperator != null) {
             volumeList.addAll(userOperator.getVolumes());
             volumeList.add(createTempDirVolume(USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+            volumeList.add(VolumeUtils.createSecretVolume(EUO_CERTS_VOLUME_NAME, EntityUserOperator.secretName(cluster), isOpenShift));
         }
 
         volumeList.add(createTempDirVolume(TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.secretName(cluster), isOpenShift));
+        volumeList.add(VolumeUtils.createSecretVolume(ETO_CERTS_VOLUME_NAME, EntityTopicOperator.secretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;
-    }
-
-    /**
-     * Generate the Secret containing the Entity Operator certificate signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka and Zookeeper.
-     * It also contains the related Entity Operator private key.
-     *
-     * @param clusterCa The cluster CA.
-     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
-     *                                          This is used for certificate renewals
-     * @return The generated Secret.
-     */
-    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
-        if (!isDeployed()) {
-            return null;
-        }
-        Secret secret = clusterCa.entityOperatorSecret();
-        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, EntityOperator.secretName(cluster), name,
-                "entity-operator", labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -139,6 +139,10 @@ public class EntityOperator extends AbstractModel {
         return zookeeperConnect;
     }
 
+    public static String secretName(String cluster) {
+        return KafkaResources.entityOperatorSecretName(cluster);
+    }
+
     public void setDeployed(boolean isDeployed) {
         this.isDeployed = isDeployed;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.Volume;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -20,6 +21,7 @@ import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -179,6 +181,10 @@ public class EntityTopicOperator extends AbstractModel {
         return cluster + NAME_SUFFIX;
     }
 
+    public static String secretName(String cluster) {
+        return KafkaResources.entityTopicOperatorSecretName(cluster);
+    }
+
     public static String metricAndLogConfigsName(String cluster) {
         return cluster + METRICS_AND_LOG_CONFIG_SUFFIX;
     }
@@ -300,7 +306,7 @@ public class EntityTopicOperator extends AbstractModel {
     private List<VolumeMount> getVolumeMounts() {
         return asList(createTempDirVolumeMount(TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
                 VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
-                VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
+                VolumeUtils.createVolumeMount(EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
     }
 
@@ -358,4 +364,19 @@ public class EntityTopicOperator extends AbstractModel {
         return super.createLog4jProperties(properties);
     }
 
+    /**
+     * Generate the Secret containing the Entity Topic Operator certificate signed by the cluster CA certificate used for TLS based
+     * internal communication with Kafka and Zookeeper.
+     * It also contains the related Entity Topic Operator private key.
+     *
+     * @param clusterCa The cluster CA.
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
+     * @return The generated Secret.
+     */
+    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
+        Secret secret = clusterCa.entityTopicOperatorSecret();
+        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, EntityTopicOperator.secretName(cluster), name,
+                APPLICATION_NAME, labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -362,21 +361,5 @@ public class EntityTopicOperator extends AbstractModel {
             properties.addPair("monitorInterval", "30");
         }
         return super.createLog4jProperties(properties);
-    }
-
-    /**
-     * Generate the Secret containing the Entity Topic Operator certificate signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka and Zookeeper.
-     * It also contains the related Entity Topic Operator private key.
-     *
-     * @param clusterCa The cluster CA.
-     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
-     *                                          This is used for certificate renewals
-     * @return The generated Secret.
-     */
-    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
-        Secret secret = clusterCa.entityTopicOperatorSecret();
-        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, EntityTopicOperator.secretName(cluster), name,
-                APPLICATION_NAME, labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -61,7 +61,7 @@ public class EntityUserOperator extends AbstractModel {
     public static final String ENV_VAR_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
     public static final String ENV_VAR_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
     public static final String ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
-    public static final String ENV_VAR_EUO_KEY_SECRET_NAME = "STRIMZI_EUO_KEY_SECRET_NAME";
+    public static final String ENV_VAR_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
     public static final String ENV_VAR_SECRET_PREFIX = "STRIMZI_SECRET_PREFIX";
     public static final String ENV_VAR_ACLS_ADMIN_API_SUPPORTED = "STRIMZI_ACLS_ADMIN_API_SUPPORTED";
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT)
@@ -283,7 +283,7 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_VALIDITY, Integer.toString(clientsCaValidityDays)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));
         varList.add(buildEnvVar(ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME, KafkaCluster.clusterCaCertSecretName(cluster)));
-        varList.add(buildEnvVar(ENV_VAR_EUO_KEY_SECRET_NAME, EntityUserOperator.secretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_EO_KEY_SECRET_NAME, EntityUserOperator.secretName(cluster)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         varList.add(buildEnvVar(ENV_VAR_SECRET_PREFIX, secretPrefix));
         varList.add(buildEnvVar(ENV_VAR_ACLS_ADMIN_API_SUPPORTED, String.valueOf(aclsAdminApiSupported)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -21,6 +22,7 @@ import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -59,7 +61,7 @@ public class EntityUserOperator extends AbstractModel {
     public static final String ENV_VAR_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
     public static final String ENV_VAR_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
     public static final String ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
-    public static final String ENV_VAR_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
+    public static final String ENV_VAR_EUO_KEY_SECRET_NAME = "STRIMZI_EUO_KEY_SECRET_NAME";
     public static final String ENV_VAR_SECRET_PREFIX = "STRIMZI_SECRET_PREFIX";
     public static final String ENV_VAR_ACLS_ADMIN_API_SUPPORTED = "STRIMZI_ACLS_ADMIN_API_SUPPORTED";
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT)
@@ -148,6 +150,10 @@ public class EntityUserOperator extends AbstractModel {
 
     public String getSecretPrefix() {
         return secretPrefix;
+    }
+
+    public static String secretName(String cluster) {
+        return KafkaResources.entityUserOperatorSecretName(cluster);
     }
 
     public void setSecretPrefix(String secretPrefix) {
@@ -277,7 +283,7 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_VALIDITY, Integer.toString(clientsCaValidityDays)));
         varList.add(buildEnvVar(ENV_VAR_CLIENTS_CA_RENEWAL, Integer.toString(clientsCaRenewalDays)));
         varList.add(buildEnvVar(ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME, KafkaCluster.clusterCaCertSecretName(cluster)));
-        varList.add(buildEnvVar(ENV_VAR_EO_KEY_SECRET_NAME, EntityOperator.secretName(cluster)));
+        varList.add(buildEnvVar(ENV_VAR_EUO_KEY_SECRET_NAME, EntityUserOperator.secretName(cluster)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         varList.add(buildEnvVar(ENV_VAR_SECRET_PREFIX, secretPrefix));
         varList.add(buildEnvVar(ENV_VAR_ACLS_ADMIN_API_SUPPORTED, String.valueOf(aclsAdminApiSupported)));
@@ -298,7 +304,7 @@ public class EntityUserOperator extends AbstractModel {
     private List<VolumeMount> getVolumeMounts() {
         return asList(createTempDirVolumeMount(USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
                 VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
-                VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT),
+                VolumeUtils.createVolumeMount(EntityOperator.EUO_CERTS_VOLUME_NAME, EntityOperator.EUO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
     }
 
@@ -354,5 +360,21 @@ public class EntityUserOperator extends AbstractModel {
             properties.addPair("monitorInterval", "30");
         }
         return super.createLog4jProperties(properties);
+    }
+
+    /**
+     * Generate the Secret containing the Entity User Operator certificate signed by the cluster CA certificate used for TLS based
+     * internal communication with Kafka and Zookeeper.
+     * It also contains the related Entity User Operator private key.
+     *
+     * @param clusterCa The cluster CA.
+     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
+     *                                          This is used for certificate renewals
+     * @return The generated Secret.
+     */
+    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
+        Secret secret = clusterCa.entityUserOperatorSecret();
+        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, EntityUserOperator.secretName(cluster), name,
+                APPLICATION_NAME, labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -469,7 +469,8 @@ public class KafkaBrokerConfigurationBuilder {
 
             // Broker super users
             superUsers.add(String.format("User:CN=%s,O=io.strimzi", KafkaResources.kafkaStatefulSetName(clusterName)));
-            superUsers.add(String.format("User:CN=%s-%s,O=io.strimzi", clusterName, "entity-operator"));
+            superUsers.add(String.format("User:CN=%s-%s,O=io.strimzi", clusterName, "entity-topic-operator"));
+            superUsers.add(String.format("User:CN=%s-%s,O=io.strimzi", clusterName, "entity-user-operator"));
             superUsers.add(String.format("User:CN=%s-%s,O=io.strimzi", clusterName, "kafka-exporter"));
             superUsers.add(String.format("User:CN=%s-%s,O=io.strimzi", clusterName, "cruise-control"));
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3547,7 +3547,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityTopicOperatorSecret(Supplier<Date> dateSupplier) {
-            return updateCertificateSecretWithDiff(EntityTopicOperator.secretName(name), entityOperator == null || entityOperator.getTopicOperator() == null ? null : entityOperator.getTopicOperator().generateSecret(clusterCa, isMaintenanceTimeWindowsSatisfied(dateSupplier)))
+            // Since the TLS Sidecar uses the same certificate as the topic operator, we need to create the Topic Operator Certificate even if Only the User Operator is configured.
+            return updateCertificateSecretWithDiff(EntityTopicOperator.secretName(name), entityOperator == null ? null : entityOperator.generateSecret(clusterCa, isMaintenanceTimeWindowsSatisfied(dateSupplier)))
                     .map(changed -> {
                         existingEntityTopicOperatorCertsChanged = changed;
                         return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -347,6 +347,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.entityOperatorUserOpRoleBindingForRole())
                 .compose(state -> state.entityOperatorTopicOpAncillaryCm())
                 .compose(state -> state.entityOperatorUserOpAncillaryCm())
+                .compose(state -> state.entityOperatorSecret())
                 .compose(state -> state.entityTopicOperatorSecret(this::dateSupplier))
                 .compose(state -> state.entityUserOperatorSecret(this::dateSupplier))
                 .compose(state -> state.entityOperatorDeployment())
@@ -3544,6 +3545,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 }).map(i -> this);
             }
             return withVoid(Future.succeededFuture());
+        }
+
+        // Clean up the old entity-operator-certificate which is generated in the old releases.
+        // Starting from this release, the Topic Operator and User Operator will use new dedicated certificate.
+        // Therefore, we need to remove the unused entity-operator-certificate
+        Future<ReconciliationState> entityOperatorSecret() {
+            return withVoid(secretOperations.reconcile(reconciliation, namespace, EntityOperator.secretName(name), null));
         }
 
         Future<ReconciliationState> entityTopicOperatorSecret(Supplier<Date> dateSupplier) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -3547,8 +3547,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityTopicOperatorSecret(Supplier<Date> dateSupplier) {
-            // Since the TLS Sidecar uses the same certificate as the topic operator, we need to create the Topic Operator Certificate even if Only the User Operator is configured.
-            return updateCertificateSecretWithDiff(EntityTopicOperator.secretName(name), entityOperator == null ? null : entityOperator.generateSecret(clusterCa, isMaintenanceTimeWindowsSatisfied(dateSupplier)))
+            return updateCertificateSecretWithDiff(EntityTopicOperator.secretName(name), entityOperator == null || entityOperator.getTopicOperator() == null ? null : entityOperator.getTopicOperator().generateSecret(clusterCa, isMaintenanceTimeWindowsSatisfied(dateSupplier)))
                     .map(changed -> {
                         existingEntityTopicOperatorCertsChanged = changed;
                         return this;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -140,7 +140,7 @@ public class EntityOperatorTest {
         assertThat(EntityOperatorTest.volumeMounts(tlsSidecarContainer.getVolumeMounts()), is(map(
                         EntityOperator.TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                         EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
-                        EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT)));
+                        EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT)));
         assertThat(tlsSidecarContainer.getReadinessProbe().getInitialDelaySeconds(), is(Integer.valueOf(tlsHealthDelay)));
         assertThat(tlsSidecarContainer.getReadinessProbe().getTimeoutSeconds(), is(Integer.valueOf(tlsHealthTimeout)));
         assertThat(tlsSidecarContainer.getLivenessProbe().getInitialDelaySeconds(), is(Integer.valueOf(tlsHealthDelay)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -224,7 +224,7 @@ public class EntityTopicOperatorTest {
                 EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
-                EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT)));
+                EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT)));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -124,7 +124,7 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaCertSecretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_NAMESPACE).withValue(namespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clusterCaCertSecretName(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_EUO_KEY_SECRET_NAME).withValue(EntityUserOperator.secretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_EO_KEY_SECRET_NAME).withValue(EntityUserOperator.secretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_VALIDITY).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_RENEWAL).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS)).build());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -124,7 +124,7 @@ public class EntityUserOperatorTest {
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clientsCaCertSecretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_NAMESPACE).withValue(namespace).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME).withValue(KafkaCluster.clusterCaCertSecretName(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_EO_KEY_SECRET_NAME).withValue(EntityOperator.secretName(cluster)).build());
+        expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_EUO_KEY_SECRET_NAME).withValue(EntityUserOperator.secretName(cluster)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_STRIMZI_GC_LOG_ENABLED).withValue(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_VALIDITY).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS)).build());
         expected.add(new EnvVarBuilder().withName(EntityUserOperator.ENV_VAR_CLIENTS_CA_RENEWAL).withValue(Integer.toString(CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS)).build());
@@ -241,7 +241,7 @@ public class EntityUserOperatorTest {
                 EntityUserOperator.USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-user-operator-metrics-and-logging", "/opt/user-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
-                EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_EO_CERTS_VOLUME_MOUNT)));
+                EntityOperator.EUO_CERTS_VOLUME_NAME, EntityOperator.EUO_CERTS_VOLUME_MOUNT)));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -164,7 +164,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         assertThat(configuration, isEquivalent("authorizer.class.name=kafka.security.authorizer.AclAuthorizer\n" +
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jakub;User:CN=kuba"));
+                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jakub;User:CN=kuba"));
     }
 
     @ParallelTest
@@ -177,7 +177,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         assertThat(configuration, isEquivalent("authorizer.class.name=kafka.security.authorizer.AclAuthorizer\n" +
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
+                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
     @ParallelTest
@@ -214,7 +214,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "strimzi.authorization.ssl.endpoint.identification.algorithm=\n" +
                 "strimzi.authorization.grants.refresh.period.seconds=120\n" +
                 "strimzi.authorization.grants.refresh.pool.size=10\n" +
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:giada;User:CN=paccu"));
+                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:giada;User:CN=paccu"));
     }
 
     @ParallelTest
@@ -244,7 +244,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "strimzi.authorization.ssl.truststore.type=PKCS12\n" +
                 "strimzi.authorization.ssl.secure.random.implementation=SHA1PRNG\n" +
                 "strimzi.authorization.ssl.endpoint.identification.algorithm=HTTPS\n" +
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
+                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
     @ParallelTest
@@ -263,7 +263,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "opa.authorizer.cache.initial.capacity=5000\n" +
                 "opa.authorizer.cache.maximum.size=50000\n" +
                 "opa.authorizer.cache.expire.after.seconds=3600\n" +
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
+                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi"));
     }
 
     @ParallelTest
@@ -287,7 +287,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "opa.authorizer.cache.initial.capacity=1000\n" +
                 "opa.authorizer.cache.maximum.size=10000\n" +
                 "opa.authorizer.cache.expire.after.seconds=60\n" +
-                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jack;User:CN=conor"));
+                "super.users=User:CN=my-cluster-kafka,O=io.strimzi;User:CN=my-cluster-entity-topic-operator,O=io.strimzi;User:CN=my-cluster-entity-user-operator,O=io.strimzi;User:CN=my-cluster-kafka-exporter,O=io.strimzi;User:CN=my-cluster-cruise-control,O=io.strimzi;User:CN=cluster-operator,O=io.strimzi;User:jack;User:CN=conor"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -59,6 +59,8 @@ import io.strimzi.operator.cluster.model.ClientsCa;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.EntityOperator;
+import io.strimzi.operator.cluster.model.EntityTopicOperator;
+import io.strimzi.operator.cluster.model.EntityUserOperator;
 import io.strimzi.operator.cluster.model.JmxTrans;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaExporter;
@@ -592,7 +594,8 @@ public class KafkaAssemblyOperatorTest {
         expectedSecrets.addAll(secrets.stream().map(s -> s.getMetadata().getName()).collect(Collectors.toSet()));
         if (eoConfig != null) {
             // it's expected only when the Entity Operator is deployed by the Cluster Operator
-            expectedSecrets.add(EntityOperator.secretName(kafkaName));
+            expectedSecrets.add(EntityTopicOperator.secretName(kafkaName));
+            expectedSecrets.add(EntityUserOperator.secretName(kafkaName));
         }
 
         when(mockDepOps.reconcile(any(), anyString(), anyString(), any())).thenAnswer(invocation -> {
@@ -1110,7 +1113,7 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.brokersSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );
-        when(mockSecretOps.getAsync(clusterNamespace, EntityOperator.secretName(clusterName))).thenReturn(
+        when(mockSecretOps.getAsync(clusterNamespace, EntityTopicOperator.secretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaExporter.secretName(clusterName))).thenReturn(

--- a/docker-images/kafka-based/kafka/stunnel-scripts/entity_operator_stunnel_config_generator.sh
+++ b/docker-images/kafka-based/kafka/stunnel-scripts/entity_operator_stunnel_config_generator.sh
@@ -2,7 +2,7 @@
 set -e
 
 # path were the Secret with EO certificates is mounted
-EO_CERTS_KEYS=/etc/tls-sidecar/eo-certs
+ETO_CERTS_KEYS=/etc/eto-certs
 # Combine all the certs in the cluster CA into one file
 CA_CERTS=/tmp/cluster-ca.crt
 for cert in /etc/tls-sidecar/cluster-ca-certs/*.crt; do
@@ -19,8 +19,8 @@ cat <<-EOF
 [zookeeper-2181]
 client = yes
 CAfile = ${CA_CERTS}
-cert = ${EO_CERTS_KEYS}/entity-operator.crt
-key = ${EO_CERTS_KEYS}/entity-operator.key
+cert = ${ETO_CERTS_KEYS}/entity-topic-operator.crt
+key = ${ETO_CERTS_KEYS}/entity-topic-operator.key
 accept = 127.0.0.1:2181
 connect = ${STRIMZI_ZOOKEEPER_CONNECT:-zookeeper-client:2181}
 delay = yes

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -626,7 +626,7 @@ class KafkaST extends AbstractST {
         //Waiting when EO pod will be recreated without TO
         PodUtils.deletePodWithWait(namespaceName, eoPodName);
         DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
-        PodUtils.waitUntilPodContainersCount(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 2);
+        PodUtils.waitUntilPodContainersCount(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
 
         //Checking that TO was removed
         kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName)).forEach(pod -> {

--- a/topic-operator/scripts/tls_prepare_certificates.sh
+++ b/topic-operator/scripts/tls_prepare_certificates.sh
@@ -39,9 +39,9 @@ if [ "$STRIMZI_TLS_AUTH_ENABLED" != "false" ]; then
   STORE=/tmp/topic-operator/replication.keystore.p12
   rm -f "$STORE"
   create_keystore "$STORE" "$CERTS_STORE_PASSWORD" \
-      /etc/tls-sidecar/eo-certs/entity-operator.crt \
-      /etc/tls-sidecar/eo-certs/entity-operator.key \
+      /etc/eto-certs/entity-topic-operator.crt \
+      /etc/eto-certs/entity-topic-operator.key \
       /etc/tls-sidecar/cluster-ca-certs/ca.crt \
-      entity-operator
+      entity-topic-operator
   echo "Preparing key store certificates for internal communication is completed"
 fi

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -114,18 +114,18 @@ public class Main {
         } else {
             clusterCaCertSecretFuture = Future.succeededFuture(null);
         }
-        Future<Secret> eoKeySecretFuture;
-        if (config.getEoKeySecretName() != null && !config.getEoKeySecretName().isEmpty()) {
-            eoKeySecretFuture = secretOperations.getAsync(config.getCaNamespace(), config.getEoKeySecretName());
+        Future<Secret> euoKeySecretFuture;
+        if (config.getEuoKeySecretName() != null && !config.getEuoKeySecretName().isEmpty()) {
+            euoKeySecretFuture = secretOperations.getAsync(config.getCaNamespace(), config.getEuoKeySecretName());
         } else {
-            eoKeySecretFuture = Future.succeededFuture(null);
+            euoKeySecretFuture = Future.succeededFuture(null);
         }
 
-        CompositeFuture.join(clusterCaCertSecretFuture, eoKeySecretFuture)
+        CompositeFuture.join(clusterCaCertSecretFuture, euoKeySecretFuture)
                 .onComplete(ar -> {
                     if (ar.succeeded()) {
                         Admin adminClient = adminClientProvider.createAdminClient(config.getKafkaBootstrapServers(),
-                                clusterCaCertSecretFuture.result(), eoKeySecretFuture.result(), eoKeySecretFuture.result() != null ? "entity-operator" : null);
+                                clusterCaCertSecretFuture.result(), euoKeySecretFuture.result(), euoKeySecretFuture.result() != null ? "entity-user-operator" : null);
                         promise.complete(adminClient);
                     } else {
                         promise.fail(ar.cause());

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -21,7 +21,7 @@ public class UserOperatorConfig {
     public static final String STRIMZI_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
     public static final String STRIMZI_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
     public static final String STRIMZI_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
-    public static final String STRIMZI_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
+    public static final String STRIMZI_EUO_KEY_SECRET_NAME = "STRIMZI_EUO_KEY_SECRET_NAME";
     public static final String STRIMZI_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
     public static final String STRIMZI_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     public static final String STRIMZI_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
@@ -44,7 +44,7 @@ public class UserOperatorConfig {
     private final String caCertSecretName;
     private final String caKeySecretName;
     private final String clusterCaCertSecretName;
-    private final String eoKeySecretName;
+    private final String euoKeySecretName;
     private final String caNamespace;
     private final String secretPrefix;
     private final int clientsCaValidityDays;
@@ -62,7 +62,7 @@ public class UserOperatorConfig {
      * @param caCertSecretName Name of the secret containing the clients Certification Authority certificate.
      * @param caKeySecretName The name of the secret containing the clients Certification Authority key.
      * @param clusterCaCertSecretName Name of the secret containing the cluster Certification Authority certificate.
-     * @param eoKeySecretName The name of the secret containing the Entity Operator key and certificate
+     * @param euoKeySecretName The name of the secret containing the Entity User Operator key and certificate
      * @param caNamespace Namespace with the CA secret.
      * @param secretPrefix Prefix used for the Secret names
      * @param aclsAdminApiSupported Indicates whether Kafka Admin API can be used to manage ACL rights
@@ -78,7 +78,7 @@ public class UserOperatorConfig {
                               String caCertSecretName,
                               String caKeySecretName,
                               String clusterCaCertSecretName,
-                              String eoKeySecretName,
+                              String euoKeySecretName,
                               String caNamespace,
                               String secretPrefix,
                               boolean aclsAdminApiSupported,
@@ -92,7 +92,7 @@ public class UserOperatorConfig {
         this.caCertSecretName = caCertSecretName;
         this.caKeySecretName = caKeySecretName;
         this.clusterCaCertSecretName = clusterCaCertSecretName;
-        this.eoKeySecretName = eoKeySecretName;
+        this.euoKeySecretName = euoKeySecretName;
         this.caNamespace = caNamespace;
         this.secretPrefix = secretPrefix;
         this.aclsAdminApiSupported = aclsAdminApiSupported;
@@ -151,7 +151,7 @@ public class UserOperatorConfig {
 
         String clusterCaCertSecretName = map.get(UserOperatorConfig.STRIMZI_CLUSTER_CA_CERT_SECRET_NAME);
 
-        String eoKeySecretName = map.get(UserOperatorConfig.STRIMZI_EO_KEY_SECRET_NAME);
+        String euoKeySecretName = map.get(UserOperatorConfig.STRIMZI_EUO_KEY_SECRET_NAME);
 
         String caNamespace = map.get(UserOperatorConfig.STRIMZI_CA_NAMESPACE);
         if (caNamespace == null || caNamespace.isEmpty()) {
@@ -170,7 +170,7 @@ public class UserOperatorConfig {
         int clientsCaRenewalDays = getIntProperty(map, UserOperatorConfig.STRIMZI_CLIENTS_CA_RENEWAL, CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS);
 
         return new UserOperatorConfig(namespace, reconciliationInterval, kafkaBootstrapServers, labels,
-                caCertSecretName, caKeySecretName, clusterCaCertSecretName, eoKeySecretName, caNamespace, secretPrefix,
+                caCertSecretName, caKeySecretName, clusterCaCertSecretName, euoKeySecretName, caNamespace, secretPrefix,
                 aclsAdminApiSupported, clientsCaValidityDays, clientsCaRenewalDays, scramPasswordLength);
     }
 
@@ -267,10 +267,10 @@ public class UserOperatorConfig {
     }
 
     /**
-     * @return  The name of the secret with Entity Operator key and certificate
+     * @return  The name of the secret with Entity User Operator key and certificate
      */
-    public String getEoKeySecretName() {
-        return eoKeySecretName;
+    public String getEuoKeySecretName() {
+        return euoKeySecretName;
     }
 
     /**
@@ -317,7 +317,7 @@ public class UserOperatorConfig {
                 ",labels=" + labels +
                 ",caName=" + caCertSecretName +
                 ",clusterCaCertSecretName=" + clusterCaCertSecretName +
-                ",eoKeySecretName=" + eoKeySecretName +
+                ",euoKeySecretName=" + euoKeySecretName +
                 ",caNamespace=" + caNamespace +
                 ",secretPrefix=" + secretPrefix +
                 ",aclsAdminApiSupported=" + aclsAdminApiSupported +

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -21,7 +21,7 @@ public class UserOperatorConfig {
     public static final String STRIMZI_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
     public static final String STRIMZI_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
     public static final String STRIMZI_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
-    public static final String STRIMZI_EUO_KEY_SECRET_NAME = "STRIMZI_EUO_KEY_SECRET_NAME";
+    public static final String STRIMZI_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
     public static final String STRIMZI_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
     public static final String STRIMZI_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     public static final String STRIMZI_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
@@ -151,7 +151,7 @@ public class UserOperatorConfig {
 
         String clusterCaCertSecretName = map.get(UserOperatorConfig.STRIMZI_CLUSTER_CA_CERT_SECRET_NAME);
 
-        String euoKeySecretName = map.get(UserOperatorConfig.STRIMZI_EUO_KEY_SECRET_NAME);
+        String euoKeySecretName = map.get(UserOperatorConfig.STRIMZI_EO_KEY_SECRET_NAME);
 
         String caNamespace = map.get(UserOperatorConfig.STRIMZI_CA_NAMESPACE);
         if (caNamespace == null || caNamespace.isEmpty()) {


### PR DESCRIPTION
NOT A CONTRIBUTION

This is to address the following issue:
https://github.com/strimzi/strimzi-kafka-operator/issues/5791

Signed-off-by: Yaodong Yang <yyang48@apple.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

_Please describe your pull request_

Currently we use the same certificates for both Topic Operator and User Operator. As a result, they are using the same User/KafkaPrincipal when communicate to Kafka Brokers. From the monitoring perspective, there is no way to differentiate the activities from both of these operators, as described in the original issue.

This PR will create a separate certificate to the Topic Operator and User Operator. With this change, they will use two different user/KafkaPrincipal when talk to Kafka Brokers. The TLS sidecar will still share the certificate with the Topic Operator, as it did today.
 
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

