### PR TITLE
docs: adds the custom option to the listener authn

### DIFF
--- a/documentation/modules/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/con-securing-kafka-authentication.adoc
@@ -5,8 +5,8 @@
 [id='con-securing-kafka-authentication-{context}']
 = Listener authentication
 
+[role="_abstract"]
 For clients inside the Kubernetes cluster, you can create `plain` (without encryption) or `tls` _internal_ listeners.
-
 For clients outside the Kubernetes cluster, you create _external_ listeners and specify a connection mechanism,
 which can be `nodeport`, `loadbalancer`, `ingress` or `route` (on OpenShift).
 
@@ -16,9 +16,12 @@ Supported authentication options:
 
 . Mutual TLS authentication (only on the listeners with TLS enabled encryption)
 . SCRAM-SHA-512 authentication
-. xref:assembly-oauth-authentication_str[OAuth 2.0 token based authentication]
+. xref:assembly-oauth-authentication_str[OAuth 2.0 token-based authentication]
+. xref:type-KafkaListenerAuthenticationCustom-reference[Custom authentication]
 
 The authentication option you choose depends on how you wish to authenticate client access to Kafka brokers.
+
+NOTE: Try exploring the standard authentication options before using custom authentication. Custom authentication allows for any type of kafka-supported authentication. It can provide more flexibility, but also adds complexity.
 
 .Kafka listener authentication options
 image::listener-config-options.png[options for listener authentication configuration]

--- a/documentation/modules/overview/con-security-configuration-authentication.adoc
+++ b/documentation/modules/overview/con-security-configuration-authentication.adoc
@@ -11,9 +11,12 @@ Supported authentication mechanisms:
 * Mutual TLS client authentication (on listeners with TLS enabled encryption)
 * SASL SCRAM-SHA-512
 * OAuth 2.0 token based authentication
+* Custom authentication
 
 The User Operator manages user credentials for TLS and SCRAM authentication, but not OAuth 2.0.
 For example, through the User Operator you can create a user representing a client that requires access to the Kafka cluster, and specify TLS as the authentication type.
 
 Using OAuth 2.0 token-based authentication, application clients can access Kafka brokers without exposing account credentials.
 An authorization server handles the granting of access and inquiries about access.
+
+Custom authentication allows for any type of kafka-supported authentication. It can provide more flexibility, but also adds complexity.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Documentation

Adds `custom` option and link to the _Listener authentication_ section of the _Configuring_ guide
The diagram will be updated to reflect this change.

Authentication section of the _Overview_ also updated with `custom` option.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

