### PR TITLE
Added fix for renewal of user provided CAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for Kafka 3.1.0; remove Kafka 2.8.0 and 2.8.1
 * Update Open Policy Agent authorizer to 1.4.0 and add support for enabling metrics 
 * Added the option `createBootstrapService` in the Kafka Spec to disable the creation of the bootstrap service for the Load Balancer Type Listener. It will save the cost of one load balancer resource, specially in the public cloud.
+* Fix renewing your own CA certificates [#5466](https://github.com/strimzi/strimzi-kafka-operator/issues/5466)
 
 ## 0.27.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -979,6 +979,10 @@ public abstract class AbstractModel {
         return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, emptyMap(), emptyMap());
     }
 
+    protected Secret createSecret(String name, Map<String, String> data, Map<String, String> customAnnotations) {
+        return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, customAnnotations, emptyMap());
+    }
+
     protected Secret createJmxSecret(String name, Map<String, String> data) {
         return ModelUtils.createSecret(name, namespace, labels, createOwnerReference(), data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -242,18 +242,18 @@ public class ClusterCa extends Ca {
     }
 
     @Override
-    protected String caCertThumbprintAnnotation() {
-        return ANNO_STRIMZI_IO_CLUSTER_CA_THUMBPRINT;
+    protected String caCertGenerationAnnotation() {
+        return ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION;
     }
 
     @SuppressWarnings("BooleanExpressionComplexity")
     @Override
-    protected boolean isCaCertThumbprintChanged() {
+    protected boolean isCaCertGenerationChanged() {
         // at least one Secret has a different cluster CA certificate thumbprint.
         // it is useful when a renewal cluster CA certificate process needs to be recovered after an operator crash
-        return isCaCertThumbprintChanged(zkNodesSecret) || isCaCertThumbprintChanged(brokersSecret) ||
-                isCaCertThumbprintChanged(entityTopicOperatorSecret) || isCaCertThumbprintChanged(entityUserOperatorSecret) ||
-                isCaCertThumbprintChanged(kafkaExporterSecret) || isCaCertThumbprintChanged(cruiseControlSecret) ||
-                isCaCertThumbprintChanged(clusterOperatorSecret);
+        return isCaCertGenerationChanged(zkNodesSecret) || isCaCertGenerationChanged(brokersSecret) ||
+                isCaCertGenerationChanged(entityTopicOperatorSecret) || isCaCertGenerationChanged(entityUserOperatorSecret) ||
+                isCaCertGenerationChanged(kafkaExporterSecret) || isCaCertGenerationChanged(cruiseControlSecret) ||
+                isCaCertGenerationChanged(clusterOperatorSecret);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -248,12 +248,12 @@ public class ClusterCa extends Ca {
 
     @SuppressWarnings("BooleanExpressionComplexity")
     @Override
-    protected boolean isCaCertGenerationChanged() {
+    protected boolean hasCaCertGenerationChanged() {
         // at least one Secret has a different cluster CA certificate thumbprint.
         // it is useful when a renewal cluster CA certificate process needs to be recovered after an operator crash
-        return isCaCertGenerationChanged(zkNodesSecret) || isCaCertGenerationChanged(brokersSecret) ||
-                isCaCertGenerationChanged(entityTopicOperatorSecret) || isCaCertGenerationChanged(entityUserOperatorSecret) ||
-                isCaCertGenerationChanged(kafkaExporterSecret) || isCaCertGenerationChanged(cruiseControlSecret) ||
-                isCaCertGenerationChanged(clusterOperatorSecret);
+        return hasCaCertGenerationChanged(zkNodesSecret) || hasCaCertGenerationChanged(brokersSecret) ||
+                hasCaCertGenerationChanged(entityTopicOperatorSecret) || hasCaCertGenerationChanged(entityUserOperatorSecret) ||
+                hasCaCertGenerationChanged(kafkaExporterSecret) || hasCaCertGenerationChanged(cruiseControlSecret) ||
+                hasCaCertGenerationChanged(clusterOperatorSecret);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -241,4 +241,19 @@ public class ClusterCa extends Ca {
             isMaintenanceTimeWindowsSatisfied);
     }
 
+    @Override
+    protected String caCertThumbprintAnnotation() {
+        return ANNO_STRIMZI_IO_CLUSTER_CA_THUMBPRINT;
+    }
+
+    @SuppressWarnings("BooleanExpressionComplexity")
+    @Override
+    protected boolean isCaCertThumbprintChanged() {
+        // at least one Secret has a different cluster CA certificate thumbprint.
+        // it is useful when a renewal cluster CA certificate process needs to be recovered after an operator crash
+        return isCaCertThumbprintChanged(zkNodesSecret) || isCaCertThumbprintChanged(brokersSecret) ||
+                isCaCertThumbprintChanged(entityTopicOperatorSecret) || isCaCertThumbprintChanged(entityUserOperatorSecret) ||
+                isCaCertThumbprintChanged(kafkaExporterSecret) || isCaCertThumbprintChanged(cruiseControlSecret) ||
+                isCaCertThumbprintChanged(clusterOperatorSecret);
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -692,7 +692,8 @@ public class CruiseControl extends AbstractModel {
         data.put(keyCertName + ".p12", cert.keyStoreAsBase64String());
         data.put(keyCertName + ".password", cert.storePasswordAsBase64String());
 
-        return createSecret(CruiseControl.secretName(cluster), data);
+        return createSecret(CruiseControl.secretName(cluster), data,
+                Collections.singletonMap(clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint()));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -693,7 +693,7 @@ public class CruiseControl extends AbstractModel {
         data.put(keyCertName + ".password", cert.storePasswordAsBase64String());
 
         return createSecret(CruiseControl.secretName(cluster), data,
-                Collections.singletonMap(clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint()));
+                Collections.singletonMap(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1357,9 +1357,11 @@ public class KafkaCluster extends AbstractModel {
      * internal communication with Zookeeper.
      * It also contains the related Kafka brokers private keys.
      *
+     * @param clusterCa The CA for cluster certificates
+     * @param clientsCa The CA for clients certificates
      * @return The generated Secret
      */
-    public Secret generateBrokersSecret() {
+    public Secret generateBrokersSecret(ClusterCa clusterCa, ClientsCa clientsCa) {
 
         Map<String, String> data = new HashMap<>(replicas * 4);
         for (int i = 0; i < replicas; i++) {
@@ -1369,7 +1371,10 @@ public class KafkaCluster extends AbstractModel {
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
-        return createSecret(KafkaCluster.brokersSecretName(cluster), data);
+        Map<String, String> annotations = Map.of(
+                clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint(),
+                clientsCa.caCertThumbprintAnnotation(), clientsCa.currentCaCertThumbprint());
+        return createSecret(KafkaCluster.brokersSecretName(cluster), data, annotations);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1371,9 +1371,10 @@ public class KafkaCluster extends AbstractModel {
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
             data.put(KafkaCluster.kafkaPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
+
         Map<String, String> annotations = Map.of(
-                clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint(),
-                clientsCa.caCertThumbprintAnnotation(), clientsCa.currentCaCertThumbprint());
+                clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration()),
+                clientsCa.caCertGenerationAnnotation(), String.valueOf(clientsCa.certGeneration()));
         return createSecret(KafkaCluster.brokersSecretName(cluster), data, annotations);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -144,7 +144,9 @@ public class ModelUtils {
             reasons.add("certificate doesn't exist yet");
             shouldBeRegenerated = true;
         } else {
-            if (clusterCa.keyCreated() || clusterCa.certRenewed() || (isMaintenanceTimeWindowsSatisfied && clusterCa.isExpiring(secret, keyCertName + ".crt"))) {
+            if (clusterCa.keyCreated() || clusterCa.certRenewed() ||
+                    (isMaintenanceTimeWindowsSatisfied && clusterCa.isExpiring(secret, keyCertName + ".crt")) ||
+                    clusterCa.isCaCertThumbprintChanged(secret)) {
                 reasons.add("certificate needs to be renewed");
                 shouldBeRegenerated = true;
             }
@@ -191,7 +193,8 @@ public class ModelUtils {
             data.put(keyCertName + ".password", certAndKey.storePasswordAsBase64String());
         }
 
-        return createSecret(secretName, namespace, labels, ownerReference, data, emptyMap(), emptyMap());
+        return createSecret(secretName, namespace, labels, ownerReference, data,
+                Collections.singletonMap(clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint()), emptyMap());
     }
 
     public static Secret createSecret(String name, String namespace, Labels labels, OwnerReference ownerReference,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -146,7 +146,7 @@ public class ModelUtils {
         } else {
             if (clusterCa.keyCreated() || clusterCa.certRenewed() ||
                     (isMaintenanceTimeWindowsSatisfied && clusterCa.isExpiring(secret, keyCertName + ".crt")) ||
-                    clusterCa.isCaCertGenerationChanged(secret)) {
+                    clusterCa.hasCaCertGenerationChanged(secret)) {
                 reasons.add("certificate needs to be renewed");
                 shouldBeRegenerated = true;
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -146,7 +146,7 @@ public class ModelUtils {
         } else {
             if (clusterCa.keyCreated() || clusterCa.certRenewed() ||
                     (isMaintenanceTimeWindowsSatisfied && clusterCa.isExpiring(secret, keyCertName + ".crt")) ||
-                    clusterCa.isCaCertThumbprintChanged(secret)) {
+                    clusterCa.isCaCertGenerationChanged(secret)) {
                 reasons.add("certificate needs to be renewed");
                 shouldBeRegenerated = true;
             }
@@ -194,7 +194,7 @@ public class ModelUtils {
         }
 
         return createSecret(secretName, namespace, labels, ownerReference, data,
-                Collections.singletonMap(clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint()), emptyMap());
+                Collections.singletonMap(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())), emptyMap());
     }
 
     public static Secret createSecret(String name, String namespace, Labels labels, OwnerReference ownerReference,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -576,9 +576,10 @@ public class ZookeeperCluster extends AbstractModel {
      * internal communication with Kafka.
      * It also contains the related Zookeeper nodes private keys.
      *
+     * @param clusterCa The CA for cluster certificates
      * @return The generated Secret.
      */
-    public Secret generateNodesSecret() {
+    public Secret generateNodesSecret(ClusterCa clusterCa) {
 
         Map<String, String> data = new HashMap<>(replicas * 4);
         for (int i = 0; i < replicas; i++) {
@@ -588,7 +589,8 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
             data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
-        return createSecret(ZookeeperCluster.nodesSecretName(cluster), data);
+        return createSecret(ZookeeperCluster.nodesSecretName(cluster), data,
+                Collections.singletonMap(clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint()));
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -589,8 +589,9 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
             data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
+
         return createSecret(ZookeeperCluster.nodesSecretName(cluster), data,
-                Collections.singletonMap(clusterCa.caCertThumbprintAnnotation(), clusterCa.currentCaCertThumbprint()));
+                Collections.singletonMap(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())));
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -676,7 +676,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 ModelUtils.getCertificateValidity(clientsCaConfig),
                                 ModelUtils.getRenewalDays(clientsCaConfig),
                                 clientsCaConfig == null || clientsCaConfig.isGenerateCertificateAuthority(), clientsCaConfig != null ? clientsCaConfig.getCertificateExpirationPolicy() : null);
-                        this.clientsCa.initCaSecrets(brokersSecret);
+                        this.clientsCa.initBrokerSecret(brokersSecret);
                         clientsCa.createRenewOrReplace(reconciliation.namespace(), reconciliation.name(),
                                 caLabels.toMap(), emptyMap(), emptyMap(),
                                 clientsCaConfig != null && !clientsCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -58,12 +58,12 @@ public class CaRenewalTest {
             }
 
             @Override
-            protected boolean isCaCertThumbprintChanged() {
+            protected boolean isCaCertGenerationChanged() {
                 return false;
             }
 
             @Override
-            protected String caCertThumbprintAnnotation() {
+            protected String caCertGenerationAnnotation() {
                 return null;
             }
         };
@@ -125,12 +125,12 @@ public class CaRenewalTest {
             }
 
             @Override
-            protected boolean isCaCertThumbprintChanged() {
+            protected boolean isCaCertGenerationChanged() {
                 return false;
             }
 
             @Override
-            protected String caCertThumbprintAnnotation() {
+            protected String caCertGenerationAnnotation() {
                 return null;
             }
         };
@@ -221,12 +221,12 @@ public class CaRenewalTest {
             }
 
             @Override
-            protected boolean isCaCertThumbprintChanged() {
+            protected boolean isCaCertGenerationChanged() {
                 return false;
             }
 
             @Override
-            protected String caCertThumbprintAnnotation() {
+            protected String caCertGenerationAnnotation() {
                 return null;
             }
         };
@@ -317,12 +317,12 @@ public class CaRenewalTest {
             }
 
             @Override
-            protected boolean isCaCertThumbprintChanged() {
+            protected boolean isCaCertGenerationChanged() {
                 return false;
             }
 
             @Override
-            protected String caCertThumbprintAnnotation() {
+            protected String caCertGenerationAnnotation() {
                 return null;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -56,6 +56,16 @@ public class CaRenewalTest {
                         "new-password" + index
                 );
             }
+
+            @Override
+            protected boolean isCaCertThumbprintChanged() {
+                return false;
+            }
+
+            @Override
+            protected String caCertThumbprintAnnotation() {
+                return null;
+            }
         };
 
         int replicas = 3;
@@ -112,6 +122,16 @@ public class CaRenewalTest {
                         ("new-keystore" + index).getBytes(),
                         "new-password" + index
                 );
+            }
+
+            @Override
+            protected boolean isCaCertThumbprintChanged() {
+                return false;
+            }
+
+            @Override
+            protected String caCertThumbprintAnnotation() {
+                return null;
             }
         };
 
@@ -199,6 +219,16 @@ public class CaRenewalTest {
                         "new-password" + index
                 );
             }
+
+            @Override
+            protected boolean isCaCertThumbprintChanged() {
+                return false;
+            }
+
+            @Override
+            protected String caCertThumbprintAnnotation() {
+                return null;
+            }
         };
 
         Secret initialSecret = new SecretBuilder()
@@ -284,6 +314,16 @@ public class CaRenewalTest {
                         ("new-keystore" + index).getBytes(),
                         "new-password" + index
                 );
+            }
+
+            @Override
+            protected boolean isCaCertThumbprintChanged() {
+                return false;
+            }
+
+            @Override
+            protected String caCertThumbprintAnnotation() {
+                return null;
             }
         };
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CaRenewalTest.java
@@ -6,8 +6,11 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
 import io.strimzi.certs.Subject;
+import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -30,43 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class CaRenewalTest {
     @ParallelTest
     public void renewalOfStatefulSetCertificatesWithNullSecret() throws IOException {
-        Ca mockedCa = new Ca(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null) {
-            private AtomicInteger invocationCount = new AtomicInteger(0);
-
-            @Override
-            public boolean certRenewed() {
-                return false;
-            }
-
-            @Override
-            public boolean isExpiring(Secret secret, String certKey)  {
-                return false;
-            }
-
-            @Override
-            protected CertAndKey generateSignedCert(Subject subject,
-                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
-                int index = invocationCount.getAndIncrement();
-
-                return new CertAndKey(
-                        ("new-key" + index).getBytes(),
-                        ("new-cert" + index).getBytes(),
-                        ("new-truststore" + index).getBytes(),
-                        ("new-keystore" + index).getBytes(),
-                        "new-password" + index
-                );
-            }
-
-            @Override
-            protected boolean isCaCertGenerationChanged() {
-                return false;
-            }
-
-            @Override
-            protected String caCertGenerationAnnotation() {
-                return null;
-            }
-        };
+        Ca mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
 
         int replicas = 3;
         Function<Integer, Subject> subjectFn = i -> new Subject.Builder().build();
@@ -97,43 +64,8 @@ public class CaRenewalTest {
 
     @ParallelTest
     public void renewalOfStatefulSetCertificatesWithCaRenewal() throws IOException {
-        Ca mockedCa = new Ca(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null) {
-            private AtomicInteger invocationCount = new AtomicInteger(0);
-
-            @Override
-            public boolean certRenewed() {
-                return true;
-            }
-
-            @Override
-            public boolean isExpiring(Secret secret, String certKey)  {
-                return false;
-            }
-
-            @Override
-            protected CertAndKey generateSignedCert(Subject subject,
-                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
-                int index = invocationCount.getAndIncrement();
-
-                return new CertAndKey(
-                        ("new-key" + index).getBytes(),
-                        ("new-cert" + index).getBytes(),
-                        ("new-truststore" + index).getBytes(),
-                        ("new-keystore" + index).getBytes(),
-                        "new-password" + index
-                );
-            }
-
-            @Override
-            protected boolean isCaCertGenerationChanged() {
-                return false;
-            }
-
-            @Override
-            protected String caCertGenerationAnnotation() {
-                return null;
-            }
-        };
+        MockedCa mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        mockedCa.setCertRenewed(true);
 
         Secret initialSecret = new SecretBuilder()
                 .withNewMetadata()
@@ -183,53 +115,8 @@ public class CaRenewalTest {
 
     @ParallelTest
     public void renewalOfStatefulSetCertificatesDelayedRenewalInWindow() throws IOException {
-        Ca mockedCa = new Ca(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null) {
-            private AtomicInteger invocationCount = new AtomicInteger(0);
-
-            @Override
-            public boolean certRenewed() {
-                return false;
-            }
-
-            @Override
-            public boolean isExpiring(Secret secret, String certKey)  {
-                return true;
-            }
-
-            @Override
-            protected boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
-                return false;
-            }
-
-            @Override
-            public X509Certificate getAsX509Certificate(Secret secret, String key)    {
-                return null;
-            }
-
-            @Override
-            protected CertAndKey generateSignedCert(Subject subject,
-                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
-                int index = invocationCount.getAndIncrement();
-
-                return new CertAndKey(
-                        ("new-key" + index).getBytes(),
-                        ("new-cert" + index).getBytes(),
-                        ("new-truststore" + index).getBytes(),
-                        ("new-keystore" + index).getBytes(),
-                        "new-password" + index
-                );
-            }
-
-            @Override
-            protected boolean isCaCertGenerationChanged() {
-                return false;
-            }
-
-            @Override
-            protected String caCertGenerationAnnotation() {
-                return null;
-            }
-        };
+        MockedCa mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        mockedCa.setCertExpiring(true);
 
         Secret initialSecret = new SecretBuilder()
                 .withNewMetadata()
@@ -279,53 +166,8 @@ public class CaRenewalTest {
 
     @ParallelTest
     public void renewalOfStatefulSetCertificatesDelayedRenewalOutsideWindow() throws IOException {
-        Ca mockedCa = new Ca(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null) {
-            private AtomicInteger invocationCount = new AtomicInteger(0);
-
-            @Override
-            public boolean certRenewed() {
-                return false;
-            }
-
-            @Override
-            public boolean isExpiring(Secret secret, String certKey)  {
-                return true;
-            }
-
-            @Override
-            protected boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
-                return false;
-            }
-
-            @Override
-            public X509Certificate getAsX509Certificate(Secret secret, String key)    {
-                return null;
-            }
-
-            @Override
-            protected CertAndKey generateSignedCert(Subject subject,
-                                                    File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
-                int index = invocationCount.getAndIncrement();
-
-                return new CertAndKey(
-                        ("new-key" + index).getBytes(),
-                        ("new-cert" + index).getBytes(),
-                        ("new-truststore" + index).getBytes(),
-                        ("new-keystore" + index).getBytes(),
-                        "new-password" + index
-                );
-            }
-
-            @Override
-            protected boolean isCaCertGenerationChanged() {
-                return false;
-            }
-
-            @Override
-            protected String caCertGenerationAnnotation() {
-                return null;
-            }
-        };
+        MockedCa mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        mockedCa.setCertExpiring(true);
 
         Secret initialSecret = new SecretBuilder()
                 .withNewMetadata()
@@ -371,5 +213,67 @@ public class CaRenewalTest {
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
         assertThat(new String(newCerts.get("pod2").keyStore()), is("old-keystore"));
         assertThat(newCerts.get("pod2").storePassword(), is("old-password"));
+    }
+
+    public class MockedCa extends Ca {
+        private boolean isCertRenewed;
+        private boolean isCertExpiring;
+        private AtomicInteger invocationCount = new AtomicInteger(0);
+
+        public MockedCa(Reconciliation reconciliation, CertManager certManager, PasswordGenerator passwordGenerator, String commonName, String caCertSecretName, Secret caCertSecret, String caKeySecretName, Secret caKeySecret, int validityDays, int renewalDays, boolean generateCa, CertificateExpirationPolicy policy) {
+            super(reconciliation, certManager, passwordGenerator, commonName, caCertSecretName, caCertSecret, caKeySecretName, caKeySecret, validityDays, renewalDays, generateCa, policy);
+        }
+
+        @Override
+        public boolean certRenewed() {
+            return isCertRenewed;
+        }
+
+        @Override
+        public boolean isExpiring(Secret secret, String certKey)  {
+            return isCertExpiring;
+        }
+
+        @Override
+        protected boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
+            return false;
+        }
+
+        @Override
+        public X509Certificate getAsX509Certificate(Secret secret, String key)    {
+            return null;
+        }
+
+        @Override
+        protected CertAndKey generateSignedCert(Subject subject,
+                                                File csrFile, File keyFile, File certFile, File keyStoreFile) throws IOException {
+            int index = invocationCount.getAndIncrement();
+
+            return new CertAndKey(
+                    ("new-key" + index).getBytes(),
+                    ("new-cert" + index).getBytes(),
+                    ("new-truststore" + index).getBytes(),
+                    ("new-keystore" + index).getBytes(),
+                    "new-password" + index
+            );
+        }
+
+        @Override
+        protected boolean hasCaCertGenerationChanged() {
+            return false;
+        }
+
+        @Override
+        protected String caCertGenerationAnnotation() {
+            return null;
+        }
+
+        public void setCertRenewed(boolean certRenewed) {
+            isCertRenewed = certRenewed;
+        }
+
+        public void setCertExpiring(boolean certExpiring) {
+            isCertExpiring = certExpiring;
+        }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -44,6 +44,7 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.openshift.api.model.Route;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.GenericSecretSourceBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
@@ -1461,9 +1462,11 @@ public class KafkaClusterTest {
     private Secret generateBrokerSecret(Set<String> externalBootstrapAddress, Map<Integer, Set<String>> externalAddresses) {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        ClientsCa clientsCa = new ClientsCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), null, null, null, null, 365, 30, true, CertificateExpirationPolicy.RENEW_CERTIFICATE);
+        clientsCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
 
         kc.generateCertificates(kafkaAssembly, clusterCa, externalBootstrapAddress, externalAddresses, true);
-        return kc.generateBrokersSecret();
+        return kc.generateBrokersSecret(clusterCa, clientsCa);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -461,7 +461,7 @@ public class ZookeeperClusterTest {
         clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
 
         zc.generateCertificates(ka, clusterCa, true);
-        return zc.generateNodesSecret();
+        return zc.generateNodesSecret(clusterCa);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1336,7 +1336,7 @@ public class KafkaAssemblyOperatorTest {
             invocation -> new ArrayList<>(asList(
                     barClientsCa.caKeySecret(),
                     barClientsCa.caCertSecret(),
-                    barCluster.generateBrokersSecret(),
+                    barCluster.generateBrokersSecret(barClusterCa, barClientsCa),
                     barClusterCa.caCertSecret()))
         );
         when(mockSecretOps.get(eq(kafkaNamespace), eq(AbstractModel.clusterCaCertSecretName(bar.getMetadata().getName())))).thenReturn(barSecrets.get(0));
@@ -1421,7 +1421,7 @@ public class KafkaAssemblyOperatorTest {
             invocation -> new ArrayList<>(asList(
                     barClientsCa.caKeySecret(),
                     barClientsCa.caCertSecret(),
-                    barCluster.generateBrokersSecret(),
+                    barCluster.generateBrokersSecret(barClusterCa, barClientsCa),
                     barClusterCa.caCertSecret()))
         );
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -11,6 +11,9 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 
 public class ClientsCa extends Ca {
+
+    private Secret brokersSecret;
+
     public ClientsCa(Reconciliation reconciliation, CertManager certManager, PasswordGenerator passwordGenerator, String caCertSecretName, Secret clientsCaCert,
                      String caSecretKeyName, Secret clientsCaKey,
                      int validityDays, int renewalDays, boolean generateCa, CertificateExpirationPolicy policy) {
@@ -35,6 +38,20 @@ public class ClientsCa extends Ca {
             }
         }
         return clientsCaKey;
+    }
+
+    public void initCaSecrets(Secret secret) {
+        this.brokersSecret = secret;
+    }
+
+    @Override
+    protected String caCertThumbprintAnnotation() {
+        return ANNO_STRIMZI_IO_CLIENTS_CA_THUMBPRINT;
+    }
+
+    @Override
+    protected boolean isCaCertThumbprintChanged() {
+        return isCaCertThumbprintChanged(brokersSecret);
     }
 
     @Override

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -40,7 +40,7 @@ public class ClientsCa extends Ca {
         return clientsCaKey;
     }
 
-    public void initCaSecrets(Secret secret) {
+    public void initBrokerSecret(Secret secret) {
         this.brokersSecret = secret;
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -50,8 +50,8 @@ public class ClientsCa extends Ca {
     }
 
     @Override
-    protected boolean isCaCertGenerationChanged() {
-        return isCaCertGenerationChanged(brokersSecret);
+    protected boolean hasCaCertGenerationChanged() {
+        return hasCaCertGenerationChanged(brokersSecret);
     }
 
     @Override

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -45,13 +45,13 @@ public class ClientsCa extends Ca {
     }
 
     @Override
-    protected String caCertThumbprintAnnotation() {
-        return ANNO_STRIMZI_IO_CLIENTS_CA_THUMBPRINT;
+    protected String caCertGenerationAnnotation() {
+        return ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION;
     }
 
     @Override
-    protected boolean isCaCertThumbprintChanged() {
-        return isCaCertThumbprintChanged(brokersSecret);
+    protected boolean isCaCertGenerationChanged() {
+        return isCaCertGenerationChanged(brokersSecret);
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #5466.
Today, when a user provides his own CA certificate (cluster or client) but then he tries to follow the [renew process](https://strimzi.io/docs/operators/in-development/using.html#renewing-your-own-ca-certificates-str) as we documented, the procedure doesn't work at all.
The current code doesn't have logic for the CO to detect that a new CA certificate was provided by the user (by following the documentation and having a `Secret` with both the new CA certificate together with the old one CA-<expiration-date>).
With this PR, this first detection issue is resolved by adding the thumbprint of the cluster CA certificate, as an annotation, on all the `Secret`(s) that contains server certificates signed by that CA certificate. For example, the `<cluster>-zookeeper-nodes`, `<cluster>-kafka-brokers` and the same for the CO and EO (TO and UO) related `Secret`(s).

```yaml
annotations:
    clients-ca-thumbprint: hCyUdeqWt6gXDUKYdAtaFYDiPoZlWAwCjW7liqtWkps=
```

Just for the Kafka brokers related `Secret`(s) there is also a corresponding annotation with the thumbprint of the clients CA certificate.

```yaml
annotations:
    clients-ca-thumbprint: hCyUdeqWt6gXDUKYdAtaFYDiPoZlWAwCjW7liqtWkps=
    cluster-ca-thumbprint: DoNswf/bRfs6nF1IVx7PhbOVXKvJvjv/wOxuQY8eoTM=
```

During the periodic reconcile, the CO is able to detect that the thumbprint of the provided CA certificate is different from the one stored in such `Secret`(s).
When the change is detected, it just sets the renewal type as `REPLACE_KEY`, starting the same flow which runs when the CA certificates are handled by Strimzi itself (of course a part the CA certificate generation that is skipped).
So it runs the right pods rolls to first trust the new CA certificate and then generating the new server certificates for the different components (CO itself, Kafka, ZooKeeper, TO, UO).

In order to do so there are a couple of things to take into account that needs the documentation to be updated because the user has to follow them in order to renew the CA certificate properly:

1. The CN (Common Name) of the current CA certificate and the renewed one have to be different. This is because when they will be both trusted, the openssl tool used by stunnel in the tls-sidecar (in the TO) is not able to use both of them to trust the ZooKeeper server certificates but just one of them, so the verification would fail. When the Strimzi auto-creation of CA certificate is used, this is exactly what happens; a new CA is created with a suffix of `v1` (compared to the previous `v0`) in the CN to make them different, so manual renewal should follow same path.
2. The `Secret` containing the CA certificate has to have the `strimzi.io/ca-cert-generation` annotation as well as the one containing the key has to have the `strimzi.io/ca-key-generation`. This generation should start from 0 and increased on each renewal; even this time this is exactly how the auto-renewal process works in Strimzi doing that for you.

So the above steps need to be documented to make "handmade" renewal the same as the "auto" renewal from Strimzi operator.

Fixing this way, I made a couple of assumptions:

* when renewing the CA certificate, the user will always create a new key (as we describe in the documentation) so the reason why the fix inject into the flow with a `REPLACE_KEY` renewal type.
* the CA-<expiration-date> is not deleted by the CO automatically when it expires (as it happens for Strimzi generated CA certificate). It's the user to delete it from the `Secret`.

Documentation will come with a different PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
