### PR TITLE
Removed unused Ca method

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -113,13 +113,6 @@ public abstract class Ca {
         return caCert;
     }
 
-    protected static Secret forceReplacement(Secret caCert, Secret caKey, String key) {
-        if (caCert != null && caKey != null && caKey.getData() != null && caKey.getData().containsKey(key)) {
-            caKey = new SecretBuilder(caKey).editMetadata().addToAnnotations(ANNO_STRIMZI_IO_FORCE_REPLACE, "true").endMetadata().build();
-        }
-        return caKey;
-    }
-
     enum RenewalType {
         NOOP() {
             @Override


### PR DESCRIPTION
This trivial PR just removes an unused `forceReplacement` method from the `Ca` class.