### PR TITLE
Add separate PodSet templates for Kafka and ZooKeeper

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaClusterTemplate.java
@@ -33,6 +33,7 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
     private static final long serialVersionUID = 1L;
 
     private StatefulSetTemplate statefulset;
+    private ResourceTemplate podSet;
     private PodTemplate pod;
     private InternalServiceTemplate bootstrapService;
     private InternalServiceTemplate brokersService;
@@ -60,6 +61,16 @@ public class KafkaClusterTemplate implements Serializable, UnknownPropertyPreser
 
     public void setStatefulset(StatefulSetTemplate statefulset) {
         this.statefulset = statefulset;
+    }
+
+    @Description("Template for Kafka `StrimziPodSet` resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getPodSet() {
+        return podSet;
+    }
+
+    public void setPodSet(ResourceTemplate podSetTemplate) {
+        this.podSet = podSetTemplate;
     }
 
     @Description("Template for Kafka `Pods`.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ZookeeperClusterTemplate.java
@@ -32,6 +32,7 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
     private static final long serialVersionUID = 1L;
 
     private StatefulSetTemplate statefulset;
+    private ResourceTemplate podSet;
     private PodTemplate pod;
     private InternalServiceTemplate clientService;
     private InternalServiceTemplate nodesService;
@@ -50,6 +51,16 @@ public class ZookeeperClusterTemplate implements Serializable, UnknownPropertyPr
 
     public void setStatefulset(StatefulSetTemplate statefulset) {
         this.statefulset = statefulset;
+    }
+
+    @Description("Template for ZooKeeper `StrimziPodSet` resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getPodSet() {
+        return podSet;
+    }
+
+    public void setPodSet(ResourceTemplate podSetTemplate) {
+        this.podSet = podSetTemplate;
     }
 
     @Description("Template for ZooKeeper `Pods`.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -264,6 +264,8 @@ public abstract class AbstractModel {
      */
     protected Map<String, String> templateStatefulSetLabels;
     protected Map<String, String> templateStatefulSetAnnotations;
+    protected Map<String, String> templatePodSetLabels;
+    protected Map<String, String> templatePodSetAnnotations;
     protected Map<String, String> templateDeploymentLabels;
     protected Map<String, String> templateDeploymentAnnotations;
     protected io.strimzi.api.kafka.model.template.DeploymentStrategy templateDeploymentStrategy = io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE;
@@ -1176,9 +1178,9 @@ public abstract class AbstractModel {
         return new StrimziPodSetBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withLabels(getLabelsWithStrimziName(name, templateStatefulSetLabels).toMap())
+                    .withLabels(getLabelsWithStrimziName(name, templatePodSetLabels).toMap())
                     .withNamespace(namespace)
-                    .withAnnotations(Util.mergeLabelsOrAnnotations(setAnnotations, templateStatefulSetAnnotations))
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(setAnnotations, templatePodSetAnnotations))
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withNewSpec()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -493,6 +493,11 @@ public class KafkaCluster extends AbstractModel {
                 }
             }
 
+            if (template.getPodSet() != null && template.getPodSet().getMetadata() != null) {
+                result.templatePodSetLabels = template.getPodSet().getMetadata().getLabels();
+                result.templatePodSetAnnotations = template.getPodSet().getMetadata().getAnnotations();
+            }
+
             ModelUtils.parsePodTemplate(result, template.getPod());
             ModelUtils.parseInternalServiceTemplate(result, template.getBootstrapService());
             ModelUtils.parseInternalHeadlessServiceTemplate(result, template.getBrokersService());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -335,6 +335,11 @@ public class ZookeeperCluster extends AbstractModel {
                 }
             }
 
+            if (template.getPodSet() != null && template.getPodSet().getMetadata() != null) {
+                zk.templatePodSetLabels = template.getPodSet().getMetadata().getLabels();
+                zk.templatePodSetAnnotations = template.getPodSet().getMetadata().getAnnotations();
+            }
+
             ModelUtils.parsePodTemplate(zk, template.getPod());
             ModelUtils.parseInternalServiceTemplate(zk, template.getClientService());
             ModelUtils.parseInternalHeadlessServiceTemplate(zk, template.getNodesService());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
@@ -190,8 +190,8 @@ public class KafkaPodSetTest {
     @ParallelTest
     public void testCustomizedPodSet()   {
         // Prepare various template values
-        Map<String, String> stsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> stsAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnos = TestUtils.map("a1", "v1", "a2", "v2");
 
         Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
         Map<String, String> podAnnos = TestUtils.map("a3", "v3", "a4", "v4");
@@ -293,12 +293,12 @@ public class KafkaPodSetTest {
                         .withLivenessProbe(livenessProbe)
                         .withConfig(Map.of("foo", "bar"))
                         .withNewTemplate()
-                            .withNewStatefulset()
+                            .withNewPodSet()
                                 .withNewMetadata()
-                                    .withLabels(stsLabels)
-                                    .withAnnotations(stsAnnos)
+                                    .withLabels(spsLabels)
+                                    .withAnnotations(spsAnnos)
                                 .endMetadata()
-                            .endStatefulset()
+                            .endPodSet()
                             .withNewPod()
                                 .withNewMetadata()
                                     .withLabels(podLabels)
@@ -330,8 +330,8 @@ public class KafkaPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, null, null, Map.of("special", "annotation"));
 
         assertThat(ps.getMetadata().getName(), is(KafkaCluster.kafkaClusterName(CLUSTER)));
-        assertThat(ps.getMetadata().getLabels().entrySet().containsAll(stsLabels.entrySet()), is(true));
-        assertThat(ps.getMetadata().getAnnotations().entrySet().containsAll(stsAnnos.entrySet()), is(true));
+        assertThat(ps.getMetadata().getLabels().entrySet().containsAll(spsLabels.entrySet()), is(true));
+        assertThat(ps.getMetadata().getAnnotations().entrySet().containsAll(spsAnnos.entrySet()), is(true));
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
@@ -178,8 +178,8 @@ public class ZookeeperPodSetTest {
     @ParallelTest
     public void testCustomizedPodSet()   {
         // Prepare various template values
-        Map<String, String> stsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> stsAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnos = TestUtils.map("a1", "v1", "a2", "v2");
 
         Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
         Map<String, String> podAnnos = TestUtils.map("a3", "v3", "a4", "v4");
@@ -281,12 +281,12 @@ public class ZookeeperPodSetTest {
                         .withLivenessProbe(livenessProbe)
                         .withConfig(Map.of("foo", "bar"))
                         .withNewTemplate()
-                            .withNewStatefulset()
+                            .withNewPodSet()
                                 .withNewMetadata()
-                                    .withLabels(stsLabels)
-                                    .withAnnotations(stsAnnos)
+                                    .withLabels(spsLabels)
+                                    .withAnnotations(spsAnnos)
                                 .endMetadata()
-                            .endStatefulset()
+                            .endPodSet()
                             .withNewPod()
                                 .withNewMetadata()
                                     .withLabels(podLabels)
@@ -318,8 +318,8 @@ public class ZookeeperPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, null, null, Map.of("special", "annotation"));
 
         assertThat(ps.getMetadata().getName(), is(ZookeeperCluster.zookeeperClusterName(CLUSTER)));
-        assertThat(ps.getMetadata().getLabels().entrySet().containsAll(stsLabels.entrySet()), is(true));
-        assertThat(ps.getMetadata().getAnnotations().entrySet().containsAll(stsAnnos.entrySet()), is(true));
+        assertThat(ps.getMetadata().getLabels().entrySet().containsAll(spsLabels.entrySet()), is(true));
+        assertThat(ps.getMetadata().getAnnotations().entrySet().containsAll(spsAnnos.entrySet()), is(true));
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(zc.getSelectorLabels().toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -850,6 +850,8 @@ Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |clusterRoleBinding        1.2+<.<a|Template for the Kafka ClusterRoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|podSet                    1.2+<.<a|Template for Kafka `StrimziPodSet` resource.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
 [id='type-StatefulSetTemplate-{context}']
@@ -1104,6 +1106,8 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |serviceAccount         1.2+<.<a|Template for the ZooKeeper service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |jmxSecret              1.2+<.<a|Template for Secret of the Zookeeper Cluster JMX authentication.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|podSet                 1.2+<.<a|Template for ZooKeeper `StrimziPodSet` resource.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1660,6 +1660,22 @@ spec:
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
                           description: Template for the Kafka ClusterRoleBinding.
+                        podSet:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Metadata applied to the resource.
+                          description: Template for Kafka `StrimziPodSet` resource.
                       description: Template for Kafka cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                   required:
                     - replicas
@@ -2559,6 +2575,22 @@ spec:
                                   description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
                               description: Metadata applied to the resource.
                           description: Template for Secret of the Zookeeper Cluster JMX authentication.
+                        podSet:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.
+                              description: Metadata applied to the resource.
+                          description: Template for ZooKeeper `StrimziPodSet` resource.
                       description: Template for ZooKeeper cluster resources. The template allows users to specify how are the `StatefulSet`, `Pods` and `Services` generated.
                   required:
                     - replicas

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -2128,6 +2128,26 @@ spec:
                                   `Deployments`, `Pods`, and `Services`.
                             description: Metadata applied to the resource.
                         description: Template for the Kafka ClusterRoleBinding.
+                      podSet:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for Kafka `StrimziPodSet` resource.
                     description: Template for Kafka cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.
@@ -3165,6 +3185,26 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for Secret of the Zookeeper Cluster
                           JMX authentication.
+                      podSet:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Labels added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: Annotations added to the resource template.
+                                  Can be applied to different resources such as `StatefulSets`,
+                                  `Deployments`, `Pods`, and `Services`.
+                            description: Metadata applied to the resource.
+                        description: Template for ZooKeeper `StrimziPodSet` resource.
                     description: Template for ZooKeeper cluster resources. The template
                       allows users to specify how are the `StatefulSet`, `Pods` and
                       `Services` generated.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The StrimziPodSet (SPS) resources used currently for Kafka and Zoo (when the Feature Gate is enabled) are using the metadata template from the StatefulSet (STS) template. This is makes things not completely clear to users:
* The StatefulSet template contains some fields which are applicable only for STS and not for SPS
* The API name is confusing when used with PodSets (`.spec.(kafka|zookeeper).template.statefulset`)
* After we remove STS support, we would still be stuck with the old template name `statefulset` despite not using STS anymore.
* Should we in the future need some new template fields for the SPS resources, it might just add to the confusion

This PR adds new `podSet` section to the Kafka and ZooKeeper templates, which currently supports only the metadata configuration since nothing else is supported. Once STS support is removed, we can just deprecate and remove the whole STS template without any concerns about the pod sets.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally