### PR TITLE
Update Fabric8 for 0.27.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.10.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.10.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.10.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.10.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.10.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.10.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <okhttp.version>3.12.6</okhttp.version>
         <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the Fabric8 Kubernetes client in the 0.27 release branch to 5.10.2 before we do the patch release 0.27.1.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally