### PR TITLE
docs: groups the connector content in the deploying guide

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -21,11 +21,5 @@ include::../../modules/configuring/proc-config-kafka-connect.adoc[leveloffset=+1
 include::../../modules/configuring/con-config-kafka-connect-multiple-instances.adoc[leveloffset=+1]
 //If authorization is enabled, configure the Kafka Connect user for read/write access rights
 include::../../modules/configuring/proc-config-kafka-connect-user-authorization.adoc[leveloffset=+1]
-//Procedure to restart a Kafka connector
-include::../../modules/configuring/proc-manual-restart-connector.adoc[leveloffset=+1]
-//Procedure to restart a Kafka connector task
-include::../../modules/configuring/proc-manual-restart-connector-task.adoc[leveloffset=+1]
-//Tips to expose the Kafka Connect API
-include::../../modules/configuring/con-exposing-kafka-connect-api.adoc[leveloffset=+1]
 //Resources created for Kafka Connect
 include::../../modules/configuring/ref-config-list-of-kafka-connect-resources.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-managing-connectors.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-managing-connectors.adoc
@@ -2,7 +2,7 @@
 //
 // deploying/assembly_deploy-kafka-connect.adoc
 
-[id='con-creating-managing-connectors-{context}']
+[id='assembly-creating-managing-connectors-{context}']
 
 [role="_abstract"]
 = Creating and managing connectors
@@ -41,7 +41,6 @@ Like other Kafka resources, you declare a connector’s desired state in a `Kafk
 `KafkaConnector` resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
 You manage a running connector instance by updating its corresponding `KafkaConnector` resource, and then applying the updates.
-Annotations are used to manually restart connector instances and connector tasks.
 You remove a connector by deleting its corresponding `KafkaConnector`.
 
 To ensure compatibility with earlier versions of Strimzi, KafkaConnectors are disabled by default. To enable them for a Kafka Connect cluster, you must use annotations on the `KafkaConnect` resource.
@@ -55,12 +54,13 @@ Strimzi provides xref:deploy-examples-{context}[example configuration files], in
 
 You can use this example to create and manage a `FileStreamSourceConnector` and a `FileStreamSinkConnector`, as described in xref:proc-deploying-kafkaconnector-{context}[Deploying the example `KafkaConnector` resources].
 
-NOTE: You can link:{BookURLUsing}#proc-manual-restart-connector-str[restart a connector^] or link:{BookURLUsing}#proc-manual-restart-connector-task-str[restart a connector task^] by annotating a `KafkaConnector` resource.
+NOTE: You can xref:proc-manual-restart-connector-str[restart a connector] or xref:proc-manual-restart-connector-task-str[restart a connector task] by annotating a `KafkaConnector` resource.
 
-== Availability of the Kafka Connect REST API
-
-The Kafka Connect REST API is available on port 8083 as the `<connect-cluster-name>-connect-api` service.
-
-If KafkaConnectors are enabled, manual changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
-
-The operations supported by the REST API are described in the link:https://kafka.apache.org/documentation/#connect_rest[Apache Kafka documentation^].
+//Procedure to deploy a KafkaConnector resource
+include::modules/proc-deploying-kafkaconnector.adoc[leveloffset=+1]
+//Procedure to restart a Kafka connector
+include::modules/proc-manual-restart-connector.adoc[leveloffset=+1]
+//Procedure to restart a Kafka connector task
+include::modules/proc-manual-restart-connector-task.adoc[leveloffset=+1]
+//Tips to expose the Kafka Connect API
+include::modules/con-exposing-kafka-connect-api.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -3,7 +3,7 @@
 // deploying/assembly-deploy-kafka-connect.adoc
 
 [id='using-kafka-connect-with-plug-ins-{context}']
-= Extending Kafka Connect with connector plug-ins
+= Extending Kafka Connect with connector plugins
 
 The Strimzi container images for Kafka Connect include two built-in file connectors for moving file-based data into and out of your Kafka cluster.
 
@@ -28,7 +28,7 @@ The procedures in this section show how to add your own connector classes to con
 
 * xref:creating-new-image-from-base-{context}[Creating a container image from the Kafka Connect base image (manually or using continuous integration)]
 
-IMPORTANT: You create the configuration for connectors directly xref:con-creating-managing-connectors-{context}[using the Kafka Connect REST API or KafkaConnector custom resources].
+IMPORTANT: You create the configuration for connectors directly xref:assembly-creating-managing-connectors-{context}[using the Kafka Connect REST API or `KafkaConnector` custom resources].
 
 //Procedure to create a container images using Strimzi and Kafka Connect build
 include::modules/proc-deploy-kafka-connect-using-kafka-connect-build.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect.adoc
@@ -20,8 +20,8 @@ The procedures in this section show how to:
 * xref:deploying-kafka-connect-{context}[Deploy a Kafka Connect cluster using a `KafkaConnect` resource]
 * xref:con-kafka-connect-multiple-instances-{context}[Run multiple Kafka Connect instances]
 * xref:using-kafka-connect-with-plug-ins-{context}[Create a Kafka Connect image containing the connectors you need to make your connection]
-* xref:con-creating-managing-connectors-{context}[Create and manage connectors using a KafkaConnector resource or the Kafka Connect REST API]
-* xref:proc-deploying-kafkaconnector-{context}[Deploy a KafkaConnector resource to Kafka Connect]
+* xref:assembly-creating-managing-connectors-{context}[Create and manage connectors using a `KafkaConnector` resource or the Kafka Connect REST API]
+* xref:proc-deploying-kafkaconnector-{context}[Deploy a `KafkaConnector` resource to Kafka Connect]
 
 NOTE: The term _connector_ is used interchangeably to mean a connector instance running within a Kafka Connect cluster, or a connector class.
 In this guide, the term _connector_ is used when the meaning is clear from the context.
@@ -30,9 +30,7 @@ In this guide, the term _connector_ is used when the meaning is clear from the c
 include::modules/proc-deploy-kafka-connect.adoc[leveloffset=+1]
 //Running multiple Kafka Connect instances
 include::../../modules/configuring/con-config-kafka-connect-multiple-instances.adoc[leveloffset=+1]
-//Options to deploy Kafka Connect with new container image
+//Options to deploy Kafka Connect connector plugins
 include::assembly-deploy-kafka-connect-with-plugins.adoc[leveloffset=+1]
 //Overview of creating connectors through API
-include::modules/con-deploy-kafka-connect-managing-connectors.adoc[leveloffset=+1]
-//Procedure to deploy a KafkaConnector resource
-include::modules/proc-deploying-kafkaconnector.adoc[leveloffset=+1]
+include::assembly-deploy-kafka-connect-managing-connectors.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -8,16 +8,16 @@
 Use Kafka Connect to set up external data connections to your Kafka cluster.
 Use the properties of the `KafkaConnect` resource to configure your Kafka Connect deployment.
 
-.Kafka connector configuration
-KafkaConnector resources allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way.
+.KafkaConnector configuration
+`KafkaConnector` resources allow you to create and manage connector instances for Kafka Connect in a Kubernetes-native way.
 
 In your Kafka Connect configuration, you enable KafkaConnectors for a Kafka Connect cluster by adding the `strimzi.io/use-connector-resources` annotation.
 You can also add a `build` configuration so that Strimzi automatically builds a container image with the connector plugins you require for your data connections.
 External configuration for Kafka Connect connectors is specified through the `externalConfiguration` property.
 
-To manage connectors, you can use the Kafka Connect REST API, or use KafkaConnector custom resources.
-KafkaConnector resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
-For more information on using these methods to create, reconfigure, or delete connectors, see link:{BookURLDeploying}#con-creating-managing-connectors-str[Creating and managing connectors^] in the _Deploying and Upgrading Strimzi_ guide.
+To manage connectors, you can use the Kafka Connect REST API, or use `KafkaConnector` custom resources.
+`KafkaConnector` resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
+For more information on using these methods to create, reconfigure, or delete connectors, see link:{BookURLDeploying}#assembly-creating-managing-connectors-str[Creating and managing connectors^].
 
 Connector configuration is passed to Kafka Connect as part of an HTTP request and stored within Kafka itself.
 ConfigMaps and Secrets are standard Kubernetes resources used for storing configurations and confidential data.

--- a/documentation/modules/deploying/con-exposing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-exposing-kafka-connect-api.adoc
@@ -1,6 +1,6 @@
 // This assembly is included in the following assemblies:
 //
-//assembly-config-kafka-connect.adoc
+//deploying/assembly-deploy-kafka-connect-managing-connectors.adoc
 
 [id='con-exposing-kafka-connect-api-{context}']
 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -7,9 +7,9 @@
 
 This procedure shows how to create a custom image and add it to the `/opt/kafka/plugins` directory.
 
-You can use the Kafka container image on {DockerRepository} as a base image for creating your own custom image with additional connector plug-ins.
+You can use the Kafka container image on {DockerRepository} as a base image for creating your own custom image with additional connector plugins.
 
-At startup, the Strimzi version of Kafka Connect loads any third-party connector plug-ins contained in the `/opt/kafka/plugins` directory.
+At startup, the Strimzi version of Kafka Connect loads any third-party connector plugins contained in the `/opt/kafka/plugins` directory.
 
 .Prerequisites
 
@@ -101,8 +101,6 @@ or
 * In the `install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_KAFKA_CONNECT_IMAGES` variable to point to the new container image, and then reinstall the Cluster Operator.
 
 .Additional resources
-
-See the _Using Strimzi_ guide for more information on:
 
 * link:{BookURLUsing}#con-common-configuration-images-reference[Container image configuration and the `KafkaConnect.spec.image property`^]
 * link:{BookURLUsing}#ref-operator-cluster-str[Cluster Operator configuration and the `STRIMZI_KAFKA_CONNECT_IMAGES` variable^]

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -52,7 +52,7 @@ spec:
     # ...
 ----
 +
-<1> Name of the KafkaConnector resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
+<1> Name of the `KafkaConnector` resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
 <2> Name of the Kafka Connect cluster to create the connector instance in. Connectors must be deployed to the same namespace as the Kafka Connect cluster they link to.
 <3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
 <4> Maximum number of Kafka Connect `Tasks` that the connector can create.
@@ -127,7 +127,7 @@ kubectl exec _MY-CLUSTER_-kafka-0 -i -t -- bin/kafka-console-consumer.sh --boots
 [discrete]
 == Source and sink connector configuration options
 
-The connector configuration is defined in the `spec.config` property of the KafkaConnector resource.
+The connector configuration is defined in the `spec.config` property of the `KafkaConnector` resource.
 
 The `FileStreamSourceConnector` and `FileStreamSinkConnector` classes support the same configuration options as the Kafka Connect REST API.
 Other connectors support different configuration options.
@@ -178,8 +178,3 @@ m¦topics.regex
 ¦A regular expression matching one or more Kafka topics to read data from.
 
 |===
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:con-creating-managing-connectors-{context}[]

--- a/documentation/modules/deploying/proc-manual-restart-connector-task.adoc
+++ b/documentation/modules/deploying/proc-manual-restart-connector-task.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
-// configuring/assembly-config-kafka-connect.adoc
-// deploying/assembly-deploy-kafka-connect.adoc
+//
+// deploying/assembly-deploy-kafka-connect-managing-connectors.adoc
 
 [id='proc-manual-restart-connector-task-{context}']
 = Performing a restart of a Kafka connector task

--- a/documentation/modules/deploying/proc-manual-restart-connector.adoc
+++ b/documentation/modules/deploying/proc-manual-restart-connector.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
-// configuring/assembly-config-kafka-connect.adoc
-// deploying/assembly-deploy-kafka-connect.adoc
+//
+// deploying/assembly-deploy-kafka-connect-managing-connectors.adoc
 
 [id='proc-manual-restart-connector-{context}']
 = Performing a restart of a Kafka connector


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Groups the _connector_ content in the Kafka Connect section of the _Deploying_ guide into a separate assembly. The assembly describes KafkaConnector resources and how to deploy them. Also includes related procedures for restarting connectors and connector tasks. 

The assembly also includes details on exposing the Kafka Connect API. This content moves from the Configuring guide and replaces a similar section that was present in the _Deploying_ guide. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

