### PR TITLE
Update Log4j2 in Cruise Control to 2.17

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -31,6 +31,18 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
+            <exclusions>
+                <!-- Excluded because of CVE-2021-44228 -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the Log4j2 version used by Cruise Control to 2.17 since there os currently no Cruise Control release based on it.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally