### PR TITLE
Use Shellcheck on all shell scripts directly in `./tools/`

### DIFF
--- a/.azure/scripts/shellcheck.sh
+++ b/.azure/scripts/shellcheck.sh
@@ -12,7 +12,7 @@ docker-images/kafka-based/kafka/stunnel-scripts/*.sh
 docker-images/kafka-based/kafka/exporter-scripts/*.sh
 docker-images/jmxtrans/*.sh
 tools/olm-bundle/*.sh
-tools/report.sh"
+tools/*.sh"
 
 for SCRIPTS in $SCRIPT_DIRS; do
     shellcheck -a -P $(dirname "$SCRIPTS") -x "$SCRIPTS"

--- a/tools/kafka-versions-tools.sh
+++ b/tools/kafka-versions-tools.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154,SC2034
+# ^^^ Disables false-positives which should be ignored
 set -e
 
-VERSIONS_FILE="$(dirname $(realpath $BASH_SOURCE))/../kafka-versions.yaml"
+VERSIONS_FILE="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../kafka-versions.yaml"
 
 # Gets the default Kafka version and sets "default_kafka_version" variable
 # to the corresponding version string.
@@ -12,13 +14,13 @@ function get_default_kafka_version {
     default_kafka_version="null"
     while [ $finished -lt 1 ] 
     do
-        version="$(yq eval ".[${counter}].version" $VERSIONS_FILE )"
+        version="$(yq eval ".[${counter}].version" "$VERSIONS_FILE" )"
 
         if [ "$version" = "null" ]
         then
             finished=1
         else
-            if [ "$(yq eval ".[${counter}].default" $VERSIONS_FILE)" = "true" ]
+            if [ "$(yq eval ".[${counter}].default" "$VERSIONS_FILE")" = "true" ]
             then
                 if [ "$default_kafka_version" = "null" ]
                 then
@@ -42,39 +44,39 @@ function get_default_kafka_version {
 }
 
 function get_kafka_versions {
-    eval versions="($(yq eval '.[] | select(.supported == true) | .version' $VERSIONS_FILE))"
+    eval versions="($(yq eval '.[] | select(.supported == true) | .version' "$VERSIONS_FILE"))"
 }
 
 function get_kafka_urls {
-    eval binary_urls="($(yq eval '.[] | select(.supported == true) | .url' $VERSIONS_FILE))"
+    eval binary_urls="($(yq eval '.[] | select(.supported == true) | .url' "$VERSIONS_FILE"))"
 }
 
 function get_zookeeper_versions {
-    eval zk_versions="($(yq eval '.[] | select(.supported == true) | .zookeeper' $VERSIONS_FILE))"
+    eval zk_versions="($(yq eval '.[] | select(.supported == true) | .zookeeper' "$VERSIONS_FILE"))"
 }
 
 function get_kafka_checksums {
-    eval checksums="($(yq eval '.[] | select(.supported == true) | .checksum' $VERSIONS_FILE))"
+    eval checksums="($(yq eval '.[] | select(.supported == true) | .checksum' "$VERSIONS_FILE"))"
 }
 
 function get_kafka_third_party_libs {
-    eval libs="($(yq eval '.[] | select(.supported == true) | .third-party-libs' $VERSIONS_FILE))"
+    eval libs="($(yq eval '.[] | select(.supported == true) | .third-party-libs' "$VERSIONS_FILE"))"
 }
 
 function get_unique_kafka_third_party_libs {
-    eval libs="($(yq eval '.[] | select(.supported == true) | .third-party-libs' $VERSIONS_FILE | sort -u))"
+    eval libs="($(yq eval '.[] | select(.supported == true) | .third-party-libs' "$VERSIONS_FILE" | sort -u))"
 }
 
 function get_kafka_protocols {
-    eval protocols="($(yq eval '.[] | select(.supported == true) | .protocol' $VERSIONS_FILE))"
+    eval protocols="($(yq eval '.[] | select(.supported == true) | .protocol' "$VERSIONS_FILE"))"
 }
 
 function get_kafka_formats {
-    eval formats="($(yq eval '.[] | select(.supported == true) | .format' $VERSIONS_FILE))"
+    eval formats="($(yq eval '.[] | select(.supported == true) | .format' "$VERSIONS_FILE"))"
 }
 
 function get_kafka_does_not_support {
-    eval does_not_support="($(yq eval '.[] | select(.supported == true) | .unsupported-features' $VERSIONS_FILE))"
+    eval does_not_support="($(yq eval '.[] | select(.supported == true) | .unsupported-features' "$VERSIONS_FILE"))"
 
     get_kafka_versions
     

--- a/tools/multi-platform-support.sh
+++ b/tools/multi-platform-support.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2209,SC2034
+# ^^^ Disables false-positives which should be ignored
 
 # Define commands for Linux and MacOS
 # This script should be sourced into other scripts
@@ -16,7 +18,7 @@ HEAD=head
 TEE=tee
 
 UNAME_S=$(uname -s)
-if [ $UNAME_S = "Darwin" ];
+if [ "$UNAME_S" = "Darwin" ];
 then
     # MacOS GNU versions which can be installed through Homebrew
     FIND=gfind

--- a/tools/prerequisites-check.sh
+++ b/tools/prerequisites-check.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-source $(dirname $(realpath $0))/../tools/multi-platform-support.sh
+# shellcheck source=./multi-platform-support.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../tools/multi-platform-support.sh
 
 RED="\033[0;31m"
 NO_COLOUR="\033[0m"
@@ -19,7 +20,7 @@ check_command_present shellcheck
 # After version 3.3.1, yq --version sends the string to STDERR instead of STDOUT
 YQ_VERSION="$(yq --version 2>&1 | ${SED} 's/^.* //g')"
 
-YQ_ARRAY=($(echo "$YQ_VERSION" | tr '.' '\n'))
+IFS="." read -r -a YQ_ARRAY <<< "$YQ_VERSION"
 
 yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 4.2.1 or above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
 

--- a/tools/strimzi-oauth-version.sh
+++ b/tools/strimzi-oauth-version.sh
@@ -5,5 +5,5 @@ POM_FILE=pom.xml
 
 # Extracts strimzi-kafka-oauth dependency version from pom.xml
 function get_strimzi_oauth_version {
-    echo $(cat $POM_FILE | grep -m 1 strimzi-oauth.version | sed -e 's/.*>\(.*\)<.*/\1/')
+    grep -m 1 strimzi-oauth.version "$POM_FILE" | sed -e 's/.*>\(.*\)<.*/\1/'
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR applies the changes recommended by Shellcheck to all remaining shell scripts in `./tools/` (`report.sh` was already covered before). It updates the scripts to make them Shellcheck compliant and adds a check for it into the CI.

SC2209 & SC2034 in `multi-platform-support.sh` and SC2154 & SC2034 in `kafka-versions-tools.sh` are intentionally disabled as they create false positives.