### PR TITLE
Fix wait util

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -213,6 +213,7 @@ public class KafkaUtils {
             }
             zkPods[0] = zkSnapshot;
             kafkaPods[0] = kafkaSnaptop;
+            eoPods[0] = eoSnapshot;
             count[0] = 0;
             return false;
         });


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
`waitForClusterStability` is never ready, because EO pods are not set.

