### PR TITLE
Removed unused metric options from AbstractOpertorTest

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
@@ -22,8 +22,6 @@ import io.vertx.core.shareddata.Lock;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -46,10 +44,7 @@ class AbstractOperatorTest {
         vertx = Vertx.vertx(new VertxOptions()
                 .setBlockedThreadCheckInterval(60)
                 .setBlockedThreadCheckIntervalUnit(TimeUnit.SECONDS)
-                .setMetricsOptions(new MicrometerMetricsOptions()
-                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-                        .setEnabled(true)
-        ));
+        );
     }
 
     @AfterAll


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I had a branch where the unit test classes were being run in a different order.  It is easily reproduced by adding `<runOrder>alphabetical</runOrder>`
If AbstractOperatorTest runs before OperatorMetricsTest, then OperatorMetricsTest will fail with `createCleanMetricsProvider:516 » NullPointer`

AbstractOperatorTest does not need to setup the metricsOptions.  And starting the metrics and then closing it via `vertx.close` seems to be causing trouble for the other test (OperatorMetricTest).

### Checklist

- [ X] Make sure all tests pass

