### PR TITLE
[DOC] Add documentation for `StrimziPodSets` and `UseStrimziPodSet` feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.28.0
 
 * Add support for Kafka 3.1.0; remove Kafka 2.8.0 and 2.8.1
+* Add support for `StrimziPodSet` resources (disabled by default through the `UseStrimziPodSets` feature gate)
 * Update Open Policy Agent authorizer to 1.4.0 and add support for enabling metrics
 * Add connector context to the default logging configuration in Kafka Connect and Kafka Mirror Maker 2
 * Added the option `createBootstrapService` in the Kafka Spec to disable the creation of the bootstrap service for the Load Balancer Type Listener. It will save the cost of one load balancer resource, specially in the public cloud.

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -17,7 +17,8 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 .ZooKeeper nodes
 
-`_cluster-name_-zookeeper`:: StatefulSet which is in charge of managing the ZooKeeper node pods.
+`_cluster-name_-zookeeper`:: StatefulSet which is in charge of managing the ZooKeeper node pods (used only when xref:ref-operator-use-strimzi-pod-sets-feature-gate-{context}[`UseStrimziPodSets` feature gate] is disabled).
+`_cluster-name_-zookeeper`:: StrimziPodSet which is in charge of managing the ZooKeeper node pods (used only when xref:ref-operator-use-strimzi-pod-sets-feature-gate-{context}[`UseStrimziPodSets` feature gate] is enabled).
 `_cluster-name_-zookeeper-_idx_`:: Pods created by the ZooKeeper StatefulSet.
 `_cluster-name_-zookeeper-nodes`:: Headless Service needed to have DNS resolve the ZooKeeper pods IP addresses directly.
 `_cluster-name_-zookeeper-client`:: Service used by Kafka brokers to connect to ZooKeeper nodes as clients.
@@ -30,7 +31,8 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 .Kafka brokers
 
-`_cluster-name_-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods.
+`_cluster-name_-kafka`:: StatefulSet which is in charge of managing the Kafka broker pods (used only when xref:ref-operator-use-strimzi-pod-sets-feature-gate-{context}[`UseStrimziPodSets` feature gate] is disabled).
+`_cluster-name_-kafka`:: StrimziPodSet which is in charge of managing the Kafka broker pods (used only when xref:ref-operator-use-strimzi-pod-sets-feature-gate-{context}[`UseStrimziPodSets` feature gate] is enabled).
 `_cluster-name_-kafka-_idx_`:: Pods created by the Kafka StatefulSet.
 `_cluster-name_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
 `_cluster-name_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients connecting from within the Kubernetes cluster.

--- a/documentation/modules/managing/proc-manual-rolling-update-statefulset.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-statefulset.adoc
@@ -23,6 +23,15 @@ kubectl annotate statefulset _cluster-name_-kafka strimzi.io/manual-rolling-upda
 
 kubectl annotate statefulset _cluster-name_-zookeeper strimzi.io/manual-rolling-update=true
 ----
++
+If you enabled the xref:ref-operator-use-strimzi-pod-sets-feature-gate-{context}[`UseStrimziPodSets` feature gate], you should annotate the `StrimziPodSet` resources instead of the `StatefulSet` resources:
++
+[source,shell,subs=+quotes]
+----
+kubectl annotate strimzipodset _cluster-name_-kafka strimzi.io/manual-rolling-update=true
+
+kubectl annotate strimzipodset _cluster-name_-zookeeper strimzi.io/manual-rolling-update=true
+----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 A rolling update of all pods within the annotated `StatefulSet` is triggered, as long as the annotation was detected by the reconciliation process.

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -249,6 +249,11 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦0.27.0
 ¦ -
 
+¦`UseStrimziPodSets`
+¦0.28.0
+¦ -
+¦ -
+
 |===
 
 [discrete]
@@ -302,6 +307,32 @@ To disable service account patching, disable the `ServiceAccountPatching` featur
 Add `-ServiceAccountPatching` to the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 NOTE: The `ServiceAccountPatching` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.30.
+
+[id='ref-operator-use-strimzi-pod-sets-feature-gate-{context}']
+=== Use `StrimziPodSets` feature gate
+
+Currently, Strimzi relies on StatefulSets to create and manage Pods for the ZooKeeper and Kafka clusters.
+Strimzi creates the StatefulSet and Kubernetes creates the Pods according to the StatefulSet definition.
+When a Pod is deleted, Kubernetes is responsible for recreating it.
+The use of StatefulSets is also a cause of several limitations.
+For example:
+
+* The Pods are always created / removed based on their index numbers
+* All Pods in the StatefulSet need to have a similar configuration
+* Changing storage configuration for the Pods in the StatefulSet is complicated
+
+The `UseStrimziPodSets` feature gate introduces our own resource for managing the pods called `StrimziPodSet`.
+When the feature gate is enabled, this resource is used instead of the StatefulSets and Strimzi handles the creation and management of Pods itself.
+Using StrimziPodSets instead of StatefulSets should allow us to add more new features in the future.
+
+.Enabling the `UseStrimziPodSets` feature gate
+
+The `UseStrimziPodSets` feature gate is in the alpha stage and has a default state of _disabled_.
+To enable it, specify `+UseStrimziPodSets` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+This feature gate must be disabled when downgrading to Strimzi 0.27 and earlier.
+
+NOTE: The `UseStrimziPodSets` feature gate is currently planned to move to the beta stage in Strimzi 0.30.0.
 
 == Logging configuration by ConfigMap
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the basic documentation for the `StrimziPodSet` resources and for the `UseStrimziPodSet` feature gate. It adds the feature gate to the _Feature Gates_ section, updates the parts based on StatefulSet annotations and the list of resources.

Since it now adds the documentation, it also adds the StrimziPodSets tot he CHANGELOG.md file.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md