### PR TITLE
Remove unnecessary rolling update of Kafka PodSet when storage is resized

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1267,10 +1267,11 @@ public class KafkaCluster extends AbstractModel {
      * annotations passed from KafkaAssemblyOperator with additional annotations.
      *
      * @param existingPodAnnotations    Annotations requested from higher level classes
+     * @param storageAnnotation         Indicates whether the storage annotation should be added or not
      *
      * @return                          Map with all pod annotations required by Strimzi
      */
-    private Map<String, String> preparePodAnnotations(Map<String, String> existingPodAnnotations)   {
+    private Map<String, String> preparePodAnnotations(Map<String, String> existingPodAnnotations, boolean storageAnnotation)   {
         Map<String, String> podAnnotations;
 
         if (existingPodAnnotations != null) {
@@ -1280,7 +1281,10 @@ public class KafkaCluster extends AbstractModel {
             podAnnotations = new HashMap<>(4);
         }
 
-        podAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
+        if (storageAnnotation) {
+            podAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage));
+        }
+
         podAnnotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafkaVersion.version());
         podAnnotations.put(ANNO_STRIMZI_IO_LOG_MESSAGE_FORMAT_VERSION, getLogMessageFormatVersion());
         podAnnotations.put(ANNO_STRIMZI_IO_INTER_BROKER_PROTOCOL_VERSION, getInterBrokerProtocolVersion());
@@ -1317,7 +1321,7 @@ public class KafkaCluster extends AbstractModel {
                                            Map<String, String> podAnnotations) {
         return createStatefulSet(
                 prepareControllerAnnotations(),
-                preparePodAnnotations(podAnnotations),
+                preparePodAnnotations(podAnnotations, true),
                 getStatefulSetVolumes(isOpenShift),
                 getPersistentVolumeClaimTemplates(),
                 getMergedAffinity(),
@@ -1348,7 +1352,7 @@ public class KafkaCluster extends AbstractModel {
         return createPodSet(
                 replicas,
                 prepareControllerAnnotations(),
-                preparePodAnnotations(podAnnotations),
+                preparePodAnnotations(podAnnotations, false),
                 podName -> getPodSetVolumes(podName, isOpenShift),
                 getMergedAffinity(),
                 getInitContainers(imagePullPolicy),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -2982,56 +2982,17 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> kafkaRollToAddOrRemoveVolumes() {
             Storage storage = kafkaCluster.getStorage();
 
-            // If storage is not Jbod storage, we never add or remove volumes
-            if (storage instanceof JbodStorage) {
+            // We do the special rolling update only when:
+            //   * JBOD storage is actually used as storage
+            //   * and StatefulSets are used
+            // StrimziPodSets do not need special rolling update, they can add / remove volumes during regular rolling updates
+            if (storage instanceof JbodStorage
+                    && !featureGates.useStrimziPodSetsEnabled()) {
                 JbodStorage jbodStorage = (JbodStorage) storage;
-
-                if (featureGates.useStrimziPodSetsEnabled()) {
-                    // We need to check whether any rolling is needed first
-                    return kafkaRollToAddOrRemoveVolumesInPodSet(jbodStorage);
-                } else {
-                    // StatefulSets need a special process to roll when adding or removing volumes
-                    return kafkaRollToAddOrRemoveVolumesInStatefulSet(jbodStorage);
-                }
+                return kafkaRollToAddOrRemoveVolumesInStatefulSet(jbodStorage);
             } else {
                 return withVoid(Future.succeededFuture());
             }
-        }
-
-        /**
-         * Checks if any Kafka broker needs rolling update to add or remove JBOD volumes. If it does, we trigger a
-         * rolling update. For PodSets, it can be regular rolling update, not the sequential rolling update as for
-         * StatefulSets.
-         *
-         * This method is used only for PodSets.
-         *
-         * @param jbodStorage   Desired storage configuration
-         *
-         * @return              Future indicating the completion and result of the rolling update
-         */
-        Future<ReconciliationState> kafkaRollToAddOrRemoveVolumesInPodSet(JbodStorage jbodStorage) {
-            // We first check if any broker actually needs the rolling update. Only if at least one of them needs it,
-            // we trigger it. This check helps to not go through the rolling update if not needed.
-            return podOperations.listAsync(namespace, kafkaCluster.getSelectorLabels())
-                    .compose(pods -> {
-                        List<String> needsRestart = new ArrayList<>();
-
-                        // We collect all the pods which might need rolling
-                        for (Pod pod : pods) {
-                            if (!needsRestartBecauseAddedOrRemovedJbodVolumes(pod, jbodStorage, kafkaCurrentReplicas, kafkaCluster.getReplicas()).isEmpty())   {
-                                needsRestart.add(pod.getMetadata().getName());
-                            }
-                        }
-
-                        if (needsRestart.isEmpty()) {
-                            LOGGER.debugCr(reconciliation, "No rolling update of Kafka brokers due to added or removed JBOD volumes is needed");
-                            return withVoid(Future.succeededFuture());
-                        } else {
-                            LOGGER.debugCr(reconciliation, "Kafka brokers {} needs rolling update to add or remove JBOD volumes", needsRestart);
-                            return withVoid(maybeRollKafka(kafkaPodSetDiffs.resource().getSpec().getPods().size(),
-                                    podToCheck -> needsRestartBecauseAddedOrRemovedJbodVolumes(podToCheck, jbodStorage, kafkaCurrentReplicas, kafkaCluster.getReplicas())));
-                        }
-                    });
         }
 
         /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
@@ -148,9 +148,8 @@ public class KafkaPodSetTest {
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(kc.getLabelsWithStrimziNameAndPodName(kc.getName(), pod.getMetadata().getName(), null).withStatefulSetPod(pod.getMetadata().getName()).withStrimziPodSetController(kc.getName()).toMap().entrySet()), is(true));
-            assertThat(pod.getMetadata().getAnnotations().size(), is(5));
+            assertThat(pod.getMetadata().getAnnotations().size(), is(4));
             assertThat(pod.getMetadata().getAnnotations().get(PodRevision.STRIMZI_REVISION_ANNOTATION), is(notNullValue()));
-            assertThat(pod.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withDeleteClaim(false).build()).build())));
             assertThat(pod.getMetadata().getAnnotations().get(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION), is(notNullValue()));
             assertThat(pod.getMetadata().getAnnotations().get(KafkaCluster.ANNO_STRIMZI_IO_LOG_MESSAGE_FORMAT_VERSION), is(notNullValue()));
             assertThat(pod.getMetadata().getAnnotations().get(KafkaCluster.ANNO_STRIMZI_IO_INTER_BROKER_PROTOCOL_VERSION), is(notNullValue()));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When using StrimziPodSets, it should not be necessary to roll all the Kafka pods when storage resizing happens. For StatefulSets, we have to keep the storage configuration on the pods in an annotation to be able to detect when volumes are removed or added and trigger a special rolling update which works around the StatefulSet limitations (STS require pods to be rolled in a very specific order when adding or removing volumes). This annotation changes when volume size is changed by the user and it triggers rolling update (regular RU - not the special one for adding or removing volumes).

But StrimziPodSets do not have the same limitations and can add or remove volumes without any special rolling update. Yet, they still carried the annotation which forced their rolling update because it changes when user changes the storage size. This PR fixes that => it uses the Pod annotation with the storage configuration only when StatefulSets are used. When PodSets are used, it does not set the annotation. So when the storage size is changed by the user, there is no reason to roll the pods anymore.

I also realized that I _copied_ the special rolling udpate procedure for the Kafka PodSet - it did just regular rolling update when volumes were added or removed. But PodSets can handle this in the regular rolling update and do not need any special step for it. So I removed this part of the code as well.

This should resolve #3574.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging