### PR TITLE
[Fix] extraEnvs doesn't work for cluster operator helm charts 

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -129,7 +129,10 @@ spec:
               value: {{ .Values.connectBuildTimeoutMs | quote }}
             {{- end }}
             {{- if .Values.extraEnvs }}
-            {{ toYaml .Values.extraEnvs | indent 12 }}
+            {{- range $key, $val := .Values.extraEnvs }}
+            - name: {{ $val.name }}
+              value: {{ $val.value | quote }}
+            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -129,10 +129,7 @@ spec:
               value: {{ .Values.connectBuildTimeoutMs | quote }}
             {{- end }}
             {{- if .Values.extraEnvs }}
-            {{- range $key, $val := .Values.extraEnvs }}
-            - name: {{ $val.name }}
-              value: {{ $val.value | quote }}
-            {{- end }}
+{{ toYaml .Values.extraEnvs | indent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -22,6 +22,12 @@ operationTimeoutMs: 300000
 kubernetesServiceDnsDomain: cluster.local
 featureGates: ""
 tmpDirSizeLimit: 1Mi
+
+# Example on how to configure extraEnvs
+#  - name: ABC
+#    value: "value1"
+#  - name: XYZ
+#    value: "value2"
 extraEnvs: []
 
 tolerations: []

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -24,10 +24,10 @@ featureGates: ""
 tmpDirSizeLimit: 1Mi
 
 # Example on how to configure extraEnvs
-#  - name: ABC
-#    value: "value1"
-#  - name: XYZ
-#    value: "value2"
+# extraEnvs:
+#   - name: JAVA_OPTS
+#     value: "-Xms=256m -Xmx=256m"
+
 extraEnvs: []
 
 tolerations: []


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

_Select the type of your PR_

- Bugfix

### Description

This PR fixes the issue mentioned in #6145. It removes the use the use if `toYaml` which was giving error and makes use of `range`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

