### PR TITLE
Add `report.sh` to `make shellcheck`

### DIFF
--- a/.azure/scripts/shellcheck.sh
+++ b/.azure/scripts/shellcheck.sh
@@ -11,7 +11,8 @@ docker-images/kafka-based/kafka/cruise-control-scripts/*.sh
 docker-images/kafka-based/kafka/stunnel-scripts/*.sh
 docker-images/kafka-based/kafka/exporter-scripts/*.sh
 docker-images/jmxtrans/*.sh
-tools/olm-bundle/*.sh"
+tools/olm-bundle/*.sh
+tools/report.sh"
 
 for SCRIPTS in $SCRIPT_DIRS; do
     shellcheck -a -P $(dirname "$SCRIPTS") -x "$SCRIPTS"


### PR DESCRIPTION
### Type of change

- Task

### Description

#6234 made the `report.sh` tool valid according to Shellcheck. But it did not add it to the `make schellcheck` command used by the build and by the CI to verify the shell script. In order to make sure the code in `report.sh` stays valid, this PR adds it to Shellcheck.