### PR TITLE
Update Config Providers and MM2 Extensions to new versions

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -20,9 +20,9 @@
         <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
-        <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
+        <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
+        <kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
@@ -35,6 +35,18 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>mm2-extensions-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1159</url>
+        </repository>
+        <repository>
+            <id>env-var-cp-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1158</url>
+        </repository>
+        <repository>
+            <id>kube-cp-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1160</url>
         </repository>
     </repositories>
 
@@ -325,8 +337,28 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <!-- BEGIN: To avoid conflicts between Jackson 2.12 used by Kafka and 2.13 used by Fabric8, we have to exclude these libraries and include the right versions -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+        <!-- END: To avoid conflicts between Jackson 2.12 used by Kafka and 2.13 used by Fabric8, we have to exclude these libraries and include the right versions -->
         <!-- EnvVar Configuration Provider for Apache Kafka -->
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -20,9 +20,9 @@
         <cruise-control.version>2.5.79</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
-        <kafka-mirror-maker-2-extensions.version>1.1.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
+        <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
+        <kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.16.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
@@ -35,6 +35,18 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>mm2-extensions-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1159</url>
+        </repository>
+        <repository>
+            <id>env-var-cp-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1158</url>
+        </repository>
+        <repository>
+            <id>kube-cp-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1160</url>
         </repository>
     </repositories>
 
@@ -325,8 +337,28 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <!-- BEGIN: To avoid conflicts between Jackson 2.12 used by Kafka and 2.13 used by Fabric8, we have to exclude these libraries and include the right versions -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+        <!-- END: To avoid conflicts between Jackson 2.12 used by Kafka and 2.13 used by Fabric8, we have to exclude these libraries and include the right versions -->
         <!-- EnvVar Configuration Provider for Apache Kafka -->
         <dependency>
             <groupId>io.strimzi</groupId>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Mirror Maker 2 Extensions and Config Providers in the 3rd-party dependencies.

_Note: This currently uses the RCs of all the new components to run the tests. The dependencies might be updated in separate PRs separately once released._

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Update CHANGELOG.md