### PR TITLE
Fix unsupported Kafka version error messages in some edge cases

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -112,11 +112,16 @@ public class KafkaConfiguration extends AbstractConfiguration {
         String name = "/kafka-" + kafkaVersion.version() + "-config-model.json";
         try {
             try (InputStream in = KafkaConfiguration.class.getResourceAsStream(name)) {
-                ConfigModels configModels = new ObjectMapper().readValue(in, ConfigModels.class);
-                if (!kafkaVersion.version().equals(configModels.getVersion())) {
-                    throw new RuntimeException("Incorrect version");
+                if (in != null) {
+                    ConfigModels configModels = new ObjectMapper().readValue(in, ConfigModels.class);
+                    if (!kafkaVersion.version().equals(configModels.getVersion())) {
+                        throw new RuntimeException("Incorrect version");
+                    }
+                    return configModels.getConfigs();
+                } else {
+                    // The configuration model does not exist
+                    throw new RuntimeException("Configuration model " + name + " was not found");
                 }
-                return configModels.getConfigs();
             }
         } catch (IOException e) {
             throw new RuntimeException("Error reading from classpath resource " + name, e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -6,6 +6,7 @@
 package io.strimzi.operator.cluster.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.kafka.config.model.ConfigModel;
 import io.strimzi.kafka.config.model.ConfigModels;
@@ -108,6 +109,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param kafkaVersion The broker version.
      * @return The config model for that broker version.
      */
+    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"})
     public static Map<String, ConfigModel> readConfigModel(KafkaVersion kafkaVersion) {
         String name = "/kafka-" + kafkaVersion.version() + "-config-model.json";
         try {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -156,7 +156,7 @@ public class KafkaExporter extends AbstractModel {
                 ModelUtils.parsePodTemplate(kafkaExporter, template.getPod());
             }
 
-            kafkaExporter.setVersion(versions.version(kafkaAssembly.getSpec().getKafka().getVersion()).version());
+            kafkaExporter.setVersion(versions.supportedVersion(kafkaAssembly.getSpec().getKafka().getVersion()).version());
             kafkaExporter.setOwnerReference(kafkaAssembly);
         } else {
             kafkaExporter.isDeployed = false;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -264,7 +264,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         }
 
         InvalidResourceException asInvalidResourceException(String version, NoImageException e) {
-            return new InvalidResourceException("Version " + version + " is not supported. " +
+            return new InvalidResourceException("Kafka version " + version + " is not supported. " +
                     "Supported versions are: " + String.join(", ", supportedVersions()) + ".",
                     e);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -256,7 +256,7 @@ public class ZookeeperCluster extends AbstractModel {
 
         // Get the ZK version information from either the CRD or from the default setting
         KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
-        String version = versions.version(kafkaClusterSpec != null ? kafkaClusterSpec.getVersion() : null).zookeeperVersion();
+        String version = versions.supportedVersion(kafkaClusterSpec != null ? kafkaClusterSpec.getVersion() : null).zookeeperVersion();
         zk.setVersion(version);
 
         String image = zookeeperClusterSpec.getImage();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3799,16 +3799,33 @@ public class KafkaClusterTest {
         Kafka kafka = new KafkaBuilder(kafkaAssembly)
                 .editSpec()
                     .editKafka()
+                        .withVersion("6.6.6")
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
+        });
+
+        assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 6.6.6. Supported versions are:"));
+    }
+
+    @ParallelTest
+    public void testUnsupportedVersion() {
+        Kafka kafka = new KafkaBuilder(kafkaAssembly)
+                .editSpec()
+                    .editKafka()
                         .withVersion("2.6.0")
                     .endKafka()
                 .endSpec()
                 .build();
 
-        InvalidResourceException exc = assertThrows(InvalidResourceException.class, () -> {
+        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
             KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
         });
 
-        assertThat(exc.getMessage(), containsString("Kafka version 2.6.0 is not supported. Supported versions are:"));
+        assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 2.6.0. Supported versions are:"));
     }
 
     @ParallelTest
@@ -3822,10 +3839,10 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
 
-        InvalidResourceException exc = assertThrows(InvalidResourceException.class, () -> {
+        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
             KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
         });
 
-        assertThat(exc.getMessage(), containsString("Kafka version 2.6.0 is not supported. Supported versions are:"));
+        assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 2.6.0. Supported versions are:"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConfigurationTests.java
@@ -8,11 +8,13 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
+import org.junit.jupiter.api.Assertions;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 @ParallelSuite
 public class KafkaConfigurationTests {
@@ -93,5 +95,14 @@ public class KafkaConfigurationTests {
     @ParallelTest
     public void validVersion() {
         assertNoError("inter.broker.protocol.version", "2.5-IV0");
+    }
+
+    @ParallelTest
+    public void unsupportedVersion() {
+        RuntimeException exc = Assertions.assertThrows(RuntimeException.class, () -> {
+            KafkaConfiguration.readConfigModel(KafkaVersionTestUtils.getKafkaVersionLookup().version("2.6.0"));
+        });
+
+        assertThat(exc.getMessage(), containsString("Configuration model /kafka-2.6.0-config-model.json was not found"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiffTest.java
@@ -34,7 +34,7 @@ public class KafkaBrokerConfigurationDiffTest {
 
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final String KAFKA_VERSION = "3.0.0";
-    KafkaVersion kafkaVersion = VERSIONS.version(KAFKA_VERSION);
+    KafkaVersion kafkaVersion = VERSIONS.supportedVersion(KAFKA_VERSION);
     private int brokerId = 0;
 
     private ConfigEntry instantiateConfigEntry(String name, String val) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -392,7 +392,7 @@ public class SpecificST extends AbstractST {
     @Tag(REGRESSION)
     void testDeployUnsupportedKafka(ExtensionContext extensionContext) {
         String nonExistingVersion = "6.6.6";
-        String nonExistingVersionMessage = "Kafka version " + nonExistingVersion + " is not supported. Supported versions are.*";
+        String nonExistingVersionMessage = "Unsupported Kafka.spec.kafka.version: " + nonExistingVersion + ". Supported versions are:.*";
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(clusterName, 1, 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -392,7 +392,7 @@ public class SpecificST extends AbstractST {
     @Tag(REGRESSION)
     void testDeployUnsupportedKafka(ExtensionContext extensionContext) {
         String nonExistingVersion = "6.6.6";
-        String nonExistingVersionMessage = "Version " + nonExistingVersion + " is not supported. Supported versions are.*";
+        String nonExistingVersionMessage = "Kafka version " + nonExistingVersion + " is not supported. Supported versions are.*";
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
         resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(clusterName, 1, 1)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the past, we worked to improve the error message when a user specifies a Kafka version which is not supported. There seem to be still an edge case when a user gets very ugly error message:

```
2022-01-03 17:17:48 ERROR AbstractOperator:247 - Reconciliation #34(timer) Kafka(myproject/my-cluster): createOrUpdate failed
java.lang.IllegalArgumentException: argument "src" is null
	at com.fasterxml.jackson.databind.ObjectMapper._assertNotNull(ObjectMapper.java:4737) ~[com.fasterxml.jackson.core.jackson-databind-2.11.3.jar:2.11.3]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3504) ~[com.fasterxml.jackson.core.jackson-databind-2.11.3.jar:2.11.3]
	at io.strimzi.operator.cluster.model.KafkaConfiguration.readConfigModel(KafkaConfiguration.java:115) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.KafkaConfiguration.validate(KafkaConfiguration.java:92) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.KafkaCluster.validateConfiguration(KafkaCluster.java:648) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.KafkaCluster.fromCrd(KafkaCluster.java:424) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$getKafkaClusterDescription$62(KafkaAssemblyOperator.java:1667) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) [io.netty.netty-transport-4.1.71.Final.jar:4.1.71.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

This is when unsupported version is specified but at the same time a custom image is specified. The current error message is thrown from the container image lookup which is not called with custom images and does not trigger the error. Instead, the configuration validation fails because it fails to find the configuration model.

This PR does several changes to the code:
1) It adds explicit validation of the Kafka version to the `KafkaCluster` `fromCrd` method which is always called. This should avoid any possible edge cases and combinations when the container image lookup would not be called.
2) It fixes the `KafkaConfiguration` class and in case it happens and the configuration model is missing, is doesn't throw the ugly and confusing Jackson (see above) exception but instead throws a nice descriptive exception about the configuration model missing:
   ```
   2022-01-03 17:19:49 ERROR AbstractOperator:247 - Reconciliation #2(watch) Kafka(myproject/my-cluster): createOrUpdate failed
   java.lang.RuntimeException: Configuration model /kafka-2.7.1-config-model.json was not found
        at io.strimzi.operator.cluster.model.KafkaConfiguration.readConfigModel(KafkaConfiguration.java:123) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
        at io.strimzi.operator.cluster.model.KafkaConfiguration.validate(KafkaConfiguration.java:92) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
        at io.strimzi.operator.cluster.model.KafkaCluster.validateConfiguration(KafkaCluster.java:648) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
        at io.strimzi.operator.cluster.model.KafkaCluster.fromCrd(KafkaCluster.java:424) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
        at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$getKafkaClusterDescription$62(KafkaAssemblyOperator.java:1667) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
        at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
        at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
        at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
        at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.1.jar:4.2.1]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) [io.netty.netty-transport-4.1.71.Final.jar:4.1.71.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
        at java.lang.Thread.run(Thread.java:829) [?:?]
   ```
   In any case, this should not show up when user specifies unsupported Kafka version => only when due to some build issue the configuration model is actually missing.
3) The validation in the container image lookup is still kept in place and it might be thrown when the configuration of container images per-version is invalid.
4) It also updates the error message slightly to make it more clear that it is a Kafka version the error is talking about.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally