### PR TITLE
Wait for pod deletion when scaling down ZooKeeper PodSet

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -513,6 +513,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         when(mockPodOps.listAsync(any(), eq(zkCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(Collections.emptyList()));
         when(mockPodOps.listAsync(any(), eq(kafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(Collections.emptyList()));
         when(mockPodOps.readiness(any(), any(), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.waitFor(any(), any(), any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
 
         CrdOperator mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(KAFKA));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When scaling down ZooKeeper cluster with PodSets enabled, it seems to sometimes happen that the pods still exist when the Zoo RU is called as the next step in the reconciliation and they cause errors as seen at the end of this PR. The issue seems to eventually resolve it self when the pods are actually deleted. But this is not exactly nice behaviour and it should be investigated.

This PR adds check for the pod deletion to the scale-down process when StrimziPodSets are used. It waits until the pod is actually deleted before moving to the next steps of the reconciliation. That makes these errors disappear.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

----

```
2022-02-02 23:31:23 INFO  OperatorWatcher:38 - Reconciliation #143(watch) Kafka(myproject/my-cluster): Kafka my-cluster in namespace myproject was MODIFIED
2022-02-02 23:31:23 INFO  AbstractOperator:226 - Reconciliation #143(watch) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2022-02-02 23:31:23 INFO  KafkaAssemblyOperator:1574 - Reconciliation #143(watch) Kafka(myproject/my-cluster): Scaling Zookeeper down from 5 to 3 replicas
2022-02-02 23:31:24 INFO  StrimziPodSetController:228 - Reconciliation #144(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:24 INFO  StrimziPodSetController:262 - Reconciliation #144(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:24 INFO  StrimziPodSetController:228 - Reconciliation #145(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:24 INFO  StrimziPodSetController:262 - Reconciliation #145(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:24 INFO  StrimziPodSetController:228 - Reconciliation #146(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:24 INFO  StrimziPodSetController:262 - Reconciliation #146(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:25 INFO  StrimziPodSetController:228 - Reconciliation #147(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:25 INFO  StrimziPodSetController:262 - Reconciliation #147(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:25 INFO  StrimziPodSetController:228 - Reconciliation #148(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:25 ERROR AbstractOperator:247 - Reconciliation #143(watch) Kafka(myproject/my-cluster): createOrUpdate failed
java.lang.RuntimeException: Pod my-cluster-zookeeper-3 in namespace myproject not found in desired StrimziPodSet
    at io.strimzi.operator.cluster.operator.resource.PodRevision.hasChanged(PodRevision.java:66) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.getReasonsToRestartPod(KafkaAssemblyOperator.java:4005) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$zkRollingUpdate$46(KafkaAssemblyOperator.java:1461) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.resource.ZooKeeperRoller.lambda$maybeRollingUpdate$0(ZooKeeperRoller.java:60) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) [io.netty.netty-transport-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at java.lang.Thread.run(Thread.java:829) [?:?]
2022-02-02 23:31:25 INFO  StrimziPodSetController:262 - Reconciliation #148(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:25 INFO  StrimziPodSetController:228 - Reconciliation #149(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:25 INFO  StrimziPodSetController:262 - Reconciliation #149(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:25 INFO  CrdOperator:113 - Reconciliation #143(watch) Kafka(myproject/my-cluster): Status of Kafka my-cluster in namespace myproject has been updated
2022-02-02 23:31:26 INFO  OperatorWatcher:38 - Reconciliation #150(watch) Kafka(myproject/my-cluster): Kafka my-cluster in namespace myproject was MODIFIED
2022-02-02 23:31:26 WARN  AbstractOperator:532 - Reconciliation #143(watch) Kafka(myproject/my-cluster): Failed to reconcile
java.lang.RuntimeException: Pod my-cluster-zookeeper-3 in namespace myproject not found in desired StrimziPodSet
    at io.strimzi.operator.cluster.operator.resource.PodRevision.hasChanged(PodRevision.java:66) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.getReasonsToRestartPod(KafkaAssemblyOperator.java:4005) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$zkRollingUpdate$46(KafkaAssemblyOperator.java:1461) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.resource.ZooKeeperRoller.lambda$maybeRollingUpdate$0(ZooKeeperRoller.java:60) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) [io.netty.netty-transport-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at java.lang.Thread.run(Thread.java:829) [?:?]
2022-02-02 23:31:26 INFO  AbstractOperator:226 - Reconciliation #150(watch) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2022-02-02 23:31:26 INFO  StrimziPodSetController:228 - Reconciliation #151(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:26 ERROR AbstractOperator:247 - Reconciliation #150(watch) Kafka(myproject/my-cluster): createOrUpdate failed
java.lang.RuntimeException: Pod my-cluster-zookeeper-3 in namespace myproject not found in desired StrimziPodSet
    at io.strimzi.operator.cluster.operator.resource.PodRevision.hasChanged(PodRevision.java:66) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.getReasonsToRestartPod(KafkaAssemblyOperator.java:4005) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$zkRollingUpdate$46(KafkaAssemblyOperator.java:1461) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.resource.ZooKeeperRoller.lambda$maybeRollingUpdate$0(ZooKeeperRoller.java:60) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) [io.netty.netty-transport-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at java.lang.Thread.run(Thread.java:829) [?:?]
2022-02-02 23:31:26 INFO  StrimziPodSetController:262 - Reconciliation #151(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:26 INFO  StrimziPodSetController:228 - Reconciliation #152(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:26 WARN  AbstractOperator:532 - Reconciliation #150(watch) Kafka(myproject/my-cluster): Failed to reconcile
java.lang.RuntimeException: Pod my-cluster-zookeeper-3 in namespace myproject not found in desired StrimziPodSet
    at io.strimzi.operator.cluster.operator.resource.PodRevision.hasChanged(PodRevision.java:66) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.getReasonsToRestartPod(KafkaAssemblyOperator.java:4005) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator$ReconciliationState.lambda$zkRollingUpdate$46(KafkaAssemblyOperator.java:1461) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.strimzi.operator.cluster.operator.resource.ZooKeeperRoller.lambda$maybeRollingUpdate$0(ZooKeeperRoller.java:60) ~[io.strimzi.cluster-operator-0.28.0-SNAPSHOT.jar:0.28.0-SNAPSHOT]
    at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) [io.netty.netty-transport-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.71.Final.jar:4.1.71.Final]
    at java.lang.Thread.run(Thread.java:829) [?:?]
2022-02-02 23:31:26 INFO  StrimziPodSetController:262 - Reconciliation #152(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:26 INFO  StrimziPodSetController:228 - Reconciliation #153(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:26 INFO  StrimziPodSetController:262 - Reconciliation #153(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:26 INFO  StrimziPodSetController:228 - Reconciliation #154(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:26 INFO  StrimziPodSetController:262 - Reconciliation #154(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:27 INFO  StrimziPodSetController:228 - Reconciliation #155(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:27 INFO  StrimziPodSetController:262 - Reconciliation #155(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:27 INFO  StrimziPodSetController:228 - Reconciliation #156(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:27 INFO  StrimziPodSetController:262 - Reconciliation #156(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:27 INFO  StrimziPodSetController:228 - Reconciliation #157(watch) StrimziPodSet(myproject/my-cluster-zookeeper): StrimziPodSet will be reconciled
2022-02-02 23:31:27 INFO  StrimziPodSetController:262 - Reconciliation #157(watch) StrimziPodSet(myproject/my-cluster-zookeeper): reconciled
2022-02-02 23:31:40 INFO  ClusterOperator:123 - Triggering periodic reconciliation for namespace myproject
2022-02-02 23:31:40 INFO  AbstractOperator:226 - Reconciliation #158(timer) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2022-02-02 23:31:42 INFO  CrdOperator:113 - Reconciliation #158(timer) Kafka(myproject/my-cluster): Status of Kafka my-cluster in namespace myproject has been updated
2022-02-02 23:31:42 INFO  OperatorWatcher:38 - Reconciliation #159(watch) Kafka(myproject/my-cluster): Kafka my-cluster in namespace myproject was MODIFIED
2022-02-02 23:31:42 INFO  AbstractOperator:517 - Reconciliation #158(timer) Kafka(myproject/my-cluster): reconciled
2022-02-02 23:31:42 INFO  AbstractOperator:226 - Reconciliation #159(watch) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2022-02-02 23:31:44 INFO  AbstractOperator:517 - Reconciliation #159(watch) Kafka(myproject/my-cluster): reconciled 
```