### PR TITLE
List all the places where `jvmOptions` can be used

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -412,6 +412,9 @@ To optimize their performance on different platforms and architectures, you conf
 
 * `Kafka.spec.kafka`
 * `Kafka.spec.zookeeper`
+* `Kafka.spec.entityOperator.userOperator`
+* `Kafka.spec.entityOperator.topicOperator`
+* `Kafka.spec.cruiseControl`
 * `KafkaConnect.spec`
 * `KafkaMirrorMaker.spec`
 * `KafkaMirrorMaker2.spec`


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The docs about the `jvmOptions` field have an incomplete list of all the places where it can be used. This PR adds the missing pieces to it.

### Checklist

- [x] Update documentation