### PR TITLE
[systemtest] Set `rootLogger.level` depending on env variable

### DIFF
--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -17,7 +17,7 @@ appender.rolling.strategy.max = 5
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} %-5p [%c{1}:%L] %m%n
 
-rootLogger.level = TRACE
+rootLogger.level = ${env:STRIMZI_TEST_ROOT_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.appenderRef.console.level = ${env:STRIMZI_TEST_LOG_LEVEL:-INFO}
 rootLogger.appenderRef.rolling.ref = RollingFile


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

Currently, we have set `rootLogger.level` to `TRACE` log level and in `rootLogger.appenderRef.console.level` we are setting the `INFO` log level (if `STRIMZI_TEST_LOG_LEVEL` is not set). The problem is that `rootLogger.appenderRef.console.level` only set logging level to logging we are using in our STs, but not in dependencies like fabric8 k8s client etc. This can generate tons of log without any meaning and we are not able to get proper error once the test fails. 

This PR adds new env variable, which can will set `rootLogger.level` and will differ to `STRIMZI_TEST_LOG_LEVEL`.

### Checklist

- [ ] Make sure all tests pass

