### PR TITLE
[systemtest] Fix NPEs when running STs with CO installed with Helm

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -142,7 +142,6 @@ public class SetupClusterOperator {
         if (this.clusterOperatorRBACType == null) {
             this.clusterOperatorRBACType = ClusterOperatorRBACType.CLUSTER;
         }
-        instanceHolder = this;
     }
 
     /**
@@ -232,6 +231,7 @@ public class SetupClusterOperator {
                 cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
                 extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
             }
+
             helmResource.create(extensionContext, operationTimeout, reconciliationInterval);
         } else {
             bundleInstallation();
@@ -385,6 +385,11 @@ public class SetupClusterOperator {
         }
 
         public SetupClusterOperator createInstallation() {
+            instanceHolder = new SetupClusterOperator(this);
+            return instanceHolder;
+        }
+
+        public SetupClusterOperator buildInstallation() {
             return new SetupClusterOperator(this);
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -66,9 +66,9 @@ public class SetupClusterOperator {
 
     private static SetupClusterOperator instanceHolder;
 
-    private KubeClusterResource cluster = KubeClusterResource.getInstance();
-    private HelmResource helmResource;
-    private OlmResource olmResource;
+    private static KubeClusterResource cluster = KubeClusterResource.getInstance();
+    private static HelmResource helmResource;
+    private static OlmResource olmResource;
 
     private ExtensionContext extensionContext;
     private String clusterOperatorName;
@@ -142,6 +142,7 @@ public class SetupClusterOperator {
         if (this.clusterOperatorRBACType == null) {
             this.clusterOperatorRBACType = ClusterOperatorRBACType.CLUSTER;
         }
+        instanceHolder = this;
     }
 
     /**
@@ -231,7 +232,6 @@ public class SetupClusterOperator {
                 cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
                 extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
             }
-
             helmResource.create(extensionContext, operationTimeout, reconciliationInterval);
         } else {
             bundleInstallation();
@@ -385,11 +385,6 @@ public class SetupClusterOperator {
         }
 
         public SetupClusterOperator createInstallation() {
-            instanceHolder = new SetupClusterOperator(this);
-            return instanceHolder;
-        }
-
-        public SetupClusterOperator buildInstallation() {
             return new SetupClusterOperator(this);
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -549,7 +549,7 @@ public abstract class AbstractST implements TestSeparator {
         // 2nd case = transition from if previous suite is @IsolatedSuite and now @ParallelSuite is running we must do
         // additional check that configuration is in default
         if (clusterOperator != null &&
-            !clusterOperator.defaultInstallation().createInstallation().equals(clusterOperator) &&
+            !clusterOperator.defaultInstallation().buildInstallation().equals(clusterOperator) &&
             !ExecutionListener.isNextSuiteIsolated(extensionContext) &&
             !ExecutionListener.isLastSuite(extensionContext)) {
             // install configuration differs from default one we are gonna roll-back

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -549,7 +549,7 @@ public abstract class AbstractST implements TestSeparator {
         // 2nd case = transition from if previous suite is @IsolatedSuite and now @ParallelSuite is running we must do
         // additional check that configuration is in default
         if (clusterOperator != null &&
-            !clusterOperator.defaultInstallation().buildInstallation().equals(clusterOperator) &&
+            !clusterOperator.defaultInstallation().createInstallation().equals(clusterOperator) &&
             !ExecutionListener.isNextSuiteIsolated(extensionContext) &&
             !ExecutionListener.isLastSuite(extensionContext)) {
             // install configuration differs from default one we are gonna roll-back


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Currently on every execution of `createInstallation()` method inside the `SetupClusterOperatorBuilder` we are completely changing the `instanceHolder`, but without adding `helmResource` and `olmResource`.  In cases, where we are checking equality of default installation and current installation, invocation of new instance rewrites both of the resource variables to null (because they are instance members and not set by the builder in the SetupClusterOperator class), which leads to NPE inside the unInstall() method call..

This PR changes the fields to be `static`, so they will not be overrided and will only change on CO installation.

### Checklist

- [x] Make sure all tests pass
