### PR TITLE
docs: new feature gate versions section

### DIFF
--- a/documentation/assemblies/operators/assembly-operators.adoc
+++ b/documentation/assemblies/operators/assembly-operators.adoc
@@ -11,4 +11,8 @@ Use the Strimzi operators to manage your Kafka cluster, and Kafka topics and use
 include::assembly-using-the-cluster-operator.adoc[leveloffset=+1]
 include::assembly-using-the-topic-operator.adoc[leveloffset=+1]
 include::assembly-using-the-user-operator.adoc[leveloffset=+1]
+//feature gates overview
+include::../../modules/operators/ref-operator-cluster-feature-gates.adoc[leveloffset=+1]
+//feature gate release lifecycle
+include::../../modules/operators/ref-operator-cluster-feature-gate-releases.adoc[leveloffset=+2]
 include::../../modules/operators/con-operators-prometheus-metrics.adoc[leveloffset=+1]

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -17,9 +17,9 @@ Beta stage features are well tested and their functionality is not likely to cha
 GA stage features are stable and should not change in the future.
 Alpha and beta stage features are removed if they do not prove to be useful.
 
-* The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.31.
-* The `ServiceAccountPatching` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.30.
-* The `UseStrimziPodSets` feature gate is currently planned to move to the beta stage in Strimzi 0.30.0.
+* The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27 and is expected to remain in the beta stage until Strimzi 0.31.
+* The `ServiceAccountPatching` feature gate moved to beta stage in Strimzi 0.27 and is expected to remain in the beta stage until Strimzi 0.30.
+* The `UseStrimziPodSets` feature gate is currently planned to move to the beta stage in Strimzi 0.30.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -33,28 +33,26 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦GA
 
 ¦`ControlPlaneListener`
-¦0.23.0
-¦0.27.0
+¦0.23
+¦0.27
 ¦ -
 
 ¦`ServiceAccountPatching`
-¦0.24.0
-¦0.27.0
+¦0.24
+¦0.27
 ¦ -
 
 ¦`UseStrimziPodSets`
-¦0.28.0
+¦0.28
 ¦ -
 ¦ -
 
 |===
 
-== Disabling feature gates when upgrading Strimzi
-
-If a feature gate is enabled, you may need to disable it before upgrading or downgrading Strimzi.
+If a feature gate is enabled, you may need to disable it before upgrading or downgrading from a specific Strimzi version.
 The following table shows which feature gates you need to disable when upgrading or downgrading Strimzi versions.
 
-.Disable feature gates when upgrading or downgrading
+.Feature gates to disable when upgrading or downgrading Strimzi
 [cols="3*",options="header",stripes="none",separator=¦]
 |===
 
@@ -65,10 +63,6 @@ The following table shows which feature gates you need to disable when upgrading
 ¦`ControlPlaneListener`
 ¦0.22 and earlier
 ¦0.22 and earlier
-
-¦`ServiceAccountPatching`
-¦-
-¦-
 
 ¦`UseStrimziPodSets`
 ¦-

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-cluster-operator.adoc
+
+[id='ref-operator-cluster-feature-gate-releases-{context}']
+= Feature gate releases
+
+[role="_abstract"]
+Feature gates have three stages of maturity:
+
+* Alpha — typically disabled by default
+* Beta — typically enabled by default
+* General Availability (GA) — typically always enabled
+
+Alpha stage features might be experimental or unstable, subject to change, or not sufficiently tested for production use.
+Beta stage features are well tested and their functionality is not likely to change.
+GA stage features are stable and should not change in the future.
+Alpha and beta stage features are removed if they do not prove to be useful.
+
+* The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.31.
+* The `ServiceAccountPatching` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.30.
+* The `UseStrimziPodSets` feature gate is currently planned to move to the beta stage in Strimzi 0.30.0.
+
+NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
+
+.Feature gates and the Strimzi versions when they moved to alpha, beta, or GA
+[cols="4*",options="header",stripes="none",separator=¦]
+|===
+
+¦Feature gate
+¦Alpha
+¦Beta
+¦GA
+
+¦`ControlPlaneListener`
+¦0.23.0
+¦0.27.0
+¦ -
+
+¦`ServiceAccountPatching`
+¦0.24.0
+¦0.27.0
+¦ -
+
+¦`UseStrimziPodSets`
+¦0.28.0
+¦ -
+¦ -
+
+|===
+
+== Disabling feature gates when upgrading Strimzi
+
+If a feature gate is enabled, you may need to disable it before upgrading or downgrading Strimzi.
+The following table shows which feature gates you need to disable when upgrading or downgrading Strimzi versions.
+
+.Disable feature gates when upgrading or downgrading
+[cols="3*",options="header",stripes="none",separator=¦]
+|===
+
+¦Disable Feature gate
+¦Upgrading from Strimzi version
+¦Downgrading to Strimzi version
+
+¦`ControlPlaneListener`
+¦0.22 and earlier
+¦0.22 and earlier
+
+¦`ServiceAccountPatching`
+¦-
+¦-
+
+¦`UseStrimziPodSets`
+¦-
+¦0.27 and earlier
+
+|===

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -32,14 +32,17 @@ Use the `ControlPlaneListener` feature gate to change the communication paths us
 In Strimzi, control plane traffic consists of controller connections that maintain the desired state of the Kafka cluster.
 Data plane traffic mainly consists of data replication between the leader broker and the follower brokers.
 
-To disable the `ControlPlaneListener` feature gate, specify `-ControlPlaneListener` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-When the `ControlPlaneListener` feature gate is disabled, control plane and data plane traffic go through the same internal listener on port 9091.
-This was the default behavior before the feature gate was introduced.
-
 When `ControlPlaneListener` is enabled, control plane traffic goes through a dedicated _control plane listener_ on port 9090.
 Data plane traffic continues to use the internal listener on port 9091.
 
 Using control plane listeners might improve performance because important controller connections, such as partition leadership changes, are not delayed by data replication across brokers.
+
+.Disabling the ControlPlaneListener feature gate
+To disable the `ControlPlaneListener` feature gate, specify `-ControlPlaneListener` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+When the `ControlPlaneListener` feature gate is disabled, control plane and data plane traffic go through the same internal listener on port 9091.
+This was the default behavior before the feature gate was introduced.
+
+IMPORTANT: The `ControlPlaneListener` feature gate must be disabled when upgrading from or downgrading to Strimzi 0.22 and earlier versions.
 
 == ServiceAccountPatching feature gate
 
@@ -49,14 +52,13 @@ By default, the Cluster Operator reconciles service accounts and updates them wh
 For example, you can change service account labels and annotations after the operands are already created.
 To disable service account patching, disable the `ServiceAccountPatching` feature gate.
 
+.Disabling the ControlPlaneListener feature gate
 To disable the `ServiceAccountPatching` feature gate, specify `-ServiceAccountPatching` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 [id='ref-operator-use-strimzi-pod-sets-feature-gate-{context}']
 == UseStrimziPodSets feature gate
 
 The `UseStrimziPodSets` feature gate has a default state of _disabled_.
-
-To enable it, specify `+UseStrimziPodSets` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 Currently, Strimzi relies on StatefulSets to create and manage pods for the ZooKeeper and Kafka clusters.
 Strimzi creates the StatefulSet and Kubernetes creates the pods according to the StatefulSet definition.
@@ -71,3 +73,8 @@ The `UseStrimziPodSets` feature gate introduces a resource for managing pods cal
 When the feature gate is enabled, this resource is used instead of the StatefulSets.
 Strimzi handles the creation and management of pods instead of Kubernetes.
 Using StrimziPodSets instead of StatefulSets provides more control over the functionality.
+
+.Enabling the UseStrimziPodSets feature gate
+To enable the `UseStrimziPodSets` feature gate, specify `+UseStrimziPodSets` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+IMPORTANT: The `UseStrimziPodSets` feature gate must be disabled when downgrading to Strimzi 0.27 and earlier versions.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-cluster-operator.adoc
+
+[id='ref-operator-cluster-feature-gates-{context}']
+= Configuring feature gates
+
+[role="_abstract"]
+Strimzi operators support _feature gates_ to enable or disable certain features and functionality.
+Enabling a feature gate changes the behavior of the relevant operator and introduces the feature to your Strimzi deployment.
+
+Feature gates have a default state of either _enabled_ or _disabled_.
+
+To modify a feature gate's default state, use the `STRIMZI_FEATURE_GATES` environment variable in the operator's configuration.
+You can modify multiple feature gates using this single environment variable.
+Specify a comma-separated list of feature gate names and prefixes.
+A `+` prefix enables the feature gate and a `-` prefix  disables it.
+
+.Example feature gate configuration that enables `FeatureGate1` and disables `FeatureGate2`
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_FEATURE_GATES
+    value: +FeatureGate1,-FeatureGate2
+----
+
+== ControlPlaneListener feature gate
+
+The `ControlPlaneListener` feature gate has a default state of _enabled_.
+
+Use the `ControlPlaneListener` feature gate to change the communication paths used for inter-broker communications within your Kafka cluster.
+In Strimzi, control plane traffic consists of controller connections that maintain the desired state of the Kafka cluster.
+Data plane traffic mainly consists of data replication between the leader broker and the follower brokers.
+
+To disable the `ControlPlaneListener` feature gate, specify `-ControlPlaneListener` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+When the `ControlPlaneListener` feature gate is disabled, control plane and data plane traffic go through the same internal listener on port 9091.
+This was the default behavior before the feature gate was introduced.
+
+When `ControlPlaneListener` is enabled, control plane traffic goes through a dedicated _control plane listener_ on port 9090.
+Data plane traffic continues to use the internal listener on port 9091.
+
+Using control plane listeners might improve performance because important controller connections, such as partition leadership changes, are not delayed by data replication across brokers.
+
+== ServiceAccountPatching feature gate
+
+The `ServiceAccountPatching` feature gate has a default state of _enabled_.
+
+By default, the Cluster Operator reconciles service accounts and updates them when needed.
+For example, you can change service account labels and annotations after the operands are already created.
+To disable service account patching, disable the `ServiceAccountPatching` feature gate.
+
+To disable the `ServiceAccountPatching` feature gate, specify `-ServiceAccountPatching` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+[id='ref-operator-use-strimzi-pod-sets-feature-gate-{context}']
+== UseStrimziPodSets feature gate
+
+The `UseStrimziPodSets` feature gate has a default state of _disabled_.
+
+To enable it, specify `+UseStrimziPodSets` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+Currently, Strimzi relies on StatefulSets to create and manage pods for the ZooKeeper and Kafka clusters.
+Strimzi creates the StatefulSet and Kubernetes creates the pods according to the StatefulSet definition.
+When a pod is deleted, Kubernetes is responsible for recreating it.
+The use of StatefulSets has the following limitations:
+
+* Pods are always created or removed based on their index numbers
+* All pods in the StatefulSet need to have a similar configuration
+* Changing storage configuration for the Pods in the StatefulSet is complicated
+
+The `UseStrimziPodSets` feature gate introduces a resource for managing pods called `StrimziPodSet`.
+When the feature gate is enabled, this resource is used instead of the StatefulSets.
+Strimzi handles the creation and management of pods instead of Kubernetes.
+Using StrimziPodSets instead of StatefulSets provides more control over the functionality.

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -5,6 +5,7 @@
 [id='ref-operator-cluster-{context}']
 = Cluster Operator configuration
 
+[role="_abstract"]
 You can configure the Cluster Operator using supported environment variables, and through its logging configuration.
 
 The environment variables relate to container configuration for the deployment of the Cluster Operator image.
@@ -204,135 +205,7 @@ Set this environment variable to `false` to disable network policy generation. Y
 Number of seconds to cache successful name lookups in local DNS resolver. Any negative value means cache forever. Zero means do not cache. This can be useful to avoid connection errors due to long caching policies being applied.
 
 `STRIMZI_FEATURE_GATES`:: Optional.
-Enables or disables features and functionality controlled by feature gates.
-For more information about each feature gate, see xref:ref-operator-cluster-feature-gates-{context}[].
-
-[id='ref-operator-cluster-feature-gates-{context}']
-== Feature gates
-
-Strimzi operators support _feature gates_ to enable or disable certain features and functionality.
-Enabling a feature gate changes the behavior of the relevant operator and introduces the feature to your Strimzi deployment.
-
-Feature gates have a default state of either _enabled_ or _disabled_.
-To modify a feature gate's default state, use the `STRIMZI_FEATURE_GATES` environment variable in the operator's configuration.
-You can modify multiple feature gates using this single environment variable.
-
-Feature gates have three stages of maturity:
-
-* Alpha — typically disabled by default
-* Beta — typically enabled by default
-* General Availability (GA) — typically always enabled
-
-Alpha stage features might be experimental or unstable, subject to change, or not sufficiently tested for production use.
-Beta stage features are well tested and their functionality is not likely to change.
-GA stage features are stable and should not change in the future.
-Alpha and beta stage features are removed if they do not prove to be useful.
-
-NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
-
-.All feature gates and the Strimzi versions when they moved to alpha, beta, or GA
-[cols="4*",options="header",stripes="none",separator=¦]
-|===
-
-¦Feature gate
-¦Alpha
-¦Beta
-¦GA
-
-¦`ControlPlaneListener`
-¦0.23.0
-¦0.27.0
-¦ -
-
-¦`ServiceAccountPatching`
-¦0.24.0
-¦0.27.0
-¦ -
-
-¦`UseStrimziPodSets`
-¦0.28.0
-¦ -
-¦ -
-
-|===
-
-[discrete]
-=== Configuring feature gates
-
-You configure feature gates using the `STRIMZI_FEATURE_GATES` environment variable in the operator's configuration.
-Specify a comma-separated list of feature gate names and prefixes.
-A `+` prefix enables the feature gate and a `-` prefix  disables it.
-
-.Example feature gate configuration that enables `FeatureGate1` and disables `FeatureGate2`
-[source,yaml,options="nowrap"]
-----
-env:
-  - name: STRIMZI_FEATURE_GATES
-    value: +FeatureGate1,-FeatureGate2
-----
-
-=== Control plane listener feature gate
-
-Use the `ControlPlaneListener` feature gate to change the communication paths used for inter-broker communications within your Kafka cluster.
-In Strimzi, control plane traffic consists of controller connections that maintain the desired state of the Kafka cluster.
-Data plane traffic mainly consists of data replication between the leader broker and the follower brokers.
-
-When the `ControlPlaneListener` feature gate is disabled, control plane and data plane traffic go through the same internal listener on port 9091.
-This was the default behavior before the feature gate was introduced.
-
-When `ControlPlaneListener` is enabled, control plane traffic goes through a dedicated _control plane listener_ on port 9090.
-Data plane traffic continues to use the internal listener on port 9091.
-
-Using control plane listeners might improve performance because important controller connections, such as partition leadership changes, are not delayed by data replication across brokers.
-
-.Disabling the control plane listener feature gate
-
-The `ControlPlaneListener` feature gate is in the beta stage and has a default state of _enabled_.
-To disable it, specify `-ControlPlaneListener` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-
-This feature gate must be disabled when:
-
-* Upgrading from Strimzi 0.22 and earlier
-* Downgrading to Strimzi 0.22 and earlier
-
-NOTE: The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.31.
-
-=== Service Account patching feature gate
-
-The `ServiceAccountPatching` feature gate is currently in the beta phase and enabled by default.
-By default, the Cluster Operator reconciles service accounts and updates them when needed.
-For example, you can change service account labels and annotations after the operands are already created.
-To disable service account patching, disable the `ServiceAccountPatching` feature gate.
-
-Add `-ServiceAccountPatching` to the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-
-NOTE: The `ServiceAccountPatching` feature gate moved to beta stage in Strimzi 0.27.0 and is expected to remain in the beta stage until Strimzi 0.30.
-
-[id='ref-operator-use-strimzi-pod-sets-feature-gate-{context}']
-=== `UseStrimziPodSets` feature gate
-
-Currently, Strimzi relies on StatefulSets to create and manage Pods for the ZooKeeper and Kafka clusters.
-Strimzi creates the StatefulSet and Kubernetes creates the Pods according to the StatefulSet definition.
-When a Pod is deleted, Kubernetes is responsible for recreating it.
-The use of StatefulSets has the following limitations:
-
-* Pods are always created or removed based on their index numbers
-* All Pods in the StatefulSet need to have a similar configuration
-* Changing storage configuration for the Pods in the StatefulSet is complicated
-
-The `UseStrimziPodSets` feature gate introduces our own resource for managing the pods called `StrimziPodSet`.
-When the feature gate is enabled, this resource is used instead of the StatefulSets.
-Strimzi handles the creation and management of pods instead of Kubernetes.
-Using StrimziPodSets instead of StatefulSets provides more control over the functionality.
-
-.Enabling the `UseStrimziPodSets` feature gate
-
-The `UseStrimziPodSets` feature gate is in the alpha stage and has a default state of _disabled_.
-To enable it, specify `+UseStrimziPodSets` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-
-This feature gate must be disabled when downgrading to Strimzi 0.27 and earlier.
-
-NOTE: The `UseStrimziPodSets` feature gate is currently planned to move to the beta stage in Strimzi 0.30.0.
+Enables or disables features and functionality controlled by xref:ref-operator-cluster-feature-gates-{context}[feature gates].
 
 == Logging configuration by ConfigMap
 
@@ -388,7 +261,7 @@ if the operator is not running, or if a notification is not received for any rea
 In order to handle failovers properly, a periodic reconciliation process is executed by the Cluster Operator so that it can compare the state of the desired resources with the current cluster deployments in order to have a consistent state across all of them.
 You can set the time interval for the periodic reconciliations using the xref:STRIMZI_FULL_RECONCILIATION_INTERVAL_MS[] variable.
 
-= Provisioning Role-Based Access Control (RBAC)
+== Provisioning Role-Based Access Control (RBAC)
 
 For the Cluster Operator to function it needs permission within the Kubernetes cluster to interact with resources such as `Kafka`, `KafkaConnect`, and so on, as well as the managed resources, such as `ConfigMaps`, `Pods`, `Deployments`, `StatefulSets` and `Services`.
 Such permission is described in terms of Kubernetes role-based access control (RBAC) resources:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updates the _Using Strimzi Operators_ section of the _Configuring_ guide.
Separates the lifecycle stages and Strimzi versioning information from the feature gate descriptions to make clearer.
Pulls the sections up a level to make the content easier to locate

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

