### PR TITLE
Use the `/healthz` endpoint in Kafka Exporter health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.29.0
 
-* n/a
+* Use `/healthz` endpoint for Kafka Exporter health checks
 
 ## 0.28.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -46,9 +46,9 @@ public class KafkaExporter extends AbstractModel {
     protected static final String CLUSTER_CA_CERTS_VOLUME_MOUNT = "/etc/kafka-exporter/cluster-ca-certs/";
 
     // Configuration defaults
-    private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
-    private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 15;
-    private static final int DEFAULT_HEALTHCHECK_PERIOD = 30;
+    /*test*/ static final int DEFAULT_HEALTHCHECK_DELAY = 15;
+    /*test*/ static final int DEFAULT_HEALTHCHECK_TIMEOUT = 15;
+    /*test*/ static final int DEFAULT_HEALTHCHECK_PERIOD = 30;
     public static final Probe READINESS_PROBE_OPTIONS = new ProbeBuilder().withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT).withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).withPeriodSeconds(DEFAULT_HEALTHCHECK_PERIOD).build();
 
     protected static final String ENV_VAR_KAFKA_EXPORTER_LOGGING = "KAFKA_EXPORTER_LOGGING";
@@ -89,9 +89,9 @@ public class KafkaExporter extends AbstractModel {
         super(reconciliation, resource, APPLICATION_NAME);
         this.name = KafkaExporterResources.deploymentName(cluster);
         this.replicas = 1;
-        this.readinessPath = "/metrics";
+        this.readinessPath = "/healthz";
         this.readinessProbeOptions = READINESS_PROBE_OPTIONS;
-        this.livenessPath = "/metrics";
+        this.livenessPath = "/healthz";
         this.livenessProbeOptions = READINESS_PROBE_OPTIONS;
 
         this.saramaLoggingEnabled = false;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

the Kafka Exporter deployment is currently using the `/metrics` endpoints for health checks. This endpoint returns all metrics, so using it for health checks does not seem to be optimal - especially with large clusters (see for example [this](https://cloud-native.slack.com/archives/CMH3Q3SNP/p1644532252009529) Slack discussion). The latest version of the Kafka Exporter which we use now seems to have also the `/healthz` endpoint available which seems to be better for the health checks. It is also used in Kafka Exporter's own Helm Chart (https://github.com/danielqsj/kafka_exporter/blob/master/charts/kafka-exporter/templates/deployment.yaml#L70-L89).

This PR updates Strimzi to use the `/healthz` endpoint as well. It also adds tests and removes some unused fields and methods from the `KafkaExporterTest` class (the methods are probably related to when we had a Kafka Exporter service, the fields seem to be just a bad copy-paste).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md