### PR TITLE
Add Vertx shutdown hook to Main class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -22,10 +22,6 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.ClusterRoleOperator;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,6 +34,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
@@ -47,8 +47,17 @@ import org.apache.logging.log4j.Logger;
 @SuppressFBWarnings("DM_EXIT")
 public class Main {
     private static final Logger LOGGER = LogManager.getLogger(Main.class.getName());
+    private static Vertx vertx = Vertx.vertx(
+        new VertxOptions().setMetricsOptions(
+            new MicrometerMetricsOptions()
+                .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                .setJvmMetricsEnabled(true)
+                .setEnabled(true)));
 
     static {
+        // Verticle.stop() methods are not executed if you don't call Vertx.close()
+        // Vertx registers a shutdown hook for that, but only if you use its Launcher as main class
+        Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx)));
         try {
             Crds.registerCustomKinds();
         } catch (Error | RuntimeException t) {
@@ -63,18 +72,10 @@ public class Main {
 
         // setting DNS cache TTL
         Security.setProperty("networkaddress.cache.ttl", String.valueOf(config.getDnsCacheTtlSec()));
-
-        //Setup Micrometer metrics options
-        VertxOptions options = new VertxOptions().setMetricsOptions(
-                new MicrometerMetricsOptions()
-                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-                        .setJvmMetricsEnabled(true)
-                        .setEnabled(true));
-        Vertx vertx = Vertx.vertx(options);
         
         KubernetesClient client = new DefaultKubernetesClient();
 
-        maybeCreateClusterRoles(vertx, config, client).onComplete(crs -> {
+        maybeCreateClusterRoles(config, client).onComplete(crs -> {
             if (crs.succeeded())    {
                 PlatformFeaturesAvailability.create(vertx, client).onComplete(pfa -> {
                     if (pfa.succeeded()) {
@@ -160,7 +161,7 @@ public class Main {
         return CompositeFuture.join(futures);
     }
 
-    /*test*/ static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
+    /*test*/ static Future<Void> maybeCreateClusterRoles(ClusterOperatorConfig config, KubernetesClient client)  {
         if (config.isCreateClusterRoles()) {
             List<Future> futures = new ArrayList<>();
             ClusterRoleOperator cro = new ClusterRoleOperator(vertx, client);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ShutdownHook.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ShutdownHook.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+public class ShutdownHook implements Runnable {
+    private static final Logger LOGGER = LogManager.getLogger(ShutdownHook.class.getName());
+    
+    private Vertx vertx;
+    
+    public ShutdownHook(Vertx vertx) {
+        this.vertx = vertx;
+    }
+    
+    @Override
+    public void run() {
+        LOGGER.info("Shutting down");
+        CountDownLatch latch = new CountDownLatch(1);
+        if (vertx != null) {
+            vertx.close(ar -> {
+                if (!ar.succeeded()) {
+                    LOGGER.error("Failure in stopping Vertx", ar.cause());
+                }
+                latch.countDown();
+            });
+            try {
+                if (!latch.await(2, TimeUnit.MINUTES)) {
+                    LOGGER.error("Timed out waiting to undeploy all Verticles");
+                }
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        LOGGER.info("Shutdown complete");
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -22,8 +22,6 @@ import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -49,8 +47,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class ClusterOperatorTest {
-    private static Vertx vertx;
     private static final Logger LOGGER = LogManager.getLogger(ClusterOperatorTest.class);
+    private static Vertx vertx = Vertx.vertx(
+        new VertxOptions().setMetricsOptions(
+            new MicrometerMetricsOptions()
+                .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                .setEnabled(true)));
 
     private static Map<String, String> buildEnv(String namespaces, boolean strimziPodSets) {
         Map<String, String> env = new HashMap<>();
@@ -66,20 +68,6 @@ public class ClusterOperatorTest {
         }
 
         return env;
-    }
-
-    @BeforeAll
-    public static void before() {
-        VertxOptions options = new VertxOptions().setMetricsOptions(
-                new MicrometerMetricsOptions()
-                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-                        .setEnabled(true));
-        vertx = Vertx.vertx(options);
-    }
-
-    @AfterAll
-    public static void after() {
-        vertx.close();
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/MainIT.java
@@ -67,7 +67,7 @@ public class MainIT {
         ClusterRoleOperator cro = new ClusterRoleOperator(vertx, client);
 
         Checkpoint a = context.checkpoint();
-        Main.maybeCreateClusterRoles(vertx, config, client)
+        Main.maybeCreateClusterRoles(config, client)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat(cro.get("strimzi-cluster-operator-namespaced"), is(notNullValue()));
                 assertThat(cro.get("strimzi-cluster-operator-global"), is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ShutdownHookTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ShutdownHookTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class ShutdownHookTest {
+    private static Vertx vertx = Vertx.vertx();
+
+    @Test
+    public void testTerminationRunnable() {
+        final int nVerticles = 10;
+        List<MyVerticle> verticles = new ArrayList<>(nVerticles);
+        while (verticles.size() < nVerticles) {
+            MyVerticle myVerticle = new MyVerticle();
+            vertx.deployVerticle(myVerticle);
+            verticles.add(myVerticle);
+        }
+        assertThat("Verticles were not deployed", vertx.deploymentIDs(), hasSize(nVerticles));
+        ShutdownHook hook = new ShutdownHook(vertx);
+        hook.run();
+        assertThat("Verticles were not closed", vertx.deploymentIDs(), empty());
+        for (MyVerticle verticle : verticles) {
+            assertThat("Verticle stop was not executed", verticle.getCounter(), is(1));
+        }
+    }
+    
+    static class MyVerticle extends AbstractVerticle {
+        private int counter = 0;
+        
+        @Override
+        public void stop() {
+            counter++;
+        }
+        
+        public int getCounter() {
+            return counter;
+        }
+    } 
+}


### PR DESCRIPTION
`Verticle.stop()` methods are not executed if you don't call `Vertx.close()`. Vertx registers a shutdown hook for that, but only if you use its Launcher as main class.

This PR adds our own shutdown hook, which is similar to what Vertx has in its Launcher, but that we can further customize if needed. As a consequence, the ClusterOpertator.stop() is now executed on JVM's regular shutdown.
