### PR TITLE
[MO] - [system test] -> oauth group extraction

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -67,10 +67,17 @@ public class OauthAbstractST extends AbstractST {
     // broker oauth configuration
     protected static final Integer CONNECT_TIMEOUT_S = 100;
     protected static final Integer READ_TIMEOUT_S = 100;
+    protected static final String GROUPS_CLAIM = "$.groups";
+    protected static final String GROUPS_CLAIM_DELIMITER = "."; // default is `,`
 
-    protected static final Map<String, Object> FIELDS_TO_VERIFY = Map.of(
+    protected static final Map<String, Object> COMPONENT_FIELDS_TO_VERIFY = Map.of(
         "connectTimeout", CONNECT_TIMEOUT_S,
         "readTimeout", READ_TIMEOUT_S
+    );
+
+    protected static final Map<String, Object> LISTENER_FIELDS_TO_VERIFY = Map.of(
+        "groupsClaimQuery", GROUPS_CLAIM,
+        "groupsClaimDelimiter", GROUPS_CLAIM_DELIMITER
     );
 
     protected final String audienceListenerPort = "9098";
@@ -159,16 +166,28 @@ public class OauthAbstractST extends AbstractST {
     }
 
     /**
-     * Checks {@link #FIELDS_TO_VERIFY} oauth configuration for components logs (i.e., Kafka, KafkaConnect, KafkaBridge,
+     * Checks {@link #COMPONENT_FIELDS_TO_VERIFY} oauth configuration for components logs (i.e., Kafka, KafkaConnect, KafkaBridge,
      * KafkaMirrorMaker, KafkaMirrorMaker2).
      *
      * @param componentLogs specific component logs scraped from pod
      */
     protected final void verifyOauthConfiguration(final String componentLogs) {
-        for (Map.Entry<String, Object> configField : FIELDS_TO_VERIFY.entrySet()) {
+        for (Map.Entry<String, Object> configField : COMPONENT_FIELDS_TO_VERIFY.entrySet()) {
             assertThat(componentLogs, CoreMatchers.containsString(configField.getKey() + ": " + configField.getValue()));
         }
         assertThat(componentLogs, CoreMatchers.containsString("Successfully logged in"));
+    }
+
+    /**
+     * Checks {@link #LISTENER_FIELDS_TO_VERIFY} oauth configuration for Kafka Oauth listener.
+     *
+     * @param kafkaLogs kafka logs to proof that configuration is propagated inside Pods
+     */
+    protected final void verifyOauthListenerConfiguration(final String kafkaLogs) {
+        for (Map.Entry<String, Object> configField : LISTENER_FIELDS_TO_VERIFY.entrySet()) {
+            assertThat(kafkaLogs, CoreMatchers.containsString(configField.getKey() + ": " + configField.getValue()));
+        }
+        assertThat(kafkaLogs, CoreMatchers.containsString("Successfully logged in"));
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -6,8 +6,6 @@ package io.strimzi.systemtest.security.oauth;
 
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
-import io.strimzi.api.kafka.model.InlineLogging;
-import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
@@ -33,7 +31,6 @@ import io.strimzi.systemtest.templates.crd.KafkaMirrorMakerTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
-import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
+import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
+import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -33,6 +33,7 @@ import io.strimzi.systemtest.templates.crd.KafkaMirrorMakerTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
@@ -766,6 +767,8 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
                                     .withUserNameClaim(keycloakInstance.getUserNameClaim())
                                     .withEnablePlain(true)
                                     .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                                    .withGroupsClaim(GROUPS_CLAIM)
+                                    .withGroupsClaimDelimiter(GROUPS_CLAIM_DELIMITER)
                                 .endKafkaListenerAuthenticationOAuth()
                                 .build(),
                             new GenericKafkaListenerBuilder()
@@ -804,6 +807,8 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
                 .endKafka()
             .endSpec()
             .build());
+
+        verifyOauthListenerConfiguration(kubeClient(INFRA_NAMESPACE).logsInSpecificNamespace(INFRA_NAMESPACE, KafkaResources.kafkaPodName(oauthClusterName, 0)));
     }
 
     @AfterAll


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is relatively the same as https://github.com/strimzi/strimzi-kafka-operator/pull/6351, which added check for (connect and read timeout). Here I add checks for `group claim` and `group claim delimiter` for new options in [0.10.0 ](https://github.com/strimzi/strimzi-kafka-oauth/releases/tag/0.10.0). The overall functionality is tested in the [strimzi-oauth-repo](https://github.com/strimzi/strimzi-kafka-oauth) but here I adding a check that each option is properly propagated and detected in the Kafka listener. This check is verified inside the logs of each component.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass