### PR TITLE
Fix kafka version comparing when message format is used instead

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -449,6 +449,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      * 1 if version1 &gt; version2.
      */
     public static int compareDottedIVVersions(String version1, String version2) {
+        // Due to validation in KafkaConfiguration.validate only values like 2.8 or 2.8-IV0 can get there
         String trimmedVersion1 = version1.split("-")[0];
         String trimmedVersion2 = version2.split("-")[0];
         return compareDottedVersions(trimmedVersion1, trimmedVersion2);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -423,9 +423,6 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      * 1 if version1 &gt; version2.
      */
     public static int compareDottedVersions(String version1, String version2) {
-        // Version like X.Y-IVZ can get through validation
-        version1 = version1.split("-")[0];
-        version2 = version2.split("-")[0];
         String[] components = version1.split("\\.");
         String[] otherComponents = version2.split("\\.");
         for (int i = 0; i < Math.min(components.length, otherComponents.length); i++) {
@@ -441,6 +438,20 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         }
         // mismatch was not found, but the versions are of different length, e.g. 2.8 and 2.8.0
         return 0;
+    }
+
+    /**
+     * Compare two decimal version strings, e.g. 3.0 &gt; 2.7-IV1. Ignores the IV part
+     * @param version1 The first version.
+     * @param version2 The second version.
+     * @return Zero if version1 == version2;
+     * -1 if version1 &lt; version2;
+     * 1 if version1 &gt; version2.
+     */
+    public static int compareDottedIVVersion(String version1, String version2) {
+        String trimmedVersion1 = version1.split("-")[0];
+        String trimmedVersion2 = version2.split("-")[0];
+        return compareDottedVersions(trimmedVersion1, trimmedVersion2);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -423,6 +423,9 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      * 1 if version1 &gt; version2.
      */
     public static int compareDottedVersions(String version1, String version2) {
+        // Version like X.Y-IVZ can get through validation
+        version1 = version1.split("-")[0];
+        version2 = version2.split("-")[0];
         String[] components = version1.split("\\.");
         String[] otherComponents = version2.split("\\.");
         for (int i = 0; i < Math.min(components.length, otherComponents.length); i++) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -448,7 +448,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      * -1 if version1 &lt; version2;
      * 1 if version1 &gt; version2.
      */
-    public static int compareDottedIVVersion(String version1, String version2) {
+    public static int compareDottedIVVersions(String version1, String version2) {
         String trimmedVersion1 = version1.split("-")[0];
         String trimmedVersion2 = version2.split("-")[0];
         return compareDottedVersions(trimmedVersion1, trimmedVersion2);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1005,7 +1005,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             && !kafkaCluster.getKafkaVersion().protocolVersion().equals(highestInterBrokerProtocolVersion)) {
                         LOGGER.infoCr(reconciliation, "Upgrading Kafka inter.broker.protocol.version from {} to {}", highestInterBrokerProtocolVersion, kafkaCluster.getKafkaVersion().protocolVersion());
 
-                        if (compareDottedVersions(kafkaCluster.getKafkaVersion().protocolVersion(), "3.0") >= 0) {
+                        if (compareDottedIVVersions(kafkaCluster.getKafkaVersion().protocolVersion(), "3.0") >= 0) {
                             // From Kafka 3.0.0, the LMFV is ignored when IBPV is set to 3.0 or higher
                             // We set the LMFV immediately to the same version as IPBV to avoid unnecessary rolling update
                             kafkaCluster.setLogMessageFormatVersion(kafkaCluster.getKafkaVersion().messageVersion());
@@ -1035,8 +1035,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
                     // We make sure that the highest log.message.format.version or inter.broker.protocol.version
                     // used by any of the brokers is not higher than the broker version we upgrade from.
-                    if ((highestLogMessageFormatVersion != null && compareDottedVersions(versionChange.from().messageVersion(), highestLogMessageFormatVersion) < 0)
-                            || (highestInterBrokerProtocolVersion != null && compareDottedVersions(versionChange.from().protocolVersion(), highestInterBrokerProtocolVersion) < 0)) {
+                    if ((highestLogMessageFormatVersion != null && compareDottedIVVersions(versionChange.from().messageVersion(), highestLogMessageFormatVersion) < 0)
+                            || (highestInterBrokerProtocolVersion != null && compareDottedIVVersions(versionChange.from().protocolVersion(), highestInterBrokerProtocolVersion) < 0)) {
                         LOGGER.warnCr(reconciliation, "log.message.format.version ({}) and inter.broker.protocol.version ({}) used by the brokers have to be lower or equal to the Kafka broker version we upgrade from ({})", highestLogMessageFormatVersion, highestInterBrokerProtocolVersion, versionChange.from().version());
                         throw new KafkaUpgradeException("log.message.format.version (" + highestLogMessageFormatVersion + ") and inter.broker.protocol.version (" + highestInterBrokerProtocolVersion + ") used by the brokers have to be lower or equal to the Kafka broker version we upgrade from (" + versionChange.from().version() + ")");
                     }
@@ -1048,7 +1048,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     // cannot be higher that the Kafka version we are upgrading from. If it is, we override it with the
                     // version we are upgrading from. If it is not set, we set it to the version we are upgrading from.
                     if (desiredLogMessageFormat == null
-                            || compareDottedVersions(versionChange.from().messageVersion(), desiredLogMessageFormat) < 0) {
+                            || compareDottedIVVersions(versionChange.from().messageVersion(), desiredLogMessageFormat) < 0) {
                         kafkaCluster.setLogMessageFormatVersion(versionChange.from().messageVersion());
                     }
 
@@ -1056,7 +1056,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     // cannot be higher that the Kafka version we are upgrading from. If it is, we override it with the
                     // version we are upgrading from. If it is not set, we set it to the version we are upgrading from.
                     if (desiredInterBrokerProtocol == null
-                            || compareDottedVersions(versionChange.from().protocolVersion(), desiredInterBrokerProtocol) < 0) {
+                            || compareDottedIVVersions(versionChange.from().protocolVersion(), desiredInterBrokerProtocol) < 0) {
                         kafkaCluster.setInterBrokerProtocolVersion(versionChange.from().protocolVersion());
                     }
                 } else {
@@ -1068,9 +1068,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     // we assume that it will use the default value which is the from version. In such case we fail the
                     // reconciliation as well.
                     if (highestLogMessageFormatVersion == null
-                            || compareDottedVersions(versionChange.to().messageVersion(), highestLogMessageFormatVersion) < 0
+                            || compareDottedIVVersions(versionChange.to().messageVersion(), highestLogMessageFormatVersion) < 0
                             || highestInterBrokerProtocolVersion == null
-                            || compareDottedVersions(versionChange.to().protocolVersion(), highestInterBrokerProtocolVersion) < 0) {
+                            || compareDottedIVVersions(versionChange.to().protocolVersion(), highestInterBrokerProtocolVersion) < 0) {
                         LOGGER.warnCr(reconciliation, "log.message.format.version ({}) and inter.broker.protocol.version ({}) used by the brokers have to be set and be lower or equal to the Kafka broker version we downgrade to ({})", highestLogMessageFormatVersion, highestInterBrokerProtocolVersion, versionChange.to().version());
                         throw new KafkaUpgradeException("log.message.format.version (" + highestLogMessageFormatVersion + ") and inter.broker.protocol.version (" + highestInterBrokerProtocolVersion + ") used by the brokers have to be set and be lower or equal to the Kafka broker version we downgrade to (" + versionChange.to().version() + ")");
                     }
@@ -1093,8 +1093,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     // Either log.message.format.version or inter.broker.protocol.version are higher than the Kafka
                     // version we are downgrading to. This should normally not happen since that should not pass the CR
                     // validation. But we still double check it as safety.
-                    if (compareDottedVersions(versionChange.to().messageVersion(), desiredLogMessageFormat) < 0
-                            || compareDottedVersions(versionChange.to().protocolVersion(), desiredInterBrokerProtocol) < 0) {
+                    if (compareDottedIVVersions(versionChange.to().messageVersion(), desiredLogMessageFormat) < 0
+                            || compareDottedIVVersions(versionChange.to().protocolVersion(), desiredInterBrokerProtocol) < 0) {
                         LOGGER.warnCr(reconciliation, "log.message.format.version ({}) and inter.broker.protocol.version ({}) used in the Kafka CR have to be set and be lower or equal to the Kafka broker version we downgrade to ({})", highestLogMessageFormatVersion, highestInterBrokerProtocolVersion, versionChange.to().version());
                         throw new KafkaUpgradeException("log.message.format.version and inter.broker.protocol.version used in the Kafka CR have to be set and be lower or equal to the Kafka broker version we downgrade to");
                     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -145,7 +145,7 @@ import java.util.stream.Collectors;
 import static io.strimzi.operator.cluster.model.AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG;
 import static io.strimzi.operator.cluster.model.AbstractModel.ANNO_STRIMZI_IO_STORAGE;
 import static io.strimzi.operator.cluster.model.KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION;
-import static io.strimzi.operator.cluster.model.KafkaVersion.compareDottedIVVersion;
+import static io.strimzi.operator.cluster.model.KafkaVersion.compareDottedIVVersions;
 import static io.strimzi.operator.cluster.model.KafkaVersion.compareDottedVersions;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -1701,7 +1701,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             if (currentMessageFormat != null) {
                                 if (highestLogMessageFormatVersion == null)  {
                                     highestLogMessageFormatVersion = currentMessageFormat;
-                                } else if (compareDottedIVVersion(highestLogMessageFormatVersion, currentMessageFormat) < 0) {
+                                } else if (compareDottedIVVersions(highestLogMessageFormatVersion, currentMessageFormat) < 0) {
                                     highestLogMessageFormatVersion = currentMessageFormat;
                                 }
                             }
@@ -1711,7 +1711,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             if (currentIbp != null)  {
                                 if (highestInterBrokerProtocolVersion == null)  {
                                     highestInterBrokerProtocolVersion = currentIbp;
-                                } else if (compareDottedIVVersion(highestInterBrokerProtocolVersion, currentIbp) < 0) {
+                                } else if (compareDottedIVVersions(highestInterBrokerProtocolVersion, currentIbp) < 0) {
                                     highestInterBrokerProtocolVersion = currentIbp;
                                 }
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -145,6 +145,7 @@ import java.util.stream.Collectors;
 import static io.strimzi.operator.cluster.model.AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG;
 import static io.strimzi.operator.cluster.model.AbstractModel.ANNO_STRIMZI_IO_STORAGE;
 import static io.strimzi.operator.cluster.model.KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION;
+import static io.strimzi.operator.cluster.model.KafkaVersion.compareDottedIVVersion;
 import static io.strimzi.operator.cluster.model.KafkaVersion.compareDottedVersions;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -1700,7 +1701,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             if (currentMessageFormat != null) {
                                 if (highestLogMessageFormatVersion == null)  {
                                     highestLogMessageFormatVersion = currentMessageFormat;
-                                } else if (compareDottedVersions(highestLogMessageFormatVersion, currentMessageFormat) < 0) {
+                                } else if (compareDottedIVVersion(highestLogMessageFormatVersion, currentMessageFormat) < 0) {
                                     highestLogMessageFormatVersion = currentMessageFormat;
                                 }
                             }
@@ -1710,7 +1711,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             if (currentIbp != null)  {
                                 if (highestInterBrokerProtocolVersion == null)  {
                                     highestInterBrokerProtocolVersion = currentIbp;
-                                } else if (compareDottedVersions(highestInterBrokerProtocolVersion, currentIbp) < 0) {
+                                } else if (compareDottedIVVersion(highestInterBrokerProtocolVersion, currentIbp) < 0) {
                                     highestInterBrokerProtocolVersion = currentIbp;
                                 }
                             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -32,6 +32,20 @@ public class KafkaVersionTest {
     }
 
     @ParallelTest
+    public void parsingInvalidVersionTest() {
+        // 2.8-IV1 is not a valid kafka version. However it can be used in CO as it is looking for the MM/MMP versions
+        KafkaVersion kv = new KafkaVersion("2.8-IV1", "2.8-IV1", "2.8-IV1", "3.6.9", false, true, "");
+        assertThat(KafkaVersion.compareDottedVersions("2.8.0", kv.version()), is(0));
+        assertThat(KafkaVersion.compareDottedVersions("3.0.0", kv.version()), greaterThan(0));
+        assertThat(KafkaVersion.compareDottedVersions("2.7.0", kv.version()), lessThan(0));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            KafkaVersion kvFail = new KafkaVersion("why", "you", "little", "3.6.9", false, true, "");
+            assertThat(KafkaVersion.compareDottedVersions("2.8.0", kvFail.version()), is(0));
+        });
+    }
+
+    @ParallelTest
     public void parsingTest() throws Exception {
         Map<String, KafkaVersion> map = new HashMap<>();
         KafkaVersion defaultVersion = KafkaVersion.parseKafkaVersions(getKafkaVersionsReader(KAFKA_VERSIONS_VALID_RESOURCE), map);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -38,8 +38,7 @@ public class KafkaVersionTest {
         assertThat(KafkaVersion.compareDottedIVVersions("2.9-IV1", kv.protocolVersion()), greaterThan(0));
 
         assertThrows(NumberFormatException.class, () -> {
-            KafkaVersion kvFail = new KafkaVersion("2.8.0", "2.8", "2.8", "3.6.9", false, true, "");
-            KafkaVersion.compareDottedIVVersions("wrong", kvFail.protocolVersion());
+            KafkaVersion.compareDottedIVVersions("wrong", kv.protocolVersion());
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -33,16 +33,20 @@ public class KafkaVersionTest {
 
     @ParallelTest
     public void parsingInvalidVersionTest() {
-        // 2.8-IV1 is not a valid kafka version. However it can be used in CO as it is looking for the MM/MMP versions
-        KafkaVersion kv = new KafkaVersion("2.8-IV1", "2.8-IV1", "2.8-IV1", "3.6.9", false, true, "");
-        assertThat(KafkaVersion.compareDottedVersions("2.8.0", kv.version()), is(0));
-        assertThat(KafkaVersion.compareDottedVersions("3.0.0", kv.version()), greaterThan(0));
-        assertThat(KafkaVersion.compareDottedVersions("2.7.0", kv.version()), lessThan(0));
+        KafkaVersion kv = new KafkaVersion("2.8", "2.8-IV1", "2.8-IV1", "3.6.9", false, true, "");
+        assertThat(KafkaVersion.compareDottedIVVersions("2.7-IV1", kv.protocolVersion()), lessThan(0));
+        assertThat(KafkaVersion.compareDottedIVVersions("2.9-IV1", kv.protocolVersion()), greaterThan(0));
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(NumberFormatException.class, () -> {
             KafkaVersion kvFail = new KafkaVersion("why", "you", "little", "3.6.9", false, true, "");
-            assertThat(KafkaVersion.compareDottedVersions("2.8.0", kvFail.version()), is(0));
+            KafkaVersion.compareDottedIVVersions("2.8.0", kvFail.protocolVersion());
         });
+
+        assertThrows(NumberFormatException.class, () -> {
+            KafkaVersion kvFail = new KafkaVersion("2.8.1-IV1", "you", "little", "3.6.9", false, true, "");
+            KafkaVersion.compareDottedVersions("2.8.0", kvFail.protocolVersion());
+        });
+
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -33,20 +33,14 @@ public class KafkaVersionTest {
 
     @ParallelTest
     public void parsingInvalidVersionTest() {
-        KafkaVersion kv = new KafkaVersion("2.8", "2.8-IV1", "2.8-IV1", "3.6.9", false, true, "");
+        KafkaVersion kv = new KafkaVersion("2.8.0", "2.8", "2.8", "3.6.9", false, true, "");
         assertThat(KafkaVersion.compareDottedIVVersions("2.7-IV1", kv.protocolVersion()), lessThan(0));
         assertThat(KafkaVersion.compareDottedIVVersions("2.9-IV1", kv.protocolVersion()), greaterThan(0));
 
         assertThrows(NumberFormatException.class, () -> {
-            KafkaVersion kvFail = new KafkaVersion("why", "you", "little", "3.6.9", false, true, "");
-            KafkaVersion.compareDottedIVVersions("2.8.0", kvFail.protocolVersion());
+            KafkaVersion kvFail = new KafkaVersion("2.8.0", "2.8", "2.8", "3.6.9", false, true, "");
+            KafkaVersion.compareDottedIVVersions("wrong", kvFail.protocolVersion());
         });
-
-        assertThrows(NumberFormatException.class, () -> {
-            KafkaVersion kvFail = new KafkaVersion("2.8.1-IV1", "you", "little", "3.6.9", false, true, "");
-            KafkaVersion.compareDottedVersions("2.8.0", kvFail.protocolVersion());
-        });
-
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -221,8 +221,8 @@ public class KafkaUpgradeDowngradeMockTest {
                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION + iv);
 
         Kafka updatedKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
-                KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
-                KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION);
+                KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION + iv,
+                KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION + iv);
 
         Checkpoint reconciliation = context.checkpoint();
         initialize(context, initialKafka)
@@ -237,8 +237,8 @@ public class KafkaUpgradeDowngradeMockTest {
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertVersionsInStatefulSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
-                            KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
-                            KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
+                            KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION + iv,
+                            KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION + iv,
                             KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
 
                     reconciliation.flag();


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
`compareDottedVersions` does not cope with versions like `3.0-IV1` so it cannot be used for comparing `inter.broker.protocol.version`. 
If the version contains `-` character, only its prefix is used. So if we provide `2.8-IV1`, the version `2.8` will be used.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/6048

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

