### PR TITLE
Use the same model for printing executed commands in all containers

### DIFF
--- a/docker-images/jmxtrans/docker-entrypoint.sh
+++ b/docker-images/jmxtrans/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 EXEC="-jar $JAR_FILE -e -j $JSON_DIR -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR $ADDITIONAL_JARS_OPTS"
 GC_OPTS="-Xms${HEAP_SIZE}m -Xmx${HEAP_SIZE}m -XX:PermSize=${PERM_SIZE}m -XX:MaxPermSize=${MAX_PERM_SIZE}m"

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -51,6 +51,8 @@ if [ -z "$KAFKA_JVM_PERFORMANCE_OPTS" ]; then
   KAFKA_JVM_PERFORMANCE_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+DisableExplicitGC -Djava.awt.headless=true"
 fi
 
+set -x
+
 # starting Cruise Control server with final configuration
 # shellcheck disable=SC2086
 exec /usr/bin/tini -w -e 143 -- java ${KAFKA_HEAP_OPTS} ${KAFKA_JVM_PERFORMANCE_OPTS} ${KAFKA_GC_LOG_OPTS} ${KAFKA_JMX_OPTS} ${KAFKA_LOG4J_OPTS} ${KAFKA_OPTS} -classpath "${CLASSPATH}" com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain /tmp/cruisecontrol.properties

--- a/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -58,4 +58,6 @@ EOT
 
 chmod +x /tmp/run.sh
 
+set -x
+
 exec /usr/bin/tini -w -e 143 -- /tmp/run.sh

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -70,5 +70,7 @@ fi
 
 . ./set_kafka_gc_options.sh
 
+set -x
+
 # starting Kafka server with final configuration
 exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/connect-distributed.sh" /tmp/strimzi-connect.properties

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 # Generate temporary keystore password
 CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 # Generate temporary keystore password
 CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
@@ -110,6 +111,8 @@ if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
 fi
 
 . ./set_kafka_gc_options.sh
+
+set -x
 
 # starting Kafka Mirror Maker with final configuration
 # shellcheck disable=SC2086,SC2090

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-set -x
+set +x
 
 STRIMZI_BROKER_ID=$(hostname | awk -F'-' '{print $NF}')
 export STRIMZI_BROKER_ID
@@ -59,6 +59,8 @@ if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
 fi
 
 . ./set_kafka_gc_options.sh
+
+set -x
 
 # starting Kafka server with final configuration
 exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/kafka-server-start.sh" /tmp/strimzi.properties

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 # volume for saving Zookeeper server logs
 export ZOOKEEPER_VOLUME="/var/lib/zookeeper/"
@@ -76,6 +77,8 @@ fi
 # We need to disable the native ZK authorisation (we secure ZK through the TLS-Sidecars) to allow use of the reconfiguration options.
 KAFKA_OPTS="$KAFKA_OPTS -Dzookeeper.skipACL=yes"
 export KAFKA_OPTS
+
+set -x
 
 # starting Zookeeper with final configuration
 exec /usr/bin/tini -w -e 143 -- "${KAFKA_HOME}/bin/zookeeper-server-start.sh" /tmp/zookeeper.properties

--- a/docker-images/kafka-based/kafka/stunnel-scripts/cruise_control_stunnel_run.sh
+++ b/docker-images/kafka-based/kafka/stunnel-scripts/cruise_control_stunnel_run.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 # Generate and print the config file
 echo "Starting Stunnel with configuration:"
 "${STUNNEL_HOME}"/cruise_control_stunnel_config_generator.sh | tee /tmp/stunnel.conf
 echo ""
+
+set -x
 
 # starting Stunnel with final configuration
 exec /usr/bin/tini -w -e 143 -- /usr/bin/stunnel /tmp/stunnel.conf

--- a/docker-images/kafka-based/kafka/stunnel-scripts/entity_operator_stunnel_run.sh
+++ b/docker-images/kafka-based/kafka/stunnel-scripts/entity_operator_stunnel_run.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 # Generate and print the config file
 echo "Starting Stunnel with configuration:"
 "${STUNNEL_HOME}"/entity_operator_stunnel_config_generator.sh | tee /tmp/stunnel.conf
 echo ""
+
+set -x
 
 # starting Stunnel with final configuration
 exec /usr/bin/tini -w -e 143 -- /usr/bin/stunnel /tmp/stunnel.conf

--- a/docker-images/kafka-based/test-client/scripts/consumer.sh
+++ b/docker-images/kafka-based/test-client/scripts/consumer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set +x
 
 . ./set_kafka_gc_options.sh
 

--- a/docker-images/kafka-based/test-client/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/test-client/scripts/kafka_tls_prepare_certificates.sh
@@ -7,8 +7,6 @@ KEYSTORE_LOCATION=$(eval "echo \$$(echo KEYSTORE_LOCATION_${USER})")
 USER_LOCATION=$(eval "echo \$$(echo USER_LOCATION_${USER})")
 KAFKA_USER=$(eval "echo \$$(echo KAFKA_USER_${USER})")
 
-set -x
-
 # Parameters:
 # $1: Path to the new truststore
 # $2: Truststore password

--- a/docker-images/kafka-based/test-client/scripts/producer.sh
+++ b/docker-images/kafka-based/test-client/scripts/producer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set +x
 
 # Defaults
 CONFIG_REGEX="USER=([A-Za-z0-9\_]*)"

--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-set -x
+set +x
 
 # expand gc options based upon java version
 function get_gc_opts {
@@ -22,6 +22,8 @@ JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
 # Deny illegal access option is supported only on Java 9 and higher
 JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
+
+set -x
 
 # shellcheck disable=SC2086
 exec /usr/bin/tini -w -e 143 -- java $JAVA_OPTS -classpath "$JAVA_CLASSPATH" "$JAVA_MAIN" "$@"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We have currently in each container different policy of which commands executed during the startup are or aren't printed using the `set -x` and `set +x` fields. This PR tries to unify it to:
* Always print the main command we are starting
* Don't print all the preparation of the config files etc. (it still prints intentionally logged messages using `echo`)

This should help to create a cleaner log output when the containers start while still showing the important part which is the main command.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally