### PR TITLE
[DOC] Make titles around partition reassignment and cluster balancing linkable

### DIFF
--- a/documentation/modules/configuring/con-partition-reassignment.adoc
+++ b/documentation/modules/configuring/con-partition-reassignment.adoc
@@ -32,7 +32,6 @@ If you need to cancel a reassignment, wait for it to complete and then perform a
 The `kafka-reassign-partitions.sh` will print the reassignment JSON for this reversion as part of its output.
 Very large reassignments should be broken down into a number of smaller reassignments in case there is a need to stop in-progress reassignment.
 
-[discrete]
 == Partition reassignment JSON file
 
 The _reassignment JSON file_ has a specific structure:
@@ -84,7 +83,6 @@ The following is an example reassignment JSON file that assigns partition `4` of
 
 Partitions not included in the JSON are not changed.
 
-[discrete]
 == Partition reassignment between JBOD volumes
 
 When using JBOD storage in your Kafka cluster, you can choose to reassign the partitions between specific volumes and their log directories (each volume has a single log directory).

--- a/documentation/modules/cruise-control/con-rebalance-performance.adoc
+++ b/documentation/modules/cruise-control/con-rebalance-performance.adoc
@@ -9,7 +9,6 @@
 You can adjust several performance tuning options for cluster rebalances. 
 These options control how partition replica and leadership movements in a rebalance are executed, as well as the bandwidth that is allocated to a rebalance operation.
 
-[discrete]
 == Partition reassignment commands
 
 xref:con-optimization-proposals-{context}[Optimization proposals] are comprised of separate partition reassignment commands. 
@@ -26,7 +25,6 @@ A partition reassignment command consists of either of the following types of op
 Cruise Control issues partition reassignment commands to the Kafka cluster in batches.
 The performance of the cluster during the rebalance is affected by the number of each type of movement contained in each batch.
 
-[discrete]
 == Replica movement strategies
 
 Cluster rebalance performance is also influenced by the _replica movement strategy_ that is applied to the batches of partition reassignment commands. 
@@ -44,7 +42,6 @@ These strategies can be configured as a sequence.
 The first strategy attempts to compare two partition reassignments using its internal logic. 
 If the reassignments are equivalent, then it passes them to the next strategy in the sequence to decide the order, and so on.
 
-[discrete]
 == Intra-broker disk balancing
 
 Moving a large amount of data between disks on the same broker has less impact than between separate brokers.
@@ -54,7 +51,6 @@ To perform an intra-broker disk balance, set `rebalanceDisk` to `true` under the
 When setting `rebalanceDisk` to `true`, do not set a `goals` field in the `KafkaRebalance.spec`, as Cruise Control will automatically set the intra-broker goals and ignore the inter-broker goals.
 Cruise Control does not perform inter-broker and intra-broker balancing at the same time.
 
-[discrete]
 == Rebalance tuning options
 
 Cruise Control provides several configuration options for tuning the rebalance parameters discussed above.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The content around partitions reassignment and rebalancing comes up quite often in questions. And some of the important titles currently cannot be shared as linked. This PR removes the discrete markers which makes the chapters links and makes them easy to share.