### PR TITLE
Fix the doc: Remove the extra interval explanation

### DIFF
--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -84,7 +84,6 @@ Use a comma-separated list to specify two or three broker addresses in case a se
 <5> The label selector used to identify the `KafkaUser` resources managed by the User Operator.
 <6> The interval between periodic reconciliations, in milliseconds.
 The default is `120000` (2 minutes).
-The default is `18000` (18 seconds).
 <7> The level for printing logging messages.
 You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
 <8> Enables garbage collection (GC) logging.


### PR DESCRIPTION
NOT A CONTRIBUTION

The extra period is for the ZK, not for the user operator.

Signed-off-by: Yaodong Yang <yyang48@apple.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

