### PR TITLE
Reset counters when namespace is not reconcilable

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -105,7 +105,7 @@ public class ClusterOperator extends AbstractVerticle {
                 kafkaConnectAssemblyOperator, kafkaBridgeAssemblyOperator, kafkaMirrorMaker2AssemblyOperator));
         for (AbstractOperator<?, ?, ?, ?> operator : operators) {
             watchFutures.add(operator.createWatch(namespace, operator.recreateWatch(namespace)).compose(w -> {
-                LOGGER.info("Opened watch for {} operator", operator.kind());
+                LOGGER.info("Opened watch for {} operator in namespace {}", operator.kind(), namespace);
                 watchByKind.put(operator.kind(), w);
                 return Future.succeededFuture();
             }));

--- a/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Operator.java
@@ -61,6 +61,8 @@ public interface Operator {
                 reconcileThese(trigger, ar.result(), namespace, handler);
                 periodicReconciliationsCounter(namespace).increment();
             } else {
+                resourceCounter(namespace).set(0);
+                pausedResourceCounter(namespace).set(0);
                 handler.handle(ar.map((Void) null));
             }
         });


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Bugfix

### Description
If the namespace is removed, the CO is not able to set the correct resource count (0). Checking the result of `allResourceNames` for failure can be used for such a case.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/6107
### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

