### PR TITLE
Update operators to use Kafka 3.1.0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -194,7 +194,7 @@ class KafkaAvailability {
 
     protected Future<Collection<TopicDescription>> describeTopics(Set<String> names) {
         Promise<Collection<TopicDescription>> descPromise = Promise.promise();
-        ac.describeTopics(names).all()
+        ac.describeTopics(names).allTopicNames()
                 .whenComplete((tds, error) -> {
                     if (error != null) {
                         descPromise.fail(error);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -110,6 +110,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -609,7 +610,7 @@ public class ResourceUtils {
                 } catch (ReflectiveOperationException e) {
                     throw new RuntimeException(e);
                 }
-                when(mock.describeTopics(any())).thenReturn(dtr);
+                when(mock.describeTopics(any(Collection.class))).thenReturn(dtr);
 
                 DescribeConfigsResult dcfr;
                 try {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailabilityTest.java
@@ -187,7 +187,7 @@ public class KafkaAvailabilityTest {
         }
 
         void mockDescribeTopics(Admin mockAc) {
-            when(mockAc.describeTopics(any())).thenAnswer(invocation -> {
+            when(mockAc.describeTopics(any(Collection.class))).thenAnswer(invocation -> {
                 DescribeTopicsResult dtr = mock(DescribeTopicsResult.class);
                 Collection<String> topicNames = invocation.getArgument(0);
                 Throwable throwable = null;
@@ -198,7 +198,7 @@ public class KafkaAvailabilityTest {
                     }
                 }
                 if (throwable != null) {
-                    when(dtr.all()).thenReturn(failedFuture(throwable));
+                    when(dtr.allTopicNames()).thenReturn(failedFuture(throwable));
                 } else {
                     Map<String, TopicDescription> tds = topics.entrySet().stream().collect(Collectors.toMap(
                         e -> e.getKey(),
@@ -214,8 +214,8 @@ public class KafkaAvailabilityTest {
                                     }).collect(Collectors.toList()));
                         }
                     ));
-                    when(dtr.all()).thenReturn(KafkaFuture.completedFuture(tds));
-                    when(dtr.values()).thenThrow(notImplemented());
+                    when(dtr.allTopicNames()).thenReturn(KafkaFuture.completedFuture(tds));
+                    when(dtr.topicNameValues()).thenThrow(notImplemented());
                 }
                 return dtr;
             });

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <fasterxml.jackson-databind.version>2.11.3</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.10.5</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.11.3</fasterxml.jackson-annotations.version>
-        <kafka.version>3.0.0</kafka.version>
+        <kafka.version>3.1.0</kafka.version>
         <!-- keep in-sync with dataformat-yaml -->
         <json-path.version>4.1.1</json-path.version>
         <zkclient.version>0.11</zkclient.version>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaImpl.java
@@ -110,7 +110,7 @@ public class KafkaImpl implements Kafka {
         return topicExists(reconciliation, topicName).compose(exists -> {
             if (exists) {
                 Future<TopicDescription> topicDescriptionFuture = mapFuture(adminClient.describeTopics(
-                        singleton(topicName.toString())).values().get(topicName.toString()));
+                        singleton(topicName.toString())).topicNameValues().get(topicName.toString()));
                 Future<Config> configFuture = mapFuture(adminClient.describeConfigs(
                         singleton(resource)).values().get(resource));
                 return CompositeFuture.all(topicDescriptionFuture, configFuture)

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreService.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreService.java
@@ -143,7 +143,7 @@ public class KafkaStreamsTopicStoreService {
     private CompletionStage<Void> validateExistingStoreTopic(String storeTopic, Admin admin, Context c) {
         LOGGER.info("Validating existing store topic: {}", storeTopic);
         ConfigResource storeTopicConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, storeTopic);
-        return toCS(admin.describeTopics(Collections.singleton(storeTopic)).values().get(storeTopic))
+        return toCS(admin.describeTopics(Collections.singleton(storeTopic)).topicNameValues().get(storeTopic))
             .thenApply(td -> c.setRf(td.partitions().stream().map(tp -> tp.replicas().size()).min(Integer::compare).orElseThrow()))
             .thenCompose(c2 -> toCS(admin.describeConfigs(Collections.singleton(storeTopicConfigResource)).values().get(storeTopicConfigResource))
                     .thenApply(cr -> c2.setMinISR(parseInt(cr.get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value()))))

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaImplTest.java
@@ -123,7 +123,7 @@ public class KafkaImplTest {
 
     private void mockDescribeTopics(Admin admin, Map<String, Either<TopicDescription, Exception>> result) {
         DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
-        when(describeTopicsResult.values()).thenReturn(result.entrySet().stream().collect(toMap(
+        when(describeTopicsResult.topicNameValues()).thenReturn(result.entrySet().stream().collect(toMap(
             Map.Entry::getKey,
             entry1 -> {
                 KafkaFutureImpl<TopicDescription> kafkaFuture1 = new KafkaFutureImpl<>();
@@ -138,9 +138,9 @@ public class KafkaImplTest {
         if (first.isPresent()) {
             KafkaFutureImpl<Map<String, TopicDescription>> kafkaFuture = new KafkaFutureImpl<>();
             kafkaFuture.completeExceptionally(first.get().right());
-            when(describeTopicsResult.all()).thenReturn(kafkaFuture);
+            when(describeTopicsResult.allTopicNames()).thenReturn(kafkaFuture);
         } else {
-            when(describeTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(
+            when(describeTopicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(
                 result.entrySet().stream().collect(toMap(
                     Map.Entry::getKey,
                     entry -> entry.getValue().left()))


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

#6121 added support for running Kafka 3.1.0 as operand. This PR updates also the Kafka version used in Strimzi operators. The code changes related to this are related to deprecated methods which are replaced with the new alternatives and related mocking changes. It also updates the `describeTopics(...)` mock since there is now another method with this name and a single parameter the mock was not able to resolve which method was being mocked.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally