### PR TITLE
Fix Maven cache use in Azure Pipelines build

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -4,7 +4,7 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
+        'build_strimzi_java-11':
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
           main_build: 'true'
@@ -15,12 +15,8 @@ jobs:
       vmImage: Ubuntu-20.04
     # Pipeline steps
     steps:
-      # Get cached files
-      - task: Cache@2
-        inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
-          path: $(HOME)/.m2/repository
-        displayName: Maven cache
+      # Get cached Maven repository
+      - template: "../../steps/maven_cache.yaml"
       - task: Cache@2
         inputs:
           key: '"kafka-binaries" | kafka-versions.yaml'

--- a/.azure/templates/jobs/build/deploy_strimzi_java.yaml
+++ b/.azure/templates/jobs/build/deploy_strimzi_java.yaml
@@ -4,7 +4,7 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
+        'deploy_strimzi_java-11':
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
           main_build: 'true'
@@ -15,12 +15,8 @@ jobs:
       vmImage: 'Ubuntu-20.04'
     # Pipeline steps
     steps:
-      # Get cached files
-      - task: Cache@2
-        inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
-          path: $(HOME)/.m2/repository
-        displayName: Maven cache
+      # Get cached Maven repository
+      - template: "../../steps/maven_cache.yaml"
 
       # Install Prerequisites
       - template: "../../steps/prerequisites/install_yq.yaml"

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -4,7 +4,7 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
+        'test_strimzi_java-11':
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
           main_build: 'true'
@@ -15,12 +15,8 @@ jobs:
       vmImage: Ubuntu-20.04
     # Pipeline steps
     steps:
-      # Get cached files
-      - task: Cache@2
-        inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
-          path: $(HOME)/.m2/repository
-        displayName: Maven cache
+      # Get cached Maven repository
+      - template: "../../steps/maven_cache.yaml"
 
       # Install Prerequisites
       - template: "../../steps/prerequisites/install_yq.yaml"

--- a/.azure/templates/steps/maven_cache.yaml
+++ b/.azure/templates/steps/maven_cache.yaml
@@ -1,0 +1,9 @@
+steps:
+  - task: Cache@2
+    inputs:
+      key: 'maven-cache | $(System.JobName) | **/pom.xml'
+      restoreKeys: |
+        maven-cache | $(System.JobName)
+        maven-cache
+      path: $(HOME)/.m2/repository
+    displayName: Maven cache

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -42,12 +42,8 @@ jobs:
     # Log variables
     - template: "log_variables.yaml"
 
-    # Get cached files
-    - task: Cache@2
-      inputs:
-        key: 'mvn-m2-cache | $(System.JobName)'
-        path: $(HOME)/.m2/repository
-      displayName: Maven cache
+    # Get cached Maven repository
+    - template: "../../steps/maven_cache.yaml"
     - task: Cache@2
       inputs:
         key: '"kafka-binaries" | kafka-versions.yaml'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -43,7 +43,7 @@ jobs:
     - template: "log_variables.yaml"
 
     # Get cached Maven repository
-    - template: "../../steps/maven_cache.yaml"
+    - template: "./maven_cache.yaml"
     - task: Cache@2
       inputs:
         key: '"kafka-binaries" | kafka-versions.yaml'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR tries to fix the build issues with the Maven cache. The Maven cache currently doesn't seem to be used, but not updated. So many current dependency versions are not cache while it is full of some old versions not used anymore.

This PR:
* Uses a step template for configuring the cache instead of having it in the pipeline on several different places
* Renames the cache to get rid of the old cache and start fresh
* Uses the fingerprint of the project `pom.xml` files as the cache key to make sure the cache is updated when the pom files change (possibly together with dependencies)
* Uses the restore keys for partial matching of the cache (to reuse the old cache when there is no match)

**Thanks to @see-quick for parsing through the build logs and discovering that the cache does not work.**

_Note: The cache is hard to test from PR -> we should observe how it behaves after we merge this._