### PR TITLE
Fix decrement metric when resource is deleted

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -252,6 +252,12 @@ public abstract class AbstractOperator<
 
                 return createOrUpdate.future();
             } else {
+                if (resourceCounter(namespace).get() > 0) {
+                    resourceCounter(namespace).getAndDecrement();
+                }
+                if (pausedResourceCounter(namespace).get() > 0) {
+                    pausedResourceCounter(namespace).getAndDecrement();
+                }
                 LOGGER.infoCr(reconciliation, "{} {} should be deleted", kind, name);
                 return delete(reconciliation).map(deleteResult -> {
                     if (deleteResult) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -107,6 +107,12 @@ public abstract class AbstractOperator<
     }
 
     @Override
+    public void resetCounters() {
+        resourceCounterMap.entrySet().forEach(entry -> entry.getValue().set(0));
+        pausedResourceCounterMap.entrySet().forEach(entry -> entry.getValue().set(0));
+    }
+
+    @Override
     public String kind() {
         return kind;
     }
@@ -252,12 +258,6 @@ public abstract class AbstractOperator<
 
                 return createOrUpdate.future();
             } else {
-                if (resourceCounter(namespace).get() > 0) {
-                    resourceCounter(namespace).getAndDecrement();
-                }
-                if (pausedResourceCounter(namespace).get() > 0) {
-                    pausedResourceCounter(namespace).getAndDecrement();
-                }
                 LOGGER.infoCr(reconciliation, "{} {} should be deleted", kind, name);
                 return delete(reconciliation).map(deleteResult -> {
                     if (deleteResult) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -85,8 +85,6 @@ public interface Operator {
             }
             CompositeFuture.join(futures).map((Void) null).onComplete(handler);
         } else {
-            resourceCounter(namespace).set(0);
-            pausedResourceCounter(namespace).set(0);
             handler.handle(Future.succeededFuture());
         }
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Abstraction of an operator which is driven by resources of a given {@link #kind()}.


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
If all namespaces are watched, one verticle is used so we can reset all the records in the metrics map. If multiple namespaces are used, each of them has to reset its own part of the metrics map.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/6058

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

