### PR TITLE
Build the Strimzi Java project when running STs against releases

### DIFF
--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -59,7 +59,7 @@ jobs:
         JDK_PATH: $(jdk_path)
         JDK_VERSION: $(jdk_version)
 
-    # Build Strimzi and its images
+    # Build Strimzi and its images => used when running STs against PR or main branch where container images should be built
     - bash: |
         eval $(minikube docker-env)
         make java_install
@@ -70,6 +70,14 @@ jobs:
         MVN_ARGS: '-B -DskipTests -Dmaven.javadoc.skip=true'
       displayName: "Build Strimzi images"
       condition: eq(variables['docker_tag'], 'latest')
+
+    # Build Strimzi without images => used when running the STs against releases or release candidates where the images
+    # are already built, and we need only the Java build
+    - bash: "make java_install"
+      env:
+        MVN_ARGS: "-DskipTests -Dmaven.javadoc.skip=true  -e -V -B"
+      displayName: "Build Strimzi Java code"
+      condition: ne(variables['docker_tag'], 'latest')
 
     - bash: mkdir -p docker-images/artifacts/binaries/kafka/archives
       displayName: "Create dir for Kafka binaries cache"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In order to run the STs against releases on Azure, we need to build the Java project. This currently happens only when we build against main branch or PRs. But when running against releases (or release candidates), the step is skipped because we do not need to build the container images (which are build as part of the release pipeline). But when we skip it, we are missing the Java artifacts for the STs.

This PR adds additional step which is run for releases only and which builds the Java part of Strimzi. That should allo the STs to run and test RCs or GA release.