### PR TITLE
Update Cruise Control to 2.5.79

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
-        <cruise-control.version>2.5.74</cruise-control.version>
+        <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.3.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.74</cruise-control.version>
+        <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.3.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.74</cruise-control.version>
+        <cruise-control.version>2.5.79</cruise-control.version>
     </properties>
 
     <repositories>
@@ -31,18 +31,6 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
-            <exclusions>
-                <!-- Excluded because of CVE-2021-44228 -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Cruise Control to 2.5.79. 2.5.79 uses natively Log4j2 2.16, so we can also remove the override.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally