### PR TITLE
docs: cruise control capacity values format

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacity.java
@@ -44,7 +44,9 @@ public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Pattern("^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$")
-    @Description("Broker capacity for disk in bytes, for example, 100Gi.")
+    @Description("Broker capacity for disk in bytes. " +
+            "Use a number value with either standard Kubernetes byte units (K, M, G, or T), their bibyte (power of two) equivalents (Ki, Mi, Gi, or Ti), or a byte value with or without E notation. " +
+            "For example, 100000M, 100000Mi, 104857600000, or 1e+11.")
     public String getDisk() {
         return disk;
     }
@@ -67,7 +69,9 @@ public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Pattern("^[0-9]+([KMG]i?)?B/s$")
-    @Description("Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s")
+    @Description("Broker capacity for inbound network throughput in bytes per second. " +
+            "Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. " +
+            "For example, 10000KiB/s.")
     public String getInboundNetwork() {
         return inboundNetwork;
     }
@@ -78,7 +82,9 @@ public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Pattern("^[0-9]+([KMG]i?)?B/s$")
-    @Description("Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s")
+    @Description("Broker capacity for outbound network throughput in bytes per second. " +
+            "Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. " +
+            "For example, 10000KiB/s.")
     public String getOutboundNetwork() {
         return outboundNetwork;
     }

--- a/documentation/contributing/styleguide.adoc
+++ b/documentation/contributing/styleguide.adoc
@@ -26,7 +26,7 @@ spec:
 ------
 <1> Syntax for the example. Here the source language is `yaml`. Use _subs_ to apply attributes and formatting.
 In this example, `{KafkaApiVersion}` is substituted with an attribute value specified in the `/shared/attributes.adoc` file.
-If _quotes_ is specified in _subs_, asciidoc formatting is applied to the code block. Here, bold is applied to the *3* value of `replicas`. If _quotes_ isn't used, ascidoc formatting is ignored in the code block.
+If _quotes_ is specified in _subs_, asciidoc formatting is applied to the code block. Here, bold is applied to the *3* value of `replicas`. If _quotes_ isn't used, asciidoc formatting is ignored in the code block.
 <2> Add callouts to describe a line of code or configuration. Use a hash (`#`) before the callout number so that the example is copy-friendly.
 <3> Use a hash and ellipsis (`# ...`) to show that part of the code or configuration has been omitted.
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1320,13 +1320,13 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 [options="header"]
 |====
 |Property                |Description
-|disk             1.2+<.<a|Broker capacity for disk in bytes, for example, 100Gi.
+|disk             1.2+<.<a|Broker capacity for disk in bytes. Use a number value with either standard Kubernetes byte units (K, M, G, or T), their bibyte (power of two) equivalents (Ki, Mi, Gi, or Ti), or a byte value with or without E notation. For example, 100000M, 100000Mi, 104857600000, or 1e+11.
 |string
 |cpuUtilization   1.2+<.<a|Broker capacity for CPU resource utilization as a percentage (0 - 100).
 |integer
-|inboundNetwork   1.2+<.<a|Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s.
+|inboundNetwork   1.2+<.<a|Broker capacity for inbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string
-|outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s.
+|outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string
 |====
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -75,22 +75,25 @@ For more information, see {CruiseControlApiDocs}.
 [discrete]
 == Capacity configuration
 
-Cruise Control uses _capacity limits_ to determine if optimization goals for resource distribution are being broken. 
+Cruise Control uses _capacity limits_ to determine if optimization goals for resource distribution are being broken.
 There are four goals of this type:
 
 * `DiskUsageDistributionGoal`            - Disk utilization distribution
-* `CpuUsageDistributionGoal`             - CPU utilization distribution    
+* `CpuUsageDistributionGoal`             - CPU utilization distribution
 * `NetworkInboundUsageDistributionGoal`  - Network inbound utilization distribution
 * `NetworkOutboundUsageDistributionGoal` - Network outbound utilization distribution
 
-You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` . 
-They are enabled by default and you can change their default values. 
-Capacity limits can be set for the following broker resources, using the standard Kubernetes byte units (K, M, G and T) or their bibyte (power of two) equivalents (Ki, Mi, Gi and Ti):
+You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` .
+They are enabled by default and you can change their default values.
+Capacity limits can be set for the following broker resources:
 
 * `disk`            - Disk storage per broker (Default: 100000Mi)
 * `cpuUtilization`  - CPU utilization as a percentage (Default: 100)
 * `inboundNetwork`  - Inbound network throughput in byte units per second (Default: 10000KiB/s)
 * `outboundNetwork` - Outbound network throughput in byte units per second (Default: 10000KiB/s)
+
+For disk storage, use a number value with either standard Kubernetes byte units (K, M, G, or T), their bibyte (power of two) equivalents (Ki, Mi, Gi, or Ti), or a byte value with or without E notation.
+For network throughput, use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second.
 
 Because Strimzi Kafka brokers are homogeneous, Cruise Control applies the same capacity limits to every broker it is monitoring.
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -4560,7 +4560,7 @@ spec:
                         disk:
                           type: string
                           pattern: ^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$
-                          description: Broker capacity for disk in bytes, for example, 100Gi.
+                          description: Broker capacity for disk in bytes. Use a number value with either standard Kubernetes byte units (K, M, G, or T), their bibyte (power of two) equivalents (Ki, Mi, Gi, or Ti), or a byte value with or without E notation. For example, 100000M, 100000Mi, 104857600000, or 1e+11.
                         cpuUtilization:
                           type: integer
                           minimum: 0
@@ -4569,11 +4569,11 @@ spec:
                         inboundNetwork:
                           type: string
                           pattern: ^[0-9]+([KMG]i?)?B/s$
-                          description: Broker capacity for inbound network throughput in bytes per second, for example, 10000KB/s.
+                          description: Broker capacity for inbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
                         outboundNetwork:
                           type: string
                           pattern: ^[0-9]+([KMG]i?)?B/s$
-                          description: Broker capacity for outbound network throughput in bytes per second, for example 10000KB/s.
+                          description: Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
                       description: The Cruise Control `brokerCapacity` configuration.
                     config:
                       x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/NOTES.txt
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/NOTES.txt
@@ -2,4 +2,4 @@ Thank you for installing {{ .Chart.Name }}-{{ .Chart.Version }}
 
 To create a Kafka cluster refer to the following documentation.
 
-https://strimzi.io/docs/operators/latest/using.html#deploying-cluster-operator-helm-chart-str
+https://strimzi.io/docs/operators/latest/deploying.html#deploying-cluster-operator-helm-chart-str

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -5407,8 +5407,11 @@ spec:
                       disk:
                         type: string
                         pattern: ^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$
-                        description: Broker capacity for disk in bytes, for example,
-                          100Gi.
+                        description: Broker capacity for disk in bytes. Use a number
+                          value with either standard Kubernetes byte units (K, M,
+                          G, or T), their bibyte (power of two) equivalents (Ki, Mi,
+                          Gi, or Ti), or a byte value with or without E notation.
+                          For example, 100000M, 100000Mi, 104857600000, or 1e+11.
                       cpuUtilization:
                         type: integer
                         minimum: 0
@@ -5419,12 +5422,16 @@ spec:
                         type: string
                         pattern: ^[0-9]+([KMG]i?)?B/s$
                         description: Broker capacity for inbound network throughput
-                          in bytes per second, for example, 10000KB/s.
+                          in bytes per second. Use an integer value with standard
+                          Kubernetes byte units (K, M, G) or their bibyte (power of
+                          two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
                       outboundNetwork:
                         type: string
                         pattern: ^[0-9]+([KMG]i?)?B/s$
                         description: Broker capacity for outbound network throughput
-                          in bytes per second, for example 10000KB/s.
+                          in bytes per second. Use an integer value with standard
+                          Kubernetes byte units (K, M, G) or their bibyte (power of
+                          two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
                     description: The Cruise Control `brokerCapacity` configuration.
                   config:
                     x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates the descriptions for capacity configuration -- disk and network throughput -- _BrokerCapacity schema reference_ and _Capacity configuration_ sections in the _Using_ guide.

Also fixes a link to the docs from Helm notes.txt

This PR fixes #3320 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

