### PR TITLE
Pass Java system properties to Cruise Control

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -293,6 +293,10 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.setGcLoggingEnabled(spec.getJvmOptions() == null ? DEFAULT_JVM_GC_LOGGING_ENABLED : spec.getJvmOptions().isGcLoggingEnabled());
             cruiseControl.setJvmOptions(spec.getJvmOptions());
 
+            if (spec.getJvmOptions() != null) {
+                cruiseControl.setJavaSystemProperties(spec.getJvmOptions().getJavaSystemProperties());
+            }
+
             cruiseControl.setResources(spec.getResources());
             cruiseControl.setOwnerReference(kafkaAssembly);
             cruiseControl = updateTemplate(spec, cruiseControl);
@@ -542,6 +546,10 @@ public class CruiseControl extends AbstractModel {
 
         if (configuration != null && !configuration.getConfiguration().isEmpty()) {
             varList.add(buildEnvVar(ENV_VAR_CRUISE_CONTROL_CONFIGURATION, configuration.getConfiguration()));
+        }
+
+        if (javaSystemProperties != null) {
+            varList.add(buildEnvVar(ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES, ModelUtils.getJavaSystemPropertiesToString(javaSystemProperties)));
         }
 
         // Add shared environment variables used for all containers

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -24,6 +24,11 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=file:$CRUISE_CONTROL_HOME/custom-config/log4j2.properties"
 fi
 
+# System properties passed through the Kafka custom resource
+if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
+    export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
+fi
+
 # enabling Prometheus JMX exporter as Java agent
 if [ "$CRUISE_CONTROL_METRICS_ENABLED" = "true" ]; then
   KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$CRUISE_CONTROL_HOME/custom-config/metrics-config.json"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For Cruise Control, users can specify system properties in `.spec.cruiseControl.jvmOptions.javaSystemProperties` .These should be passed to the Cruise Control process, but they are currently completely ignored. This PR fixes that and passes them to the container and uses them there to configure the CC process. This bug was found during the recent Log4j2 issues when it was not possible to use this to pass any system properties.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally