### PR TITLE
Fix InternalKafkaClient and VerifiableClient

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
@@ -312,6 +312,9 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
 
         boolean hasPassed = consumerGroups.run(timeoutMs);
         LOGGER.info("ConsumerGroups finished correctly: {}", hasPassed);
+        if (!hasPassed) {
+            throw new RuntimeException("VerifiableClient has failed. Check stderr for more details.");
+        }
 
         // output parsing
         Map<String, String> currentOffsets = new HashMap<>();

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -330,9 +330,16 @@ public class VerifiableClient {
         Matcher current = pattern.matcher(clientVersion);
         Matcher minimal = pattern.matcher(minimalVersion);
         if (current.find() && minimal.find()) {
-            return Integer.parseInt(current.group("major")) >= Integer.parseInt(minimal.group("major"))
-                    && Integer.parseInt(current.group("minor")) >= Integer.parseInt(minimal.group("minor"))
-                    && Integer.parseInt(current.group("micro")) >= Integer.parseInt(minimal.group("micro"));
+            int major = Integer.parseInt(current.group("major")), 
+                minor = Integer.parseInt(current.group("minor")),
+                micro = Integer.parseInt(current.group("micro"));
+            int minMajor = Integer.parseInt(minimal.group("major")), 
+                minMinor = Integer.parseInt(minimal.group("minor")),
+                minMicro = Integer.parseInt(minimal.group("micro")); 
+            return 
+                    (major > minMajor)
+                    || (major == minMajor && minor > minMinor)
+                    || (major == minMajor && minor == minMinor && micro >= minMicro);
         }
         return false;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.kafkaclients.internalClients;
 
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
 import java.io.IOException;
@@ -121,19 +120,11 @@ public class VerifiableClient {
         this.clientArgumentMap.put(ClientArgument.MAX_MESSAGES, Integer.toString(maxMessages));
         if (kafkaUsername != null) this.clientArgumentMap.put(ClientArgument.USER, kafkaUsername.replace("-", "_"));
 
-        String image = kubeClient().namespace(podNamespace).getPod(podNamespace, this.podName).getSpec().getContainers().get(0).getImage();
-        String clientVersion = image.substring(image.length() - 5);
-
-        this.clientArgumentMap.put(allowParameter("2.5.0", clientVersion) ? ClientArgument.BOOTSTRAP_SERVER : ClientArgument.BROKER_LIST, bootstrapServer);
+        this.clientArgumentMap.put(ClientArgument.BOOTSTRAP_SERVER, bootstrapServer);
 
         if (clientType == ClientType.CLI_KAFKA_VERIFIABLE_CONSUMER) {
             this.consumerGroupName = verifiableClientBuilder.consumerGroupName;
             this.clientArgumentMap.put(ClientArgument.GROUP_ID, consumerGroupName);
-
-            if (allowParameter("2.3.0", clientVersion)) {
-                this.consumerInstanceId = verifiableClientBuilder.consumerInstanceId;
-                this.clientArgumentMap.put(ClientArgument.GROUP_INSTANCE_ID, this.consumerInstanceId);
-            }
         }
 
         if (clientType == ClientType.CLI_KAFKA_CONSUMER_GROUPS) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -12,8 +12,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -314,25 +312,6 @@ public class VerifiableClient {
 
     public String getBootstrapServer() {
         return bootstrapServer;
-    }
-
-    private boolean allowParameter(String minimalVersion, String clientVersion) {
-        Pattern pattern = Pattern.compile("(?<major>[0-9]).(?<minor>[0-9]).(?<micro>[0-9])");
-        Matcher current = pattern.matcher(clientVersion);
-        Matcher minimal = pattern.matcher(minimalVersion);
-        if (current.find() && minimal.find()) {
-            int major = Integer.parseInt(current.group("major")), 
-                minor = Integer.parseInt(current.group("minor")),
-                micro = Integer.parseInt(current.group("micro"));
-            int minMajor = Integer.parseInt(minimal.group("major")), 
-                minMinor = Integer.parseInt(minimal.group("minor")),
-                minMicro = Integer.parseInt(minimal.group("micro")); 
-            return 
-                    (major > minMajor)
-                    || (major == minMajor && minor > minMinor)
-                    || (major == minMajor && minor == minMinor && micro >= minMicro);
-        }
-        return false;
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptST.java
@@ -58,7 +58,7 @@ public class ColdBackupScriptST extends AbstractST {
 
         // save consumer group offsets
         Map<String, String> offsetsBeforeBackup = clients.getCurrentOffsets();
-        assertThat("Empty offsets map before backup", offsetsBeforeBackup.size() > 0);
+        assertThat("No offsets map before backup", offsetsBeforeBackup != null && offsetsBeforeBackup.size() > 0);
 
         // send additional messages
         clients.setMessageCount(secondBatchSize);

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptST.java
@@ -58,6 +58,7 @@ public class ColdBackupScriptST extends AbstractST {
 
         // save consumer group offsets
         Map<String, String> offsetsBeforeBackup = clients.getCurrentOffsets();
+        assertThat("Empty offsets map before backup", offsetsBeforeBackup.size() > 0);
 
         // send additional messages
         clients.setMessageCount(secondBatchSize);


### PR DESCRIPTION
Even though the ColdBackupScriptST was running fine, there were two errors printed to stderr. One of them revealed a couple of bugs in the ST framework (who tests the testing framework?).

### 1s error (not a problem)

```log
ls: cannot access '/home/vsts/work/1/s/systemtest/target/infra-namespace/my-cluster-95134611': No such file or directory
```

The fact that we have non empty stderr does not necessary mean that the script has failed, it could be expected like in this case. We only have one `ls` command in the entire script. As I show below, the exit code is 0 when the directory is not found. We can suppress the stderr, but that would hide other important errors (e.g. not having permissions to list files).

```
$ if [[ ! -z "$(ls -A foo)" ]]; then
 echo "Non empty directory"
fi
ls: cannot access 'foo': No such file or directory
$ echo $?
0
```

### 2nd error (ST framework bugs)

```log
Missing required argument "[bootstrap-server]"...
```

##### 1st bug
 
This happens two times when getting the offsets map, before the backup and after the restore. Instead of returning a runtime error, the `InternalKafkaClient.getCurrentOffsets()` returns an empty map, so the final assertion which compares them still holds true (added an additional check to avoid this).

##### 2nd bug

The `InternalKafkaClient` uses the `VerifiableClient.allowParameter()` to choose between `--bootstrap-server` and the deprecated `--broker-list` parameters. Recently we moved from Kafka 2.x to Kafka 3.x, and the following expression used in that method does not work anymore.

```java
return Integer.parseInt(current.group("major")) >= Integer.parseInt(minimal.group("major"))
    && Integer.parseInt(current.group("minor")) >= Integer.parseInt(minimal.group("minor"))
    && Integer.parseInt(current.group("micro")) >= Integer.parseInt(minimal.group("micro"));
```


