### PR TITLE
Fix multi-arch build of the Kaniko-executor image

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -15,8 +15,10 @@ public class KafkaConnectBuildUtils {
      *
      * @return      True if the Pod is already complete, false otherwise
      */
+    @SuppressWarnings("BooleanExpressionComplexity")
     public static boolean buildPodComplete(Pod pod)   {
-        return pod.getStatus() != null
+        return pod != null
+                && pod.getStatus() != null
                 && pod.getStatus().getContainerStatuses() != null
                 && pod.getStatus().getContainerStatuses().size() > 0
                 && pod.getStatus().getContainerStatuses().get(0) != null

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -5,7 +5,7 @@ docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from
 	# scratch. We just pull the one released by Kaniko, retag it and push it to our repository to have our versioning on
 	# it and have it stored there in our other images.
-	$(DOCKER_CMD) pull $(KANIKO_EXECUTOR)
+	$(DOCKER_CMD) pull $(DOCKER_PLATFORM) $(KANIKO_EXECUTOR)
 	$(DOCKER_CMD) tag $(KANIKO_EXECUTOR) strimzi/$(PROJECT_NAME):latest
 	$(DOCKER_CMD) tag $(KANIKO_EXECUTOR) strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The multi-arch build of the Kaniko executor image currently doesn't work properly. It builds a manifest with two images, but both of them are for the `amd64` platform instead of `arm64`. This PR fixes it and makes sure the manifests links to images for the different platforms.

In addition to that, it also fixes an NPE exception during the Kafka Connect Build when the pod does not exist.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally