### PR TITLE
docs: removes duplicate procedures from deploying guide

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -22,8 +22,6 @@ The procedures in this section show how to:
 * xref:using-kafka-connect-with-plug-ins-{context}[Create a Kafka Connect image containing the connectors you need to make your connection]
 * xref:con-creating-managing-connectors-{context}[Create and manage connectors using a KafkaConnector resource or the Kafka Connect REST API]
 * xref:proc-deploying-kafkaconnector-{context}[Deploy a KafkaConnector resource to Kafka Connect]
-* xref:proc-manual-restart-connector-{context}[Restart a Kafka connector by annotating a KafkaConnector resource]
-* xref:proc-manual-restart-connector-task-{context}[Restart a Kafka connector task by annotating a KafkaConnector resource]
 
 NOTE: The term _connector_ is used interchangeably to mean a connector instance running within a Kafka Connect cluster, or a connector class.
 In this guide, the term _connector_ is used when the meaning is clear from the context.
@@ -38,7 +36,3 @@ include::assembly-deploy-kafka-connect-with-plugins.adoc[leveloffset=+1]
 include::modules/con-deploy-kafka-connect-managing-connectors.adoc[leveloffset=+1]
 //Procedure to deploy a KafkaConnector resource
 include::modules/proc-deploying-kafkaconnector.adoc[leveloffset=+1]
-//Procedure to restart a Kafka connector
-include::../../modules/configuring/proc-manual-restart-connector.adoc[leveloffset=+1]
-//Procedure to restart a Kafka connector task
-include::../../modules/configuring/proc-manual-restart-connector-task.adoc[leveloffset=+1]

--- a/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/modules/deploying/con-deploy-kafka-connect-managing-connectors.adoc
@@ -20,7 +20,7 @@ Sink connector:: A sink connector is a runtime entity that fetches messages from
 
 Strimzi provides two APIs for creating and managing connectors:
 
-* KafkaConnector resources (referred to as KafkaConnectors)
+* `KafkaConnector` resources (referred to as KafkaConnectors)
 * Kafka Connect REST API
 
 Using the APIs, you can:
@@ -37,15 +37,15 @@ Using the APIs, you can:
 == KafkaConnector resources
 
 KafkaConnectors allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way, so an HTTP client such as cURL is not required.
-Like other Kafka resources, you declare a connector’s desired state in a KafkaConnector YAML file that is deployed to your Kubernetes cluster to create the connector instance.
-KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
+Like other Kafka resources, you declare a connector’s desired state in a `KafkaConnector` YAML file that is deployed to your Kubernetes cluster to create the connector instance.
+`KafkaConnector` resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
-You manage a running connector instance by updating its corresponding KafkaConnector resource, and then applying the updates.
+You manage a running connector instance by updating its corresponding `KafkaConnector` resource, and then applying the updates.
 Annotations are used to manually restart connector instances and connector tasks.
-You remove a connector by deleting its corresponding KafkaConnector.
+You remove a connector by deleting its corresponding `KafkaConnector`.
 
 To ensure compatibility with earlier versions of Strimzi, KafkaConnectors are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource.
-For instructions, see link:{BookURLUsing}#proc-kafka-connect-config-str[Configuring Kafka Connect^] in the _Using Strimzi_ guide.
+For instructions, see link:{BookURLUsing}#proc-kafka-connect-config-str[Configuring Kafka Connect^].
 
 When KafkaConnectors are enabled, the Cluster Operator begins to watch for them. It updates the configurations of running connector instances to match the configurations defined in their KafkaConnectors.
 
@@ -53,7 +53,9 @@ Strimzi provides xref:deploy-examples-{context}[example configuration files], in
 
 * `examples/connect/source-connector.yaml`.
 
-You can use this example to create and manage a `FileStreamSourceConnector` and a `FileStreamSinkConnector` as described in xref:proc-deploying-kafkaconnector-{context}[].
+You can use this example to create and manage a `FileStreamSourceConnector` and a `FileStreamSinkConnector`, as described in xref:proc-deploying-kafkaconnector-{context}[Deploying the example `KafkaConnector` resources].
+
+NOTE: You can link:{BookURLUsing}#proc-manual-restart-connector-str[restart a connector^] or link:{BookURLUsing}#proc-manual-restart-connector-task-str[restart a connector task^] by annotating a `KafkaConnector` resource.
 
 == Availability of the Kafka Connect REST API
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Removes the following procedures from _Deploying_ guide.

- Performing a restart of a Kafka connector
- Performing a restart of a Kafka connector task

The procedures are present in the _Using_ (Configuring) guide
Links to the procedures replaces the duplication.

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

