### PR TITLE
[MO] - [system test] -> tests fixes, instance holder, annotation lock…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/ParallelTest.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/ParallelTest.java
@@ -24,7 +24,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(ElementType.METHOD)
 @Retention(RUNTIME)
 @Execution(ExecutionMode.CONCURRENT)
-@ResourceLock(mode = ResourceAccessMode.READ, value = "parallel-test")
+@ResourceLock(mode = ResourceAccessMode.READ, value = "global")
 @Test
 public @interface ParallelTest {
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -606,14 +606,13 @@ public class SetupClusterOperator {
         }
     }
 
-    public synchronized SetupClusterOperator rollbackToDefaultConfiguration() {
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
+    public synchronized void rollbackToDefaultConfiguration() {
         // un-install old cluster operator
         unInstall();
 
         // install new one with default configuration
-        return defaultInstallation()
-            .createInstallation()
-            .runInstallation();
+        instanceHolder = defaultInstallation().createInstallation().runInstallation();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -67,7 +67,7 @@ public class KafkaTopicUtils {
     public static String waitTopicHasRolled(final String namespaceName, String topicName, String topicUid) {
         TestUtils.waitFor("Topic " + topicName + " has rolled", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> !topicUid.equals(topicSnapshot(namespaceName, topicName)));
-        return topicSnapshot(topicName);
+        return topicSnapshot(namespaceName, topicName);
     }
 
     public static String waitTopicHasRolled(String topicName, String topicUid) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -536,6 +536,8 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     private final void afterAllMustExecute(ExtensionContext extensionContext)  {
+        clusterOperator = SetupClusterOperator.getInstanceHolder();
+
         if (StUtils.isParallelSuite(extensionContext)) {
             parallelSuiteController.removeParallelSuite(extensionContext);
         }
@@ -559,7 +561,7 @@ public abstract class AbstractST implements TestSeparator {
             LOGGER.debug("Default Cluster Operator configuration:\n" + clusterOperator.defaultInstallation().createInstallation().toString());
             LOGGER.info("Current Cluster Operator configuration differs from default Cluster Operator in these attributes:{}", clusterOperator.diff(clusterOperator.defaultInstallation().createInstallation()));
             LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
-            clusterOperator = clusterOperator.rollbackToDefaultConfiguration();
+            clusterOperator.rollbackToDefaultConfiguration();
         }
     }
 


### PR DESCRIPTION
… changed

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR adds a few fixes:
1. bad namespace handling in our Utils class
2. Resource lock changed to `global` because it could happen a situation where @ParallelTest and IsolatedTest lock their own locks and thus Isolated test can run with parallel one. By specifying the same lock this situation will not happen anymore.
3.  Our diff method in cluster operator could provide NPE because the cluster operator instance was not using the current configuration, which results in NPE when two instances were compared (default and current).
### Checklist

- [ ] Make sure all tests pass

