### PR TITLE
[systemtest] Change the way how we are logging exceptions inside the `waitFor`

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -72,7 +72,7 @@ public class KafkaConnectUtils {
     public static void waitForMessagesInKafkaConnectFileSink(String namespaceName, String kafkaConnectPodName, String sinkFileName, String message) {
         LOGGER.info("Waiting for messages in file sink on {}", kafkaConnectPodName);
         TestUtils.waitFor("messages in file sink", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_SEND_RECEIVE_MSG,
-            () -> cmdKubeClient(namespaceName).execInPod(kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(message));
+            () -> cmdKubeClient(namespaceName).execInPod(false, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(message));
         LOGGER.info("Expected messages are in file sink on {}", kafkaConnectPodName);
     }
 

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -147,10 +147,8 @@ public final class TestUtils {
                     LOGGER.error("While waiting for {} exception occurred: {}", description, exceptionMessage);
                     // log the stacktrace
                     e.printStackTrace(new PrintWriter(stackTraceError));
-                } else if (exceptionMessage != null && !exceptionMessage.equals(previousExceptionMessage)) {
-                    if (++newExceptionAppearance == 2) {
-                        previousExceptionMessage = exceptionMessage;
-                    }
+                } else if (exceptionMessage != null && !exceptionMessage.equals(previousExceptionMessage) && ++newExceptionAppearance == 2) {
+                    previousExceptionMessage = exceptionMessage;
                 }
 
                 result = false;

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -275,9 +275,14 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     @Override
     public ExecResult execInPod(String pod, String... command) {
+        return execInPod(true, pod, command);
+    }
+
+    @Override
+    public ExecResult execInPod(boolean logToOutput, String pod, String... command) {
         List<String> cmd = namespacedCommand("exec", pod, "--");
         cmd.addAll(asList(command));
-        return Exec.exec(cmd);
+        return Exec.exec(null, cmd, 0, logToOutput);
     }
 
     @Override

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -101,6 +101,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      */
     ExecResult execInPod(String pod, String... command);
 
+    ExecResult execInPod(boolean logToOutput, String pod, String... command);
+
     ExecResult execInCurrentNamespace(String... commands);
 
     ExecResult execInCurrentNamespace(boolean logToOutput, String... commands);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes issue with our error logging -> in `TestUtils.waitFor()` we are logging first exception that is raised when we execute `Exec`. So there can be situations when we can get this output:
```
2021-11-17 13:02:05 [main] INFO  [KafkaConnectUtils:73] Waiting for messages in file sink on my-cluster-973149044-connect-846c79df55-jx6bx
2021-11-17 13:02:05 [main] INFO  [Exec:168] Failed to exec command: kubectl --namespace infra-namespace exec my-cluster-973149044-connect-846c79df55-jx6bx -- /bin/bash -c cat /tmp/test-file-sink.txt
2021-11-17 13:02:05 [main] INFO  [Exec:172] RETURN code: 1
2021-11-17 13:02:05 [main] INFO  [Exec:179] ======STDERR START=======
2021-11-17 13:02:05 [main] INFO  [Exec:180] cat: /tmp/test-file-sink.txt: No such file or directory
command terminated with exit code 1
2021-11-17 13:02:05 [main] INFO  [Exec:181] ======STDERR END======
2021-11-17 13:02:05 [main] ERROR [TestUtils:136] Exception waiting for messages in file sink, `kubectl --namespace infra-namespace exec my-cluster-973149044-connect-846c79df55-jx6bx -- /bin/bash -c cat /tmp/test-file-sink.txt` got status code 1 and stderr:
------
cat: /tmp/test-file-sink.txt: No such file or directory
command terminated with exit code 1

------
and stdout:
------

------
2021-11-17 13:02:10 [main] INFO  [KafkaConnectUtils:76] Expected messages are in file sink on my-cluster-973149044-connect-846c79df55-jx6bx
```

It seems that check (waiting for messages to be in file sink) passed, but the first error is confusing.

This PR fixes this issue.

### Checklist

- [x] Make sure all tests pass
