### PR TITLE
[systemtest] Add test for SPS recovery from pods deletion, remove STS only checks

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -561,4 +561,47 @@ public class StUtils {
             return kubeClient().getStatefulSet(namespaceName, resourceName).getSpec().getTemplate().getSpec().getAffinity();
         }
     }
+
+    public static void deleteStrimziPodSetOrStatefulSet(String namespaceName, String resourceName) {
+        if (Environment.isStrimziPodSetEnabled()) {
+            StrimziPodSetResource.strimziPodSetClient().inNamespace(namespaceName).withName(resourceName).delete();
+        } else {
+            kubeClient(namespaceName).deleteStatefulSet(resourceName);
+        }
+    }
+
+    public static void deleteStrimziPodSetOrStatefulSet(String resourceName) {
+        deleteStrimziPodSetOrStatefulSet(kubeClient().getNamespace(), resourceName);
+    }
+
+    public static void waitForStrimziPodSetOrStatefulSetRecovery(String resourceName, String resourceUID) {
+        if (Environment.isStrimziPodSetEnabled()) {
+            StrimziPodSetUtils.waitForStrimziPodSetRecovery(resourceName, resourceUID);
+        } else {
+            StatefulSetUtils.waitForStatefulSetRecovery(resourceName, resourceUID);
+        }
+    }
+
+    public static void waitForStrimziPodSetOrStatefulSetAndPodsReady(String namespaceName, String resourceName, int expectPods) {
+        if (Environment.isStrimziPodSetEnabled()) {
+            StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(namespaceName, resourceName, expectPods);
+        } else {
+            StatefulSetUtils.waitForAllStatefulSetPodsReady(namespaceName, resourceName, expectPods);
+        }
+    }
+
+    public static void waitForStrimziPodSetOrStatefulSetAndPodsReady(String resourceName, int expectPods) {
+        waitForStrimziPodSetOrStatefulSetAndPodsReady(kubeClient().getNamespace(), resourceName, expectPods);
+    }
+
+    public static String getStrimziPodSetOrStatefulSetUID(String namespaceName, String resourceName) {
+        if (Environment.isStrimziPodSetEnabled()) {
+            return StrimziPodSetResource.strimziPodSetClient().inNamespace(namespaceName).withName(resourceName).get().getMetadata().getUid();
+        }
+        return kubeClient(namespaceName).getStatefulSetUid(resourceName);
+    }
+
+    public static String getStrimziPodSetOrStatefulSetUID(String resourceName) {
+        return getStrimziPodSetOrStatefulSetUID(kubeClient().getNamespace(), resourceName);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StatefulSetUtils.java
@@ -47,6 +47,10 @@ public class StatefulSetUtils {
         LOGGER.info("StatefulSet {} is ready", statefulSetName);
     }
 
+    public static void waitForAllStatefulSetPodsReady(String namespaceName, String statefulSetName, int expectPods) {
+        waitForAllStatefulSetPodsReady(namespaceName, statefulSetName, expectPods, READINESS_TIMEOUT);
+    }
+
     public static void waitForAllStatefulSetPodsReady(String statefulSetName, int expectPods, long timeout) {
         waitForAllStatefulSetPodsReady(kubeClient().getNamespace(), statefulSetName, expectPods, timeout);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -621,7 +621,7 @@ class RollingUpdateST extends AbstractST {
 
         LabelSelector coLabelSelector = kubeClient(INFRA_NAMESPACE).getDeployment(INFRA_NAMESPACE, ResourceManager.getCoDeploymentName()).getSpec().getSelector();
         LOGGER.info("Deleting Cluster Operator pod with labels {}", coLabelSelector);
-        kubeClient(INFRA_NAMESPACE).deletePod(coLabelSelector);
+        kubeClient(INFRA_NAMESPACE).deletePodsByLabelSelector(coLabelSelector);
         LOGGER.info("Cluster Operator pod deleted");
 
         RollingUpdateUtils.waitTillComponentHasRolled(namespace, zkSelector, 3, zkPods);
@@ -630,7 +630,7 @@ class RollingUpdateST extends AbstractST {
             () -> kubeClient(namespace).listPods().stream().map(pod -> pod.getStatus().getPhase()).collect(Collectors.toList()).contains("Pending"));
 
         LOGGER.info("Deleting Cluster Operator pod with labels {}", coLabelSelector);
-        kubeClient(INFRA_NAMESPACE).deletePod(coLabelSelector);
+        kubeClient(INFRA_NAMESPACE).deletePodsByLabelSelector(coLabelSelector);
         LOGGER.info("Cluster Operator pod deleted");
 
         RollingUpdateUtils.waitTillComponentHasRolled(namespace, kafkaSelector, 3, kafkaPods);

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -345,7 +345,7 @@ public class KubeClient {
     /**
      * Deletes pod
      */
-    public Boolean deletePod(LabelSelector labelSelector) {
+    public Boolean deletePodsByLabelSelector(LabelSelector labelSelector) {
         return client.pods().inNamespace(getNamespace()).withLabelSelector(labelSelector).delete();
     }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

In #6323 most of the workarounds were removed from our STs. But in `RecoveryST` there were 2 tests, which was just checking the `StatefulSet` recovery - we want to have these checks for both STS and SPS.

This PR removes these "`StatefulSet` only" checks, so they will work with SPS too. Also adds the new test for recovery from pods deletion, as it was handled by k8s until now (Strimzi has to handle it for SPS by itself).

### Checklist

- [x] Write test
- [x] Make sure all tests pass
