### PR TITLE
[MO] - [system test] -> additional check for connectTimeout and readT…

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -19,6 +19,7 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -33,6 +34,7 @@ import java.util.Map;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
@@ -61,6 +63,15 @@ public class OauthAbstractST extends AbstractST {
     protected static final String OAUTH_TEAM_B_SECRET = "team-b-client-secret";
     protected static final String OAUTH_KAFKA_CLIENT_SECRET = "kafka-client-secret";
     protected static final String OAUTH_KEY = "clientSecret";
+
+    // broker oauth configuration
+    protected static final Integer CONNECT_TIMEOUT_S = 100;
+    protected static final Integer READ_TIMEOUT_S = 100;
+
+    protected static final Map<String, Object> FIELDS_TO_VERIFY = Map.of(
+        "connectTimeout", CONNECT_TIMEOUT_S,
+        "readTimeout", READ_TIMEOUT_S
+    );
 
     protected final String audienceListenerPort = "9098";
 
@@ -145,6 +156,19 @@ public class OauthAbstractST extends AbstractST {
         SecretUtils.createSecret(namespace, BRIDGE_OAUTH_SECRET, OAUTH_KEY, "kafka-bridge-secret");
         SecretUtils.createSecret(namespace, OAUTH_CLIENT_AUDIENCE_SECRET, OAUTH_KEY, "kafka-audience-secret");
         SecretUtils.createSecret(namespace, OAUTH_KAFKA_CLIENT_SECRET, OAUTH_KEY, "kafka-client-secret");
+    }
+
+    /**
+     * Checks {@link #FIELDS_TO_VERIFY} oauth configuration for components logs (i.e., Kafka, KafkaConnect, KafkaBridge,
+     * KafkaMirrorMaker, KafkaMirrorMaker2).
+     *
+     * @param componentLogs specific component logs scraped from pod
+     */
+    protected final void verifyOauthConfiguration(final String componentLogs) {
+        for (Map.Entry<String, Object> configField : FIELDS_TO_VERIFY.entrySet()) {
+            assertThat(componentLogs, CoreMatchers.containsString(configField.getKey() + ": " + configField.getValue()));
+        }
+        assertThat(componentLogs, CoreMatchers.containsString("Successfully logged in"));
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -41,6 +41,7 @@ import io.strimzi.test.k8s.KubeClusterResource;
 import io.vertx.core.cli.annotations.Description;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -327,7 +328,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(INFRA_NAMESPACE, kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
 
-        final String kafkaConnectLogs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(false, "logs", kafkaConnectPodName).out();
+        final String kafkaConnectLogs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(Level.DEBUG, "logs", kafkaConnectPodName).out();
         verifyOauthConfiguration(kafkaConnectLogs);
     }
 
@@ -441,7 +442,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
                 .build());
 
         final String kafkaMirrorMakerPodName = kubeClient(INFRA_NAMESPACE).listPods(INFRA_NAMESPACE, oauthClusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND).get(0).getMetadata().getName();
-        final String kafkaMirrorMakerLogs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(false, "logs", kafkaMirrorMakerPodName).out();
+        final String kafkaMirrorMakerLogs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(Level.DEBUG, "logs", kafkaMirrorMakerPodName).out();
         verifyOauthConfiguration(kafkaMirrorMakerLogs);
 
         TestUtils.waitFor("Waiting for Mirror Maker will copy messages from " + oauthClusterName + " to " + targetKafkaCluster,
@@ -593,7 +594,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
             .build());
 
         final String kafkaMirrorMaker2PodName = kubeClient(INFRA_NAMESPACE).listPods(INFRA_NAMESPACE, oauthClusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getName();
-        final String kafkaMirrorMaker2Logs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(false, "logs", kafkaMirrorMaker2PodName).out();
+        final String kafkaMirrorMaker2Logs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(Level.DEBUG, "logs", kafkaMirrorMaker2PodName).out();
         verifyOauthConfiguration(kafkaMirrorMaker2Logs);
 
         TestUtils.waitFor("Waiting for Mirror Maker 2 will copy messages from " + kafkaSourceClusterName + " to " + kafkaTargetClusterName,
@@ -685,7 +686,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
             .build());
 
         final String kafkaBridgePodName = kubeClient(INFRA_NAMESPACE).listPods(INFRA_NAMESPACE, oauthClusterName, Labels.STRIMZI_KIND_LABEL, KafkaBridge.RESOURCE_KIND).get(0).getMetadata().getName();
-        final String kafkaBridgeLogs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(false, "logs", kafkaBridgePodName).out();
+        final String kafkaBridgeLogs = KubeClusterResource.cmdKubeClient(INFRA_NAMESPACE).execInCurrentNamespace(Level.DEBUG, "logs", kafkaBridgePodName).out();
         verifyOauthConfiguration(kafkaBridgeLogs);
 
         String bridgeProducerName = "bridge-producer-" + clusterName;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
+import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaConnect;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.time.Duration;
+import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
@@ -657,6 +659,10 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
+
+        InlineLogging ilDebug = new InlineLogging();
+        ilDebug.setLoggers(Map.of("rootLogger.level", "DEBUG"));
+
         resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridge(oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
             .editMetadata()
                 .withNamespace(INFRA_NAMESPACE)
@@ -672,14 +678,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
                     .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
                     .withReadTimeoutSeconds(READ_TIMEOUT_S)
                 .endKafkaClientAuthenticationOAuth()
-                .withNewInlineLogging()
-                    // TODO: bridge logs seems to be only on INFO level
-                    // I tried this and nothing works...
-                        // 1. `bridge.root.logger.level`
-                        // 2. `logger.bridge.level`
-                        // 3. `bridge.root.logger`
-                    .addToLoggers("rootLogger.level", "DEBUG")
-                .endInlineLogging()
+                .withLogging(ilDebug)
             .endSpec()
             .build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -313,6 +313,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
                 .endKafkaClientAuthenticationOAuth()
                 .withTls(null)
                 .withNewInlineLogging()
+                    // needed for a verification of oauth configuration
                     .addToLoggers("connect.root.logger.level", "DEBUG")
                 .endInlineLogging()
             .endSpec()
@@ -660,6 +661,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
 
+        // needed for a verification of oauth configuration
         InlineLogging ilDebug = new InlineLogging();
         ilDebug.setLoggers(Map.of("rootLogger.level", "DEBUG"));
 


### PR DESCRIPTION
…imeout

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR adds checks for new options in [`0.10.0` ](https://github.com/strimzi/strimzi-kafka-oauth/releases/tag/0.10.0). Specifically, connect and read timeout. The overall functionality is tested in the [strimzi-oauth-repo](https://github.com/strimzi/strimzi-kafka-oauth) but here I adding a check that each option is properly propagated and detected in the components (i.e., `KafkaBridge`, `KafkaConnect`, `KafkaMirrorMaker`, `KafkaMirrorMaker2`..). This check is verified inside the logs of each component.

### Checklist

- [x] Make sure all tests pass