### PR TITLE
Update the CHANGELOG before the 0.27 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@
 * Allow setting any extra environment variables for the Cluster Operator container through Helm using a new `extraEnvs` value.
 * Added SCRAM-SHA-256 authentication for Kafka clients
 * Update OPA Authorizer to 1.3.0
+* Update to Cruise Control version 2.5.79
+* Update Log4j2 to 2.17.0
 
 ### Changes, deprecations and removals
 
 * The `ControlPlaneListener` feature gate is now enabled by default.
   When upgrading from Strimzi 0.22 or earlier, you have to disable the `ControlPlaneListener` feature gate when upgrading the cluster operator to make sure the Kafka cluster stays available during the upgrade.
   When downgrading to Strimzi 0.22 or earlier, you have to disable the `ControlPlaneListener` feature gate before downgrading the cluster operator to make sure the Kafka cluster stays available during the downgrade.
-* Update to Cruise Control version 2.5.74
 
 ## 0.26.0
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR slightly updates CHANGELOG.md file before the 0.27.0 release. It:
* Moves the Cruise Control reference to the right place and fixes the version
* It adds the Log4j2 version to tot he list since it is notable change many people will be asking about