### PR TITLE
Add Strimzi 0.28.0 to the upgrade/downgrade system tests

### DIFF
--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -1,21 +1,21 @@
 [
   {
     "fromVersion":"HEAD",
-    "toVersion":"0.27.0",
+    "toVersion":"0.28.0",
     "fromExamples":"HEAD",
-    "toExamples":"strimzi-0.27.0",
+    "toExamples":"strimzi-0.28.0",
     "urlFrom":"HEAD",
-    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.27.0/strimzi-0.27.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.28.0/strimzi-0.28.0.zip",
     "generateTopics": true,
     "additionalTopics": 2,
-    "oldestKafka": "2.8.0",
+    "oldestKafka": "3.0.0",
     "imagesAfterOperatorDowngrade": {
-      "zookeeper": "strimzi/kafka:0.27.0-kafka-3.0.0",
-      "kafka": "strimzi/kafka:0.27.0-kafka-3.0.0",
-      "topicOperator": "strimzi/operator:0.27.0",
-      "userOperator": "strimzi/operator:0.27.0"
+      "zookeeper": "strimzi/kafka:0.28.0-kafka-3.1.0",
+      "kafka": "strimzi/kafka:0.28.0-kafka-3.1.0",
+      "topicOperator": "strimzi/operator:0.28.0",
+      "userOperator": "strimzi/operator:0.28.0"
     },
-    "deployKafkaVersion": "3.0.0",
+    "deployKafkaVersion": "3.1.0",
     "client": {
       "continuousClientsMessages": 500
     },

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -70,9 +70,9 @@
     "strimziFeatureGatesFlags": ""
   },
   {
-    "fromVersion":"0.27.0",
-    "fromExamples":"strimzi-0.27.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.27.0/strimzi-0.27.0.zip",
+    "fromVersion":"0.28.0",
+    "fromExamples":"strimzi-0.28.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.28.0/strimzi-0.28.0.zip",
     "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",
@@ -80,10 +80,10 @@
     },
     "generateTopics": true,
     "additionalTopics": 2,
-    "oldestKafka": "2.8.0",
+    "oldestKafka": "3.0.0",
     "imagesBeforeKafkaUpgrade": {
-      "zookeeper": "strimzi/kafka:latest-kafka-3.0.0",
-      "kafka": "strimzi/kafka:latest-kafka-3.0.0",
+      "zookeeper": "strimzi/kafka:latest-kafka-3.1.0",
+      "kafka": "strimzi/kafka:latest-kafka-3.1.0",
       "topicOperator": "strimzi/operator:latest",
       "userOperator": "strimzi/operator:latest"
     },


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the Strimzi 0.28.0 release to the upgrade / downgrade system tests.