### PR TITLE
Update Log4j2 to 2.17.1

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <vertx.version>4.2.1</vertx.version>
         <vertx-junit5.version>4.2.1</vertx-junit5.version>
         <vertx.kafka.client>4.2.1</vertx.kafka.client>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson-core.version>2.11.3</fasterxml.jackson-core.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Log4j2 to 2.17.1 to fis another CVE ([CVE-2021-44832](https://nvd.nist.gov/vuln/detail/CVE-2021-44832)).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally