### PR TITLE
SystemTests: Secretutils encode/decode passwords method

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -76,7 +76,7 @@ public class SecretUtils {
                 .withNamespace(namespaceName)
             .endMetadata()
             .withType("Opaque")
-                .withData(Collections.singletonMap(dataKey, dataValue))
+                .withStringData(Collections.singletonMap(dataKey, dataValue))
             .build());
     }
 
@@ -180,13 +180,5 @@ public class SecretUtils {
                 .execInCurrentNamespace("annotate", "secret", resourceName, annotationKey + "=" + annotationValue)
                 .out()
                 .trim();
-    }
-
-    public static String encodeStringPassword(String plainPassword) {
-        return new String(Base64.getEncoder().encode(plainPassword.getBytes()), StandardCharsets.US_ASCII);
-    }
-
-    public static String decodeStringPassword(String encodedPassword) {
-        return new String(Base64.getDecoder().decode(encodedPassword), StandardCharsets.US_ASCII);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -181,4 +181,12 @@ public class SecretUtils {
                 .out()
                 .trim();
     }
+
+    public static String encodeStringPassword(String plainPassword) {
+        return new String(Base64.getEncoder().encode(plainPassword.getBytes()), StandardCharsets.US_ASCII);
+    }
+
+    public static String decodeStringPassword(String encodedPassword) {
+        return new String(Base64.getDecoder().decode(encodedPassword), StandardCharsets.US_ASCII);
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -67,7 +67,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
@@ -75,7 +74,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -651,7 +649,7 @@ class SecurityST extends AbstractST {
         // 1. Create the Secrets already, and a certificate that's already expired
         InputStream secretInputStream = getClass().getClassLoader().getResourceAsStream("security-st-certs/expired-cluster-ca.crt");
         String clusterCaCert = TestUtils.readResource(secretInputStream);
-        SecretUtils.createSecret(namespaceName, clusterCaCertificateSecretName(clusterName), "ca.crt", new String(Base64.getEncoder().encode(clusterCaCert.getBytes()), StandardCharsets.US_ASCII));
+        SecretUtils.createSecret(namespaceName, clusterCaCertificateSecretName(clusterName), "ca.crt", clusterCaCert);
 
         // 2. Now create a cluster
         createKafkaCluster(extensionContext);
@@ -1217,7 +1215,7 @@ class SecurityST extends AbstractST {
 
         InputStream secretInputStream = getClass().getClassLoader().getResourceAsStream("security-st-certs/expired-cluster-ca.crt");
         String clusterCaCert = TestUtils.readResource(secretInputStream);
-        SecretUtils.createSecret(namespaceName, clusterCaCertificateSecretName(clusterName), "ca.crt", new String(Base64.getEncoder().encode(clusterCaCert.getBytes()), StandardCharsets.US_ASCII));
+        SecretUtils.createSecret(namespaceName, clusterCaCertificateSecretName(clusterName), "ca.crt", clusterCaCert);
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> {
             k.getSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -131,17 +131,17 @@ public class OauthAbstractST extends AbstractST {
      * f.e name kafka-broker-secret -> will be encoded to base64 format and use as a key.
      */
     private void createSecretsForDeployments(final String namespace) {
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_PRODUCER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("hello-world-producer-secret"));
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CONSUMER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("hello-world-streams-secret"));
-        SecretUtils.createSecret(namespace, OAUTH_TEAM_A_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("team-a-client-secret"));
-        SecretUtils.createSecret(namespace, OAUTH_TEAM_B_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("team-b-client-secret"));
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_BROKER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-broker-secret"));
-        SecretUtils.createSecret(namespace, CONNECT_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-connect-secret"));
-        SecretUtils.createSecret(namespace, MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-mirror-maker-secret"));
-        SecretUtils.createSecret(namespace, MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-mirror-maker-2-secret"));
-        SecretUtils.createSecret(namespace, BRIDGE_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-bridge-secret"));
-        SecretUtils.createSecret(namespace, OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-audience-secret"));
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CLIENT_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-client-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_PRODUCER_SECRET, OAUTH_KEY, "hello-world-producer-secret");
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CONSUMER_SECRET, OAUTH_KEY, "hello-world-streams-secret");
+        SecretUtils.createSecret(namespace, OAUTH_TEAM_A_SECRET, OAUTH_KEY, "team-a-client-secret");
+        SecretUtils.createSecret(namespace, OAUTH_TEAM_B_SECRET, OAUTH_KEY, "team-b-client-secret");
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_BROKER_SECRET, OAUTH_KEY, "kafka-broker-secret");
+        SecretUtils.createSecret(namespace, CONNECT_OAUTH_SECRET, OAUTH_KEY, "kafka-connect-secret");
+        SecretUtils.createSecret(namespace, MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, "kafka-mirror-maker-secret");
+        SecretUtils.createSecret(namespace, MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, "kafka-mirror-maker-2-secret");
+        SecretUtils.createSecret(namespace, BRIDGE_OAUTH_SECRET, OAUTH_KEY, "kafka-bridge-secret");
+        SecretUtils.createSecret(namespace, OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, "kafka-audience-secret");
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CLIENT_SECRET, OAUTH_KEY, "kafka-client-secret");
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -136,7 +136,8 @@ public class OauthAbstractST extends AbstractST {
         SecretUtils.createSecret(namespace, OAUTH_TEAM_A_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("team-a-client-secret"));
         SecretUtils.createSecret(namespace, OAUTH_TEAM_B_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("team-b-client-secret"));
         SecretUtils.createSecret(namespace, OAUTH_KAFKA_BROKER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-broker-secret"));
-        SecretUtils.createSecret(namespace, MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-connect-secret"));
+        SecretUtils.createSecret(namespace, CONNECT_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-connect-secret"));
+        SecretUtils.createSecret(namespace, MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-mirror-maker-secret"));
         SecretUtils.createSecret(namespace, MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-mirror-maker-2-secret"));
         SecretUtils.createSecret(namespace, BRIDGE_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-bridge-secret"));
         SecretUtils.createSecret(namespace, OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-audience-secret"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -131,17 +131,16 @@ public class OauthAbstractST extends AbstractST {
      * f.e name kafka-broker-secret -> will be encoded to base64 format and use as a key.
      */
     private void createSecretsForDeployments(final String namespace) {
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_PRODUCER_SECRET, OAUTH_KEY, "aGVsbG8td29ybGQtcHJvZHVjZXItc2VjcmV0");
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CONSUMER_SECRET, OAUTH_KEY, "aGVsbG8td29ybGQtc3RyZWFtcy1zZWNyZXQ=");
-        SecretUtils.createSecret(namespace, OAUTH_TEAM_A_SECRET, OAUTH_KEY, "dGVhbS1hLWNsaWVudC1zZWNyZXQ=");
-        SecretUtils.createSecret(namespace, OAUTH_TEAM_B_SECRET, OAUTH_KEY, "dGVhbS1iLWNsaWVudC1zZWNyZXQ=");
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_BROKER_SECRET, OAUTH_KEY, "a2Fma2EtYnJva2VyLXNlY3JldA==");
-        SecretUtils.createSecret(namespace, CONNECT_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtY29ubmVjdC1zZWNyZXQ=");
-        SecretUtils.createSecret(namespace, MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtbWlycm9yLW1ha2VyLXNlY3JldA==");
-        SecretUtils.createSecret(namespace, MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtbWlycm9yLW1ha2VyLTItc2VjcmV0");
-        SecretUtils.createSecret(namespace, BRIDGE_OAUTH_SECRET, OAUTH_KEY, "a2Fma2EtYnJpZGdlLXNlY3JldA==");
-        SecretUtils.createSecret(namespace, OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, "a2Fma2EtYXVkaWVuY2Utc2VjcmV0");
-        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CLIENT_SECRET, OAUTH_KEY, "a2Fma2EtY2xpZW50LXNlY3JldA==");
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_PRODUCER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("hello-world-producer-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CONSUMER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("hello-world-streams-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_TEAM_A_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("team-a-client-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_TEAM_B_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("team-b-client-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_BROKER_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-broker-secret"));
+        SecretUtils.createSecret(namespace, MIRROR_MAKER_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-connect-secret"));
+        SecretUtils.createSecret(namespace, MIRROR_MAKER_2_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-mirror-maker-2-secret"));
+        SecretUtils.createSecret(namespace, BRIDGE_OAUTH_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-bridge-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-audience-secret"));
+        SecretUtils.createSecret(namespace, OAUTH_KAFKA_CLIENT_SECRET, OAUTH_KEY, SecretUtils.encodeStringPassword("kafka-client-secret"));
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Michal T <mtoth@redhat.com>

- Refactoring ST

Use encoding method for plain passwords (added decode method as well)

- [x] Make sure all tests pass

