### PR TITLE
Use `PodSetUtils` in more places

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodSetUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodSetUtils.java
@@ -4,11 +4,14 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Shared methods for working with StrimziPodSet resources
@@ -29,6 +32,30 @@ public class PodSetUtils {
     }
 
     /**
+     * Converts Pod to String
+     *
+     * @param pod   Pod which should be converted
+     *
+     * @throws JsonProcessingException  Throws JsonProcessingException when the conversion to String fails
+     *
+     * @return      String with the Pod definition
+     */
+    public static String podToString(Pod pod) throws JsonProcessingException {
+        return MAPPER.writeValueAsString(pod);
+    }
+
+    /**
+     * Converts List of Pods to List of Maps which can be used in StrimziPodSets
+     *
+     * @param pods  List of Pods which should be converted
+     *
+     * @return      List of Maps with the Pod structures
+     */
+    public static List<Map<String, Object>> podsToMaps(List<Pod> pods)  {
+        return pods.stream().map(p -> podToMap(p)).collect(Collectors.toList());
+    }
+
+    /**
      * Converts Map to Pod for decoding of StrimziPodSets
      *
      * @param map   Pod represented as Map which should be decoded
@@ -37,5 +64,16 @@ public class PodSetUtils {
      */
     public static Pod mapToPod(Map<String, Object> map) {
         return MAPPER.convertValue(map, Pod.class);
+    }
+
+    /**
+     * Converts List of Maps to List of Pods which can be used in StrimziPodSets
+     *
+     * @param maps  List of Maps which should be converted
+     *
+     * @return      List of Maps with the Pod structures
+     */
+    public static List<Pod> mapsToPods(List<Map<String, Object>> maps)  {
+        return maps.stream().map(m -> mapToPod(m)).collect(Collectors.toList());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -23,6 +22,7 @@ import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.status.StrimziPodSetStatus;
 import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
 import io.strimzi.operator.common.Reconciliation;
@@ -48,8 +48,6 @@ import java.util.stream.Collectors;
  */
 public class StrimziPodSetController implements Runnable {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StrimziPodSetController.class);
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private Thread controllerThread;
 
@@ -244,7 +242,7 @@ public class StrimziPodSetController implements Runnable {
                 podCounter.pods = podSet.getSpec().getPods().size();
 
                 for (Map<String, Object> desiredPod : podSet.getSpec().getPods()) {
-                    Pod pod = MAPPER.convertValue(desiredPod, Pod.class);
+                    Pod pod = PodSetUtils.mapToPod(desiredPod);
                     desiredPods.add(pod.getMetadata().getName());
 
                     maybeCreateOrPatchPod(reconciliation, pod, ModelUtils.createOwnerReference(podSet), podCounter);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -42,7 +41,6 @@ import io.strimzi.test.annotations.ParallelTest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -59,7 +57,6 @@ import static org.hamcrest.Matchers.hasProperty;
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 @ParallelSuite
 public class KafkaPodSetTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER = "my-cluster";
@@ -148,7 +145,7 @@ public class KafkaPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(kc.getLabelsWithStrimziNameAndPodName(kc.getName(), pod.getMetadata().getName(), null).withStatefulSetPod(pod.getMetadata().getName()).withStrimziPodSetController(kc.getName()).toMap().entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().size(), is(5));
@@ -339,7 +336,7 @@ public class KafkaPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(podAnnos.entrySet()), is(true));
@@ -417,7 +414,7 @@ public class KafkaPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, null, secrets, Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(2));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(true));
@@ -447,7 +444,7 @@ public class KafkaPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, null, List.of(secret1), Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(1));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(false));
@@ -463,7 +460,7 @@ public class KafkaPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, ImagePullPolicy.ALWAYS, null, Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
         }
@@ -472,7 +469,7 @@ public class KafkaPodSetTest {
         ps = kc.generatePodSet(3, true, ImagePullPolicy.IFNOTPRESENT, null, Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -40,7 +39,6 @@ import io.strimzi.test.annotations.ParallelTest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -57,7 +55,6 @@ import static org.hamcrest.Matchers.hasProperty;
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 @ParallelSuite
 public class ZookeeperPodSetTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER = "my-cluster";
@@ -139,7 +136,7 @@ public class ZookeeperPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(zc.getLabelsWithStrimziNameAndPodName(zc.getName(), pod.getMetadata().getName(), null).withStatefulSetPod(pod.getMetadata().getName()).withStrimziPodSetController(zc.getName()).toMap().entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().size(), is(1));
@@ -327,7 +324,7 @@ public class ZookeeperPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(podAnnos.entrySet()), is(true));
@@ -406,7 +403,7 @@ public class ZookeeperPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, null, secrets, Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(2));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(true));
@@ -436,7 +433,7 @@ public class ZookeeperPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, null, List.of(secret1), Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(1));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(false));
@@ -452,7 +449,7 @@ public class ZookeeperPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, ImagePullPolicy.ALWAYS, null, Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
         }
@@ -461,7 +458,7 @@ public class ZookeeperPodSetTest {
         ps = zc.generatePodSet(3, true, ImagePullPolicy.IFNOTPRESENT, null, Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        pods = ps.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).collect(Collectors.toList());
+        pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -22,6 +21,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
@@ -59,7 +59,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaAssemblyOperatorPodSetTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.V1_18;
     private static final MockCertManager CERT_MANAGER = new MockCertManager();
@@ -555,7 +554,7 @@ public class KafkaAssemblyOperatorPodSetTest {
 
     // Internal utility methods
     private Pod podFromPodSet(StrimziPodSet podSet, String name) {
-        return podSet.getSpec().getPods().stream().map(p -> MAPPER.convertValue(p, Pod.class)).filter(p -> name.equals(p.getMetadata().getName())).findFirst().orElse(null);
+        return PodSetUtils.mapsToPods(podSet.getSpec().getPods()).stream().filter(p -> name.equals(p.getMetadata().getName())).findFirst().orElse(null);
     }
 
     class MockKafkaAssemblyOperator extends KafkaAssemblyOperator  {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -24,6 +22,7 @@ import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -45,7 +44,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -58,8 +56,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @ExtendWith(VertxExtension.class)
 public class StrimziPodSetControllerIT {
     private static final Logger LOGGER = LogManager.getLogger(StrimziPodSetControllerIT.class);
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, Object>> POD_TYPE = new TypeReference<>() { };
     private static final String NAMESPACE = "strimzi-pod-set-controller-test";
     private static final String KAFKA_NAME = "foo";
     private static final Map<String, String> MATCHING_LABELS = Map.of("selector", "matching");
@@ -180,7 +176,7 @@ public class StrimziPodSetControllerIT {
                     .endMetadata()
                     .withNewSpec()
                         .withSelector(new LabelSelector(null, Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, kafkaName)))
-                        .withPods(Arrays.stream(pods).map(p -> MAPPER.convertValue(p, POD_TYPE)).collect(Collectors.toList()))
+                        .withPods(PodSetUtils.podsToMaps(Arrays.asList(pods)))
                     .endSpec()
                     .build();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/PodRevisionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/PodRevisionTest.java
@@ -4,14 +4,13 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
+import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -19,7 +18,6 @@ import io.strimzi.test.annotations.ParallelTest;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -27,8 +25,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ParallelSuite
 public class PodRevisionTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, Object>> POD_TYPE = new TypeReference<>() { };
     private static final Pod POD = new PodBuilder()
                 .withNewMetadata()
                     .withName("my-pod")
@@ -135,7 +131,7 @@ public class PodRevisionTest {
                 .endMetadata()
                 .withNewSpec()
                     .withSelector(new LabelSelector(null, Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, "my-kafka")))
-                    .withPods(Arrays.stream(pods).map(p -> MAPPER.convertValue(p, POD_TYPE)).collect(Collectors.toList()))
+                    .withPods(PodSetUtils.podsToMaps(Arrays.asList(pods)))
                 .endSpec()
                 .build();
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

In #6186 we intruduced new class `PodSetUtils` with some helper methods for working with Pod Sets. For example methods for decoding Maps into Pods or the other way around. To simplify the review, #6186 did not used `PodSetUtils` in any previously existing classes. This PR tries to rectify it and update other classes to use `PodSetUtils` as well. This should help to have all these methods in central place and also reduce the amount of ObjectMappers we have defined in different classes.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally