### PR TITLE
Remove `log.message.format.version` from Kafka examples

### DIFF
--- a/packaging/examples/cruise-control/kafka-cruise-control.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/packaging/examples/kafka/kafka-ephemeral-single.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral-single.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/packaging/examples/kafka/kafka-ephemeral.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/kafka/kafka-persistent-single.yaml
+++ b/packaging/examples/kafka/kafka-persistent-single.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -19,7 +19,6 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -27,7 +27,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -40,7 +40,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -21,7 +21,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod


### PR DESCRIPTION
### Type of change

- Task

### Description

From Kafka 3.0.0, the `log.message.format.version` field in Kafka configuration is deprecated and ignored when `inter.broker.protocol.version` is set to 3.0 or higher. This means that we do not need this field in our example YAMLs anymore, which use currently set both `log.message.format.version: "3.0"` and `inter.broker.protocol.version: "3.0"` which makes it ignored.