### PR TITLE
Update OPA Authorizer to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the option to configure the Cluster Operator's Zookeeper admin client session timeout via an new env var: `STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS`
 * The `ControlPlaneListener` and `ServiceAccountPatching` feature gates are now in the _beta_ phase and are enabled by default.
 * Allow setting any extra environment variables for the Cluster Operator container through Helm using a new `extraEnvs` value.
+* Update OPA Authorizer to 1.3.0
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
@@ -30,7 +30,7 @@ public class KafkaAuthorizationOpa extends KafkaAuthorization {
 
     public static final String TYPE_OPA = "opa";
 
-    public static final String AUTHORIZER_CLASS_NAME = "com.bisnode.kafka.authorization.OpaAuthorizer";
+    public static final String AUTHORIZER_CLASS_NAME = "org.openpolicyagent.kafka.OpaAuthorizer";
 
     private List<String> superUsers;
     private String url;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -257,7 +257,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withAuthorization("my-cluster", auth)
                 .build();
 
-        assertThat(configuration, isEquivalent("authorizer.class.name=com.bisnode.kafka.authorization.OpaAuthorizer\n" +
+        assertThat(configuration, isEquivalent("authorizer.class.name=org.openpolicyagent.kafka.OpaAuthorizer\n" +
                 "opa.authorizer.url=http://opa:8181/v1/data/kafka/allow\n" +
                 "opa.authorizer.allow.on.error=false\n" +
                 "opa.authorizer.cache.initial.capacity=5000\n" +
@@ -281,7 +281,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withAuthorization("my-cluster", auth)
                 .build();
 
-        assertThat(configuration, isEquivalent("authorizer.class.name=com.bisnode.kafka.authorization.OpaAuthorizer\n" +
+        assertThat(configuration, isEquivalent("authorizer.class.name=org.openpolicyagent.kafka.OpaAuthorizer\n" +
                 "opa.authorizer.url=http://opa:8181/v1/data/kafka/allow\n" +
                 "opa.authorizer.allow.on.error=true\n" +
                 "opa.authorizer.cache.initial.capacity=1000\n" +

--- a/docker-images/artifacts/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <cruise-control.version>2.5.74</cruise-control.version>
-        <opa-authorizer.version>1.1.0</opa-authorizer.version>
+        <opa-authorizer.version>1.3.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
@@ -277,7 +277,7 @@
         </dependency>
         <!-- Open Policy Authorization plugin -->
         <dependency>
-            <groupId>com.bisnode.kafka.authorization</groupId>
+            <groupId>org.openpolicyagent.kafka</groupId>
             <artifactId>opa-authorizer</artifactId>
             <version>${opa-authorizer.version}</version>
             <exclusions>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
         <cruise-control.version>2.5.74</cruise-control.version>
-        <opa-authorizer.version>1.2.0</opa-authorizer.version>
+        <opa-authorizer.version>1.3.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
@@ -277,7 +277,7 @@
         </dependency>
         <!-- Open Policy Authorization plugin -->
         <dependency>
-            <groupId>com.bisnode.kafka.authorization</groupId>
+            <groupId>org.openpolicyagent.kafka</groupId>
             <artifactId>opa-authorizer</artifactId>
             <version>${opa-authorizer.version}</version>
             <exclusions>

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationOpa.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationOpa.adoc
@@ -1,7 +1,7 @@
 To use link:https://www.openpolicyagent.org/[Open Policy Agent^] authorization, set the `type` property in the `authorization` section to the value `opa`,
 and configure OPA properties as required.
-Strimzi uses Bisnode's Kafka authorization plugin as the Open Policy Agent authorizer.
-For more information about the format of the input data and policy examples, see {BisnodeOPAAuthorizer}.
+Strimzi uses Open Policy Agent plugin for Kafka authorization as the authorizer.
+For more information about the format of the input data and policy examples, see {OPAAuthorizer}.
 
 === `url`
 The URL used to connect to the Open Policy Agent server.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -114,7 +114,7 @@
 :JaegerArch: link:https://www.jaegertracing.io/docs/1.18/architecture/[Jaeger architecure^]
 :JaegerArch: link:https://www.jaegertracing.io/docs/1.18/architecture/[Jaeger architecure^]
 :OpenTracingDocs: link:https://opentracing.io/docs/overview/[OpenTracing documentation^]
-:BisnodeOPAAuthorizer: link:https://github.com/Bisnode/opa-kafka-plugin[Open Policy Agent plugin for Kafka authorization^]
+:OPAAuthorizer: link:https://github.com/anderseknert/opa-kafka-plugin[Open Policy Agent plugin for Kafka authorization^]
 :LatestBridgeAPIDocs: link:https://strimzi.io/docs/bridge/latest/[Kafka Bridge API reference^]
 :external-cors-link: https://www.w3.org/TR/cors/
 :HelmCustomResourceDefinitions: link:https://helm.sh/docs/chart_best_practices/custom_resource_definitions/[Custom Resource Definitions for Helm^]


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR update the Open Policy Agent Authorizer to 1.3.0. The original authorizer also moved and changed the group name and package name (new home is https://github.com/anderseknert/opa-kafka-plugin). So this PR updates that as well. It also updates the old references in the documentation.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md