### PR TITLE
[DOC] Make Kafka Listener docs a bit more clear

### DIFF
--- a/documentation/modules/security/con-kafka-listener-certificates.adoc
+++ b/documentation/modules/security/con-kafka-listener-certificates.adoc
@@ -6,7 +6,7 @@
 
 = Kafka listener certificates
 
-You can provide your own server certificates and private keys for any listener with enabled TLS encryption.
+You can provide your own server certificates and private keys for any listener with TLS encryption enabled.
 These user-provided certificates are called _Kafka listener certificates_.
 
 Providing Kafka listener certificates allows you to leverage existing security infrastructure, such as your organization's private CA or a public CA.

--- a/documentation/modules/security/con-kafka-listener-certificates.adoc
+++ b/documentation/modules/security/con-kafka-listener-certificates.adoc
@@ -6,14 +6,10 @@
 
 = Kafka listener certificates
 
-You can provide your own server certificates and private keys for the following types of listeners:
-
-* Internal TLS listeners for communication within the Kubernetes cluster
-* External listeners (`route`, `loadbalancer`, `ingress`, and `nodeport` types), which have TLS encryption enabled, for communication between Kafka clients and Kafka brokers
-
+You can provide your own server certificates and private keys for any listener with enabled TLS encryption.
 These user-provided certificates are called _Kafka listener certificates_.
 
-Providing Kafka listener certificates for external listeners allows you to leverage existing security infrastructure, such as your organization's private CA or a public CA.
-Kafka clients will connect to Kafka brokers using Kafka listener certificates rather than certificates signed by the cluster CA or clients CA.
+Providing Kafka listener certificates allows you to leverage existing security infrastructure, such as your organization's private CA or a public CA.
+Kafka clients will need to trust the CA which was used to sign the listener certificate.
 
 You must manually renew Kafka listener certificates when needed.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR cleans up the docs about the Kafka listener certificates:
* Remove the list of listener types where it can be used which is not needed since the list contains all listeners with TLS
* Makes it hopefully a bit more clear that this is about the server certificate and has no relation ship to TLS client authentication

This is based on discussion from #6355 