### PR TITLE
Update OPA Authoriser and add support for enabling metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.28.0
 
+* Update Open Policy Agent authorizer to 1.4.0 and add support for enabling metrics 
+
 ## 0.27.0
 
 * Multi-arch container images with support for x86_64 / AMD64 and AArch64 / ARM64 platforms

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
@@ -38,6 +38,7 @@ public class KafkaAuthorizationOpa extends KafkaAuthorization {
     private int initialCacheCapacity = 5000;
     private int maximumCacheSize = 50000;
     private long expireAfterMs = 3600000;
+    private boolean enableMetrics = false;
 
     @Description("Must be `" + TYPE_OPA + "`")
     @Override
@@ -125,5 +126,16 @@ public class KafkaAuthorizationOpa extends KafkaAuthorization {
 
     public void setExpireAfterMs(long expireAfterMs) {
         this.expireAfterMs = expireAfterMs;
+    }
+
+    @Description("Defines whether the Open Policy Agent authorizer plugin should provide metrics. " +
+            "Defaults to `false`.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean isEnableMetrics() {
+        return enableMetrics;
+    }
+
+    public void setEnableMetrics(boolean enableMetrics) {
+        this.enableMetrics = enableMetrics;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -507,6 +507,7 @@ public class KafkaBrokerConfigurationBuilder {
 
             writer.println(String.format("%s=%s", "opa.authorizer.url", opaAuthz.getUrl()));
             writer.println(String.format("%s=%b", "opa.authorizer.allow.on.error", opaAuthz.isAllowOnError()));
+            writer.println(String.format("%s=%b", "opa.authorizer.metrics.enabled", opaAuthz.isEnableMetrics()));
             writer.println(String.format("%s=%d", "opa.authorizer.cache.initial.capacity", opaAuthz.getInitialCacheCapacity()));
             writer.println(String.format("%s=%d", "opa.authorizer.cache.maximum.size", opaAuthz.getMaximumCacheSize()));
             writer.println(String.format("%s=%d", "opa.authorizer.cache.expire.after.seconds", Duration.ofMillis(opaAuthz.getExpireAfterMs()).getSeconds()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -260,6 +260,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("authorizer.class.name=org.openpolicyagent.kafka.OpaAuthorizer\n" +
                 "opa.authorizer.url=http://opa:8181/v1/data/kafka/allow\n" +
                 "opa.authorizer.allow.on.error=false\n" +
+                "opa.authorizer.metrics.enabled=false\n" +
                 "opa.authorizer.cache.initial.capacity=5000\n" +
                 "opa.authorizer.cache.maximum.size=50000\n" +
                 "opa.authorizer.cache.expire.after.seconds=3600\n" +
@@ -284,6 +285,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         assertThat(configuration, isEquivalent("authorizer.class.name=org.openpolicyagent.kafka.OpaAuthorizer\n" +
                 "opa.authorizer.url=http://opa:8181/v1/data/kafka/allow\n" +
                 "opa.authorizer.allow.on.error=true\n" +
+                "opa.authorizer.metrics.enabled=false\n" +
                 "opa.authorizer.cache.initial.capacity=1000\n" +
                 "opa.authorizer.cache.maximum.size=10000\n" +
                 "opa.authorizer.cache.expire.after.seconds=60\n" +

--- a/docker-images/artifacts/kafka-thirdparty-libs/2.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/2.8.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.8.1</strimzi-oauth.version>
         <cruise-control.version>2.5.79</cruise-control.version>
-        <opa-authorizer.version>1.3.0</opa-authorizer.version>
+        <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.0.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.9.0</strimzi-oauth.version>
         <cruise-control.version>2.5.79</cruise-control.version>
-        <opa-authorizer.version>1.3.0</opa-authorizer.version>
+        <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -534,6 +534,8 @@ It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 |integer
 |superUsers            1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
 |string array
+|enableMetrics         1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
+|boolean
 |====
 
 [id='type-KafkaAuthorizationKeycloak-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -524,6 +524,9 @@ spec:
                         disableTlsHostnameVerification:
                           type: boolean
                           description: Enable or disable TLS hostname verification. Default value is `false`.
+                        enableMetrics:
+                          type: boolean
+                          description: Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
                         expireAfterMs:
                           type: integer
                           description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -798,6 +798,10 @@ spec:
                         type: boolean
                         description: Enable or disable TLS hostname verification.
                           Default value is `false`.
+                      enableMetrics:
+                        type: boolean
+                        description: Defines whether the Open Policy Agent authorizer
+                          plugin should provide metrics. Defaults to `false`.
                       expireAfterMs:
                         type: integer
                         description: The expiration of the records kept in the local


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates the OPA Authorizer to 1.4.0. The new version has support for metrics, which for performance reasons can be disabled or enabled. So we also add support for the enabling / disabling flag to the OPA authorization configuration.

The OPA metrics are not exposed by default in our metrics examples, because I don't think majority of users use OPA authorization. But OPA users can of course modify the JMX Exporter configuration they use.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md