### PR TITLE
docs: offset-syncs topic default location

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
@@ -40,7 +40,7 @@ The following table describes connector properties and the connectors you config
 |✓
 |
 
-|offset-syncs.topic.location:: The location of the `offset-syncs` topic, which can be the `source` (default) or `target` cluster. If you set the property to `target`, read-only access to the source cluster is granted to MirrorMaker.
+|offset-syncs.topic.location:: The location of the `offset-syncs` topic, which can be the `source` (default) or `target` cluster.
 |✓
 |✓
 |

--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -78,13 +78,18 @@ Only MirrorMaker 2.0 can write to remote topics.
 == Offset tracking
 MirrorMaker 2.0 tracks offsets for consumer groups using _internal topics_.
 
-* The _offset sync_ topic maps the source and target offsets for replicated topic partitions from record metadata
-* The _checkpoint_ topic maps the last committed offset in the source and target cluster for replicated topic partitions in each consumer group
+* The _offset-syncs_ topic maps the source and target offsets for replicated topic partitions from record metadata
+* The _checkpoints_ topic maps the last committed offset in the source and target cluster for replicated topic partitions in each consumer group
 
-Offsets for the _checkpoint_ topic are tracked at predetermined intervals through configuration.
+Offsets for the _checkpoints_ topic are tracked at predetermined intervals through configuration.
 Both topics enable replication to be fully restored from the correct offset position on failover.
 
 MirrorMaker 2.0 uses its `MirrorCheckpointConnector` to emit _checkpoints_ for offset tracking.
+
+The location of the _offset-syncs_ topic is the source cluster by default.
+You can use the `offset-syncs.topic.location` connector configuration to change this to the target cluster.
+You need read/write access to the cluster that contains the topic.
+If you change the default, then you'll only need read access on the source cluster.
 
 == Synchronizing consumer group offsets
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -86,10 +86,10 @@ Both topics enable replication to be fully restored from the correct offset posi
 
 MirrorMaker 2.0 uses its `MirrorCheckpointConnector` to emit _checkpoints_ for offset tracking.
 
-The location of the _offset-syncs_ topic is the source cluster by default.
-You can use the `offset-syncs.topic.location` connector configuration to change this to the target cluster.
+The location of the _offset-syncs_ topic is the `source` cluster by default.
+You can use the `offset-syncs.topic.location` connector configuration to change this to the `target` cluster.
 You need read/write access to the cluster that contains the topic.
-If you change the default, then you'll only need read access on the source cluster.
+Using the target cluster as the location of the _offset-syncs_ topic allows you to use MirrorMaker 2.0 even if you have only read access to the source cluster.
 
 == Synchronizing consumer group offsets
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updates the _MirrorMaker 2_ section of the _Configuring_ guide
Adds information on the default location of the MirrorMaker _offset-syncs_ topic.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

