### PR TITLE
Make KafkaRoller work with list of pod names instead of number of replicas

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -312,6 +312,26 @@ public class KafkaCluster extends AbstractModel {
         return cluster + KafkaCluster.KAFKA_JMX_SECRET_SUFFIX;
     }
 
+    public static List<String> generatePodList(String cluster, int replicas) {
+
+        ArrayList<String> podNames = new ArrayList<>(replicas);
+
+        for (int podId = 0; podId < replicas; podId++) {
+
+            podNames.add(kafkaPodName(cluster, podId));
+
+        }
+        return podNames;
+    }
+
+    /**
+     * @param cluster The name of the cluster.
+     * @return The name of the clients CA certificate Secret.
+     */
+    public static String clientsCaCertSecretName(String cluster) {
+        return KafkaResources.clientsCaCertificateSecretName(cluster);
+    }
+
     public static KafkaCluster fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
         return fromCrd(reconciliation, kafkaAssembly, versions, null, 0);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -1202,7 +1202,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 1_000,
                                 operationTimeoutMs,
                                 () -> new BackOff(250, 2, 10),
-                                replicas,
+                                KafkaCluster.generatePodList(reconciliation.name(), replicas),
                                 compositeFuture.resultAt(0),
                                 compositeFuture.resultAt(1),
                                 adminClientProvider,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -769,7 +769,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                             if (podSet != null) {
                                                 return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), podSet.getSpec().getPods().size()));
                                             } else {
-                                                return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), 0));
+                                                return Future.succeededFuture(new ArrayList<String>());
                                             }
                                         });
                             } else {
@@ -778,7 +778,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                             if (sts != null)    {
                                                 return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), sts.getSpec().getReplicas()));
                                             } else {
-                                                return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), 0));
+                                                return Future.succeededFuture(new ArrayList<String>());
                                             }
                                         });
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -769,7 +769,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                             if (podSet != null) {
                                                 return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), podSet.getSpec().getPods().size()));
                                             } else {
-                                                return Future.succeededFuture(new ArrayList<String>());
+                                                return Future.succeededFuture(List.<String>of());
                                             }
                                         });
                             } else {
@@ -778,7 +778,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                             if (sts != null)    {
                                                 return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), sts.getSpec().getReplicas()));
                                             } else {
-                                                return Future.succeededFuture(new ArrayList<String>());
+                                                return Future.succeededFuture(List.<String>of());
                                             }
                                         });
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -766,19 +766,19 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                             if (featureGates.useStrimziPodSetsEnabled())   {
                                 return strimziPodSetOperator.getAsync(namespace, KafkaResources.kafkaStatefulSetName(name))
                                         .compose(podSet -> {
-                                            if (podSet != null)    {
-                                                return Future.succeededFuture(podSet.getSpec().getPods().size());
+                                            if (podSet != null) {
+                                                return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), podSet.getSpec().getPods().size()));
                                             } else {
-                                                return Future.succeededFuture(0);
+                                                return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), 0));
                                             }
                                         });
                             } else {
                                 return stsOperations.getAsync(namespace, KafkaResources.kafkaStatefulSetName(name))
                                         .compose(sts -> {
                                             if (sts != null)    {
-                                                return Future.succeededFuture(sts.getSpec().getReplicas());
+                                                return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), sts.getSpec().getReplicas()));
                                             } else {
-                                                return Future.succeededFuture(0);
+                                                return Future.succeededFuture(KafkaCluster.generatePodList(reconciliation.name(), 0));
                                             }
                                         });
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -58,7 +58,7 @@ class KafkaAvailability {
      * Determine whether the given broker can be rolled without affecting
      * producers with acks=all publishing to topics with a {@code min.in.sync.replicas}.
      */
-    Future<Boolean> canRoll(int  podId) {
+    Future<Boolean> canRoll(int podId) {
         LOGGER.debugCr(reconciliation, "Determining whether broker {} can be rolled", podId);
         return canRollBroker(descriptions, podId);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAvailability.java
@@ -58,7 +58,7 @@ class KafkaAvailability {
      * Determine whether the given broker can be rolled without affecting
      * producers with acks=all publishing to topics with a {@code min.in.sync.replicas}.
      */
-    Future<Boolean> canRoll(int podId) {
+    Future<Boolean> canRoll(int  podId) {
         LOGGER.debugCr(reconciliation, "Determining whether broker {} can be rolled", podId);
         return canRollBroker(descriptions, podId);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -193,7 +193,7 @@ public class KafkaRoller {
             for (int podIndex = 0; podIndex < podList.size(); podIndex++) {
                 // Order the podNames unready first otherwise repeated reconciliations might each restart a pod
                 // only for it not to become ready and thus drive the cluster to a worse state.
-                pods.add(podOperations.isReady(namespace, podList.get(podIndex)) ? pods.size() : 0, new PodRef(podList.get(podIndex), indexOfPod(podList.get(podIndex))));
+                pods.add(podOperations.isReady(namespace, podList.get(podIndex)) ? pods.size() : 0, new PodRef(podList.get(podIndex), idOfPod(podList.get(podIndex))));
             }
             LOGGER.debugCr(reconciliation, "Initial order for rolling restart {}", pods);
             List<Future> futures = new ArrayList<>(podList.size());
@@ -399,7 +399,7 @@ public class KafkaRoller {
         return false;
     }
 
-    private int indexOfPod(String podName)  {
+    private int idOfPod(String podName)  {
         return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
     }
 


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Task

### Description

The KafkaRoller currently expects to get as parameter number of Kafka replicas. This PR tries to remove the use of replicas in Kafka Roller and introduce the use of pod list.'

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

