### PR TITLE
Add make targets to generate release files checksums

### DIFF
--- a/.azure/scripts/release_files_check.sh
+++ b/.azure/scripts/release_files_check.sh
@@ -8,8 +8,7 @@ SHA1SUM=sha1sum
 RETURN_CODE=0
 
 # Helm Charts
-CHECKSUM="$(find ./helm-charts/ -type f -print0 | sort -z | xargs -0 ${SHA1SUM} | ${SHA1SUM})"
-echo "checksum of ./helm-charts/ is CHECKSUM=${CHECKSUM}"
+CHECKSUM="$(make checksum_helm)"
 
 if [ "$CHECKSUM" != "$HELM_CHART_CHECKSUM" ]; then
   echo "ERROR checksum of ./helm-charts does not match expected"
@@ -24,12 +23,13 @@ if [ "$CHECKSUM" != "$HELM_CHART_CHECKSUM" ]; then
   echo "->"
   echo "HELM_CHART_CHECKSUM=\"${CHECKSUM}\""
   RETURN_CODE=$((RETURN_CODE+1))
+else
+  echo "checksum of ./helm-charts/ matches expected checksum => OK"
 fi
 
 
 # install
-CHECKSUM="$(find ./install/ -type f -print0 | sort -z | xargs -0 ${SHA1SUM} | ${SHA1SUM})"
-echo "checksum of ./install/ is CHECKSUM=${CHECKSUM}"
+CHECKSUM="$(make checksum_install)"
 
 if [ "$CHECKSUM" != "$INSTALL_CHECKSUM" ]; then
   echo "ERROR checksum of ./install does not match expected"
@@ -44,11 +44,12 @@ if [ "$CHECKSUM" != "$INSTALL_CHECKSUM" ]; then
   echo "->"
   echo "INSTALL_CHECKSUM=\"${CHECKSUM}\""
   RETURN_CODE=$((RETURN_CODE+1))
+else
+  echo "checksum of ./install/ matches expected checksum => OK"
 fi
 
 # examples
-CHECKSUM="$(find ./examples/ -type f -print0 | sort -z | xargs -0 ${SHA1SUM} | ${SHA1SUM})"
-echo "checksum of ./examples/ is CHECKSUM=${CHECKSUM}"
+CHECKSUM="$(make checksum_examples)"
 
 if [ "$CHECKSUM" != "$EXAMPLES_CHECKSUM" ]; then
   echo "ERROR checksum of ./install does not match expected"
@@ -63,6 +64,8 @@ if [ "$CHECKSUM" != "$EXAMPLES_CHECKSUM" ]; then
   echo "->"
   echo "EXAMPLES_CHECKSUM=\"${CHECKSUM}\""
   RETURN_CODE=$((RETURN_CODE+1))
+else
+  echo "checksum of ./examples/ matches expected checksum => OK"
 fi
 
 exit $RETURN_CODE

--- a/.azure/scripts/release_files_check.sh
+++ b/.azure/scripts/release_files_check.sh
@@ -8,7 +8,7 @@ SHA1SUM=sha1sum
 RETURN_CODE=0
 
 # Helm Charts
-CHECKSUM="$(make checksum_helm)"
+CHECKSUM="$(make --no-print-directory checksum_helm)"
 
 if [ "$CHECKSUM" != "$HELM_CHART_CHECKSUM" ]; then
   echo "ERROR checksum of ./helm-charts does not match expected"
@@ -29,7 +29,7 @@ fi
 
 
 # install
-CHECKSUM="$(make checksum_install)"
+CHECKSUM="$(make --no-print-directory checksum_install)"
 
 if [ "$CHECKSUM" != "$INSTALL_CHECKSUM" ]; then
   echo "ERROR checksum of ./install does not match expected"
@@ -49,7 +49,7 @@ else
 fi
 
 # examples
-CHECKSUM="$(make checksum_examples)"
+CHECKSUM="$(make --no-print-directory checksum_examples)"
 
 if [ "$CHECKSUM" != "$EXAMPLES_CHECKSUM" ]; then
   echo "ERROR checksum of ./install does not match expected"

--- a/Makefile
+++ b/Makefile
@@ -192,4 +192,13 @@ systemtest_make:
 prerequisites_check:
 	SED=$(SED) ./tools/prerequisites-check.sh
 
+checksum_examples:
+	@$(FIND) ./examples/ -type f -print0 | $(SORT) -z | $(XARGS) -0 $(SHA1SUM) | $(SHA1SUM)
+
+checksum_install:
+	@$(FIND) ./install/ -type f -print0 | $(SORT) -z | $(XARGS) -0 $(SHA1SUM) | $(SHA1SUM)
+
+checksum_helm:
+	@$(FIND) ./helm-charts/ -type f -print0 | $(SORT) -z | $(XARGS) -0 $(SHA1SUM) | $(SHA1SUM)
+
 .PHONY: all $(SUBDIRS) $(DOCKERDIRS) $(DOCKER_TARGETS) systemtests docu_versions spotbugs docu_check prerequisites_check

--- a/Makefile.os
+++ b/Makefile.os
@@ -5,6 +5,7 @@ CP = cp
 UNIQ = uniq
 SORT = sort
 SHA1SUM = sha1sum
+XARGS = xargs
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -15,4 +16,5 @@ ifeq ($(UNAME_S),Darwin)
 	UNIQ = guniq
 	SORT = gsort
 	SHA1SUM = gsha1sum
+	XARGS = gxargs
 endif


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The CI pipeline checks the changes to the release files using checksums which are stored in the `.checksums` file. This file needs to be updated after every release when the release files change. To make sure the returned checksum is the same on all platforms, it needs to make sure that even on systems such as MacOS, the GNU versions of the tools such as `find`, `sort` or `sha1sum` are used. To make it easier to calculate these checksums on all platforms, this PR adds a targets for it to  `Makefile` where it uses the multi-platform support already used by some of our other tools.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally