### PR TITLE
docs: adds custom listener authentication doc

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationCustom.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.GenericSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -17,6 +18,7 @@ import java.util.Map;
 /**
  * Configures a listener to use custom authentication.
  */
+@DescriptionFile
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API

--- a/documentation/api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc
@@ -46,9 +46,7 @@ Secrets are mounted to `/opt/kafka/custom-authn-secrets/custom-listener-_<listen
 For example, the mounted secret (`example`) in the example configuration would be located at `/opt/kafka/custom-authn-secrets/custom-listener-oauth-bespoke-9093/example`.
 
 === Principal builder
-Kafka's principal builder supports authentication.
-You can implement a custom authentication principal builder in the Kafka cluster configuration.
-
+You can set a custom principal builder in the Kafka cluster configuration.
 However, the principal builder is subject to the following requirements:
 
 * The specified principal builder class must exist on the image.

--- a/documentation/api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc
@@ -17,7 +17,7 @@ spec:
         authentication:
           type: custom
           sasl: true
-          listener-config:
+          listenerConfig:
             oauthbearer.sasl.client.callback.handler.class: client.class
             oauthbearer.sasl.server.callback.handler.class: server.class
             oauthbearer.sasl.login.callback.handler.class: login.class
@@ -29,41 +29,43 @@ spec:
             - name: example
 ----
 
-.Protocol map
-A protocol map is generated that uses the above `sasl` and `tls` fields to determine which protocol to map to the listener.
+A protocol map is generated that uses the `sasl` and `tls` values to determine which protocol to map to the listener.
 
 * SASL = True, TLS = True -> SASL_SSL
 * SASL = False, TLS = True -> SSL
 * SASL = True, TLS = False -> SASL_PLAINTEXT
 * SASL = False, TLS = False -> PLAINTEXT
 
-.`listener-config`
-All configuration listed under `listener-config` is prefixed with `listener.name._<listener_name>-<port>_`.
+=== `listenerConfig`
+Listener configuration specified using `listenerConfig` is prefixed with `listener.name._<listener_name>-<port>_`.
 For example, `sasl.enabled.mechanisms` becomes `listener.name._<listener_name>-<port>_.sasl.enabled.mechanisms`.
 
-.Secrets
-`Secrets` are mounted to `/opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_` in the Kafka broker nodes' containers.
+=== `secrets`
+Secrets are mounted to `/opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_` in the Kafka broker nodes' containers.
 
-For example, the mounted secret (`example`) in the example configuration would be located at `/opt/kafka/custom-authn-secrets/custom-oauth-bespoke-9093/example`.
+For example, the mounted secret (`example`) in the example configuration would be located at `/opt/kafka/custom-authn-secrets/custom-listener-oauth-bespoke-9093/example`.
 
-.Principal
-You can set a custom principal builder in the Kafka cluster config.
+=== Principal builder
+Kafka's principal builder supports authentication.
+You can implement a custom authentication principal builder in the Kafka cluster configuration.
 
 However, the principal builder is subject to the following requirements:
 
-. The specified principal builder class must exist on the image.
-If you're using the open source Strimzi images, you'll need to rebuild one with the required classes.
-TIP: _Before_ building your own, check if one already exists.
-. No other listener is using `oauth` type authentication.
+* The specified principal builder class must exist on the image.
+_Before_ building your own, check if one already exists.
+You'll need to rebuild the Strimzi images with the required classes.
+* No other listener is using `oauth` type authentication.
 This is because an OAuth listener appends its own principle builder to the Kafka configuration.
-. The specified principal builder is compatible with Strimzi.
+* The specified principal builder is compatible with Strimzi.
 
 Custom principal builders must support peer certificates for authentication, as Strimzi uses these to manage the Kafka cluster.
+
 ifdef::Downloading[]
 A custom OAuth principal builder might be identical or very similar to the Strimzi https://github.com/strimzi/strimzi-kafka-oauth/blob/main/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipalBuilder.java[OAuth principal builder].
 endif::Downloading[]
-NOTE: https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java#L73-L79[Kafka's default principal builder class] supports the building of principals based on the names of peer certificates.
-The custom principal builder should provide a principal of type "user" using the name of the SSL peer certificate.
+
+NOTE: link:https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java#L73-L79[Kafka's default principal builder class] supports the building of principals based on the names of peer certificates.
+The custom principal builder should provide a principal of type `user` using the name of the SSL peer certificate.
 
 The following example shows a custom principal builder that satisfies the OAuth requirements of Strimzi.
 
@@ -80,7 +82,7 @@ public final class CustomKafkaPrincipalBuilder implements KafkaPrincipalBuilder 
             SSLSession sslSession = ((SslAuthenticationContext) context).session();
             try {
                 return new KafkaPrincipal(
-                        KafkaPrincipal.USER_TYPE, sslSession.getPeerPrincipal().getName());
+                    KafkaPrincipal.USER_TYPE, sslSession.getPeerPrincipal().getName());
             } catch (SSLPeerUnverifiedException e) {
                 throw new IllegalArgumentException("Cannot use an unverified peer for authentication", e);
             }

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -251,7 +251,7 @@ Authentication for the listener can be specified as:
 * Mutual TLS (`tls`)
 * SCRAM-SHA-512 (`scram-sha-512`)
 * Token-based OAuth 2.0 (`oauth`)
-* xref:io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc[Custom (`custom`)]
+* xref:type-KafkaListenerAuthenticationCustom-reference[Custom (`custom`)]
 
 [id='configuration-listener-network-policy-{context}']
 === `networkPolicyPeers`

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -272,6 +272,13 @@ Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizatio
 
 Used in: xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`]
 
+xref:type-KafkaListenerAuthenticationCustom-schema-{context}[Full list of `KafkaListenerAuthenticationCustom` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc[leveloffset=+1]
+
+[id='type-KafkaListenerAuthenticationCustom-schema-{context}']
+==== `KafkaListenerAuthenticationCustom` schema properties
+
 
 The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationCustom` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`].
 It must have the value `custom` for the type `KafkaListenerAuthenticationCustom`.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
- Adds the custom listener doc to the _Configuring_ guide.
- Adds the annotation to build it.
- Updates the `listener-config` property name to `listenerConfig`
- Fixes reference to the custom listener authentication doc

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

