### PR TITLE
Update the Vert.x and Fabric8 dependencies

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -78,10 +78,6 @@
             <artifactId>zjsonpatch</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -20,7 +20,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
-import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -127,7 +126,6 @@ public class ClusterOperatorTest {
             client = mock(KubernetesClient.class);
             when(client.isAdaptable(eq(OpenShiftClient.class))).thenReturn(false);
         }
-        when(client.isAdaptable(eq(OkHttpClient.class))).thenReturn(true);
 
         try {
             when(client.getMasterUrl()).thenReturn(new URL("http://localhost"));
@@ -230,7 +228,6 @@ public class ClusterOperatorTest {
             client = mock(KubernetesClient.class);
             when(client.isAdaptable(eq(OpenShiftClient.class))).thenReturn(false);
         }
-        when(client.isAdaptable(eq(OkHttpClient.class))).thenReturn(true);
 
         try {
             when(client.getMasterUrl()).thenReturn(new URL("http://localhost"));

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -74,10 +74,6 @@
             <artifactId>kubernetes-model-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,15 +90,13 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.10.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.10.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.10.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.11.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.11.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.11.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <okhttp.version>3.12.6</okhttp.version>
-        <okio.version>1.15.0</okio.version>
-        <vertx.version>4.2.1</vertx.version>
-        <vertx-junit5.version>4.2.1</vertx-junit5.version>
-        <vertx.kafka.client>4.2.1</vertx.kafka.client>
+        <vertx.version>4.2.3</vertx.version>
+        <vertx-junit5.version>4.2.3</vertx-junit5.version>
+        <vertx.kafka.client>4.2.3</vertx.kafka.client>
         <log4j.version>2.17.1</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
@@ -319,11 +317,6 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>zjsonpatch</artifactId>
                 <version>${fabric8.zjsonpatch.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -87,10 +87,6 @@
             <version>${fabric8.kubernetes-model.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <scope>compile</scope>

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -43,11 +43,11 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
-import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -918,14 +918,19 @@ public class KubeClient {
         }
 
         @Override
-        public void onOpen(Response response) {
+        public void onOpen() {
             LOGGER.info("The shell will remain open for 10 seconds.");
             execLatch.countDown();
         }
 
         @Override
         public void onFailure(Throwable t, Response response) {
-            LOGGER.info("shell barfed with code {} and message {}", response.code(), response.message());
+            try {
+                LOGGER.info("shell barfed with code {} and body {}", response.code(), response.body());
+            } catch (IOException e) {
+                LOGGER.info("shell barfed with code {} and body() throws exception", response.code(), e);
+            }
+
             execLatch.countDown();
         }
 

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kubernetes.java
@@ -5,21 +5,19 @@
 package io.strimzi.test.k8s.cluster;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import io.strimzi.test.executor.Exec;
 import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import io.strimzi.test.k8s.cmdClient.Kubectl;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
-import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link KubeCluster} implementation for any {@code Kubernetes} cluster.
@@ -54,14 +52,14 @@ public class Kubernetes implements KubeCluster {
 
     @Override
     public KubeClient defaultClient() {
-        OkHttpClient httpClient = HttpClientUtils.createHttpClient(CONFIG);
+        HttpClient httpClient = HttpClientUtils.createHttpClient(CONFIG);
 
         httpClient = httpClient.newBuilder()
-            .protocols(Collections.singletonList(Protocol.HTTP_1_1))
-            .connectTimeout(Duration.ofSeconds(60))
-            .writeTimeout(Duration.ofSeconds(60))
-            .readTimeout(Duration.ofSeconds(60))
-            .build();
+                .preferHttp11()
+                .connectTimeout(60L, TimeUnit.SECONDS)
+                .writeTimeout(60L, TimeUnit.SECONDS)
+                .readTimeout(60L, TimeUnit.SECONDS)
+                .build();
 
         return new KubeClient(new DefaultKubernetesClient(httpClient, CONFIG), "default");
     }


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Vert.x and Fabric8 dependencies. Fabric8 5.11 does some changes around the HttpClient. It does not expose OkHttp anymore and instead of it abstracts it (possibly to replace it in the future). This is reflected in this PR. In the `PlaftformFeaturesAvailability`, it replaces the use of the HTTP client by use of some new Fabric8 methods which were originally not available. In other places, it now uses the new abstracted HttpClient from Fabric8 itself.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally