### PR TITLE
fix indenting in helm deployment cluster operator

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -129,7 +129,7 @@ spec:
               value: {{ .Values.connectBuildTimeoutMs | quote }}
             {{- end }}
             {{- if .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 12 }}
+{{ toYaml .Values.extraEnvs | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:
@@ -147,7 +147,7 @@ spec:
           securityContext: {{ toYaml .| nindent 12 }}
           {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

When using the strimi-cluster-operator as a dependency in another chart, you cannot configure the extraEnvs because the indenting is wrong.  
In the meantime I also updated any existing `indent` usages in the file.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

