### PR TITLE
Execute system tests against release versions properly

### DIFF
--- a/.azure/acceptance-pipeline.yaml
+++ b/.azure/acceptance-pipeline.yaml
@@ -7,6 +7,13 @@ pr:
     include:
       - '*'
 
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_jobs.yaml'
 

--- a/.azure/acceptance-pipeline.yaml
+++ b/.azure/acceptance-pipeline.yaml
@@ -16,5 +16,7 @@ parameters:
 
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_jobs.yaml'
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 
 

--- a/.azure/acceptance-pipeline.yaml
+++ b/.azure/acceptance-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 jobs:

--- a/.azure/feature-gates-namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/feature-gates-namespace-rbac-scope-regression-pipeline.yaml
@@ -6,7 +6,14 @@ pr:
   branches:
     include:
       - '*'
-      -
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml'

--- a/.azure/feature-gates-namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/feature-gates-namespace-rbac-scope-regression-pipeline.yaml
@@ -17,4 +17,7 @@ parameters:
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 

--- a/.azure/feature-gates-namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/feature-gates-namespace-rbac-scope-regression-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job

--- a/.azure/feature-gates-regression-pipeline.yaml
+++ b/.azure/feature-gates-regression-pipeline.yaml
@@ -6,7 +6,14 @@ pr:
   branches:
     include:
       - '*'
-      -
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/feature_gates_regression_jobs.yaml'

--- a/.azure/feature-gates-regression-pipeline.yaml
+++ b/.azure/feature-gates-regression-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job

--- a/.azure/feature-gates-regression-pipeline.yaml
+++ b/.azure/feature-gates-regression-pipeline.yaml
@@ -17,3 +17,6 @@ parameters:
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/feature_gates_regression_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/helm-acceptance-pipeline.yaml
+++ b/.azure/helm-acceptance-pipeline.yaml
@@ -7,6 +7,13 @@ pr:
     include:
       - '*'
 
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_helm_jobs.yaml'
 

--- a/.azure/helm-acceptance-pipeline.yaml
+++ b/.azure/helm-acceptance-pipeline.yaml
@@ -16,5 +16,8 @@ parameters:
 
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_helm_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 
 

--- a/.azure/helm-acceptance-pipeline.yaml
+++ b/.azure/helm-acceptance-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 jobs:

--- a/.azure/helm-namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/helm-namespace-rbac-scope-acceptance-pipeline.yaml
@@ -7,6 +7,13 @@ pr:
     include:
       - '*'
 
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_helm_namespace_rbac_jobs.yaml'
 

--- a/.azure/helm-namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/helm-namespace-rbac-scope-acceptance-pipeline.yaml
@@ -16,6 +16,9 @@ parameters:
 
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_helm_namespace_rbac_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 
 
 

--- a/.azure/helm-namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/helm-namespace-rbac-scope-acceptance-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 jobs:

--- a/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
@@ -7,6 +7,13 @@ pr:
     include:
       - '*'
 
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_namespace_rbac_jobs.yaml'
 

--- a/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 jobs:

--- a/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-acceptance-pipeline.yaml
@@ -16,5 +16,8 @@ parameters:
 
 jobs:
   - template: 'templates/jobs/system-tests/acceptance_namespace_rbac_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 
 

--- a/.azure/namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-regression-pipeline.yaml
@@ -6,7 +6,14 @@ pr:
   branches:
     include:
       - '*'
-      -
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/regression_namespace_rbac_jobs.yaml'

--- a/.azure/namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-regression-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job

--- a/.azure/namespace-rbac-scope-regression-pipeline.yaml
+++ b/.azure/namespace-rbac-scope-regression-pipeline.yaml
@@ -17,4 +17,7 @@ parameters:
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/regression_namespace_rbac_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 

--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -17,3 +17,6 @@ parameters:
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/regression_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job

--- a/.azure/regression-pipeline.yaml
+++ b/.azure/regression-pipeline.yaml
@@ -6,7 +6,14 @@ pr:
   branches:
     include:
       - '*'
-      -
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 # Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
 jobs:
   - template: 'templates/jobs/system-tests/regression_jobs.yaml'

--- a/.azure/run-all-tests.yaml
+++ b/.azure/run-all-tests.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 stages:

--- a/.azure/run-all-tests.yaml
+++ b/.azure/run-all-tests.yaml
@@ -19,29 +19,50 @@ stages:
     dependsOn: []
     jobs:
       - template: 'templates/jobs/system-tests/acceptance_helm_jobs.yaml'
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
 
       - template: 'templates/jobs/system-tests/acceptance_helm_namespace_rbac_jobs.yaml'
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
 
       - template: 'templates/jobs/system-tests/acceptance_jobs.yaml'
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
 
   - stage: "upgrade"
     dependsOn: []
     jobs:
       - template: 'templates/jobs/system-tests/upgrade_jobs.yaml'
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
 
   - stage: "regression"
     dependsOn: [ "acceptance","upgrade" ]
     jobs:
       - template: "templates/jobs/system-tests/regression_jobs.yaml"
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
 
   - stage: "regression_feature_gates"
     dependsOn: [ "acceptance","regression","upgrade" ]
     condition: succeeded('acceptance','upgrade','regression')
     jobs:
       - template: "templates/jobs/system-tests/feature_gates_regression_jobs.yaml"
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
 
   - stage: "regression_namespace_rbac"
     dependsOn: [ "acceptance","regression","upgrade","regression_feature_gates" ]
     condition: succeeded('acceptance','upgrade','regression','regression_feature_gates')
     jobs:
       - template: "templates/jobs/system-tests/regression_namespace_rbac_jobs.yaml"
+        # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+        parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/run-all-tests.yaml
+++ b/.azure/run-all-tests.yaml
@@ -7,6 +7,13 @@ pr:
     include:
       - '*'
 
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 stages:
   - stage: "acceptance"
     dependsOn: []

--- a/.azure/templates/jobs/system-tests/acceptance_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/acceptance_jobs.yaml
@@ -6,3 +6,4 @@ jobs:
       profile: 'acceptance'
       cluster_operator_install_type: 'bundle'
       timeout: 240
+      releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -31,8 +31,8 @@ jobs:
   timeoutInMinutes: ${{ parameters.timeout }}
   # Pipeline steps
   steps:
-    - script: echo "##vso[task.setvariable variable=docker_tag]$([[ $(cat release.version) == *SNAPSHOT* ]] && echo "latest" || tr '[:upper:]' '[:lower:]' < release.version  )"
-      displayName: "Set release tag as DOCKER_TAG for tests"
+    - script: echo "##vso[task.setvariable variable=docker_tag]${{ parameters.release.Version }}"
+      displayName: "Set DOCKER_TAG to ${{ parameters.release.Version }}"
 
     # Log variables
     - template: "log_variables.yaml"

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -31,8 +31,8 @@ jobs:
   timeoutInMinutes: ${{ parameters.timeout }}
   # Pipeline steps
   steps:
-    - script: echo "##vso[task.setvariable variable=docker_tag]${{ parameters.release.Version }}"
-      displayName: "Set DOCKER_TAG to ${{ parameters.release.Version }}"
+    - script: echo "##vso[task.setvariable variable=docker_tag]${{ parameters.releaseVersion }}"
+      displayName: "Set DOCKER_TAG to ${{ parameters.releaseVersion }}"
 
     # Log variables
     - template: "log_variables.yaml"

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -11,6 +11,7 @@ parameters:
   # If these resources will be upgraded in the future, we can enable parallelism.
   parallel: '1'
   run_parallel: false
+  releaseVersion: "latest"
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'

--- a/.azure/upgrade-pipeline.yaml
+++ b/.azure/upgrade-pipeline.yaml
@@ -16,6 +16,9 @@ parameters:
 
 jobs:
   - template: 'templates/jobs/system-tests/upgrade_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
 
 
 

--- a/.azure/upgrade-pipeline.yaml
+++ b/.azure/upgrade-pipeline.yaml
@@ -7,6 +7,13 @@ pr:
     include:
       - '*'
 
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    default: "latest"
+
 jobs:
   - template: 'templates/jobs/system-tests/upgrade_jobs.yaml'
 

--- a/.azure/upgrade-pipeline.yaml
+++ b/.azure/upgrade-pipeline.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: releaseVersion
     displayName: Release Version
     type: string
-    # If releaseVersion == latest then the version is extracted from release.version file in root directory of the repo
+    # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
 
 jobs:


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR adds the option to run regression pipelines against a specific release version/tag passed by a parameter. The default value is set to `latest` atm.

### Checklist

- [x] Make sure all tests pass

