### PR TITLE
[MO] - increase timeout of build pipeline

### DIFF
--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -9,7 +9,7 @@ jobs:
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
-    timeoutInMinutes: 60
+    timeoutInMinutes: 70
     # Base system
     pool:
       vmImage: Ubuntu-20.04


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR increases the timeout of our `build pipeline` specifically the verification phase (i.e., UT and IT). The reason for such change is because we used `EmbeddedKafkaCluster` and it create a Kafka cluster in-memory. In Strimzi test containers we deploy containers (more heavy-weight) and thus it needs more time to spin up. We should definitely investigate if we really need 3 node clusters in such test cases or we are okay with just single-node.

### Checklist

- [ ] Make sure all tests pass