### PR TITLE
Update spotbugs and checkstyle

### DIFF
--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -4,6 +4,25 @@
     <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
   </Match>
   <Match>
+    <!-- This allows us to use singleton pattern -->
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Bug pattern="MS_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Bug pattern="MS_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_STATIC_REP2"/>
+  </Match>
+  <Match>
+    <Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR"/>
+  </Match>
+  <Match>
     <!-- Java11 build throws false positives: https://github.com/spotbugs/spotbugs/issues/811 -->
     <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
   </Match>

--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -288,7 +288,7 @@ public class Crds {
 
     public static <T extends CustomResource> String kind(Class<T> cls) {
         try {
-            return cls.newInstance().getKind();
+            return cls.getDeclaredConstructor().newInstance().getKind();
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         HasMetadata hasMetadata = mock(HasMetadata.class);
         when(mockResource.get()).thenReturn(resource);
 
-        when(mockResource.withPropagationPolicy(true ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockR);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockR);
         when(mockR.patch((T) any())).thenReturn(hasMetadata);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
@@ -132,7 +132,7 @@ public abstract class AbstractNonNamespacedResourceOperatorTest<C extends Kubern
         T resource = resource();
         Resource mockResource = mock(resourceType());
         when(mockResource.get()).thenReturn(resource);
-        when(mockResource.withPropagationPolicy(true ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockResource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockResource);
         when(mockResource.patch(any())).thenReturn(resource);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
         <maven.dependency.version>3.1.1</maven.dependency.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
-        <checkstyle.version>9.0.1</checkstyle.version>
-        <spotbugs.version>4.0.3</spotbugs.version>
+        <checkstyle.version>9.2.1</checkstyle.version>
+        <spotbugs.version>4.5.3</spotbugs.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
         <jacoco.version>0.7.9</jacoco.version>
         <license.maven.version>2.11</license.maven.version>
@@ -1021,7 +1021,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.0</version><dependencies>
+                <version>4.5.3.0</version><dependencies>
                 <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
                 <dependency>
                     <groupId>com.github.spotbugs</groupId>

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeoutException;
 public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient.Builder> {
 
     private static final Logger LOGGER = LogManager.getLogger(ExternalKafkaClient.class);
+    private final Random random = new Random();
 
     protected ExternalKafkaClient(AbstractKafkaClient.Builder<ExternalKafkaClient.Builder> builder) {
         super(builder);
@@ -64,7 +65,7 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
             .withBootstrapServerConfig(getBootstrapServerFromStatus())
             .withKeySerializerConfig(StringSerializer.class)
             .withValueSerializerConfig(StringSerializer.class)
-            .withClientIdConfig("producer-" + new Random().nextInt(Integer.MAX_VALUE));
+            .withClientIdConfig("producer-" + random.nextInt(Integer.MAX_VALUE));
     }
 
     private ConsumerProperties.ConsumerPropertiesBuilder getConsumerProperties() {
@@ -74,7 +75,7 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
             .withBootstrapServerConfig(getBootstrapServerFromStatus())
             .withKeyDeserializerConfig(StringDeserializer.class)
             .withValueDeserializerConfig(StringDeserializer.class)
-            .withClientIdConfig("consumer-" + new Random().nextInt(Integer.MAX_VALUE))
+            .withClientIdConfig("consumer-" + random.nextInt(Integer.MAX_VALUE))
             .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
             .withGroupIdConfig(consumerGroup);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeoutException;
 public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient.Builder> {
 
     private static final Logger LOGGER = LogManager.getLogger(ExternalKafkaClient.class);
-    private final Random random = new Random();
+    private static final Random RANDOM = new Random();
 
     protected ExternalKafkaClient(AbstractKafkaClient.Builder<ExternalKafkaClient.Builder> builder) {
         super(builder);
@@ -65,7 +65,7 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
             .withBootstrapServerConfig(getBootstrapServerFromStatus())
             .withKeySerializerConfig(StringSerializer.class)
             .withValueSerializerConfig(StringSerializer.class)
-            .withClientIdConfig("producer-" + random.nextInt(Integer.MAX_VALUE));
+            .withClientIdConfig("producer-" + RANDOM.nextInt(Integer.MAX_VALUE));
     }
 
     private ConsumerProperties.ConsumerPropertiesBuilder getConsumerProperties() {
@@ -75,7 +75,7 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
             .withBootstrapServerConfig(getBootstrapServerFromStatus())
             .withKeyDeserializerConfig(StringDeserializer.class)
             .withValueDeserializerConfig(StringDeserializer.class)
-            .withClientIdConfig("consumer-" + random.nextInt(Integer.MAX_VALUE))
+            .withClientIdConfig("consumer-" + RANDOM.nextInt(Integer.MAX_VALUE))
             .withAutoOffsetResetConfig(OffsetResetStrategy.EARLIEST)
             .withGroupIdConfig(consumerGroup);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
@@ -36,7 +36,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
     // name of KafkaUser with/without prefix for secret
     private String completeKafkaUsername = secretPrefix == null ? kafkaUsername : secretPrefix + kafkaUsername;
 
-    private final Random random = new Random();
+    private static final Random RANDOM = new Random();
 
     public static class Builder extends AbstractKafkaClient.Builder<Builder> {
 
@@ -149,7 +149,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .withConsumerGroupName(consumerGroup)
-            .withConsumerInstanceId("instance" + random.nextInt(Integer.MAX_VALUE))
+            .withConsumerInstanceId("instance" + RANDOM.nextInt(Integer.MAX_VALUE))
             .build();
 
 
@@ -185,7 +185,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .withConsumerGroupName(consumerGroup)
-            .withConsumerInstanceId("instance" + random.nextInt(Integer.MAX_VALUE))
+            .withConsumerInstanceId("instance" + RANDOM.nextInt(Integer.MAX_VALUE))
             .build();
 
         LOGGER.info("Starting verifiableClient tls consumer with the following configuration: {}", consumerTls.toString());

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/InternalKafkaClient.java
@@ -36,6 +36,8 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
     // name of KafkaUser with/without prefix for secret
     private String completeKafkaUsername = secretPrefix == null ? kafkaUsername : secretPrefix + kafkaUsername;
 
+    private final Random random = new Random();
+
     public static class Builder extends AbstractKafkaClient.Builder<Builder> {
 
         private String podName;
@@ -147,7 +149,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .withConsumerGroupName(consumerGroup)
-            .withConsumerInstanceId("instance" + new Random().nextInt(Integer.MAX_VALUE))
+            .withConsumerInstanceId("instance" + random.nextInt(Integer.MAX_VALUE))
             .build();
 
 
@@ -183,7 +185,7 @@ public class InternalKafkaClient extends AbstractKafkaClient<InternalKafkaClient
             .withBootstrapServer(getBootstrapServerFromStatus())
             .withTopicName(topicName)
             .withConsumerGroupName(consumerGroup)
-            .withConsumerInstanceId("instance" + new Random().nextInt(Integer.MAX_VALUE))
+            .withConsumerInstanceId("instance" + random.nextInt(Integer.MAX_VALUE))
             .build();
 
         LOGGER.info("Starting verifiableClient tls consumer with the following configuration: {}", consumerTls.toString());

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/VerifiableClient.java
@@ -123,8 +123,9 @@ public class VerifiableClient {
 
         if (clientType == ClientType.CLI_KAFKA_VERIFIABLE_CONSUMER) {
             this.consumerGroupName = verifiableClientBuilder.consumerGroupName;
-            this.clientArgumentMap.put(ClientArgument.GROUP_ID, consumerGroupName);
             this.consumerInstanceId = verifiableClientBuilder.consumerInstanceId;
+            this.clientArgumentMap.put(ClientArgument.GROUP_ID, consumerGroupName);
+            this.clientArgumentMap.put(ClientArgument.GROUP_INSTANCE_ID, consumerInstanceId);
         }
 
         if (clientType == ClientType.CLI_KAFKA_CONSUMER_GROUPS) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -22,7 +22,6 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class TestExecutionWatcher implements TestExecutionExceptionHandler, LifecycleMethodExecutionExceptionHandler {
 
     private static final Logger LOGGER = LogManager.getLogger(TestExecutionWatcher.class);
-    private static final Random RANDOM = new Random();
 
     @Override
     public void handleTestExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -22,6 +22,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 public class TestExecutionWatcher implements TestExecutionExceptionHandler, LifecycleMethodExecutionExceptionHandler {
 
     private static final Logger LOGGER = LogManager.getLogger(TestExecutionWatcher.class);
+    private static final Random RANDOM = new Random();
 
     @Override
     public void handleTestExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -25,6 +25,7 @@ final public class TestStorage {
     private static final String PRODUCER = "hello-world-producer";
     private static final String CONSUMER = "hello-world-consumer";
     private static final String CLUSTER_NAME_PREFIX = "my-cluster-";
+    private static final Random RANDOM = new Random();
 
     private ExtensionContext extensionContext;
     private String namespaceName;
@@ -44,7 +45,7 @@ final public class TestStorage {
     public TestStorage(ExtensionContext extensionContext, String namespaceName) {
         this.extensionContext = extensionContext;
         this.namespaceName = StUtils.isParallelNamespaceTest(extensionContext) ? StUtils.getNamespaceBasedOnRbac(namespaceName, extensionContext) : namespaceName;
-        this.clusterName = CLUSTER_NAME_PREFIX + new Random().nextInt(Integer.MAX_VALUE);
+        this.clusterName = CLUSTER_NAME_PREFIX + RANDOM.nextInt(Integer.MAX_VALUE);
         this.topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.streamsTopicTargetName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.kafkaClientsName = clusterName + "-" + Constants.KAFKA_CLIENTS;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -29,6 +29,7 @@ public class KafkaTopicUtils {
     private static final String TOPIC_NAME_PREFIX = "my-topic-";
     private static final long READINESS_TIMEOUT = ResourceOperation.getTimeoutForResourceReadiness(KafkaTopic.RESOURCE_KIND);
     private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
+    private static final Random RANDOM = new Random();
 
     private KafkaTopicUtils() {}
 
@@ -37,7 +38,7 @@ public class KafkaTopicUtils {
      * @return random name with additional salt
      */
     public static String generateRandomNameOfTopic() {
-        String salt = new Random().nextInt(Integer.MAX_VALUE) + "-" + new Random().nextInt(Integer.MAX_VALUE);
+        String salt = RANDOM.nextInt(Integer.MAX_VALUE) + "-" + RANDOM.nextInt(Integer.MAX_VALUE);
 
         return  TOPIC_NAME_PREFIX + salt;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -31,6 +31,7 @@ public class KafkaUserUtils {
     private static final Logger LOGGER = LogManager.getLogger(KafkaUserUtils.class);
     private static final String KAFKA_USER_NAME_PREFIX = "my-user-";
     private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
+    private static final Random RANDOM = new Random();
 
     private KafkaUserUtils() {}
 
@@ -39,7 +40,7 @@ public class KafkaUserUtils {
      * @return random name with additional salt
      */
     public static String generateRandomNameOfKafkaUser() {
-        String salt = new Random().nextInt(Integer.MAX_VALUE) + "-" + new Random().nextInt(Integer.MAX_VALUE);
+        String salt = RANDOM.nextInt(Integer.MAX_VALUE) + "-" + RANDOM.nextInt(Integer.MAX_VALUE);
 
         return  KAFKA_USER_NAME_PREFIX + salt;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -59,6 +59,7 @@ public class KafkaUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUtils.class);
     private static final long DELETION_TIMEOUT = ResourceOperation.getTimeoutForResourceDeletion();
+    private static final Random RANDOM = new Random();
 
     private KafkaUtils() {}
 
@@ -378,7 +379,7 @@ public class KafkaUtils {
      * @return name with prefix and random salt
      */
     public static String generateRandomNameOfKafka(String clusterName) {
-        return clusterName + "-" + new Random().nextInt(Integer.MAX_VALUE);
+        return clusterName + "-" + RANDOM.nextInt(Integer.MAX_VALUE);
     }
 
     public static String getVersionFromKafkaPodLibs(String kafkaPodName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfSharedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfSharedST.java
@@ -152,7 +152,7 @@ public class DynamicConfSharedST extends AbstractST {
                             stochasticChosenValue = false;
                             break;
                         default:
-                            stochasticChosenValue = ThreadLocalRandom.current().nextInt(2) == 0 ? true : false;
+                            stochasticChosenValue = ThreadLocalRandom.current().nextInt(2) == 0;
                     }
                     testCases.put(key, stochasticChosenValue);
                     break;


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

### Type of change
- Chores

### Description
Updated spotbugs and checkstyle. Spotbugs now checks access to the private members from the static methods. So using singleton pattern triggers `*_EXPOSE_REP*` warnings (also public method getting or setting private field). I added those to spotbugs exclude.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

