### PR TITLE
Update Log4j2 in Cruise Control

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -31,6 +31,18 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
+            <exclusions>
+                <!-- Excluded because of CVE-2021-44228 -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Since there is not yet a new release of Cruise Control, this PR just overrides the Log4j version used in the Cruise Control deployment and updates it to 2.15. The override can be removed later when Cruise Control has a new release.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally