### PR TITLE
Add connector context to the default logging configuration in Kafka Connect and Kafka Mirror Maker 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.28.0
 
 * Add support for Kafka 3.1.0; remove Kafka 2.8.0 and 2.8.1
-* Update Open Policy Agent authorizer to 1.4.0 and add support for enabling metrics 
+* Update Open Policy Agent authorizer to 1.4.0 and add support for enabling metrics
+* Add connector context to the default logging configuration in Kafka Connect and Kafka Mirror Maker 2
 * Added the option `createBootstrapService` in the Kafka Spec to disable the creation of the bootstrap service for the Load Balancer Type Listener. It will save the cost of one load balancer resource, specially in the public cloud.
 * Add support for disabling the FIPS mode in OpenJDK
 * Fix renewing your own CA certificates [#5466](https://github.com/strimzi/strimzi-kafka-operator/issues/5466)

--- a/cluster-operator/src/main/resources/kafkaConnectDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaConnectDefaultLoggingProperties
@@ -1,6 +1,6 @@
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
 connect.root.logger.level=INFO
 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 log4j.logger.org.apache.zookeeper=ERROR

--- a/cluster-operator/src/main/resources/kafkaMirrorMaker2DefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/kafkaMirrorMaker2DefaultLoggingProperties
@@ -1,6 +1,6 @@
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
 connect.root.logger.level=INFO
 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 log4j.logger.org.apache.zookeeper=ERROR

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -727,7 +727,7 @@ class LoggingChangeST extends AbstractST {
         String log4jConfig =
                 "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
                         "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-                        "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                        "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n\n" +
                         "log4j.rootLogger=OFF, CONSOLE\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
                         "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
@@ -1143,7 +1143,7 @@ class LoggingChangeST extends AbstractST {
         String log4jConfig =
                 "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
                         "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
-                        "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
+                        "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n\n" +
                         "log4j.rootLogger=OFF, CONSOLE\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
                         "log4j.logger.org.I0Itec.zkclient=ERROR\n" +


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In Kafka 3.0.0 ([KIP-721](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177047379)), Kafka added the connector context to the default logging pattern for Kafka Connect. 

This adds information about the connector to which the log message belongs. In some cases, this provides duplicate info with the thread name or the consumer / producer information included in the log messages already. But it looks like something useful in general and this PR follows Apache Kafka default logging configuration and adds the connector context to our default logging configuration for Kafka Connect and for Mirror Maker 2 (which in our cases is deployed as connectors on top of Kafka Connect).

If needed, users can use the external logging configuration to customize the pattern independently on this change.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md