### PR TITLE
Refactor storage handling in model classes to minimize duplicate logic

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -63,9 +63,6 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.api.kafka.model.storage.JbodStorage;
-import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
-import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.ExternalTrafficPolicy;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
@@ -1312,8 +1309,8 @@ public class KafkaCluster extends AbstractModel {
         return createStatefulSet(
                 prepareControllerAnnotations(),
                 preparePodAnnotations(podAnnotations),
-                getStsVolumes(isOpenShift),
-                getVolumeClaims(),
+                getStatefulSetVolumes(isOpenShift),
+                getPersistentVolumeClaimTemplates(),
                 getMergedAffinity(),
                 getInitContainers(imagePullPolicy),
                 getContainers(imagePullPolicy),
@@ -1343,7 +1340,7 @@ public class KafkaCluster extends AbstractModel {
                 replicas,
                 prepareControllerAnnotations(),
                 preparePodAnnotations(podAnnotations),
-                podName -> getPodVolumes(podName, isOpenShift),
+                podName -> getPodSetVolumes(podName, isOpenShift),
                 getMergedAffinity(),
                 getInitContainers(imagePullPolicy),
                 getContainers(imagePullPolicy),
@@ -1426,27 +1423,7 @@ public class KafkaCluster extends AbstractModel {
      * @return The PersistentVolumeClaims.
      */
     public List<PersistentVolumeClaim> generatePersistentVolumeClaims(Storage storage) {
-        List<PersistentVolumeClaim> pvcs = new ArrayList<>();
-
-        if (storage != null) {
-            if (storage instanceof PersistentClaimStorage) {
-                Integer id = ((PersistentClaimStorage) storage).getId();
-                String pvcBaseName = VolumeUtils.getVolumePrefix(id) + "-" + name;
-
-                for (int i = 0; i < replicas; i++) {
-                    pvcs.add(createPersistentVolumeClaim(i, pvcBaseName + "-" + i, (PersistentClaimStorage) storage));
-                }
-            } else if (storage instanceof JbodStorage) {
-                for (SingleVolumeStorage volume : ((JbodStorage) storage).getVolumes()) {
-                    if (volume.getId() == null)
-                        throw new InvalidResourceException("Volumes under JBOD storage type have to have 'id' property");
-                    // it's called recursively for setting the information from the current volume
-                    pvcs.addAll(generatePersistentVolumeClaims(volume));
-                }
-            }
-        }
-
-        return pvcs;
+        return createPersistentVolumeClaims(storage, false);
     }
 
     /**
@@ -1512,16 +1489,16 @@ public class KafkaCluster extends AbstractModel {
 
     /**
      * Generates a list of volumes used by StatefulSet. For StatefulSet, it needs to include only ephemeral data
-     * volumes. Persistent claim volumes are generated directly byStatfulSet.
+     * volumes. Persistent claim volumes are generated directly by StatefulSet.
      *
      * @param isOpenShift   Flag whether we are on OpenShift or not
      *
-     * @return              List of volumes to be included in the StatfulSet pod template
+     * @return              List of volumes to be included in the StatefulSet pod template
      */
-    private List<Volume> getStsVolumes(boolean isOpenShift) {
+    private List<Volume> getStatefulSetVolumes(boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>();
 
-        volumeList.addAll(VolumeUtils.getDataVolumes(storage));
+        volumeList.addAll(VolumeUtils.createStatefulSetVolumes(storage, false));
         volumeList.addAll(getNonDataVolumes(isOpenShift));
 
         return volumeList;
@@ -1536,22 +1513,28 @@ public class KafkaCluster extends AbstractModel {
      *
      * @return              List of volumes to be included in the StrimziPodSet pod
      */
-    private List<Volume> getPodVolumes(String podName, boolean isOpenShift) {
+    private List<Volume> getPodSetVolumes(String podName, boolean isOpenShift) {
         List<Volume> volumeList = new ArrayList<>();
 
-        volumeList.addAll(VolumeUtils.getPodDataVolumes(podName, storage, false));
+        volumeList.addAll(VolumeUtils.createPodSetVolumes(podName, storage, false));
         volumeList.addAll(getNonDataVolumes(isOpenShift));
 
         return volumeList;
     }
 
-    /* test */ List<PersistentVolumeClaim> getVolumeClaims() {
-        return VolumeUtils.getDataPersistentVolumeClaims(storage);
+    /**
+     * Creates a list of Persistent Volume Claim templates for use in StatefulSets
+     *
+     * @return  List of Persistent Volume Claim Templates
+     */
+    /* test */ List<PersistentVolumeClaim> getPersistentVolumeClaimTemplates() {
+        return VolumeUtils.createPersistentVolumeClaimTemplates(storage, false);
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        List<VolumeMount> volumeMountList = new ArrayList<>(VolumeUtils.getDataVolumeMountPaths(storage, mountPath));
+        List<VolumeMount> volumeMountList = new ArrayList<>();
 
+        volumeMountList.addAll(VolumeUtils.createVolumeMounts(storage, mountPath, false));
         volumeMountList.add(createTempDirVolumeMount());
         volumeMountList.add(VolumeUtils.createVolumeMount(CLUSTER_CA_CERTS_VOLUME, CLUSTER_CA_CERTS_VOLUME_MOUNT));
         volumeMountList.add(VolumeUtils.createVolumeMount(BROKER_CERTS_VOLUME, BROKER_CERTS_VOLUME_MOUNT));
@@ -2056,7 +2039,7 @@ public class KafkaCluster extends AbstractModel {
                 .withBrokerId()
                 .withRackId(rack)
                 .withZookeeper(cluster)
-                .withLogDirs(VolumeUtils.getDataVolumeMountPaths(storage, mountPath))
+                .withLogDirs(VolumeUtils.createVolumeMounts(storage, mountPath, false))
                 .withListeners(cluster, namespace, listeners, controlPlaneListener)
                 .withAuthorization(cluster, authorization)
                 .withCruiseControl(cluster, cruiseControlSpec, ccNumPartitions, ccReplicationFactor, ccMinInSyncReplicas)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -7,12 +7,20 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
+import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
+import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -20,6 +28,7 @@ import io.strimzi.test.TestUtils;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -212,4 +221,110 @@ public class AbstractModelTest {
         assertThat(am.determineImagePullPolicy(null, "docker.io/repo/image:latest-kafka-2.7.0"), is(ImagePullPolicy.ALWAYS.toString()));
     }
 
+    @ParallelTest
+    public void testCreatePersistentVolumeClaims()    {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName("my-cluster")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withListeners(new GenericKafkaListenerBuilder().withName("plain").withPort(9092).withTls(false).withType(KafkaListenerType.INTERNAL).build())
+                        .withReplicas(2)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, KafkaVersionTestUtils.getKafkaVersionLookup());
+
+        // JBOD Storage
+        Storage storage = new JbodStorageBuilder().withVolumes(
+                        new PersistentClaimStorageBuilder()
+                                .withDeleteClaim(false)
+                                .withId(0)
+                                .withSize("20Gi")
+                                .build(),
+                        new PersistentClaimStorageBuilder()
+                                .withDeleteClaim(true)
+                                .withId(1)
+                                .withSize("10Gi")
+                                .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims(storage);
+
+        assertThat(pvcs.size(), is(4));
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(1).getMetadata().getName(), is("data-0-my-cluster-kafka-1"));
+        assertThat(pvcs.get(2).getMetadata().getName(), is("data-1-my-cluster-kafka-0"));
+        assertThat(pvcs.get(3).getMetadata().getName(), is("data-1-my-cluster-kafka-1"));
+
+        // JBOD with Ephemeral storage
+        storage = new JbodStorageBuilder().withVolumes(
+                        new PersistentClaimStorageBuilder()
+                                .withDeleteClaim(false)
+                                .withId(0)
+                                .withSize("20Gi")
+                                .build(),
+                        new EphemeralStorageBuilder()
+                                .withId(1)
+                                .build())
+                .build();
+
+        pvcs = kc.generatePersistentVolumeClaims(storage);
+
+        assertThat(pvcs.size(), is(2));
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(1).getMetadata().getName(), is("data-0-my-cluster-kafka-1"));
+
+        // Persistent Claim storage
+        storage = new PersistentClaimStorageBuilder()
+                .withDeleteClaim(false)
+                .withSize("20Gi")
+                .build();
+
+        pvcs = kc.generatePersistentVolumeClaims(storage);
+
+        assertThat(pvcs.size(), is(2));
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-my-cluster-kafka-0"));
+        assertThat(pvcs.get(1).getMetadata().getName(), is("data-my-cluster-kafka-1"));
+
+        // Persistent Claim with ID storage
+        storage = new PersistentClaimStorageBuilder()
+                .withDeleteClaim(false)
+                .withId(0)
+                .withSize("20Gi")
+                .build();
+
+        pvcs = kc.generatePersistentVolumeClaims(storage);
+
+        assertThat(pvcs.size(), is(2));
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-my-cluster-kafka-0"));
+        assertThat(pvcs.get(1).getMetadata().getName(), is("data-my-cluster-kafka-1"));
+
+        // Ephemeral Storage
+        storage = new EphemeralStorageBuilder().build();
+
+        pvcs = kc.generatePersistentVolumeClaims(storage);
+
+        assertThat(pvcs.size(), is(0));
+
+        // JBOD Storage without ID
+        final Storage finalStorage = new JbodStorageBuilder().withVolumes(
+                        new PersistentClaimStorageBuilder()
+                                .withDeleteClaim(false)
+                                .withSize("20Gi")
+                                .build())
+                .build();
+
+        InvalidResourceException ex = Assertions.assertThrows(
+                InvalidResourceException.class,
+                () -> kc.generatePersistentVolumeClaims(finalStorage)
+        );
+
+        assertThat(ex.getMessage(), is("The 'id' property is required for volumes in JBOD storage."));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -340,7 +340,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
-                .withLogDirs(VolumeUtils.getDataVolumeMountPaths(storage, "/var/lib/kafka"))
+                .withLogDirs(VolumeUtils.createVolumeMounts(storage, "/var/lib/kafka", false))
                 .build();
 
         assertThat(configuration, isEquivalent("log.dirs=/var/lib/kafka/data/kafka-log${STRIMZI_BROKER_ID}"));
@@ -355,7 +355,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
-                .withLogDirs(VolumeUtils.getDataVolumeMountPaths(storage, "/var/lib/kafka"))
+                .withLogDirs(VolumeUtils.createVolumeMounts(storage, "/var/lib/kafka", false))
                 .build();
 
         assertThat(configuration, isEquivalent("log.dirs=/var/lib/kafka/data/kafka-log${STRIMZI_BROKER_ID}"));
@@ -387,7 +387,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
-                .withLogDirs(VolumeUtils.getDataVolumeMountPaths(storage, "/var/lib/kafka"))
+                .withLogDirs(VolumeUtils.createVolumeMounts(storage, "/var/lib/kafka", false))
                 .build();
 
         assertThat(configuration, isEquivalent("log.dirs=/var/lib/kafka/data-1/kafka-log${STRIMZI_BROKER_ID},/var/lib/kafka/data-2/kafka-log${STRIMZI_BROKER_ID},/var/lib/kafka/data-5/kafka-log${STRIMZI_BROKER_ID}"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -589,7 +589,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, assembly, VERSIONS);
 
-        List<PersistentVolumeClaim> pvcs = kc.getVolumeClaims();
+        List<PersistentVolumeClaim> pvcs = kc.getPersistentVolumeClaimTemplates();
 
         for (int i = 0; i < replicas; i++) {
             assertThat(pvcs.get(0).getMetadata().getName() + "-" + KafkaCluster.kafkaPodName(cluster, i),
@@ -609,7 +609,7 @@ public class KafkaClusterTest {
                 .build();
         kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, assembly, VERSIONS);
 
-        pvcs = kc.getVolumeClaims();
+        pvcs = kc.getPersistentVolumeClaimTemplates();
 
         for (int i = 0; i < replicas; i++) {
             int id = 0;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -431,7 +431,7 @@ public class ZookeeperClusterTest {
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ka, VERSIONS);
 
-        PersistentVolumeClaim pvc = zc.getVolumeClaims().get(0);
+        PersistentVolumeClaim pvc = zc.getPersistentVolumeClaimTemplates().get(0);
 
         for (int i = 0; i < replicas; i++) {
             assertThat(pvc.getMetadata().getName() + "-" + ZookeeperCluster.zookeeperPodName(cluster, i),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -156,7 +156,7 @@ public class JbodStorageTest {
                     for (SingleVolumeStorage volume : this.volumes) {
                         if (volume instanceof PersistentClaimStorage) {
 
-                            String expectedPvcName = VolumeUtils.getVolumePrefix(volume.getId()) + "-" + KafkaCluster.kafkaPodName(NAME, podId);
+                            String expectedPvcName = VolumeUtils.createVolumePrefix(volume.getId(), true) + "-" + KafkaCluster.kafkaPodName(NAME, podId);
                             List<PersistentVolumeClaim> matchingPvcs = pvcs.stream()
                                     .filter(pvc -> pvc.getMetadata().getName().equals(expectedPvcName))
                                     .collect(Collectors.toList());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -544,7 +544,7 @@ public class KafkaAssemblyOperatorTest {
 
         Map<String, PersistentVolumeClaim> kafkaPvcs = createPvcs(kafkaNamespace, kafkaCluster.getStorage(), kafkaCluster.getReplicas(),
             (replica, storageId) -> {
-                String name = VolumeUtils.getVolumePrefix(storageId);
+                String name = VolumeUtils.createVolumePrefix(storageId, false);
                 return name + "-" + KafkaCluster.kafkaPodName(kafkaName, replica);
             });
 
@@ -918,12 +918,12 @@ public class KafkaAssemblyOperatorTest {
         Map<String, PersistentVolumeClaim> kafkaPvcs =
                 createPvcs(clusterNamespace, originalKafkaCluster.getStorage(), originalKafkaCluster.getReplicas(),
                     (replica, storageId) -> {
-                        String name = VolumeUtils.getVolumePrefix(storageId);
+                        String name = VolumeUtils.createVolumePrefix(storageId, false);
                         return name + "-" + KafkaCluster.kafkaPodName(clusterName, replica);
                     });
         kafkaPvcs.putAll(createPvcs(clusterNamespace, updatedKafkaCluster.getStorage(), updatedKafkaCluster.getReplicas(),
             (replica, storageId) -> {
-                String name = VolumeUtils.getVolumePrefix(storageId);
+                String name = VolumeUtils.createVolumePrefix(storageId, false);
                 return name + "-" + KafkaCluster.kafkaPodName(clusterName, replica);
             }));
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

While working on the StatefulSet removal, I noticed that some of the methods for working with storage in `KafkaCluster` and `ZooKeeperCluster` were to some extent duplicated. I moved these classes to a single place (most of it to `VolumeUtils`, with the exception of the `createPersistentVolumeClaims` method which is too much dependent on the `AbstractModel` class). These methods are now shared by both Kafka and ZooKeeper. I also centralized the check for the mandatory IDs for JBOD volumes so that it is done in one place only.

Additionally, I also:
* added better tests to cover all the different situations
* used more consistent method names
* added Javadoc to most of the methdos

This PR should make sure that most of the logic is in one place and has better test coverage.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally