### PR TITLE
Add Strimzi Operators 0.27.0 and Drain Cleaner 0.3.0 releases to the `main` branch

### DIFF
--- a/.checksums
+++ b/.checksums
@@ -6,7 +6,7 @@
 # if this checksum has changed as part of any non-release specific changes, please apply your changes to the
 #   development version of the helm charts in ./packaging/helm-charts
 ### IMPORTANT ###
-HELM_CHART_CHECKSUM="3681f0de5a6d1c09e31254f17dc607b94c0d493f  -"
+HELM_CHART_CHECKSUM="dc9b39aa2adf68773677031ff45842c785dee378  -"
 
 ### IMPORTANT ###
 # if the below line has changed, this means the ./install directory has changed
@@ -14,7 +14,7 @@ HELM_CHART_CHECKSUM="3681f0de5a6d1c09e31254f17dc607b94c0d493f  -"
 # if this checksum has changed as part of any non-release specific changes, please apply your changes to the
 #   development version of the helm charts in ./packaging/install
 ### IMPORTANT ###
-INSTALL_CHECKSUM="2abbbfacdf240cfb2e7b836408571c34a2214af8  -"
+INSTALL_CHECKSUM="e30a4ce43ea22f841900a102952ab9ed49bbf554  -"
 
 ### IMPORTANT ###
 # if the below line has changed, this means the ./examples directory has changed
@@ -22,4 +22,4 @@ INSTALL_CHECKSUM="2abbbfacdf240cfb2e7b836408571c34a2214af8  -"
 # if this checksum has changed as part of any non-release specific changes, please apply your changes to the
 #   development version of the helm charts in ./packaging/examples
 ### IMPORTANT ###
-EXAMPLES_CHECKSUM="a4acfb83818079948dfb09e9e6e1b36f06aa21f9  -"
+EXAMPLES_CHECKSUM="ba0d697fcfc2dc02c13261021f750b1b9c06572b  -"

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -13,7 +13,7 @@
 :toclevels: 3
 
 //Latest Strimzi version
-:ProductVersion: 0.27.0
+:ProductVersion: 0.28.0
 //Strimzi versions used in upgrades sections for API conversions
 :ConvertAfterProductVersion: 0.22
 :ConvertBeforeProductVersion: 0.23
@@ -123,7 +123,7 @@
 :DockerOrg: quay.io/strimzi
 :DockerTag: {ProductVersion}
 :BridgeDockerTag: {BridgeVersion}
-:DrainCleanerDockerTag: 0.2.0
+:DrainCleanerDockerTag: 0.3.0
 :DockerRepository: https://quay.io/organization/strimzi[Container Registry^]
 :DockerZookeeper: quay.io/strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaImageCurrent: quay.io/strimzi/kafka:{DockerTag}-kafka-{KafkaVersionHigher}

