### PR TITLE
[systemtest] Add test for KMM2 reflecting connectors state

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -356,7 +356,7 @@ public class ResourceManager {
     public static <T extends CustomResource<? extends Spec, ? extends Status>> boolean waitForResourceStatus(MixedOperation<T, ?, ?> operation, String kind, String namespace, String name, Enum<?> status, long resourceTimeoutMs) {
         LOGGER.info("Wait for {}: {} will have desired state: {}", kind, name, status);
 
-        TestUtils.waitFor(String.format("Wait for %s: %s will have desired state: %s", kind, name, status),
+        TestUtils.waitFor(String.format("%s: %s will have desired state: %s", kind, name, status),
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, resourceTimeoutMs,
             () -> operation.inNamespace(namespace)
                 .withName(name)
@@ -404,7 +404,7 @@ public class ResourceManager {
     public static <T extends CustomResource<? extends Spec, ? extends Status>> boolean waitForResourceStatusMessage(MixedOperation<T, ?, ?> operation, String kind, String namespace, String name, String message, long resourceTimeoutMs) {
         LOGGER.info("Wait for {}: {} will contain desired status message: {}", kind, name, message);
 
-        TestUtils.waitFor(String.format("Wait for %s: %s will contain desired status message: %s", kind, name, message),
+        TestUtils.waitFor(String.format("%s: %s will contain desired status message: %s", kind, name, message),
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, resourceTimeoutMs,
             () -> operation.inNamespace(namespace)
                 .withName(name)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaMirrorMaker2Utils.java
@@ -27,7 +27,7 @@ public class KafkaMirrorMaker2Utils {
      * @param clusterName name of KafkaMirrorMaker2 cluster
      * @param state desired state
      */
-    public static boolean waitForKafkaMirrorMaker2Status(String namespaceName, String clusterName, Enum<?>  state) {
+    public static boolean waitForKafkaMirrorMaker2Status(String namespaceName, String clusterName, Enum<?> state) {
         KafkaMirrorMaker2 kafkaMirrorMaker2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get();
         return ResourceManager.waitForResourceStatus(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client(), kafkaMirrorMaker2, state);
     }
@@ -37,7 +37,7 @@ public class KafkaMirrorMaker2Utils {
      * @param clusterName name of KafkaMirrorMaker2 cluster
      * @param state desired state
      */
-    public static boolean waitForKafkaMirrorMaker2Status(String clusterName, Enum<?>  state) {
+    public static boolean waitForKafkaMirrorMaker2Status(String clusterName, Enum<?> state) {
         return waitForKafkaMirrorMaker2Status(kubeClient().getNamespace(), clusterName, state);
     }
 
@@ -69,5 +69,10 @@ public class KafkaMirrorMaker2Utils {
             }
             return true;
         });
+    }
+
+    public static boolean waitForKafkaMirrorMaker2StatusMessage(String namespaceName, String clusterName, String message) {
+        KafkaMirrorMaker2 kafkaMirrorMaker2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get();
+        return ResourceManager.waitForResourceStatusMessage(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client(), kafkaMirrorMaker2, message);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -77,6 +77,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
@@ -1075,6 +1076,7 @@ class MirrorMaker2ST extends AbstractST {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String kafkaClusterSourceName = clusterName + "-source";
         String kafkaClusterTargetName = clusterName + "-target";
+        String errorMessage = "One or more connectors are in FAILED state";
 
         resourceManager.createResource(extensionContext,
             KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build(),
@@ -1090,13 +1092,16 @@ class MirrorMaker2ST extends AbstractST {
                 .endSpec()
                 .build());
 
-        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2StatusMessage(namespaceName, clusterName, "One or more connectors are in FAILED state");
+        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2StatusMessage(namespaceName, clusterName, errorMessage);
 
         KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(clusterName, mm2 ->
             mm2.getSpec().getClusters().stream().filter(mm2ClusterSpec -> mm2ClusterSpec.getAlias().equals(kafkaClusterSourceName))
                 .findFirst().get().setBootstrapServers(KafkaUtils.namespacedPlainBootstrapAddress(kafkaClusterSourceName, namespaceName)), namespaceName);
 
         KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(namespaceName, clusterName);
+
+        KafkaMirrorMaker2Status kmm2Status = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus();
+        assertFalse(kmm2Status.getConditions().stream().anyMatch(condition -> condition.getMessage() != null && condition.getMessage().contains(errorMessage)));
     }
 
     @BeforeAll


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

In #5733 was fixed problem with KMM2 and reflecting connectors state - so when we deployed KMM2 with (for example) wrong setting of any bootstrap server, the KMM2 status was `Ready`, even thought connectors were in `FAILED` state.

This PR adds simple test for this fix.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


