### PR TITLE
[MO] - replace EmbeddedKafkaCluster with Strimzi test container

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -191,36 +191,11 @@
             <artifactId>connect-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Used by EmbeddedKafkaCluster -->
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-streams</artifactId>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-streams</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.IsolatedTest;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -28,7 +29,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.connect.cli.ConnectDistributed;
 import org.apache.kafka.connect.runtime.Connect;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectApiTest {
-    private static EmbeddedKafkaCluster cluster;
+    private static StrimziKafkaCluster cluster;
     private static Vertx vertx;
     private Connect connect;
     private static final int PORT = 18083;
@@ -70,7 +70,7 @@ public class KafkaConnectApiTest {
         workerProps.put("offset.storage.topic", getClass().getSimpleName() + "-offsets");
         workerProps.put("config.storage.topic", getClass().getSimpleName() + "-config");
         workerProps.put("status.storage.topic", getClass().getSimpleName() + "-status");
-        workerProps.put("bootstrap.servers", cluster.bootstrapServers());
+        workerProps.put("bootstrap.servers", cluster.getBootstrapServers());
         //DistributedConfig config = new DistributedConfig(workerProps);
         //RestServer rest = new RestServer(config);
         //rest.initializeServer();
@@ -97,8 +97,9 @@ public class KafkaConnectApiTest {
     @BeforeAll
     public static void before() throws IOException {
         vertx = Vertx.vertx();
-
-        cluster = new EmbeddedKafkaCluster(3);
+        final Map<String, String> kafkaClusterConfiguration = new HashMap<>();
+        kafkaClusterConfiguration.put("zookeeper.connect", "zookeeper:2181");
+        cluster = new StrimziKafkaCluster(3, 1, kafkaClusterConfiguration);
         cluster.start();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -20,6 +20,7 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -29,7 +30,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -55,7 +56,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectorIT {
-    private static EmbeddedKafkaCluster cluster;
+    private static StrimziKafkaCluster cluster;
     private static Vertx vertx;
     private ConnectCluster connectCluster;
 
@@ -67,7 +68,9 @@ public class KafkaConnectorIT {
                         .setEnabled(true)
         ));
 
-        cluster = new EmbeddedKafkaCluster(3);
+        final Map<String, String> kafkaClusterConfiguration = new HashMap<>();
+        kafkaClusterConfiguration.put("zookeeper.connect", "zookeeper:2181");
+        cluster = new StrimziKafkaCluster(3, 1, kafkaClusterConfiguration);
         cluster.start();
     }
 
@@ -83,7 +86,7 @@ public class KafkaConnectorIT {
 
         // Start a 3 node connect cluster
         connectCluster = new ConnectCluster()
-                .usingBrokers(cluster.bootstrapServers())
+                .usingBrokers(cluster.getBootstrapServers())
                 .addConnectNodes(3);
         connectCluster.startup();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
+        <strimzi-test-container.version>0.100.0</strimzi-test-container.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.2.Final</registry.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
@@ -580,6 +581,11 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-streams</artifactId>
                 <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.strimzi</groupId>
+                <artifactId>strimzi-test-container</artifactId>
+                <version>${strimzi-test-container.version}</version>
             </dependency>
             <!-- Used by EmbeddedKafkaCluster -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <module>api</module>
         <module>mockkube</module>
         <module>config-model</module>
-<!--        <module>config-model-generator</module>-->
+        <module>config-model-generator</module>
         <module>operator-common</module>
         <module>topic-operator</module>
         <module>cluster-operator</module>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <module>api</module>
         <module>mockkube</module>
         <module>config-model</module>
-        <module>config-model-generator</module>
+<!--        <module>config-model-generator</module>-->
         <module>operator-common</module>
         <module>topic-operator</module>
         <module>cluster-operator</module>
@@ -587,47 +587,6 @@
                 <artifactId>strimzi-test-container</artifactId>
                 <version>${strimzi-test-container.version}</version>
             </dependency>
-            <!-- Used by EmbeddedKafkaCluster -->
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-streams</artifactId>
-                <version>${kafka.version}</version>
-                <classifier>test</classifier>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>*</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>${kafka.version}</version>
-                <classifier>test</classifier>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>*</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka_2.13</artifactId>
-                <version>${kafka.version}</version>
-                <classifier>test</classifier>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>*</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -116,26 +116,10 @@
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
         </dependency>
-        <!-- Used by EmbeddedKafkaCluster -->
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-streams</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreTest.java
@@ -10,18 +10,18 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import io.strimzi.test.container.StrimziKafkaContainer;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 public class KafkaStreamsTopicStoreTest extends TopicStoreTestBase {
     private static final Map<String, String> MANDATORY_CONFIG;
-    private static EmbeddedKafkaCluster cluster;
+    private static StrimziKafkaContainer kafkaContainer;
 
     static {
         MANDATORY_CONFIG = new HashMap<>();
@@ -60,11 +60,12 @@ public class KafkaStreamsTopicStoreTest extends TopicStoreTestBase {
 
     @BeforeAll
     public static void before() throws Exception {
-        cluster = new EmbeddedKafkaCluster(1);
-        cluster.start();
+        kafkaContainer = new StrimziKafkaContainer()
+            .withBrokerId(1);
+        kafkaContainer.start();
 
-        MANDATORY_CONFIG.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, cluster.bootstrapServers());
-        MANDATORY_CONFIG.put(Config.ZOOKEEPER_CONNECT.key, cluster.zKConnectString());
+        MANDATORY_CONFIG.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaContainer.getBootstrapServers());
+        MANDATORY_CONFIG.put(Config.ZOOKEEPER_CONNECT.key, "zookeeper:2181");
 
         service = service(Collections.emptyMap());
     }
@@ -75,7 +76,7 @@ public class KafkaStreamsTopicStoreTest extends TopicStoreTestBase {
             service.stop();
         }
 
-        cluster.stop();
+        kafkaContainer.stop();
     }
 
     @BeforeEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -225,7 +225,6 @@ public abstract class TopicOperatorBaseIT {
     protected Map<String, String> topicOperatorConfig(StrimziKafkaCluster kafkaCluster) {
         Map<String, String> m = new HashMap<>();
         m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.getBootstrapServers());
-        // TODO: check this one..
         m.put(Config.ZOOKEEPER_CONNECT.key, kafkaCluster.getZookeeper().getHost() + ":" + kafkaCluster.getZookeeper().getFirstMappedPort());
         m.put(Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000");
         m.put(Config.NAMESPACE.key, NAMESPACE);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.exceptions.NoClusterException;
@@ -34,7 +35,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -136,12 +136,12 @@ public abstract class TopicOperatorBaseIT {
         }
     }
 
-    public void setup(EmbeddedKafkaCluster kafkaCluster) throws Exception {
+    public void setup(StrimziKafkaCluster kafkaCluster) throws Exception {
         LOGGER.info("Setting up test");
         cluster.cluster();
 
         Properties p = new Properties();
-        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.bootstrapServers());
+        p.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers());
         adminClient = AdminClient.create(p);
 
         kubeClient = kubeClient().getClient();
@@ -204,7 +204,7 @@ public abstract class TopicOperatorBaseIT {
         latch.await(30, TimeUnit.SECONDS);
     }
 
-    protected void startTopicOperator(EmbeddedKafkaCluster kafkaCluster) throws InterruptedException, ExecutionException, TimeoutException {
+    protected void startTopicOperator(StrimziKafkaCluster kafkaCluster) throws InterruptedException, ExecutionException, TimeoutException {
 
         LOGGER.info("Starting Topic Operator");
         session = new Session(kubeClient, new Config(topicOperatorConfig(kafkaCluster)));
@@ -222,10 +222,11 @@ public abstract class TopicOperatorBaseIT {
         LOGGER.info("Started Topic Operator");
     }
 
-    protected Map<String, String> topicOperatorConfig(EmbeddedKafkaCluster kafkaCluster) {
+    protected Map<String, String> topicOperatorConfig(StrimziKafkaCluster kafkaCluster) {
         Map<String, String> m = new HashMap<>();
-        m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.bootstrapServers());
-        m.put(Config.ZOOKEEPER_CONNECT.key, kafkaCluster.zKConnectString());
+        m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.getBootstrapServers());
+        // TODO: check this one..
+        m.put(Config.ZOOKEEPER_CONNECT.key, kafkaCluster.getZookeeper().getHost() + ":" + kafkaCluster.getZookeeper().getFirstMappedPort());
         m.put(Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000");
         m.put(Config.NAMESPACE.key, NAMESPACE);
         m.put(Config.CLIENT_ID.key, CLIENTID);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -9,7 +9,6 @@ import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -24,11 +23,11 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.errors.InvalidRequestException;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -46,11 +45,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TopicOperatorIT extends TopicOperatorBaseIT {
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorIT.class);
-    protected static EmbeddedKafkaCluster kafkaCluster;
+    protected static StrimziKafkaCluster kafkaCluster;
 
     @BeforeAll
     public static void beforeAll() throws IOException {
-        kafkaCluster = new EmbeddedKafkaCluster(numKafkaBrokers(), kafkaClusterConfig());
+        kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
         kafkaCluster.start();
 
         setupKubeCluster();
@@ -76,9 +75,10 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         return 1;
     }
 
-    protected static Properties kafkaClusterConfig() {
-        Properties p = new Properties();
-        p.setProperty(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), "false");
+    protected static Map<String, String> kafkaClusterConfig() {
+        Map<String, String> p = new HashMap<>();
+        p.put(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), "false");
+        p.put("zookeeper.connect", "zookeeper:2181");
         return p;
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockTest.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -24,7 +25,6 @@ import io.vertx.micrometer.VertxPrometheusOptions;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -53,7 +54,7 @@ public class TopicOperatorMockTest {
 
     private KubernetesClient kubeClient;
     private Session session;
-    private EmbeddedKafkaCluster cluster;
+    private StrimziKafkaCluster kafkaCluster;
     private static Vertx vertx;
     private String deploymentId;
     private AdminClient adminClient;
@@ -83,19 +84,21 @@ public class TopicOperatorMockTest {
         //Create cluster in @BeforeEach instead of @BeforeAll as once the checkpoints causing premature success were fixed,
         //tests were failing due to topic "my-topic" already existing, and trying to delete the topics at the end of the test was timing out occasionally.
         //So works best when the cluster is recreated for each test to avoid shared state
-        cluster = new EmbeddedKafkaCluster(1);
-        cluster.start();
+        Map<String, String> config = new HashMap<>();
+        config.put("zookeeper.connect", "zookeeper:2181");
+        kafkaCluster = new StrimziKafkaCluster(1, 1, config);
+        kafkaCluster.start();
 
         MockKube mockKube = new MockKube();
         mockKube.withCustomResourceDefinition(Crds.kafkaTopic(),
                         KafkaTopic.class, KafkaTopicList.class, KafkaTopic::getStatus, KafkaTopic::setStatus);
 
         kubeClient = mockKube.build();
-        adminClient = AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers()));
+        adminClient = AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers()));
 
         Config topicConfig = new Config(Map.of(
-            Config.KAFKA_BOOTSTRAP_SERVERS.key, cluster.bootstrapServers(),
-            Config.ZOOKEEPER_CONNECT.key, cluster.zKConnectString(),
+            Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.getBootstrapServers(),
+            Config.ZOOKEEPER_CONNECT.key, kafkaCluster.getZookeeper().getHost() + ":" + kafkaCluster.getZookeeper().getFirstMappedPort(),
             Config.ZOOKEEPER_CONNECTION_TIMEOUT_MS.key, "30000",
             Config.NAMESPACE.key, "myproject",
             Config.CLIENT_ID.key, "myproject-client-id",
@@ -153,7 +156,7 @@ public class TopicOperatorMockTest {
                     adminClient.close();
                 }
 
-                cluster.stop();
+                kafkaCluster.stop();
                 
                 context.completeNow();
             });

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -5,9 +5,9 @@
 package io.strimzi.operator.topic;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.vertx.core.Future;
 import kafka.server.KafkaConfig$;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,16 +15,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
-    protected static EmbeddedKafkaCluster kafkaCluster;
+    protected static StrimziKafkaCluster kafkaCluster;
 
     @BeforeAll
     public static void beforeAll() throws IOException {
-        kafkaCluster = new EmbeddedKafkaCluster(numKafkaBrokers(), kafkaClusterConfig());
+        kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
         kafkaCluster.start();
 
         setupKubeCluster();
@@ -50,10 +51,11 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
         return 1;
     }
 
-    protected static Properties kafkaClusterConfig() {
-        Properties config = new Properties();
-        config.setProperty(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "false");
-        return config;
+    protected static Map<String, String> kafkaClusterConfig() {
+        Map<String, String> p = new HashMap<>();
+        p.put(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "false");
+        p.put("zookeeper.connect", "zookeeper:2181");
+        return p;
     }
 
     @Test

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -81,26 +81,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Used by EmbeddedKafkaCluster -->
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-streams</artifactId>
-            <classifier>test</classifier>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <!-- ^^^^^ Used by EmbeddedKafkaCluster -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/AbstractAdminApiOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/AbstractAdminApiOperatorIT.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR replaces `EmbeddedKafkaCluster` with `Strimzi test container` in the user-operator, cluster-operator and topic-operator module. Thus completely removing dependency for `EmbeddedKafkaCluster`

### Checklist

- [x] Make sure all tests pass