--- a/examples/cruise-control/kafka-cruise-control.yaml
+++ b/examples/cruise-control/kafka-cruise-control.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/examples/kafka/kafka-ephemeral-single.yaml
+++ b/examples/kafka/kafka-ephemeral-single.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
+      default.replication.factor: 1
+      min.insync.replicas: 1
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/examples/kafka/kafka-jbod.yaml
+++ b/examples/kafka/kafka-jbod.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
+      default.replication.factor: 1
+      min.insync.replicas: 1
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -652,7 +652,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(strimzi_bridge_kafka_consumer_last_heartbeat_seconds_ago != -1)",
+          "expr": "sum(strimzi_bridge_kafka_consumer_last_heartbeat_seconds_ago != bool -1)",
           "format": "time_series",
           "instant": true,
           "interval": "",

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -110,7 +110,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kafka_topic_partitions{topic=~\"$topic\"})",
+          "expr": "count(kafka_topic_partitions{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -191,7 +191,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_topic_partitions{topic=~\"$topic\"})",
+          "expr": "sum(kafka_topic_partitions{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -272,7 +272,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_topic_partition_replicas{topic=~\"$topic\"})",
+          "expr": "sum(kafka_topic_partition_replicas{topic=~\"$topic\", namespace=\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -353,7 +353,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_topic_partition_in_sync_replica{topic=~\"$topic\"})",
+          "expr": "sum(kafka_topic_partition_in_sync_replica{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -434,7 +434,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_topic_partition_under_replicated_partition{topic=~\"$topic\"})",
+          "expr": "sum(kafka_topic_partition_under_replicated_partition{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -516,7 +516,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_cluster_partition_atminisr{topic=~\"$topic\"})",
+          "expr": "sum(kafka_cluster_partition_atminisr{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -598,7 +598,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kafka_cluster_partition_underminisr{topic=~\"$topic\"})",
+          "expr": "sum(kafka_cluster_partition_underminisr{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -679,7 +679,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kafka_topic_partition_leader_is_preferred{topic=~\"$topic\"}<1)",
+          "expr": "sum(kafka_topic_partition_leader_is_preferred{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"} < bool 1)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -743,7 +743,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=~\"$topic\"}[1m])) by (topic)",
+          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}[1m])) by (topic)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{topic}}",
@@ -834,7 +834,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}[1m])/60) by (consumergroup, topic)",
+          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}[1m])/60) by (consumergroup, topic)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{consumergroup}} (topic: {{topic}})",
@@ -924,7 +924,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}) by (consumergroup, topic) ",
+          "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}) by (consumergroup, topic) ",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1033,7 +1033,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}) by (consumergroup,partition,topic)",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}) by (consumergroup,partition,topic)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1106,7 +1106,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}) by (consumergroup,partition,topic)",
+          "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}) by (consumergroup,partition,topic)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1179,7 +1179,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(kafka_topic_partitions{topic=~\"$topic\"}) by (topic)",
+          "expr": "sum(kafka_topic_partitions{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}) by (topic)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1252,7 +1252,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(kafka_topic_partition_current_offset{topic=~\"$topic\"}) by (partition,topic)",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}) by (partition,topic)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1325,7 +1325,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(kafka_topic_partition_oldest_offset{topic=~\"$topic\"}) by (partition,topic)",
+          "expr": "sum(kafka_topic_partition_oldest_offset{topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}) by (partition,topic)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
+      default.replication.factor: 1
+      min.insync.replicas: 1
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -19,7 +19,6 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -25,7 +25,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/mirror-maker/kafka-source.yaml
+++ b/examples/mirror-maker/kafka-source.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
+      default.replication.factor: 1
+      min.insync.replicas: 1
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/mirror-maker/kafka-target.yaml
+++ b/examples/mirror-maker/kafka-target.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
+      default.replication.factor: 1
+      min.insync.replicas: 1
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/security/keycloak-authorization/README.md
+++ b/examples/security/keycloak-authorization/README.md
@@ -5,10 +5,10 @@ This folder contains an example `Kafka` custom resource configured for OAuth 2.0
 - the corresponding `oauth` authentication
 The folder also contains a Keycloak realm export to import into your Keycloak instance to support the example.
 
-Full instructions for the example are available in the [Strimzi Documentation](https://strimzi.io/docs/operators/0.26.1/using.html#con-oauth-authorization-keycloak-example).
+Full instructions for the example are available in the [Strimzi Documentation](https://strimzi.io/docs/operators/0.27.0/using.html#con-oauth-authorization-keycloak-example).
 
 * [kafka-authz-realm.json](./kafka-authz-realm.json)
     * The Keycloak realm export file
 * [kafka-ephemeral-oauth-single-keycloak-authz.yaml](./kafka-ephemeral-oauth-single-keycloak-authz.yaml)
     * The Kafka CR that defines a single-node Kafka cluster with `oauth` authentication and `keycloak` authorization,
-    using the `kafka-authz` realm. See [full example instructions](https://strimzi.io/docs/operators/0.26.1/using.html#con-oauth-authorization-keycloak-example) for proper preparation and deployment.
+    using the `kafka-authz` realm. See [full example instructions](https://strimzi.io/docs/operators/0.27.0/using.html#con-oauth-authorization-keycloak-example) for proper preparation and deployment.

--- a/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -40,7 +40,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.0"
       inter.broker.protocol.version: "3.0"
     storage:
       type: ephemeral

--- a/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/examples/security/scram-sha-512-auth/kafka.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/examples/security/tls-auth/kafka.yaml
+++ b/examples/security/tls-auth/kafka.yaml
@@ -19,7 +19,8 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.0"
+      default.replication.factor: 3
+      min.insync.replicas: 2
       inter.broker.protocol.version: "3.0"
     storage:
       type: jbod

--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -1,14 +1,14 @@
 # Strimzi: Apache Kafka on Kubernetes
 
-Strimzi provides a way to run an [Apache Kafka®](https://kafka.apache.org) cluster on 
+Strimzi provides a way to run an [Apache Kafka®](https://kafka.apache.org) cluster on
 [Kubernetes](https://kubernetes.io/) or [OpenShift](https://www.openshift.com/) in various deployment configurations.
 See our [website](https://strimzi.io) for more details about the project.
 
 ## CRD Upgrades
 
-**!!! IMPORTANT !!!** 
-Strimzi 0.23 and newer supports only the API version `v1beta2` of all Strimzi custom resources. 
-This is a required as part of the migration to `apiextensionsk8s.io/v1` which is needed because Kubernetes 1.22 will remove support for `apiextensions.k8s.io/v1beta1`. 
+**!!! IMPORTANT !!!**
+Strimzi 0.23 and newer supports only the API version `v1beta2` of all Strimzi custom resources.
+This is a required as part of the migration to `apiextensionsk8s.io/v1` which is needed because Kubernetes 1.22 will remove support for `apiextensions.k8s.io/v1beta1`.
 Migration to `v1beta2` needs to be completed for all Strimzi CRDs and CRs before the upgrade to 0.23 or newer.
 For more details about the CRD upgrades, see the [documentation](https://strimzi.io/docs/operators/0.24.0/deploying.html#assembly-upgrade-resources-str).
 
@@ -98,7 +98,7 @@ the documentation for more details.
 | `watchAnyNamespace`                  | Watch the whole Kubernetes cluster (all namespaces) | `false`                                    |
 | `defaultImageRegistry`               | Default image registry for all the images | `quay.io`                                            |
 | `defaultImageRepository`             | Default image registry for all the images | `strimzi`                                            |
-| `defaultImageTag`                    | Default image tag for all the images except Kafka Bridge | `0.26.1`                              |
+| `defaultImageTag`                    | Default image tag for all the images except Kafka Bridge | `0.27.0`                              |
 | `image.registry`                     | Override default Cluster Operator image registry  | `nil`                                        |
 | `image.repository`                   | Override default Cluster Operator image repository  | `nil`                                      |
 | `image.name`                         | Cluster Operator image name               | `cluster-operator`                                   |
@@ -109,7 +109,9 @@ the documentation for more details.
 | `operationTimeoutMs`                 | Operation timeout in milliseconds         | 300000                                               |
 | `operatorNamespaceLabels`            | Labels of the namespace where the operator runs | `nil`                                          |
 | `podSecurityContext`                 | Cluster Operator pod's security context    | `nil`                                               |
+| `priorityClassName`                  | Cluster Operator pod's priority class name | `nil`                                               |
 | `securityContext`                    | Cluster Operator container's security context |  `nil`                                           |
+| `extraEnvs`                          | Extra environment variables for the Cluster operator container | `[]`                            |
 | `zookeeper.image.registry  `         | Override default ZooKeeper image registry | `nil`                                                |
 | `zookeeper.image.repository`         | Override default ZooKeeper image repository | `nil`                                              |
 | `zookeeper.image.name`               | ZooKeeper image name                      | `kafka`                                              |
@@ -157,7 +159,7 @@ the documentation for more details.
 | `kafkaBridge.image.registry`         | Override default Kafka Bridge image registry               | `quay.io`                           |
 | `kafkaBridge.image.repository`       | Override default Kafka Bridge image repository             | `strimzi`                           |
 | `kafkaBridge.image.name`             | Kafka Bridge image name                   | `kafka-bridge`                                       |
-| `kafkaBridge.image.tag`              | Override default Kafka Bridge image tag                    | `0.21.0`                            |
+| `kafkaBridge.image.tag`              | Override default Kafka Bridge image tag                    | `0.21.2`                            |
 | `kanikoExecutor.image.registry`      | Override default Kaniko Executor image registry            | `nil`                               |
 | `kanikoExecutor.image.repository`    | Override default Kaniko Executor image repository          | `nil`                               |
 | `kanikoExecutor.image.name`          | Kaniko Executor image name                | `kaniko-executor`                                    |
@@ -177,6 +179,7 @@ the documentation for more details.
 | `labels`                             | Add labels to Operator Pod                | `{}`                                                 |
 | `nodeSelector`                       | Add a node selector to Operator Pod       | `{}`                                                 |
 | `featureGates`                       | Feature Gates configuration               | `nil`                                                |
+| `tmpDirSizeLimit`                    | Set the `sizeLimit` for the tmp dir volume used by the operator  | `1Mi`                         |
 | `labelsExclusionPattern`             | Override the exclude pattern for exclude some labels             | `""`                          |
 | `generateNetworkPolicy`              | Controls whether Strimzi generates network policy resources      | `true`                        |
 | `connectBuildTimeoutMs`              | Overrides the default timeout value for building new Kafka Connect    | `300000`                 |

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -57,7 +57,7 @@ spec:
                   description: The docker image for the pods.
                 bootstrapServers:
                   type: string
-                  description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
                 tls:
                   type: object
                   properties:
@@ -189,10 +189,11 @@ spec:
                       type: string
                       enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth
-                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
@@ -1,0 +1,119 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: strimzipodsets.core.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+    component: stirmzipodsets.core.strimzi.io-crd
+spec:
+  group: core.strimzi.io
+  names:
+    kind: StrimziPodSet
+    listKind: StrimziPodSetList
+    singular: strimzipodset
+    plural: strimzipodsets
+    shortNames:
+      - sps
+    categories:
+      - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Pods
+          description: Number of pods managed by the StrimziPodSet
+          jsonPath: .status.pods
+          type: integer
+        - name: Ready Pods
+          description: Number of ready pods managed by the StrimziPodSet
+          jsonPath: .status.readyPods
+          type: integer
+        - name: Current Pods
+          description: Number of up-to-date pods managed by the StrimziPodSet
+          jsonPath: .status.currentPods
+          type: integer
+        - name: Age
+          description: Age of the StrimziPodSet
+          jsonPath: .metadata.creationTimestamp
+          type: date
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                selector:
+                  type: object
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                  description: Selector is a label query which matches all the pods managed by this `StrimziPodSet`. Only `matchLabels` is supported. If `matchExpressions` is set, it will be ignored.
+                pods:
+                  type: array
+                  items:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  description: The Pods managed by this StrimziPodSet.
+              required:
+                - selector
+                - pods
+              description: The specification of the StrimziPodSet.
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        description: The unique identifier of a condition, used to distinguish between other conditions in the resource.
+                      status:
+                        type: string
+                        description: The status of the condition, either True, False or Unknown.
+                      lastTransitionTime:
+                        type: string
+                        description: Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
+                      reason:
+                        type: string
+                        description: The reason for the condition's last transition (a single word in CamelCase).
+                      message:
+                        type: string
+                        description: Human-readable message indicating details about the condition's last transition.
+                  description: List of status conditions.
+                observedGeneration:
+                  type: integer
+                  description: The generation of the CRD that was last reconciled by the operator.
+                pods:
+                  type: integer
+                  description: Number of pods managed by the StrimziPodSet controller.
+                readyPods:
+                  type: integer
+                  description: Number of pods managed by the StrimziPodSet controller that are ready.
+                currentPods:
+                  type: integer
+                  description: Number of pods managed by the StrimziPodSet controller that have the current revision.
+              description: The status of the StrimziPodSet.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -194,10 +194,11 @@ spec:
                           type: string
                           enum:
                             - tls
+                            - scram-sha-256
                             - scram-sha-512
                             - plain
                             - oauth
-                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                         username:
                           type: string
                           description: Username used for the authentication.
@@ -352,10 +353,11 @@ spec:
                           type: string
                           enum:
                             - tls
+                            - scram-sha-256
                             - scram-sha-512
                             - plain
                             - oauth
-                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                          description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -192,10 +192,11 @@ spec:
                       type: string
                       enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth
-                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                      description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -201,10 +201,11 @@ spec:
                             type: string
                             enum:
                               - tls
+                              - scram-sha-256
                               - scram-sha-512
                               - plain
                               - oauth
-                            description: Authentication type. Currently the only supported types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
+                            description: Authentication type. Currently the only supported types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections.
                           username:
                             type: string
                             description: Username used for the authentication.

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -93,6 +93,20 @@ rules:
   - patch
   - update
 - apiGroups:
+  - "core.strimzi.io"
+  resources:
+    # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+  - strimzipodsets
+  - strimzipodsets/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
     # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
     # apps/v1 was introduced in Kubernetes 1.14
   - "extensions"

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -35,11 +35,14 @@ spec:
       {{- with .Values.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       volumes:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 1Mi
+            sizeLimit: {{ .Values.tmpDirSizeLimit }}
         - name: {{ .Values.logVolume }}
           configMap:
             name: {{ .Values.logConfigMap }}
@@ -124,6 +127,9 @@ spec:
             {{- if ne (int .Values.connectBuildTimeoutMs) 300000 }}
             - name: STRIMZI_CONNECT_BUILD_TIMEOUT_MS
               value: {{ .Values.connectBuildTimeoutMs | quote }}
+            {{- end }}
+            {{- if .Values.extraEnvs }}
+            {{ toYaml .Values.extraEnvs | indent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -7,7 +7,7 @@ watchAnyNamespace: false
 
 defaultImageRegistry: quay.io
 defaultImageRepository: strimzi
-defaultImageTag: 0.26.1
+defaultImageTag: 0.27.0
 
 image:
   registry: ""
@@ -21,12 +21,15 @@ fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000
 kubernetesServiceDnsDomain: cluster.local
 featureGates: ""
+tmpDirSizeLimit: 1Mi
+extraEnvs: []
 
 tolerations: []
 affinity: {}
 annotations: {}
 labels: {}
 nodeSelector: {}
+priorityClassName: ""
 
 podSecurityContext: {}
 securityContext: {}
@@ -87,7 +90,7 @@ kafkaBridge:
     registry: ""
     repository:
     name: kafka-bridge
-    tag: 0.21.0
+    tag: 0.21.2
 kafkaExporter:
   image:
     registry: ""

--- a/install/canary/000-ServiceAccount.yaml
+++ b/install/canary/000-ServiceAccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: strimzi-canary
+  labels:
+    app: strimzi-canary

--- a/install/canary/010-Service.yaml
+++ b/install/canary/010-Service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: strimzi-canary
+  labels:
+    app: strimzi-canary
+spec:
+  ports:
+    - port: 8080
+      name: http
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: strimzi-canary

--- a/install/canary/020-Deployment.yaml
+++ b/install/canary/020-Deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-canary
+  labels:
+    app: strimzi-canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: strimzi-canary
+  template:
+    metadata:
+      labels:
+        app: strimzi-canary
+    spec:
+      serviceAccountName: strimzi-canary
+      containers:
+      - name: strimzi-canary
+        image: quay.io/strimzi/canary:0.2.0
+        env:
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: my-cluster-kafka-bootstrap:9092
+          - name: RECONCILE_INTERVAL_MS
+            value: "10000"
+          - name: TLS_ENABLED
+            value: "false"
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30    
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+  strategy:
+    type: Recreate

--- a/install/canary/README.md
+++ b/install/canary/README.md
@@ -1,0 +1,6 @@
+# Strimzi Canary
+
+Strimzi canary is a tool which acts as an indicator of whether Kafka clusters are operating correctly.
+This is achieved by creating a canary topic and periodically producing and consuming events on the topic and getting metrics out of these exchanges.
+
+For more information and installation guide, see [https://github.com/strimzi/strimzi-canary](https://github.com/strimzi/strimzi-canary).

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -88,6 +88,20 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+      - strimzipodsets
+      - strimzipodsets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
       # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
       # apps/v1 was introduced in Kubernetes 1.14
       - "extensions"

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -59,7 +59,7 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given
-                  as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  as a comma separated list of _<hostname>_:_<port>_ pairs.
               tls:
                 type: object
                 properties:
@@ -220,14 +220,16 @@ spec:
                     type: string
                     enum:
                     - tls
+                    - scram-sha-256
                     - scram-sha-512
                     - plain
                     - oauth
                     description: Authentication type. Currently the only supported
-                      types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                      type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses
-                      SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                      Authentication. The `tls` type uses TLS Client Authentication.
+                      types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                      `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                      and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                      type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                      OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication.
                       The `tls` type is supported only over TLS connections.
                   username:
                     type: string

--- a/install/cluster-operator/042-Crd-strimzipodset.yaml
+++ b/install/cluster-operator/042-Crd-strimzipodset.yaml
@@ -1,0 +1,129 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: strimzipodsets.core.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: core.strimzi.io
+  names:
+    kind: StrimziPodSet
+    listKind: StrimziPodSetList
+    singular: strimzipodset
+    plural: strimzipodsets
+    shortNames:
+    - sps
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Pods
+      description: Number of pods managed by the StrimziPodSet
+      jsonPath: .status.pods
+      type: integer
+    - name: Ready Pods
+      description: Number of ready pods managed by the StrimziPodSet
+      jsonPath: .status.readyPods
+      type: integer
+    - name: Current Pods
+      description: Number of up-to-date pods managed by the StrimziPodSet
+      jsonPath: .status.currentPods
+      type: integer
+    - name: Age
+      description: Age of the StrimziPodSet
+      jsonPath: .metadata.creationTimestamp
+      type: date
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                description: Selector is a label query which matches all the pods
+                  managed by this `StrimziPodSet`. Only `matchLabels` is supported.
+                  If `matchExpressions` is set, it will be ignored.
+              pods:
+                type: array
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                description: The Pods managed by this StrimziPodSet.
+            required:
+            - selector
+            - pods
+            description: The specification of the StrimziPodSet.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: The unique identifier of a condition, used to distinguish
+                        between other conditions in the resource.
+                    status:
+                      type: string
+                      description: The status of the condition, either True, False
+                        or Unknown.
+                    lastTransitionTime:
+                      type: string
+                      description: Last time the condition of a type changed from
+                        one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                        in the UTC time zone.
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition
+                        (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about
+                        the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by
+                  the operator.
+              pods:
+                type: integer
+                description: Number of pods managed by the StrimziPodSet controller.
+              readyPods:
+                type: integer
+                description: Number of pods managed by the StrimziPodSet controller
+                  that are ready.
+              currentPods:
+                type: integer
+                description: Number of pods managed by the StrimziPodSet controller
+                  that have the current revision.
+            description: The status of the StrimziPodSet.

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -230,15 +230,18 @@ spec:
                         type: string
                         enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth
                         description: Authentication type. Currently the only supported
-                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                          Authentication. The `tls` type uses TLS Client Authentication.
-                          The `tls` type is supported only over TLS connections.
+                          types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                          `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                          and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                          type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                          OAUTHBEARER Authentication. The `tls` type uses TLS Client
+                          Authentication. The `tls` type is supported only over TLS
+                          connections.
                       username:
                         type: string
                         description: Username used for the authentication.
@@ -433,15 +436,18 @@ spec:
                         type: string
                         enum:
                         - tls
+                        - scram-sha-256
                         - scram-sha-512
                         - plain
                         - oauth
                         description: Authentication type. Currently the only supported
-                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                          Authentication. The `tls` type uses TLS Client Authentication.
-                          The `tls` type is supported only over TLS connections.
+                          types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                          `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                          and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                          type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                          OAUTHBEARER Authentication. The `tls` type uses TLS Client
+                          Authentication. The `tls` type is supported only over TLS
+                          connections.
                       username:
                         type: string
                         description: Username used for the authentication.

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -222,14 +222,16 @@ spec:
                     type: string
                     enum:
                     - tls
+                    - scram-sha-256
                     - scram-sha-512
                     - plain
                     - oauth
                     description: Authentication type. Currently the only supported
-                      types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                      type uses SASL SCRAM-SHA-512 Authentication. `plain` type uses
-                      SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
-                      Authentication. The `tls` type uses TLS Client Authentication.
+                      types are `tls`, `scram-sha-256`, `scram-sha-512`, and `plain`.
+                      `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256
+                      and SASL SCRAM-SHA-512 Authentication, respectively. `plain`
+                      type uses SASL PLAIN Authentication. `oauth` type uses SASL
+                      OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication.
                       The `tls` type is supported only over TLS connections.
                   username:
                     type: string

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -240,16 +240,18 @@ spec:
                           type: string
                           enum:
                           - tls
+                          - scram-sha-256
                           - scram-sha-512
                           - plain
                           - oauth
                           description: Authentication type. Currently the only supported
-                            types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
-                            type uses SASL SCRAM-SHA-512 Authentication. `plain` type
-                            uses SASL PLAIN Authentication. `oauth` type uses SASL
-                            OAUTHBEARER Authentication. The `tls` type uses TLS Client
-                            Authentication. The `tls` type is supported only over
-                            TLS connections.
+                            types are `tls`, `scram-sha-256`, `scram-sha-512`, and
+                            `plain`. `scram-sha-256` and `scram-sha-512` types use
+                            SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication,
+                            respectively. `plain` type uses SASL PLAIN Authentication.
+                            `oauth` type uses SASL OAUTHBEARER Authentication. The
+                            `tls` type uses TLS Client Authentication. The `tls` type
+                            is supported only over TLS connections.
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -27,7 +27,7 @@ spec:
             name: strimzi-cluster-operator
       containers:
         - name: strimzi-cluster-operator
-          image: quay.io/strimzi/operator:0.26.1
+          image: quay.io/strimzi/operator:0.27.0
           ports:
             - containerPort: 8080
               name: http
@@ -48,47 +48,47 @@ spec:
             - name: STRIMZI_OPERATION_TIMEOUT_MS
               value: "300000"
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-              value: quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+              value: quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+              value: quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+              value: quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
-              value: quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+              value: quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_KAFKA_IMAGES
               value: |
-                2.8.0=quay.io/strimzi/kafka:0.26.1-kafka-2.8.0
-                2.8.1=quay.io/strimzi/kafka:0.26.1-kafka-2.8.1
-                3.0.0=quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+                2.8.0=quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+                2.8.1=quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+                3.0.0=quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
-                2.8.0=quay.io/strimzi/kafka:0.26.1-kafka-2.8.0
-                2.8.1=quay.io/strimzi/kafka:0.26.1-kafka-2.8.1
-                3.0.0=quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+                2.8.0=quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+                2.8.1=quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+                3.0.0=quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
-                2.8.0=quay.io/strimzi/kafka:0.26.1-kafka-2.8.0
-                2.8.1=quay.io/strimzi/kafka:0.26.1-kafka-2.8.1
-                3.0.0=quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+                2.8.0=quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+                2.8.1=quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+                3.0.0=quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
-                2.8.0=quay.io/strimzi/kafka:0.26.1-kafka-2.8.0
-                2.8.1=quay.io/strimzi/kafka:0.26.1-kafka-2.8.1
-                3.0.0=quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
+                2.8.0=quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+                2.8.1=quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+                3.0.0=quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:0.26.1
+              value: quay.io/strimzi/operator:0.27.0
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:0.26.1
+              value: quay.io/strimzi/operator:0.27.0
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: quay.io/strimzi/operator:0.26.1
+              value: quay.io/strimzi/operator:0.27.0
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-              value: quay.io/strimzi/kafka-bridge:0.21.0
+              value: quay.io/strimzi/kafka-bridge:0.21.2
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
-              value: quay.io/strimzi/jmxtrans:0.26.1
+              value: quay.io/strimzi/jmxtrans:0.27.0
             - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-              value: quay.io/strimzi/kaniko-executor:0.26.1
+              value: quay.io/strimzi/kaniko-executor:0.27.0
             - name: STRIMZI_DEFAULT_MAVEN_BUILDER
-              value: quay.io/strimzi/maven-builder:0.26.1
+              value: quay.io/strimzi/maven-builder:0.27.0
             - name: STRIMZI_OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.1.0
+          image: quay.io/strimzi/drain-cleaner:0.3.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.1.0
+          image: quay.io/strimzi/drain-cleaner:0.3.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.1.0
+          image: quay.io/strimzi/drain-cleaner:0.3.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -33,3 +33,15 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - "core.strimzi.io"
+  resources:
+  - strimzipodsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update

--- a/install/strimzi-admin/020-ClusterRole-strimzi-view.yaml
+++ b/install/strimzi-admin/020-ClusterRole-strimzi-view.yaml
@@ -23,3 +23,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "core.strimzi.io"
+  resources:
+  - strimzipodsets
+  verbs:
+  - get
+  - list
+  - watch

--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-topic-operator
       containers:
         - name: strimzi-topic-operator
-          image: quay.io/strimzi/operator:0.26.1
+          image: quay.io/strimzi/operator:0.27.0
           args:
           - /opt/strimzi/bin/topic_operator_run.sh
           env:

--- a/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-user-operator
       containers:
         - name: strimzi-user-operator
-          image: quay.io/strimzi/operator:0.26.1
+          image: quay.io/strimzi/operator:0.27.0
           args:
           - /opt/strimzi/bin/user_operator_run.sh
           env:

--- a/packaging/helm-charts/index.yaml
+++ b/packaging/helm-charts/index.yaml
@@ -2,6 +2,34 @@ apiVersion: v1
 entries:
   strimzi-kafka-operator:
   - apiVersion: v2
+    appVersion: 0.27.0
+    created: "2021-12-22T08:40:41.38555+01:00"
+    description: 'Strimzi: Apache Kafka running on Kubernetes'
+    digest: 363897a003b2c1983a6165c9d7e1baddf210e6db0ca355205bb0b758ccefe3e1
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: Frawless
+    - name: ppatierno
+    - name: samuel-hawker
+    - name: scholzj
+    - name: tombentley
+    - name: sknot-rh
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.27.0/strimzi-kafka-operator-helm-3-chart-0.27.0.tgz
+    version: 0.27.0
+  - apiVersion: v2
     appVersion: 0.26.1
     created: "2021-12-13T14:40:44.166241+01:00"
     description: 'Strimzi: Apache Kafka running on Kubernetes'
@@ -909,4 +937,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2021-12-13T14:40:44.160318+01:00"
+generated: "2021-12-22T08:40:41.373051+01:00"

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.2.0
+          image: quay.io/strimzi/drain-cleaner:0.3.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.2.0
+          image: quay.io/strimzi/drain-cleaner:0.3.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.2.0
+          image: quay.io/strimzi/drain-cleaner:0.3.0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the new releases - Strimzi Operators 0.27.0 & Drain cleaner 0.3.0 - to the ``main` branch of the operators repo. It updates the:
* `example`, `install` and `helm-chart` dirs
* Helm Chart index in `packagin/...`
* Drain Cleaner installation in `packaging/...`
* Attributes for docs