### PR TITLE
Package canary installation files into the release artifacts

### DIFF
--- a/packaging/install/Makefile
+++ b/packaging/install/Makefile
@@ -38,6 +38,7 @@ release:
 	$(CP) -r ./topic-operator $(RELEASE_PATH)/
 	$(CP) -r ./strimzi-admin $(RELEASE_PATH)/
 	$(CP) -r ./drain-cleaner $(RELEASE_PATH)/
+	$(CP) -r ./canary $(RELEASE_PATH)/
 
 java_build: crd_install
 java_install: java_build


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The canary tool installation files are part of the install folder. But they are missing in the Makefile and as a result they are not packaged as a part of the release archives.