### PR TITLE
Fix Minikube location, remove nsenter and bump versions

### DIFF
--- a/.azure/scripts/setup-helm.sh
+++ b/.azure/scripts/setup-helm.sh
@@ -2,8 +2,6 @@
 set -x
 
 function install_helm3 {
-    install_nsenter
-
     export HELM_INSTALL_DIR=/usr/bin
     curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
     # we need to modify the script with a different path because on the Azure pipelines the HELM_INSTALL_DIR env var is not honoured

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -23,15 +23,6 @@ function install_kubectl {
     sudo cp kubectl /usr/local/bin
 }
 
-function install_nsenter {
-    # Pre-req for helm
-    curl https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${TEST_NSENTER_VERSION}/util-linux-${TEST_NSENTER_VERSION}.tar.gz -k | tar -zxf-
-    cd util-linux-${TEST_NSENTER_VERSION}
-    ./configure --without-ncurses
-    make nsenter
-    sudo cp nsenter /usr/bin
-}
-
 function label_node {
 	# It should work for all clusters
 	for nodeName in $(kubectl get nodes -o custom-columns=:.metadata.name --no-headers);
@@ -54,7 +45,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     fi
 
     curl -Lo minikube ${TEST_MINIKUBE_URL} && chmod +x minikube
-    sudo cp minikube /usr/bin
+    sudo cp minikube /usr/local/bin
 
     export MINIKUBE_WANTUPDATENOTIFICATION=false
     export MINIKUBE_WANTREPORTERRORPROMPT=false

--- a/.azure/templates/steps/default_variables.yaml
+++ b/.azure/templates/steps/default_variables.yaml
@@ -23,9 +23,7 @@ variables:
   commit_message: $(Build.SourceVersionMessage)
   test_cluster: minikube
   test_kubectl_version: v1.16.0
-  test_nsenter_version: 2.32
   test_helm_version: v2.17.0
-  test_minikube_version: v1.2.0
   strimzi_default_log_level: DEBUG
   operator_image_pull_policy: IfNotPresent
   components_image_pull_policy: IfNotPresent

--- a/.azure/templates/steps/prerequisites/install_helm.yaml
+++ b/.azure/templates/steps/prerequisites/install_helm.yaml
@@ -2,4 +2,4 @@ steps:
   - bash: ".azure/scripts/setup-helm.sh"
     displayName: "Install Helm"
     env:
-      TEST_HELM3_VERSION: 'v3.4.2'
+      TEST_HELM3_VERSION: 'v3.7.2'

--- a/.azure/templates/steps/prerequisites/install_minikube.yaml
+++ b/.azure/templates/steps/prerequisites/install_minikube.yaml
@@ -4,5 +4,4 @@ steps:
     env:
       TEST_CLUSTER: minikube
       TEST_KUBECTL_VERSION: v1.16.0
-      TEST_NSENTER_VERSION: 2.32
-      TEST_MINIKUBE_VERSION: v1.2.0
+      TEST_MINIKUBE_VERSION: v1.24.0


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Azure pipelines download Minikube of a specific version. But they do not place it into the right directory from which it is used (it is placed into `/usr/bin` instead of `/usr/local/bin`). So as a result, the version we downloaded is ignored and some default version from the base image is used. This PR changes the path so that we used fixed Minikube version.

While during this, I also discovered that the `nsenter` installation which was apparently needed for Helm doesn't work anymore. And since nothing seems to complain, this PR removes it completely. 

It also bumps some of the installed dependencies to the latets versions:
* Minikube 1.24 (which was used anyway)
* Helm to 3.7.2

Kubectl remains as 1.16 since the tests run against Kube 1.16.