### PR TITLE
Add log-dump script ST and refactoring

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -123,6 +123,7 @@ public class VerifiableClient {
         if (clientType == ClientType.CLI_KAFKA_VERIFIABLE_CONSUMER) {
             this.consumerGroupName = verifiableClientBuilder.consumerGroupName;
             this.clientArgumentMap.put(ClientArgument.GROUP_ID, consumerGroupName);
+            this.consumerInstanceId = verifiableClientBuilder.consumerInstanceId;
         }
 
         if (clientType == ClientType.CLI_KAFKA_CONSUMER_GROUPS) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/dump/LogDumpScriptST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/dump/LogDumpScriptST.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.dump;
+
+import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
+import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.TestUtils.USER_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.test.annotations.IsolatedTest;
+import io.strimzi.test.executor.Exec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@Tag(REGRESSION)
+@Tag(INTERNAL_CLIENTS_USED)
+@IsolatedSuite
+public class LogDumpScriptST extends AbstractST {
+    private static final Logger LOGGER = LogManager.getLogger(LogDumpScriptST.class);
+
+    @IsolatedTest
+    void dumpPartitions(ExtensionContext context) {
+        String clusterName = mapWithClusterNames.get(context.getDisplayName());
+        String groupId = "my-group";
+        String partitionNumber = "0";
+        String outPath = USER_PATH + "/target/" + clusterName;
+        
+        resourceManager.createResource(context, KafkaTemplates.kafkaPersistent(clusterName, 1, 1)
+            .editMetadata()
+                .withNamespace(INFRA_NAMESPACE)
+            .endMetadata()
+            .build());
+        String clientsPodName = deployAndGetInternalClientsPodName(context);
+        InternalKafkaClient clients = buildInternalClients(context, clientsPodName, groupId, 10);
+        String topicName = mapWithTestTopics.get(context.getDisplayName());
+        
+        // send messages and consume them
+        clients.sendMessagesPlain();
+        clients.receiveMessagesPlain();
+
+        // dry run
+        LOGGER.info("Print partition segments from cluster {}/{}", INFRA_NAMESPACE, clusterName);
+        String[] printCmd = new String[] {
+            USER_PATH + "/../tools/log-dump/run.sh", "partition", "--namespace", INFRA_NAMESPACE, "--cluster", clusterName, "--topic", topicName, "--partition", partitionNumber, "--dry-run"
+        };
+        Exec.exec(true, printCmd);
+        assertThat("Output directory created in dry mode", Files.notExists(Paths.get(outPath)));
+        
+        // partition dump
+        LOGGER.info("Dump topic partition from cluster {}/{}", INFRA_NAMESPACE, clusterName);
+        String[] dumpPartCmd = new String[] {
+            USER_PATH + "/../tools/log-dump/run.sh", "partition", "--namespace", INFRA_NAMESPACE, "--cluster", clusterName, "--topic", topicName, "--partition", partitionNumber, "--out-path", outPath
+        };
+        Exec.exec(true, dumpPartCmd);
+        assertThat("No output directory created", Files.exists(Paths.get(outPath)));
+        String dumpPartFilePath = outPath + "/" + topicName + "/kafka-0-" + topicName + "-" + partitionNumber + "/00000000000000000000.log";
+        assertThat("No partition file created", Files.exists(Paths.get(dumpPartFilePath)));
+        assertThat("Empty partition file", new File(dumpPartFilePath).length() > 0);
+        
+        // __consumer_offsets dump
+        LOGGER.info("Dump consumer offsets partition from cluster {}/{}", INFRA_NAMESPACE, clusterName);
+        String[] dumpCgCmd = new String[] {
+            USER_PATH + "/../tools/log-dump/run.sh", "cg_offsets", "--namespace", INFRA_NAMESPACE, "--cluster", clusterName, "--group-id", groupId, "--out-path", outPath
+        };
+        Exec.exec(true, dumpCgCmd);
+        assertThat("No output directory created", Files.exists(Paths.get(outPath)));
+        String dumpCgFilePath = outPath + "/__consumer_offsets/kafka-0-__consumer_offsets-12/00000000000000000000.log";
+        assertThat("No partition file created", Files.exists(Paths.get(dumpCgFilePath)));
+        assertThat("Empty partition file", new File(dumpCgFilePath).length() > 0);
+    }
+
+    private String deployAndGetInternalClientsPodName(ExtensionContext context) {
+        final String kafkaClientsName = mapWithKafkaClientNames.get(context.getDisplayName());
+        resourceManager.createResource(context, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
+        return ResourceManager.kubeClient().listPodsByPrefixInName(INFRA_NAMESPACE, kafkaClientsName).get(0).getMetadata().getName();
+    }
+
+    private InternalKafkaClient buildInternalClients(ExtensionContext context, String podName, String groupId, int batchSize) {
+        String clusterName = mapWithClusterNames.get(context.getDisplayName());
+        String topicName = mapWithTestTopics.get(context.getDisplayName());
+        InternalKafkaClient clients = new InternalKafkaClient.Builder()
+                .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                .withNamespaceName(INFRA_NAMESPACE)
+                .withUsingPodName(podName)
+                .withClusterName(clusterName)
+                .withTopicName(topicName)
+                .withConsumerGroupName(groupId)
+                .withMessageCount(batchSize)
+                .build();
+        return clients;
+    }
+}

--- a/tools/cold-backup/run.sh
+++ b/tools/cold-backup/run.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 if [[ $(uname -s) == "Darwin" ]]; then
-    shopt -s expand_aliases
-    alias rm="grm"
-    alias echo="gecho"
-    alias dirname="gdirname"
-    alias grep="ggrep"
-    alias readlink="greadlink"
-    alias tar="gtar"
-    alias sed="gsed"
-    alias date="gdate"
-    alias ls="gls"
+  shopt -s expand_aliases
+  alias echo="gecho"; alias dirname="gdirname"; alias grep="ggrep"; alias readlink="greadlink"
+  alias tar="gtar"; alias sed="gsed"; alias date="gdate"; alias ls="gls"
 fi
-__HOME="" && pushd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" >/dev/null \
-    && { __HOME=$PWD; popd >/dev/null; } && readonly __HOME
-trap __cleanup EXIT
+BASE="" && pushd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" >/dev/null \
+  && { BASE=$PWD; popd >/dev/null; } && readonly BASE
+trap cleanup EXIT
 
-RSYNC_POD_NAME=""
-WAIT_TIMEOUT_SEC=300
+readonly RSYNC_POD_NAME="cold-backup"
 ZK_REPLICAS=0
 ZK_PVC=()
 ZK_PVC_SIZE=""
@@ -38,343 +30,333 @@ BACKUP_NAME=""
 CUSTOM_CM=""
 CUSTOM_SE=""
 
-__start_cluster() {
-    if [[ -n $NAMESPACE && -n $CLUSTER_NAME ]]; then
-        echo "Starting cluster $CLUSTER_NAME"
-        if [[ $COMMAND == "backup" && -n $ZK_REPLICAS && -n $KAFKA_REPLICAS ]]; then
-            local zoo_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-zookeeper -o name --ignore-not-found)"
-            if [[ -n $zoo_ss ]]; then
-                kubectl -n $NAMESPACE scale $zoo_ss --replicas $ZK_REPLICAS
-                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-zookeeper
-            fi
-            local kafka_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-kafka -o name --ignore-not-found)"
-            if [[ -n $kafka_ss ]]; then
-                kubectl -n $NAMESPACE scale $kafka_ss --replicas $KAFKA_REPLICAS
-                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-kafka
-            fi
-            local eo_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-entity-operator -o name --ignore-not-found)"
-            if [[ -n $eo_deploy ]]; then
-                kubectl -n $NAMESPACE scale $eo_deploy --replicas 1
-                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-entity-operator
-            fi
-            local ke_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-kafka-exporter -o name --ignore-not-found)"
-            if [[ -n $ke_deploy ]]; then
-                kubectl -n $NAMESPACE scale $ke_deploy --replicas 1
-                __wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-kafka-exporter
-            fi
-        fi
-        if [[ $COMMAND == "backup" || $COMMAND == "restore" ]]; then
-            local co_deploy="$(kubectl -n $NAMESPACE get deploy strimzi-cluster-operator -o name --ignore-not-found)"
-            if [[ -n $co_deploy ]]; then
-                kubectl -n $NAMESPACE scale $co_deploy --replicas 1
-                __wait_for condition=ready pod strimzi.io/kind=cluster-operator
-            fi
-            if [[ $COMMAND == "restore" ]]; then
-                local i=0
-                local wait_cmd="__wait_for condition=ready pod strimzi.io/name=$CLUSTER_NAME-kafka"
-                echo "Waiting for Kafka to be ready"
-                while [[ ! $($wait_cmd) && $i -lt $WAIT_TIMEOUT_SEC ]]; do
-                    i=$((i+1))
-                    sleep 1
-                done
-                $wait_cmd
-            fi
-        fi
+start_cluster() {
+  if [[ -n $NAMESPACE && -n $CLUSTER_NAME ]]; then
+    echo "Starting cluster $CLUSTER_NAME"
+    if [[ $COMMAND == "backup" && -n $ZK_REPLICAS && -n $KAFKA_REPLICAS ]]; then
+      local zoo_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-zookeeper -o name --ignore-not-found)"
+      if [[ -n $zoo_ss ]]; then
+        kubectl -n $NAMESPACE scale $zoo_ss --replicas $ZK_REPLICAS
+        wait_for condition=ready pod "strimzi.io/name=$CLUSTER_NAME-zookeeper"
+      fi
+      local kafka_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-kafka -o name --ignore-not-found)"
+      if [[ -n $kafka_ss ]]; then
+        kubectl -n $NAMESPACE scale $kafka_ss --replicas $KAFKA_REPLICAS
+        wait_for condition=ready pod "strimzi.io/name=$CLUSTER_NAME-kafka"
+      fi
+      local eo_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-entity-operator -o name --ignore-not-found)"
+      if [[ -n $eo_deploy ]]; then
+        kubectl -n $NAMESPACE scale $eo_deploy --replicas 1
+        wait_for condition=ready pod "strimzi.io/name=$CLUSTER_NAME-entity-operator"
+      fi
+      local ke_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-kafka-exporter -o name --ignore-not-found)"
+      if [[ -n $ke_deploy ]]; then
+        kubectl -n $NAMESPACE scale $ke_deploy --replicas 1
+        wait_for condition=ready pod "strimzi.io/name=$CLUSTER_NAME-kafka-exporter"
+      fi
     fi
