### PR TITLE
Get rid of the useless warning messages about deprecated `type` field in listener status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -40,9 +39,8 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private List<String> certificates;
     private Map<String, Object> additionalProperties;
 
-    @Description("The name of the listener.")
-    @DeprecatedProperty(movedToPath = "name")
-    @Deprecated
+    @Description("*The `type` property has been deprecated, and should now be configured using `name`.* " +
+            "The name of the listener.")
     public String getType() {
         return name;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -391,7 +391,7 @@ public class KafkaStatusTest {
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(Integer.valueOf(9092)));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
 
-            assertThat(status.getConditions().size(), is(2));
+            assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("NotReady"));
             assertThat(status.getConditions().get(0).getStatus(), is("True"));
             assertThat(status.getConditions().get(0).getReason(), is("RuntimeException"));

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5956,7 +5956,7 @@ spec:
                     properties:
                       type:
                         type: string
-                        description: The name of the listener.
+                        description: '*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener.'
                       name:
                         type: string
                         description: The name of the listener.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6975,7 +6975,8 @@ spec:
                   properties:
                     type:
                       type: string
-                      description: The name of the listener.
+                      description: '*The `type` property has been deprecated, and
+                        should now be configured using `name`.* The name of the listener.'
                     name:
                       type: string
                       description: The name of the listener.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#5957 deprecated the `type` field in the listeenr status in the `Kafka` custom resurce. However, this triggers ton of annoying warning messages in the operator log which are printed every reconciliation:

```
2022-01-27 00:04:26 WARN  AbstractOperator:94 - Reconciliation #85(watch) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type has been deprecated, and should now be configured using name.
2022-01-27 00:04:26 WARN  AbstractOperator:94 - Reconciliation #85(watch) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type has been deprecated, and should now be configured using name.
2022-01-27 00:04:26 WARN  AbstractOperator:94 - Reconciliation #85(watch) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type has been deprecated, and should now be configured using name.
2022-01-27 00:04:26 WARN  AbstractOperator:94 - Reconciliation #85(watch) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type has been deprecated, and should now be configured using name.
2022-01-27 00:04:26 WARN  AbstractOperator:94 - Reconciliation #85(watch) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type has been deprecated, and should now be configured using name.
2022-01-27 00:04:26 WARN  AbstractOperator:94 - Reconciliation #85(watch) Kafka(myproject/my-cluster): In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type has been deprecated, and should now be configured using name.
```

It also adds this to the `Kafka` CR status:

```
    - lastTransitionTime: "2022-01-26T23:02:49.637711Z"
      message: In API version kafka.strimzi.io/v1beta2 the type property at path status.listeners.type
        has been deprecated, and should now be configured using name.
      reason: DeprecatedFields
      status: "True"
      type: Warning
```

We should not use the deprecation annotation on this field. These messages are useless because the user:
a) Doesn't use the API, Strimzi does
b) Cannot do anything abotu this anyway

This Pr updeprecated the field from the Java perspective which removes this messages. This field is not deprecated only in text in the documentation.

This approach was used fro similar fields already in the past.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally