### PR TITLE
[MO] - StrimziTestContinare disable ryuk in build pipeline

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -21,6 +21,10 @@ stages:
   # Runs Strimzi unit and integration tests
   - stage: test_strimzi
     displayName: Strimzi Unit & IT tests
+    env:
+      # Test container optimization and also we eliminate pulling RYUK image from DockerHub to prevent limits
+      TESTCONTAINERS_RYUK_DISABLED: TRUE
+      TESTCONTAINERS_CHECKS_DISABLE: TRUE
     dependsOn:
       - build_strimzi
     jobs:

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -21,10 +21,6 @@ stages:
   # Runs Strimzi unit and integration tests
   - stage: test_strimzi
     displayName: Strimzi Unit & IT tests
-    env:
-      # Test container optimization and also we eliminate pulling RYUK image from DockerHub to prevent limits
-      TESTCONTAINERS_RYUK_DISABLED: TRUE
-      TESTCONTAINERS_CHECKS_DISABLE: TRUE
     dependsOn:
       - build_strimzi
     jobs:

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -33,6 +33,10 @@ jobs:
 
       # Run the unit and integration tests
       - bash: "mvn -e -V -B -Dmaven.javadoc.skip=true -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2 install"
+        env:
+          # Test container optimization and also we eliminate pulling RYUK image from DockerHub to prevent limits
+          TESTCONTAINERS_RYUK_DISABLED: TRUE
+          TESTCONTAINERS_CHECKS_DISABLE: TRUE
         displayName: "Unit and Integration tests"
 
       # Publish test results


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR disable the `RYUK` container for StrimziTestContainer. We don't need them because we handle the setup and teardown process on our own. For more info please take a look [here](https://www.testcontainers.org/features/configuration/)

### Checklist

- [x] Make sure all tests pass