### PR TITLE
Allow custom log4j2.properties in cluster operator

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -187,6 +187,7 @@ the documentation for more details.
 | `mavenBuilder.image.repository`      | Maven Builder image repository            | `nil`                                                |
 | `mavenBuilder.image.name`            | Override default Maven Builder image name                  | `maven-builder`                     |
 | `mavenBuilder.image.tag`             | Override default Maven Builder image tag                   | `nil`                               |
+| `logConfiguration`                   | Override default `log4j.properties` content                | `nil`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -6,6 +6,9 @@ metadata:
     app: strimzi
 data:
   log4j2.properties: |
+    {{- if .Values.logConfiguration }}
+    {{- tpl .Values.logConfiguration . | nindent 4 }}
+    {{- else }}
     name = COConfig
     monitorInterval = 30
 
@@ -33,3 +36,4 @@ data:
     logger.netty.name = io.netty
     logger.netty.level = INFO
     logger.netty.additivity = false
+    {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -16,6 +16,7 @@ image:
   tag: ""
 logVolume: co-config-volume
 logConfigMap: strimzi-cluster-operator
+logConfiguration: ""
 logLevel: ${env:STRIMZI_LOG_LEVEL:-INFO}
 fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000


### PR DESCRIPTION
### Type of change
Enhancement / new feature

Allow custom `log4j2.properties` content in helm chart for cluster operator.

### Description
The way to configure custom logging in cluster operator is explained in https://strimzi.io/docs/operators/latest/configuring.html#logging_configuration_by_configmap, but when we use `helm`, it's an extra change after applying `helm`. This PR aims to have this part more flexible by allowing a user to define a custom `log4j.properties` content via `logConfiguration` variable.

This change could help to fix #6253 by configuring something similar to:
```yaml
logConfiguration: |
  name = COConfig
  monitorInterval = 30

  appender.console.type = Console
  appender.console.name = STDOUT
  appender.console.layout.type = JsonLayout
  appender.console.layout.properties = true
  appender.console.layout.compact = true
  appender.console.layout.eventEol = true

  rootLogger.level = {{ default .Values.logLevel .Values.logLevelOverride }}
  rootLogger.appenderRefs = stdout
  rootLogger.appenderRef.console.ref = STDOUT
  rootLogger.additivity = false

  # Kafka AdminClient logging is a bit noisy at INFO level
  logger.kafka.name = org.apache.kafka
  logger.kafka.level = WARN
  logger.kafka.additivity = false

  # Zookeeper is very verbose even on INFO level -> We set it to WARN by default
  logger.zookeepertrustmanager.name = org.apache.zookeeper
  logger.zookeepertrustmanager.level = WARN
  logger.zookeepertrustmanager.additivity = false

  # Keeps separate level for Netty logging -> to not be changed by the root logger
  logger.netty.name = io.netty
  logger.netty.level = INFO
  logger.netty.additivity = false
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards
