### PR TITLE
Change the log level of the log message that no rebuild is needed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -267,7 +267,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
             if (newBuildRevision.equals(buildState.currentBuildRevision)
                     && !buildState.forceRebuild) {
                 // The revision is the same and rebuild was not forced => nothing to do
-                LOGGER.infoCr(reconciliation, "Build configuration did not change. Nothing new to build. Container image {} will be used.", buildState.currentImage);
+                LOGGER.debugCr(reconciliation, "Build configuration did not change. Nothing new to build. Container image {} will be used.", buildState.currentImage);
                 buildState.desiredImage = buildState.currentImage;
                 buildState.desiredBuildRevision = newBuildRevision;
                 return Future.succeededFuture();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, when Kafka Connect Build is used but does not need a rebuild, we print a log message at `INFO` level about it. This seems unnecessary given this is actually the normal situation which happens 99% of the time and seems unnecessary in the log:

```
2022-01-02 22:15:49 INFO  AbstractOperator:226 - Reconciliation #72(timer) KafkaConnect(myproject/my-connect): KafkaConnect my-connect will be checked for creation or modification
2022-01-02 22:15:49 INFO  KafkaConnectAssemblyOperator:270 - Reconciliation #72(timer) KafkaConnect(myproject/my-connect): Build configuration did not change. Nothing new to build. Container image quay.io/scholzj/kafka-connect-build@sha256:b1197b2696beedfd87765dbfaace7e940971cee7ea1be6ff3e49bc418e07bcad will be used.
2022-01-02 22:15:49 INFO  AbstractOperator:517 - Reconciliation #72(timer) KafkaConnect(myproject/my-connect): reconciled
2022-01-02 22:17:49 INFO  AbstractOperator:226 - Reconciliation #74(timer) KafkaConnect(myproject/my-connect): KafkaConnect my-connect will be checked for creation or modification
2022-01-02 22:17:49 INFO  KafkaConnectAssemblyOperator:270 - Reconciliation #74(timer) KafkaConnect(myproject/my-connect): Build configuration did not change. Nothing new to build. Container image quay.io/scholzj/kafka-connect-build@sha256:b1197b2696beedfd87765dbfaace7e940971cee7ea1be6ff3e49bc418e07bcad will be used.
2022-01-02 22:17:49 INFO  AbstractOperator:517 - Reconciliation #74(timer) KafkaConnect(myproject/my-connect): reconciled
2022-01-02 22:19:49 INFO  AbstractOperator:226 - Reconciliation #76(timer) KafkaConnect(myproject/my-connect): KafkaConnect my-connect will be checked for creation or modification
2022-01-02 22:19:49 INFO  KafkaConnectAssemblyOperator:270 - Reconciliation #76(timer) KafkaConnect(myproject/my-connect): Build configuration did not change. Nothing new to build. Container image quay.io/scholzj/kafka-connect-build@sha256:b1197b2696beedfd87765dbfaace7e940971cee7ea1be6ff3e49bc418e07bcad will be used.
2022-01-02 22:19:49 INFO  AbstractOperator:517 - Reconciliation #76(timer) KafkaConnect(myproject/my-connect): reconciled
2022-01-02 22:21:49 INFO  AbstractOperator:226 - Reconciliation #78(timer) KafkaConnect(myproject/my-connect): KafkaConnect my-connect will be checked for creation or modification
2022-01-02 22:21:49 INFO  KafkaConnectAssemblyOperator:270 - Reconciliation #78(timer) KafkaConnect(myproject/my-connect): Build configuration did not change. Nothing new to build. Container image quay.io/scholzj/kafka-connect-build@sha256:b1197b2696beedfd87765dbfaace7e940971cee7ea1be6ff3e49bc418e07bcad will be used.
2022-01-02 22:21:49 INFO  AbstractOperator:517 - Reconciliation #78(timer) KafkaConnect(myproject/my-connect): reconciled
```

This PR modifies the log level and changes it to DEBUG which seems more appropriate and less distracting given its importance.