### PR TITLE
fix: Remove reference to quickstart guide that no longer exists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,7 @@ You can contribute by:
 
 All bugs, tasks or enhancements are tracked as [GitHub issues][issues]. Issues which might be a good start for new contributors are marked with the [“good-start”][newbie-issues] label.
 
-The [developer quick start guide][dev-quick-start] describes how to quickly get setup to build Strimzi from source.
-
-The [development guide][development-guide] describes in more detail the various ways you can build Strimzi and how to test your changes before submitting a patch or opening a pull request.
+The [development guide][development-guide] describes how to quickly get setup to build Strimzi from source. It also goes into more detail of various ways you can build Strimzi and how to test your changes before submitting a patch or opening a pull request.
 
 The [release checklist][release-list] describes the steps that need to be completed for a new version release.
 


### PR DESCRIPTION
Signed-off-by: Katherine Stanley <11195226+katheris@users.noreply.github.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