-}
-
-__stop_cluster() {
-    if [[ -n $NAMESPACE && -n $CLUSTER_NAME ]]; then
-        echo "Stopping cluster $CLUSTER_NAME"
-        local co_deploy="$(kubectl -n $NAMESPACE get deploy strimzi-cluster-operator -o name --ignore-not-found)"
-        if [[ -n $co_deploy ]]; then
-            kubectl -n $NAMESPACE scale $co_deploy --replicas 0
-            __wait_for delete pod strimzi.io/kind=cluster-operator
-        else
-            echo "No local operator found, make sure no cluster-wide operator is watching this namespace"
-            __confirm
-        fi
-        local eo_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-entity-operator -o name --ignore-not-found)"
-        if [[ -n $eo_deploy ]]; then
-            kubectl -n $NAMESPACE scale $eo_deploy --replicas 0
-            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-entity-operator
-        fi
-        local ke_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-kafka-exporter -o name --ignore-not-found)"
-        if [[ -n $ke_deploy ]]; then
-            kubectl -n $NAMESPACE scale $ke_deploy --replicas 0
-            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-kafka-exporter
-        fi
-        local kafka_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-kafka -o name --ignore-not-found)"
-        if [[ -n $kafka_ss ]]; then
-            kubectl -n $NAMESPACE scale $kafka_ss --replicas 0
-            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-kafka
-        fi
-        local zoo_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-zookeeper -o name --ignore-not-found)"
-        if [[ -n $zoo_ss ]]; then
-            kubectl -n $NAMESPACE scale $zoo_ss --replicas 0
-            __wait_for delete pod strimzi.io/name=$CLUSTER_NAME-zookeeper
-        fi
+    if [[ $COMMAND == "backup" || $COMMAND == "restore" ]]; then
+      local co_deploy="$(kubectl -n $NAMESPACE get deploy strimzi-cluster-operator -o name --ignore-not-found)"
+      if [[ -n $co_deploy ]]; then
+        kubectl -n $NAMESPACE scale $co_deploy --replicas 1
+        wait_for condition=ready pod "strimzi.io/kind=cluster-operator"
+      fi
+      if [[ $COMMAND == "restore" ]]; then
+        wait_for condition=ready pod "strimzi.io/name=$CLUSTER_NAME-kafka"
+      fi
     fi
+  fi
 }
 
-__cleanup() {
-    if [[ -n $COMMAND && $CLEANUP == true ]]; then
-        kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME 2>/dev/null ||true
-        __start_cluster
-    fi
-}
-
-__error() {
-    echo "$@" 1>&2
-    exit 1
-}
-
-__confirm() {
-    read -p "Please confirm (y/n) " reply
-    if [[ ! $reply =~ ^[Yy]$ ]]; then
-        CLEANUP=false
-        exit 0
-    fi
-}
-
-__check_kube_conn() {
-    kubectl version --request-timeout=10s 1>/dev/null
-}
-
-__wait_for() {
-    local condition="$1"
-    local type="$2"
-    local label="$3"
-    if [[ -n $condition && -n $type && -n $label ]]; then
-        local resource=$(kubectl -n $NAMESPACE get $type -l $label -o name --ignore-not-found)
-        if [[ -n $resource ]]; then
-            echo "Waiting for $condition of $type with label $label"
-            kubectl -n $NAMESPACE wait $type -l $label --for="$condition" --timeout="${WAIT_TIMEOUT_SEC}s"
-        fi
+stop_cluster() {
+  if [[ -n $NAMESPACE && -n $CLUSTER_NAME ]]; then
+    echo "Stopping cluster $CLUSTER_NAME"
+    local co_deploy="$(kubectl -n $NAMESPACE get deploy strimzi-cluster-operator -o name --ignore-not-found)"
+    if [[ -n $co_deploy ]]; then
+      kubectl -n $NAMESPACE scale $co_deploy --replicas 0
+      wait_for delete pod "strimzi.io/kind=cluster-operator"
     else
-        __error "Missing required parameters"
+      echo "No local operator found, make sure no cluster-wide operator is watching this namespace"
+      confirm
     fi
+    local eo_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-entity-operator -o name --ignore-not-found)"
+    if [[ -n $eo_deploy ]]; then
+      kubectl -n $NAMESPACE scale $eo_deploy --replicas 0
+      wait_for delete pod "strimzi.io/name=$CLUSTER_NAME-entity-operator"
+    fi
+    local ke_deploy="$(kubectl -n $NAMESPACE get deploy $CLUSTER_NAME-kafka-exporter -o name --ignore-not-found)"
+    if [[ -n $ke_deploy ]]; then
+      kubectl -n $NAMESPACE scale $ke_deploy --replicas 0
+      wait_for delete pod "strimzi.io/name=$CLUSTER_NAME-kafka-exporter"
+    fi
+    local kafka_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-kafka -o name --ignore-not-found)"
+    if [[ -n $kafka_ss ]]; then
+      kubectl -n $NAMESPACE scale $kafka_ss --replicas 0
+      wait_for delete pod "strimzi.io/name=$CLUSTER_NAME-kafka"
+    fi
+    local zoo_ss="$(kubectl -n $NAMESPACE get statefulset $CLUSTER_NAME-zookeeper -o name --ignore-not-found)"
+    if [[ -n $zoo_ss ]]; then
+      kubectl -n $NAMESPACE scale $zoo_ss --replicas 0
+      wait_for delete pod "strimzi.io/name=$CLUSTER_NAME-zookeeper"
+    fi
+  fi
 }
 
-__export_env() {
-    local dest_path="$1"
-    if [[ -n $dest_path ]]; then
-        echo "Exporting environment"
-        local zk_label="strimzi.io/name=$CLUSTER_NAME-zookeeper"
-        ZK_REPLICAS=$(kubectl -n $NAMESPACE get kafka $CLUSTER_NAME -o yaml | yq eval ".spec.zookeeper.replicas" -)
-        mapfile -t ZK_PVC < <(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[].metadata.name" -)
-        ZK_PVC_SIZE=$(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[0].spec.resources.requests.storage" -)
-        ZK_PVC_CLASS=$(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[0].spec.storageClassName" -)
-        local kafka_label="strimzi.io/name=$CLUSTER_NAME-kafka"
-        KAFKA_REPLICAS=$(kubectl -n $NAMESPACE get kafka $CLUSTER_NAME -o yaml | yq eval ".spec.kafka.replicas" -)
-        mapfile -t KAFKA_PVC < <(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[].metadata.name" -)
-        KAFKA_PVC_SIZE=$(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[0].spec.resources.requests.storage" -)
-        KAFKA_PVC_CLASS=$(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[0].spec.storageClassName" -)
-        declare -px ZK_REPLICAS ZK_PVC ZK_PVC_SIZE ZK_PVC_CLASS KAFKA_REPLICAS KAFKA_PVC KAFKA_PVC_SIZE KAFKA_PVC_CLASS > "$dest_path"
-    else
-        __error "Missing required parameters"
-    fi
+cleanup() {
+  if [[ -n $COMMAND && $CLEANUP == true ]]; then
+    kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME 2>/dev/null ||true
+    start_cluster
+  fi
 }
 
-__export_res() {
-    local res_type="$1"
-    local res_id="$2"
-    local dest_path="$3"
-    if [[ -n $res_type && -n $res_id && -n $dest_path ]]; then
-        local resources=$(kubectl -n $NAMESPACE get $res_type -l $res_id -o name --ignore-not-found ||true)
-        if [[ -z $resources ]]; then
-            resources=$(kubectl -n $NAMESPACE get $res_type $res_id -o name --ignore-not-found 2>/dev/null ||true)
-        fi
-        if [[ -n $resources ]]; then
-            echo "Exporting $res_type $res_id"
-            # delete runtime metadata expression
-            local exp="del(.metadata.namespace, .items[].metadata.namespace, \
-                .metadata.resourceVersion, .items[].metadata.resourceVersion, \
-                .metadata.selfLink, .items[].metadata.selfLink, \
-                .metadata.uid, .items[].metadata.uid, \
-                .status, .items[].status)"
-            local file_name=$(printf $res_type-$res_id | sed 's/\//-/g;s/ //g')
-            kubectl -n $NAMESPACE get $resources -o yaml | yq eval "$exp" - > $dest_path/$file_name.yaml
-        fi
-    else
-        __error "Missing required parameters"
-    fi
+error() {
+  echo "$@" 1>&2
+  exit 1
 }
 
-__rsync() {
-    local source="$1"
-    local target="$2"
-    if [[ -n $source && -n $target ]]; then
-        echo "Rsync from $source to $target"
-        local flags="--no-check-device --no-acls --no-xattrs --no-same-owner --warning=no-file-changed"
-        if [[ $source != "$BACKUP_PATH/"* ]]; then
-            # download from pod to local (backup)
-            flags="$flags --exclude=data/version-2/{currentEpoch,acceptedEpoch}"
-            local patch=$(sed "s@\$name@$source@g" $__HOME/templates/patch.json)
-            kubectl -n $NAMESPACE run $RSYNC_POD_NAME --image "dummy" --restart "Never" --overrides "$patch"
-            __wait_for condition=ready pod run="$RSYNC_POD_NAME"
-            # ignore the sporadic file changed error
-            kubectl -n $NAMESPACE exec -i $RSYNC_POD_NAME -- sh -c "tar $flags -C /data -c ." \
-              | tar $flags -C $target -xv -f - && if [[ $? == 1 ]]; then exit 0; fi
-            kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME
-        else
-            # upload from local to pod (restore)
-            local patch=$(sed "s@\$name@$target@g" $__HOME/templates/patch.json)
-            kubectl -n $NAMESPACE run $RSYNC_POD_NAME --image "dummy" --restart "Never" --overrides "$patch"
-            __wait_for condition=ready pod run="$RSYNC_POD_NAME"
-            tar $flags -C $source -c . \
-              | kubectl -n $NAMESPACE exec -i $RSYNC_POD_NAME -- sh -c "tar $flags -C /data -xv -f -"
-            kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME
-        fi
-    else
-        __error "Missing required parameters"
-    fi
+confirm() {
+  read -p "Please confirm (y/n) " reply
+  if [[ ! $reply =~ ^[Yy]$ ]]; then
+    CLEANUP=false
+    exit 0
+  fi
 }
 
-__create_pvc() {
-    local name="$1"
-    local size="$2"
-    local class="${3-}"
-    if [[ -n $name && -n $size ]]; then
-        local exp="s/\$name/$name/g; s/\$size/$size/g; /storageClassName/d"
-        if [[ $class != "null" ]]; then
-            exp="s/\$name/$name/g; s/\$size/$size/g; s/\$class/$class/g"
-        fi
-        echo "Creating pvc $name of size $size"
-        sed "$exp" $__HOME/templates/pvc.yaml | kubectl -n $NAMESPACE create -f -
-    else
-        __error "Missing required parameters"
-    fi
+check_kube_conn() {
+  kubectl version --request-timeout=10s 1>/dev/null
 }
 
-__compress() {
-    local source_dir="$1"
-    local target_file="$2"
-    if [[ -n $source_dir && -n $target_file ]]; then
-        local current_dir=$(pwd)
-        cd $source_dir
-        echo "Compressing $source_dir to $target_file"
-        zip -FSqr $BACKUP_NAME *
-        mv $BACKUP_NAME $BACKUP_PATH
-        cd $current_dir
-    else
-        __error "Missing required parameters"
-    fi
+wait_for() {
+  local cond="$1"
+  local resource="$2"
+  local label="${3-}"
+  local timeout_sec=300
+  if [[ -z $cond || -z $resource ]]; then
+    error "Missing parameters"
+  fi
+  if [[ -n $label ]]; then
+    resource="$resource -l $label"
+  fi
+  echo "Waiting for $cond on $resource"
+  local res_cmd="kubectl -n $NAMESPACE get $resource -o name --ignore-not-found"
+  local wait_cmd="kubectl -n $NAMESPACE wait --for=$cond $resource --timeout=${timeout_sec}s"
+  # wait for resource
+  local i=0; while [[ ! $($res_cmd) && $i -lt $timeout_sec ]]; do
+    i=$((i+1)) && sleep 1
+  done
+  # wait for condition
+  $wait_cmd
 }
 
-__uncompress() {
-    local source_file="$1"
-    local target_dir="$2"
-    if [[ -n $source_file && -n $target_dir ]]; then
-        echo "Uncompressing $source_file to $target_dir"
-        mkdir -p $target_dir
-        unzip -qo $source_file -d $target_dir
-        chmod -R ugo+rwx $target_dir
-    else
-        __error "Missing required parameters"
-    fi
+export_env() {
+  local dest_path="$1"
+  if [[ -z $dest_path ]]; then
+    error "Missing parameters"
+  fi
+  echo "Exporting environment"
+  local zk_label="strimzi.io/name=$CLUSTER_NAME-zookeeper"
+  ZK_REPLICAS=$(kubectl -n $NAMESPACE get kafka $CLUSTER_NAME -o yaml | yq eval ".spec.zookeeper.replicas" -)
+  mapfile -t ZK_PVC < <(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[].metadata.name" -)
+  ZK_PVC_SIZE=$(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[0].spec.resources.requests.storage" -)
+  ZK_PVC_CLASS=$(kubectl -n $NAMESPACE get pvc -l $zk_label -o yaml | yq eval ".items[0].spec.storageClassName" -)
+  local kafka_label="strimzi.io/name=$CLUSTER_NAME-kafka"
+  KAFKA_REPLICAS=$(kubectl -n $NAMESPACE get kafka $CLUSTER_NAME -o yaml | yq eval ".spec.kafka.replicas" -)
+  mapfile -t KAFKA_PVC < <(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[].metadata.name" -)
+  KAFKA_PVC_SIZE=$(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[0].spec.resources.requests.storage" -)
+  KAFKA_PVC_CLASS=$(kubectl -n $NAMESPACE get pvc -l $kafka_label -o yaml | yq eval ".items[0].spec.storageClassName" -)
+  declare -px ZK_REPLICAS ZK_PVC ZK_PVC_SIZE ZK_PVC_CLASS KAFKA_REPLICAS KAFKA_PVC KAFKA_PVC_SIZE KAFKA_PVC_CLASS > "$dest_path"
+}
+
+export_res() {
+  local res_type="$1"
+  local res_id="$2"
+  local dest_path="$3"
+  if [[ -z $res_type || -z $res_id || -z $dest_path ]]; then
+    error "Missing parameters"
+  fi
+  local resources=$(kubectl -n $NAMESPACE get $res_type -l $res_id -o name --ignore-not-found ||true)
+  if [[ -z $resources ]]; then
+    resources=$(kubectl -n $NAMESPACE get $res_type $res_id -o name --ignore-not-found 2>/dev/null ||true)
+  fi
+  if [[ -n $resources ]]; then
+    echo "Exporting $res_type $res_id"
+    # delete runtime metadata expression
+    local exp="del(.metadata.namespace, .items[].metadata.namespace, \
+      .metadata.resourceVersion, .items[].metadata.resourceVersion, \
+      .metadata.selfLink, .items[].metadata.selfLink, \
+      .metadata.uid, .items[].metadata.uid, \
+      .status, .items[].status)"
+    local file_name=$(printf $res_type-$res_id | sed 's/\//-/g;s/ //g')
+    kubectl -n $NAMESPACE get $resources -o yaml | yq eval "$exp" - > $dest_path/$file_name.yaml
+  fi
+}
+
+rsync() {
+  local source="$1"
+  local target="$2"
+  if [[ -z $source || -z $target ]]; then
+    error "Missing parameters"
+  fi
+  echo "Rsync from $source to $target"
+  local flags="--no-check-device --no-acls --no-xattrs --no-same-owner --warning=no-file-changed"
+  if [[ $source != "$BACKUP_PATH/"* ]]; then
+    # download from pod to local (backup)
+    flags="$flags --exclude=data/version-2/{currentEpoch,acceptedEpoch}"
+    local patch=$(sed "s@\$name@$source@g" $BASE/templates/patch.json)
+    kubectl -n $NAMESPACE run $RSYNC_POD_NAME --image "dummy" --restart "Never" --overrides "$patch"
+    wait_for condition=ready pod "run=$RSYNC_POD_NAME"
+    # ignore the sporadic file changed error
+    kubectl -n $NAMESPACE exec -i $RSYNC_POD_NAME -- sh -c "tar $flags -C /data -c ." \
+      | tar $flags -C $target -xv -f - && if [[ $? == 1 ]]; then exit 0; fi
+    kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME
+  else
+    # upload from local to pod (restore)
+    local patch=$(sed "s@\$name@$target@g" $BASE/templates/patch.json)
+    kubectl -n $NAMESPACE run $RSYNC_POD_NAME --image "dummy" --restart "Never" --overrides "$patch"
+    wait_for condition=ready pod "run=$RSYNC_POD_NAME"
+    tar $flags -C $source -c . \
+      | kubectl -n $NAMESPACE exec -i $RSYNC_POD_NAME -- sh -c "tar $flags -C /data -xv -f -"
+    kubectl -n $NAMESPACE delete pod $RSYNC_POD_NAME
+  fi
+}
+
+create_pvc() {
+  local name="$1"
+  local size="$2"
+  local class="${3-}"
+  if [[ -z $name || -z $size ]]; then
+    error "Missing parameters"
+  fi
+  local exp="s/\$name/$name/g; s/\$size/$size/g; /storageClassName/d"
+  if [[ $class != "null" ]]; then
+    exp="s/\$name/$name/g; s/\$size/$size/g; s/\$class/$class/g"
+  fi
+  echo "Creating pvc $name of size $size"
+  sed "$exp" $BASE/templates/pvc.yaml | kubectl -n $NAMESPACE create -f -
+}
+
+compress() {
+  local source_dir="$1"
+  local target_file="$2"
+  if [[ -z $source_dir || -z $target_file ]]; then
+    error "Missing parameters"
+  fi
+  local current_dir=$(pwd)
+  cd $source_dir
+  echo "Compressing $source_dir to $target_file"
+  zip -FSqr $BACKUP_NAME *
+  mv $BACKUP_NAME $BACKUP_PATH
+  cd $current_dir
+}
+
+uncompress() {
+  local source_file="$1"
+  local target_dir="$2"
+  if [[ -z $source_file || -z $target_dir ]]; then
+    error "Missing parameters" 
+  fi
+  echo "Uncompressing $source_file to $target_dir"
+  mkdir -p $target_dir
+  unzip -qo $source_file -d $target_dir
+  chmod -R ugo+rwx $target_dir
 }
 
 backup() {
-    if [[ -n $NAMESPACE && -n $CLUSTER_NAME && -n $TARGET_FILE ]]; then
-        if [[ -d "$(dirname $TARGET_FILE)" ]]; then
-            # init context
-            readonly RSYNC_POD_NAME="$CLUSTER_NAME-backup"
-            local tmp="$BACKUP_PATH/$NAMESPACE/$CLUSTER_NAME"
-            if [[ ! -z "$(ls -A $tmp)" ]]; then
-              CLEANUP=false
-              __error "Non empty directory: $tmp"
-            fi
-            __check_kube_conn
-            if [[ $CONFIRM == true ]]; then
-                echo "Backup of cluster $NAMESPACE/$CLUSTER_NAME"
-                echo "The cluster won't be available for the entire duration of the process"
-                __confirm
-            fi
-            echo "Starting backup"
-            mkdir -p $tmp/resources $tmp/data
-            __export_env $tmp/env
-            __stop_cluster
+  if [[ -z $NAMESPACE || -z $CLUSTER_NAME || -z $TARGET_FILE ]]; then
+    CLEANUP=false
+    error "Specify namespace, cluster name and target file to backup"
+  fi
+  if [[ ! -d "$(dirname $TARGET_FILE)" ]]; then
+    error "$(dirname $TARGET_FILE) not found"
+  fi
+  
+  # init context
+  local tmp="$BACKUP_PATH/$NAMESPACE/$CLUSTER_NAME"
+  if [[ ! -z "$(ls -A $tmp 2>/dev/null ||true)" ]]; then
+    CLEANUP=false
+    error "Non empty directory: $tmp"
+  fi
+  check_kube_conn
+  if [[ $CONFIRM == true ]]; then
+    echo "Backup of cluster $NAMESPACE/$CLUSTER_NAME"
+    echo "The cluster won't be available for the entire duration of the process"
+    confirm
+  fi
+  echo "Starting backup"
+  mkdir -p $tmp/resources $tmp/data
+  export_env $tmp/env
+  stop_cluster
 
-            # export resources
-            __export_res kafka $CLUSTER_NAME $tmp/resources
-            __export_res kafkatopics strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
-            __export_res kafkausers strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
-            __export_res kafkarebalances strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
-            # cluster configmap and secrets
-            __export_res configmaps app.kubernetes.io/instance=$CLUSTER_NAME $tmp/resources
-            __export_res secrets app.kubernetes.io/instance=$CLUSTER_NAME $tmp/resources
-            # custom configmap and secrets
-            if [[ -n $CUSTOM_CM ]]; then
-                for name in $(printf $CUSTOM_CM | sed "s/,/ /g"); do
-                    __export_res configmap $name $tmp/resources
-                done
-            fi
-            if [[ -n $CUSTOM_SE ]]; then
-                for name in $(printf $CUSTOM_SE | sed "s/,/ /g"); do
-                    __export_res secret $name $tmp/resources
-                done
-            fi
+  # export resources
+  export_res kafka $CLUSTER_NAME $tmp/resources
+  export_res kafkatopics strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
+  export_res kafkausers strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
+  export_res kafkarebalances strimzi.io/cluster=$CLUSTER_NAME $tmp/resources
+  # cluster configmap and secrets
+  export_res configmaps app.kubernetes.io/instance=$CLUSTER_NAME $tmp/resources
+  export_res secrets app.kubernetes.io/instance=$CLUSTER_NAME $tmp/resources
+  # custom configmap and secrets
+  if [[ -n $CUSTOM_CM ]]; then
+    for name in $(printf $CUSTOM_CM | sed "s/,/ /g"); do
+      export_res configmap $name $tmp/resources
+    done
+  fi
+  if [[ -n $CUSTOM_SE ]]; then
+    for name in $(printf $CUSTOM_SE | sed "s/,/ /g"); do
+      export_res secret $name $tmp/resources
+    done
+  fi
 
-            # for each PVC, rsync data from PV to backup
-            for name in "${ZK_PVC[@]}"; do
-                local path="$tmp/data/$name"
-                mkdir -p $path
-                __rsync $name $path
-            done
-            for name in "${KAFKA_PVC[@]}"; do
-                local path="$tmp/data/$name"
-                mkdir -p $path
-                __rsync $name $path
-            done
+  # for each PVC, rsync data from PV to backup
+  for name in "${ZK_PVC[@]}"; do
+    local path="$tmp/data/$name"
+    mkdir -p $path
+    rsync $name $path
+  done
+  for name in "${KAFKA_PVC[@]}"; do
+    local path="$tmp/data/$name"
+    mkdir -p $path
+    rsync $name $path
+  done
 
-            # create the archive
-            __compress $tmp $TARGET_FILE
-        else
-            __error "$(dirname $TARGET_FILE) not found"
-        fi
-    else
-        CLEANUP=false
-        __error "Specify namespace, cluster name and target file to backup"
-    fi
+  # create the archive
+  compress $tmp $TARGET_FILE
 }
 
 restore() {
-    if  [[ -n $NAMESPACE && -n $CLUSTER_NAME && -f $SOURCE_FILE ]]; then
-        if [[ -f $SOURCE_FILE ]]; then
-            # init context
-            readonly RSYNC_POD_NAME="$CLUSTER_NAME-restore"
-            local tmp="$BACKUP_PATH/$NAMESPACE/$CLUSTER_NAME"
-            __check_kube_conn
-            if [[ $CONFIRM == true ]]; then
-                echo "Restore of cluster $NAMESPACE/$CLUSTER_NAME"
-                __confirm
-            fi
-            __uncompress $SOURCE_FILE $tmp
-            source $tmp/env
-            __stop_cluster
+  if  [[ -z $NAMESPACE || -z $CLUSTER_NAME || -z $SOURCE_FILE ]]; then
+    CLEANUP=false
+    error "Specify namespace, cluster name and source file to restore"
+  fi
+  if [[ ! -f $SOURCE_FILE ]]; then
+    error "$SOURCE_FILE file not found"
+  fi
+  
+  # init context
+  local tmp="$BACKUP_PATH/$NAMESPACE/$CLUSTER_NAME"
+  check_kube_conn
+  if [[ $CONFIRM == true ]]; then
+    echo "Restore of cluster $NAMESPACE/$CLUSTER_NAME"
+    confirm
+  fi
+  uncompress $SOURCE_FILE $tmp
+  source $tmp/env
+  stop_cluster
 
-            # for each PVC, create it and rsync data from backup to PV
-            for name in "${ZK_PVC[@]}"; do
-                __create_pvc $name $ZK_PVC_SIZE $ZK_PVC_CLASS
-                __rsync $tmp/data/$name/. $name
-            done
-            for name in "${KAFKA_PVC[@]}"; do
-                __create_pvc $name $KAFKA_PVC_SIZE $KAFKA_PVC_CLASS
-                __rsync $tmp/data/$name/. $name
-            done
+  # for each PVC, create it and rsync data from backup to PV
+  for name in "${ZK_PVC[@]}"; do
+    create_pvc $name $ZK_PVC_SIZE $ZK_PVC_CLASS
+    rsync $tmp/data/$name/. $name
+  done
+  for name in "${KAFKA_PVC[@]}"; do
+    create_pvc $name $KAFKA_PVC_SIZE $KAFKA_PVC_CLASS
+    rsync $tmp/data/$name/. $name
+  done
 
-            # import resources
-            # KafkaTopic resources must be created *before*
-            # deploying the Topic Operator or it will delete them
-            kubectl -n $NAMESPACE apply -f $tmp/resources
-        else
-            __error "$SOURCE_FILE file not found"
-        fi
-    else
-        CLEANUP=false
-        __error "Specify namespace, cluster name and source file to restore"
-    fi
+  # import resources
+  # KafkaTopic resources must be created *before*
+  # deploying the Topic Operator or it will delete them
+  kubectl -n $NAMESPACE apply -f $tmp/resources
 }
 
 readonly USAGE="
@@ -404,59 +386,45 @@ Examples:
   $0 restore -n test-new -c my-cluster \\
     -s /tmp/my-cluster.zip
 "
-readonly OPTIONS="${@}"
-readonly ARGUMENTS=($OPTIONS)
-i=0
-for argument in $OPTIONS; do
-    i=$(($i+1))
-    case $argument in
-        -y)
-            export CONFIRM=false
-            readonly CONFIRM
-            ;;
-        -n)
-            export NAMESPACE=${ARGUMENTS[i]}
-            readonly NAMESPACE
-            ;;
-        -c)
-            export CLUSTER_NAME=${ARGUMENTS[i]}
-            readonly CLUSTER_NAME
-            ;;
-        -t)
-            export TARGET_FILE=${ARGUMENTS[i]}
-            readonly TARGET_FILE
-            export BACKUP_PATH=$(dirname $TARGET_FILE)
-            readonly BACKUP_PATH
-            export BACKUP_NAME=$(basename $TARGET_FILE)
-            readonly BACKUP_NAME
-            ;;
-        -s)
-            export SOURCE_FILE=${ARGUMENTS[i]}
-            readonly SOURCE_FILE
-            export BACKUP_PATH=$(dirname $SOURCE_FILE)
-            readonly BACKUP_PATH
-            export BACKUP_NAME=$(basename $SOURCE_FILE)
-            readonly BACKUP_NAME
-            ;;
-        -m)
-            export CUSTOM_CM=${ARGUMENTS[i]}
-            readonly CUSTOM_CM
-            ;;
-        -x)
-            export CUSTOM_SE=${ARGUMENTS[i]}
-            readonly CUSTOM_SE
-            ;;
-    esac
+readonly PARAMS="${@}"
+readonly PARRAY=($PARAMS)
+i=0; for param in $PARAMS; do
+  i=$(($i+1))
+  case $param in
+    -y)
+      readonly CONFIRM=false && export CONFIRM
+      ;;
+    -n)
+      readonly NAMESPACE=${PARRAY[i]} && export NAMESPACE
+      ;;
+    -c)
+      readonly CLUSTER_NAME=${PARRAY[i]} && export CLUSTER_NAME
+      ;;
+    -t)
+      readonly TARGET_FILE=${PARRAY[i]} && export TARGET_FILE
+      readonly BACKUP_PATH=$(dirname $TARGET_FILE) && export BACKUP_PATH
+      readonly BACKUP_NAME=$(basename $TARGET_FILE) && export BACKUP_NAME
+      ;;
+    -s)
+      readonly SOURCE_FILE=${PARRAY[i]} && export SOURCE_FILE
+      readonly BACKUP_PATH=$(dirname $SOURCE_FILE) && export BACKUP_PATH
+      readonly BACKUP_NAME=$(basename $SOURCE_FILE) && export BACKUP_NAME
+      ;;
+    -m)
+      readonly CUSTOM_CM=${PARRAY[i]} && export CUSTOM_CM
+      ;;
+    -x)
+      readonly CUSTOM_SE=${PARRAY[i]} && export CUSTOM_SE
+      ;;
+  esac
 done
 readonly COMMAND="${1-}"
-case "$COMMAND" in
-    backup)
-        backup
-        ;;
-    restore)
-        restore
-        ;;
-    *)
-        __error "$USAGE"
-        ;;
-esac
+if [[ -z "$COMMAND" ]]; then
+  error "$USAGE"
+else
+  if (declare -F "$COMMAND" >/dev/null); then
+    "$COMMAND"
+  else
+    error "Invalid command"
+  fi
+fi

--- a/tools/log-dump/README.md
+++ b/tools/log-dump/README.md
@@ -54,43 +54,43 @@ EOF
 This example shows how to dump partitions related to a simple word count transactional application running on Kubernetes. In this case we have 2 disks per broker and an output topic with 1 partition and RF=1.
 
 ```shell
-# Print partition segments across the cluster
+# Print topic partition segments
 ./tools/log-dump/run.sh partition --namespace test --cluster my-cluster \
   --topic my-topic --partition 0 --dry-run
     
 brokers: 3, storage: jbod, disks: 2
-wc-output-0 segments in kafka-0-disk-0
+my-topic-0 segments in kafka-0-disk-0
 No segment found
-wc-output-0 segments in kafka-0-disk-1
+my-topic-0 segments in kafka-0-disk-1
 No segment found
-wc-output-0 segments in kafka-1-disk-0
+my-topic-0 segments in kafka-1-disk-0
 00000000000000000000.log
-wc-output-0 segments in kafka-1-disk-1
+my-topic-0 segments in kafka-1-disk-1
 No segment found
-wc-output-0 segments in kafka-2-disk-0
+my-topic-0 segments in kafka-2-disk-0
 No segment found
-wc-output-0 segments in kafka-2-disk-1
+my-topic-0 segments in kafka-2-disk-1
 No segment found
 
-# Dump partition segments across the cluster
+# Dump topic partition
 ./tools/log-dump/run.sh partition --namespace test --cluster my-cluster \
   --topic my-topic --partition 0 --out-path ~/Downloads/my-dump
 
 brokers: 3, storage: jbod, disks: 2
-wc-output-0 segments in kafka-0-disk-0
+my-topic-0 segments in kafka-0-disk-0
 No segment found
-wc-output-0 segments in kafka-0-disk-1
+my-topic-0 segments in kafka-0-disk-1
 No segment found
-wc-output-0 segments in kafka-1-disk-0
+my-topic-0 segments in kafka-1-disk-0
 00000000000000000000.log
-wc-output-0 segments in kafka-1-disk-1
+my-topic-0 segments in kafka-1-disk-1
 No segment found
-wc-output-0 segments in kafka-2-disk-0
+my-topic-0 segments in kafka-2-disk-0
 No segment found
-wc-output-0 segments in kafka-2-disk-1
+my-topic-0 segments in kafka-2-disk-1
 No segment found
 
-# Dump consumer group offsets segments
+# Dump consumer group offsets partition by group.id
 ./tools/log-dump/run.sh cg_offsets --namespace test --cluster my-cluster \
   --group-id my-group --out-path ~/Downloads/my-dump
   
@@ -109,7 +109,7 @@ __consumer_offsets-12 segments in kafka-2-disk-0
 __consumer_offsets-12 segments in kafka-2-disk-1
 No segment found
 
-# Dump application transaction state segments
+# Dump transaction state partition by transaction.id
 ./tools/log-dump/run.sh txn_state --namespace test --cluster my-cluster \
   --txn-id my-app-my-group-my-topic-0 --out-path ~/Downloads/my-dump
   

--- a/tools/log-dump/run.sh
+++ b/tools/log-dump/run.sh
@@ -3,16 +3,15 @@ set -Eeuo pipefail
 if [[ $(uname -s) == "Darwin" ]]; then
   shopt -s expand_aliases
   alias echo="gecho"; alias dirname="gdirname"; alias grep="ggrep"; alias readlink="greadlink"
-  alias tar="gtar"; alias sed="gsed"; alias start_offsetrt="gstart_offsetrt"; alias date="gdate"; alias wc="gwc"
+  alias tar="gtar"; alias sed="gsed"; alias date="gdate"; alias wc="gwc"
 fi
+
 readonly CO_TOPIC="__consumer_offsets"
 readonly TS_TOPIC="__transaction_state"
 readonly CM_TOPIC="__cluster_metadata"
 KAFKA_BROKERS=0
 STORAGE_TYPE=""
 JBOD_DISKS=0
-
-# user input
 COMMAND=""
 OUT_PATH="/tmp/log-dump"
 NAMESPACE=""
@@ -44,17 +43,18 @@ check_kube_conn() {
 }
 
 get_kafka_setup() {
-  KAFKA_BROKERS=$(kubectl -n $NAMESPACE get k $CLUSTER -o yaml 2>/dev/null | yq eval ".spec.kafka.replicas" -) ||true
-  STORAGE_TYPE=$(kubectl -n $NAMESPACE get k $CLUSTER -o yaml 2>/dev/null | yq eval ".spec.kafka.storage.type" -) ||true
-  JBOD_DISKS=$(kubectl -n $NAMESPACE get k $CLUSTER -o yaml 2>/dev/null | yq eval ".spec.kafka.storage.volumes | length" -) ||true
-  if [[ $KAFKA_BROKERS != "null" ]]; then
+  local kafka_yaml=$(kubectl -n $NAMESPACE get k $CLUSTER -o yaml ||true)
+  KAFKA_BROKERS=$(echo "$kafka_yaml" | yq eval ".spec.kafka.replicas" -)
+  STORAGE_TYPE=$(echo "$kafka_yaml" | yq eval ".spec.kafka.storage.type" -)
+  JBOD_DISKS=$(echo "$kafka_yaml" | yq eval ".spec.kafka.storage.volumes | length" -)
+  if [[ -n $KAFKA_BROKERS && $KAFKA_BROKERS != "null" ]]; then
     echo "brokers: $KAFKA_BROKERS, storage: $STORAGE_TYPE, disks: $JBOD_DISKS"
   else
     error "Kafka cluster $CLUSTER not found in namespace $NAMESPACE"
   fi
 }
 
-coord-partition() {
+coord_partition() {
   local id="$1"
   local part="${2-$TOT_PART}"
   if [[ -n $id && -n $part ]]; then
@@ -68,48 +68,43 @@ coord-partition() {
 find_segments() {
   local broker="$1"
   local log_dir="$2"
-  if [[ -n $broker && -n $log_dir ]]; then
-    local seg_files=$(kubectl -n $NAMESPACE exec $CLUSTER-kafka-$broker -- \
-      find $log_dir -printf "%f\n" 2>/dev/null | grep ".log")
-    echo $seg_files
-  else
-    error "Missing required parameters"
+  if [[ -z $broker || -z $log_dir ]]; then
+    error "Missing parameters"
   fi
+  local seg_files=$(kubectl -n $NAMESPACE exec $CLUSTER-kafka-$broker -- \
+    find $log_dir -printf "%f\n" 2>/dev/null | grep ".log")
+  echo $seg_files
 }
 
 dump_segments() {
   local seg_files="$1"
-  if [[ -n $seg_files && $(echo "$seg_files" | sed '/^\s*$/d' | wc -l) -gt 0 ]]; then
-    
-    local flags="--deep-iteration"
-    case "$topic" in
-      "$CO_TOPIC")
-        flags="$flags --offsets-decoder"
-        ;;
-      "$TS_TOPIC")
-        flags="$flags --transaction-log-decoder"
-        ;;
-      "$CM_TOPIC")
-        flags="$flags --cluster-metadata-decoder"
-        ;;
-    esac
-    flags="$flags --files"
-    
-    for seg_file in $(echo $seg_files); do
-      if [[ -n $SEGMENT && $SEGMENT != "${seg_file%.log}" ]]; then
-        continue
-      fi
-      echo $seg_file
-      if [[ $DRY_RUN == false ]]; then
-        mkdir -p $out_dir
-        kubectl -n $NAMESPACE exec $CLUSTER-kafka-$i -- \
-          ./bin/kafka-dump-log.sh $flags $log_dir/$seg_file > $out_dir/$seg_file
-      fi
-    done
-    
-  else
+  if [[ -z $seg_files || $(echo "$seg_files" | sed '/^\s*$/d' | wc -l) -eq 0 ]]; then
     echo "No segment found"
-  fi
+  fi 
+  local flags="--deep-iteration"
+  case "$topic" in
+    "$CO_TOPIC")
+      flags="$flags --offsets-decoder"
+      ;;
+    "$TS_TOPIC")
+      flags="$flags --transaction-log-decoder"
+      ;;
+    "$CM_TOPIC")
+      flags="$flags --cluster-metadata-decoder"
+      ;;
+  esac
+  flags="$flags --files"
+  for seg_file in $(echo $seg_files); do
+    if [[ -n $SEGMENT && $SEGMENT != "${seg_file%.log}" ]]; then
+      continue
+    fi
+    echo $seg_file
+    if [[ $DRY_RUN == false ]]; then
+      mkdir -p $out_dir
+      kubectl -n $NAMESPACE exec $CLUSTER-kafka-$i -- \
+        ./bin/kafka-dump-log.sh $flags $log_dir/$seg_file > $out_dir/$seg_file
+    fi
+  done
 }
 
 dump_partition() {
@@ -117,122 +112,105 @@ dump_partition() {
   local partition="$2"
   local broker="$3"
   local disk="${4-}"
-  if [[ -n $topic && -n $partition && -n $broker ]]; then
-    
-    # context setup
-    local disk_label="$topic-$partition segments in kafka-$broker"
-    local log_dir="/var/lib/kafka/data/kafka-log$broker/$topic-$partition"
-    local out_dir="$OUT_PATH/$topic/kafka-$broker-$topic-$partition"
-    
-    if [[ -n $disk && $disk -ge 0 ]]; then
-      disk_label="$topic-$partition segments in kafka-$broker-disk-$disk"
-      log_dir="/var/lib/kafka/data-$disk/kafka-log$broker/$topic-$partition";
-      out_dir="$OUT_PATH/$topic/kafka-$broker-disk-$disk-$topic-$partition"
-    fi
-    
-    # segment dump
-    local seg_files=$(find_segments $broker $log_dir)
-    echo $disk_label
-    dump_segments "$seg_files"
-    
-  else
-    error "Missing required parameters"
+  if [[ -z $topic || -z $partition || -z $broker ]]; then
+    error "Missing parameters"
   fi
+  # context setup
+  local disk_label="$topic-$partition segments in kafka-$broker"
+  local log_dir="/var/lib/kafka/data/kafka-log$broker/$topic-$partition"
+  local out_dir="$OUT_PATH/$topic/kafka-$broker-$topic-$partition"
+  if [[ -n $disk && $disk -ge 0 ]]; then
+    disk_label="$topic-$partition segments in kafka-$broker-disk-$disk"
+    log_dir="/var/lib/kafka/data-$disk/kafka-log$broker/$topic-$partition";
+    out_dir="$OUT_PATH/$topic/kafka-$broker-disk-$disk-$topic-$partition"
+  fi
+  # segment dump
+  local seg_files=$(find_segments $broker $log_dir)
+  echo $disk_label
+  dump_segments "$seg_files"
 }
 
 partition() {
-  if [[ -n $NAMESPACE && -n $CLUSTER && -n $TOPIC && -n $PARTITION ]]; then
-    check_kube_conn
-    get_kafka_setup
-    
-    # dump topic partition across the cluster (including replicas)
-    for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
-      if [[ $STORAGE_TYPE == "jbod" ]]; then
-        for j in $(seq 0 $(($JBOD_DISKS-1))); do
-          dump_partition $TOPIC $PARTITION $i $j
-        done
-      else 
-        dump_partition $TOPIC $PARTITION $i
-      fi
-    done
-    
-  else
-    error "Missing required options"
-  fi
+  if [[ -z $NAMESPACE || -z $CLUSTER || -z $TOPIC || -z $PARTITION ]]; then
+    error "Missing parameters"
+  fi  
+  check_kube_conn
+  get_kafka_setup  
+  # dump topic partition across the cluster (including replicas)
+  for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
+    if [[ $STORAGE_TYPE == "jbod" ]]; then
+      for j in $(seq 0 $(($JBOD_DISKS-1))); do
+        dump_partition $TOPIC $PARTITION $i $j
+      done
+    else 
+      dump_partition $TOPIC $PARTITION $i
+    fi
+  done
 }
 
 cg_offsets() {
-  if [[ -n $NAMESPACE && -n $CLUSTER && -n $GROUP_ID ]]; then
-    check_kube_conn
-    get_kafka_setup
-          
-    # dump CG offsets coordinating partition across the cluster (including replicas)
-    local partition=$(coord-partition "$GROUP_ID" "$TOT_PART")
-    echo "$GROUP_ID coordinating partition: $partition"
-    for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
-      if [[ $STORAGE_TYPE == "jbod" ]]; then
-        for j in $(seq 0 $(($JBOD_DISKS-1))); do
-          dump_partition $CO_TOPIC $partition $i $j
-        done
-      else
-        dump_partition $CO_TOPIC $partition $i
-      fi
-    done
-    
-  else
-    error "Missing required options"
+  if [[ -z $NAMESPACE || -z $CLUSTER || -z $GROUP_ID ]]; then
+    error "Missing parameters"
   fi
+  check_kube_conn
+  get_kafka_setup
+  # dump CG offsets coordinating partition across the cluster (including replicas)
+  local partition=$(coord_partition "$GROUP_ID" "$TOT_PART")
+  echo "$GROUP_ID coordinating partition: $partition"
+  for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
+    if [[ $STORAGE_TYPE == "jbod" ]]; then
+      for j in $(seq 0 $(($JBOD_DISKS-1))); do
+        dump_partition $CO_TOPIC $partition $i $j
+      done
+    else
+      dump_partition $CO_TOPIC $partition $i
+    fi
+  done
 }
 
 txn_state() {
-  if [[ -n $NAMESPACE && -n $CLUSTER && -n $TXN_ID ]]; then
-    check_kube_conn
-    get_kafka_setup
-        
-    # dump TX state coordinating partition across the cluster (including replicas)
-    local partition=$(coord-partition "$TXN_ID" "$TOT_PART")
-    echo "$TXN_ID coordinating partition: $partition"
-    for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
-      if [[ $STORAGE_TYPE == "jbod" ]]; then
-        for j in $(seq 0 $(($JBOD_DISKS-1))); do
-          dump_partition $TS_TOPIC $partition $i $j
-        done
-      else
-        dump_partition $TS_TOPIC $partition $i
-      fi
-    done
-    
-  else
-    error "Missing required options"
+  if [[ -z $NAMESPACE || -z $CLUSTER || -z $TXN_ID ]]; then
+    error "Missing parameters"
   fi
+  check_kube_conn
+  get_kafka_setup    
+  # dump TX state coordinating partition across the cluster (including replicas)
+  local partition=$(coord_partition "$TXN_ID" "$TOT_PART")
+  echo "$TXN_ID coordinating partition: $partition"
+  for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
+    if [[ $STORAGE_TYPE == "jbod" ]]; then
+      for j in $(seq 0 $(($JBOD_DISKS-1))); do
+        dump_partition $TS_TOPIC $partition $i $j
+      done
+    else
+      dump_partition $TS_TOPIC $partition $i
+    fi
+  done
 }
 
 cluster_meta() {
-  if [[ -n $NAMESPACE && -n $CLUSTER ]]; then
-    check_kube_conn
-    get_kafka_setup
-        
-    # dump cluster metadata partition across the cluster (including replicas)
-    local partition="0"
-    for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
-      if [[ $STORAGE_TYPE == "jbod" ]]; then
-        for j in $(seq 0 $(($JBOD_DISKS-1))); do
-          dump_partition $CM_TOPIC $partition $i $j
-        done
-      else
-        dump_partition $CM_TOPIC $partition $i
-      fi
-    done
-
-  else
-    error "Missing required options"
+  if [[ -z $NAMESPACE || -z $CLUSTER ]]; then
+    error "Missing parameters"
   fi
+  check_kube_conn
+  get_kafka_setup
+  # dump cluster metadata partition across the cluster (including replicas)
+  local partition="0"
+  for i in $(seq 0 $(($KAFKA_BROKERS-1))); do
+    if [[ $STORAGE_TYPE == "jbod" ]]; then
+      for j in $(seq 0 $(($JBOD_DISKS-1))); do
+        dump_partition $CM_TOPIC $partition $i $j
+      done
+    else
+      dump_partition $CM_TOPIC $partition $i
+    fi
+  done
 }
 
 readonly USAGE="
 Usage: $0 [command] [params]
 
-  partition       Dump partition
+  partition       Dump topic partition
     --namespace     Kubernetes namespace
     --cluster       Kafka cluster name
     --topic         Data topic name
@@ -242,7 +220,7 @@ Usage: $0 [command] [params]
     --dry-run       Run without dumping (default: $DRY_RUN)
     --data          Include record payload (default: $DATA)
 
-  cg_offsets      Dump consumer group offsets by group.id
+  cg_offsets      Dump consumer group offsets partition by group.id
     --namespace     Kubernetes namespace
     --cluster       Kafka cluster name
     --group-id      Consumer group id
@@ -250,7 +228,7 @@ Usage: $0 [command] [params]
     --out-path      Output path (default: $OUT_PATH)
     --dry-run       Run without dumping (default: $DRY_RUN)
   
-  txn_state       Dump transactions state by transactional.id
+  txn_state       Dump transactions state partition by transactional.id
     --namespace     Kubernetes namespace
     --cluster       Kafka cluster name
     --txn-id        Transactional id
@@ -266,55 +244,43 @@ Usage: $0 [command] [params]
 "
 readonly PARAMS="${@}"
 readonly PARRAY=($PARAMS)
-i=0
-for param in $PARAMS; do
+i=0; for param in $PARAMS; do
   i=$(($i+1))
   case $param in
     --namespace)
-      export NAMESPACE=${PARRAY[i]}
-      readonly NAMESPACE
+      readonly NAMESPACE=${PARRAY[i]} && export NAMESPACE
       ;;
     --cluster)
-      export CLUSTER=${PARRAY[i]}
-      readonly CLUSTER
+      readonly CLUSTER=${PARRAY[i]} && export CLUSTER
       ;;
     --topic)
-      export TOPIC=${PARRAY[i]}
-      readonly TOPIC
+      readonly TOPIC=${PARRAY[i]} && export TOPIC
       ;;
     --partition)
-      export PARTITION=${PARRAY[i]}
-      readonly PARTITION
+      readonly PARTITION=${PARRAY[i]} && export PARTITION
       check_number $PARTITION
       ;;
     --segment)
-      export SEGMENT=${PARRAY[i]}
-      readonly SEGMENT
+      readonly SEGMENT=${PARRAY[i]} && export SEGMENT
       ;;
     --group-id)
-      export GROUP_ID=${PARRAY[i]}
-      readonly GROUP_ID
+      readonly GROUP_ID=${PARRAY[i]} && export GROUP_ID
       ;;
     --txn-id)
-      export TXN_ID=${PARRAY[i]}
-      readonly TXN_ID
+      readonly TXN_ID=${PARRAY[i]} && export TXN_ID
       ;;
     --tot-part)
-      export TOT_PART=${PARRAY[i]}
-      readonly TOT_PART
+      readonly TOT_PART=${PARRAY[i]} && export TOT_PART
       check_number $TOT_PART
       ;;
     --out-path)
-      export OUT_PATH=${PARRAY[i]}
-      readonly OUT_PATH
+      readonly OUT_PATH=${PARRAY[i]} && export OUT_PATH
       ;;
     --dry-run)
-      export DRY_RUN=true
-      readonly DRY_RUN
+      readonly DRY_RUN=true && export DRY_RUN
       ;;
     --data)
-      export DATA=true
-      readonly DATA
+      readonly DATA=true && export DATA
       ;;
     *)
       if [[ $param == --* ]]; then
@@ -324,20 +290,12 @@ for param in $PARAMS; do
   esac
 done
 readonly COMMAND="${1-}"
-case "$COMMAND" in
-  partition)
-    partition
-    ;;
-  cg_offsets)
-    cg_offsets
-    ;;
-  txn_state)
-    txn_state
-    ;;
-  cluster_meta)
-    cluster_meta
-    ;;
-  *)
-    error "$USAGE"
-    ;;
-esac
+if [[ -z "$COMMAND" ]]; then
+  error "$USAGE"
+else
+  if (declare -F "$COMMAND" >/dev/null); then
+    "$COMMAND"
+  else
+    error "Invalid command"
+  fi
+fi


### PR DESCRIPTION
This ST is much lighter than the other one (cold-backup). 

I also did some refactoring to make the two script styles consistent with each other, and improved a couple of functions (`wait_for()` in cold-backup and `get_kafka_setup()` in log-dump). Anyway, there is no interface or behavior change.

The small change to VerifiableClient is required by find-bugs.
