### PR TITLE
Test items in Kafka Connect and its external configuration

### DIFF
--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-external-configuration.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-external-configuration.yaml
@@ -24,17 +24,15 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: username
-#          path: my-group/my-username
+        items:
+        - key: username
+          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: log_level
-#          path: log_level
+        items:
+        - key: log_level
+          path: log_level

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
@@ -38,10 +38,16 @@ spec:
         secretName: "ssh-key-secret"
     - name: "foo"
       secret:
+        items:
+        - key: "username"
+          path: "my-group/my-username"
         secretName: "mysecret"
     - name: "config-map-volume"
       configMap:
         name: "my-config-map"
     - name: "config-vol"
       configMap:
+        items:
+        - key: "log_level"
+          path: "log_level"
         name: "log-config"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.yaml
@@ -38,17 +38,15 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-    # Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: username
-#          path: my-group/my-username
+        items:
+        - key: username
+          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: log_level
-#          path: log_level
+        items:
+        - key: log_level
+          path: log_level


### PR DESCRIPTION
### Type of change

- Task

### Description

Some time ago, we had to disable the use of the `items` field in the Kafka Connect external configuration due to a bug in Kubernetes. This bug is fixed from 1.16, so we should now be able to use it in the tests again.

This should close #2072

### Checklist

- [x] Make sure all tests pass