### PR TITLE
[MO] - optimize unnecessary 3-node cluster in ITs 

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -43,11 +43,11 @@ public class ConnectCluster {
             workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
             workerProps.put("value.converter.schemas.enable", "false");
             workerProps.put("offset.storage.topic", getClass().getSimpleName() + "-offsets");
-            workerProps.put("offset.storage.replication.factor", "3");
+            workerProps.put("offset.storage.replication.factor", "1");
             workerProps.put("config.storage.topic", getClass().getSimpleName() + "-config");
-            workerProps.put("config.storage.replication.factor", "3");
+            workerProps.put("config.storage.replication.factor", "1");
             workerProps.put("status.storage.topic", getClass().getSimpleName() + "-status");
-            workerProps.put("status.storage.replication.factor", "3");
+            workerProps.put("status.storage.replication.factor", "1");
             workerProps.put("bootstrap.servers", brokerList);
             //DistributedConfig config = new DistributedConfig(workerProps);
             //RestServer rest = new RestServer(config);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -18,7 +18,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.IsolatedTest;
-import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.container.StrimziKafkaContainer;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -51,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectApiTest {
-    private static StrimziKafkaContainer cluster;
+    private static StrimziKafkaContainer kafkaContainer;
     private static Vertx vertx;
     private Connect connect;
     private static final int PORT = 18083;
@@ -74,7 +73,7 @@ public class KafkaConnectApiTest {
         workerProps.put("config.storage.replication.factor", "1");
         workerProps.put("offset.storage.replication.factor", "1");
         workerProps.put("status.storage.replication.factor", "1");
-        workerProps.put("bootstrap.servers", cluster.getBootstrapServers());
+        workerProps.put("bootstrap.servers", kafkaContainer.getBootstrapServers());
         //DistributedConfig config = new DistributedConfig(workerProps);
         //RestServer rest = new RestServer(config);
         //rest.initializeServer();
@@ -103,13 +102,13 @@ public class KafkaConnectApiTest {
         vertx = Vertx.vertx();
         final Map<String, String> kafkaClusterConfiguration = new HashMap<>();
         kafkaClusterConfiguration.put("zookeeper.connect", "zookeeper:2181");
-        cluster = new StrimziKafkaContainer();
-        cluster.start();
+        kafkaContainer = new StrimziKafkaContainer();
+        kafkaContainer.start();
     }
 
     @AfterAll
     public static void after() {
-        cluster.stop();
+        kafkaContainer.stop();
         vertx.close();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiTest.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.container.StrimziKafkaCluster;
+import io.strimzi.test.container.StrimziKafkaContainer;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -50,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectApiTest {
-    private static StrimziKafkaCluster cluster;
+    private static StrimziKafkaContainer cluster;
     private static Vertx vertx;
     private Connect connect;
     private static final int PORT = 18083;
@@ -70,6 +71,9 @@ public class KafkaConnectApiTest {
         workerProps.put("offset.storage.topic", getClass().getSimpleName() + "-offsets");
         workerProps.put("config.storage.topic", getClass().getSimpleName() + "-config");
         workerProps.put("status.storage.topic", getClass().getSimpleName() + "-status");
+        workerProps.put("config.storage.replication.factor", "1");
+        workerProps.put("offset.storage.replication.factor", "1");
+        workerProps.put("status.storage.replication.factor", "1");
         workerProps.put("bootstrap.servers", cluster.getBootstrapServers());
         //DistributedConfig config = new DistributedConfig(workerProps);
         //RestServer rest = new RestServer(config);
@@ -99,7 +103,7 @@ public class KafkaConnectApiTest {
         vertx = Vertx.vertx();
         final Map<String, String> kafkaClusterConfiguration = new HashMap<>();
         kafkaClusterConfiguration.put("zookeeper.connect", "zookeeper:2181");
-        cluster = new StrimziKafkaCluster(3, 1, kafkaClusterConfiguration);
+        cluster = new StrimziKafkaContainer();
         cluster.start();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.test.container.StrimziKafkaCluster;
+import io.strimzi.test.container.StrimziKafkaContainer;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectorIT {
-    private static StrimziKafkaCluster cluster;
+    private static StrimziKafkaContainer cluster;
     private static Vertx vertx;
     private ConnectCluster connectCluster;
 
@@ -68,9 +69,7 @@ public class KafkaConnectorIT {
                         .setEnabled(true)
         ));
 
-        final Map<String, String> kafkaClusterConfiguration = new HashMap<>();
-        kafkaClusterConfiguration.put("zookeeper.connect", "zookeeper:2181");
-        cluster = new StrimziKafkaCluster(3, 1, kafkaClusterConfiguration);
+        cluster = new StrimziKafkaContainer();
         cluster.start();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -20,7 +20,6 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
-import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.container.StrimziKafkaContainer;
 import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
@@ -41,7 +40,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +55,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectorIT {
-    private static StrimziKafkaContainer cluster;
+    private static StrimziKafkaContainer kafkaContainer;
     private static Vertx vertx;
     private ConnectCluster connectCluster;
 
@@ -69,13 +67,13 @@ public class KafkaConnectorIT {
                         .setEnabled(true)
         ));
 
-        cluster = new StrimziKafkaContainer();
-        cluster.start();
+        kafkaContainer = new StrimziKafkaContainer();
+        kafkaContainer.start();
     }
 
     @AfterAll
     public static void after() {
-        cluster.stop();
+        kafkaContainer.stop();
         vertx.close();
     }
 
@@ -85,7 +83,7 @@ public class KafkaConnectorIT {
 
         // Start a 3 node connect cluster
         connectCluster = new ConnectCluster()
-                .usingBrokers(cluster.getBootstrapServers())
+                .usingBrokers(kafkaContainer.getBootstrapServers())
                 .addConnectNodes(3);
         connectCluster.startup();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <!--  TODO: just for check (master version) need to release test-container -->
-        <strimzi-test-container.version>0.101.0-SNAPSHOT</strimzi-test-container.version>
+        <strimzi-test-container.version>0.101.0</strimzi-test-container.version>
         <test-container.version>1.15.2</test-container.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.2.Final</registry.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,9 @@
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <strimzi-test-container.version>0.100.0</strimzi-test-container.version>
+        <!--  TODO: just for check (master version) need to release test-container -->
+        <strimzi-test-container.version>0.101.0-SNAPSHOT</strimzi-test-container.version>
+        <test-container.version>1.15.2</test-container.version>
         <commons-codec.version>1.13</commons-codec.version>
         <registry.version>1.3.2.Final</registry.version>
         <javax.json-api.version>1.1.4</javax.json-api.version>
@@ -585,6 +587,12 @@
                 <groupId>io.strimzi</groupId>
                 <artifactId>strimzi-test-container</artifactId>
                 <version>${strimzi-test-container.version}</version>
+            </dependency>
+            <!-- Needed because of Startable Interface -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${test-container.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -121,6 +121,10 @@
             <artifactId>strimzi-test-container</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
-import io.strimzi.test.container.StrimziKafkaCluster;
+import io.strimzi.test.container.StrimziKafkaContainer;
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TopicOperatorIT extends TopicOperatorBaseIT {
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorIT.class);
-    protected static StrimziKafkaCluster kafkaCluster;
+    protected static StrimziKafkaContainer kafkaContainer;
 
     @BeforeAll
     public void beforeAll() throws Exception {
@@ -73,13 +73,6 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
     protected static int numKafkaBrokers() {
         return 1;
-    }
-
-    protected static Map<String, String> kafkaClusterConfig() {
-        Map<String, String> p = new HashMap<>();
-        p.put(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), "false");
-        p.put("zookeeper.connect", "zookeeper:2181");
-        return p;
     }
 
 
@@ -537,7 +530,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         }
 
         // 4. Start TO
-        startTopicOperator(kafkaCluster);
+        startTopicOperator(kafkaContainer);
 
         // 5. Verify topics A, X and Y exist on both sides
         waitForTopicInKafka(topicNameA);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -47,14 +47,15 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
     @BeforeAll
     public void beforeAll() throws Exception {
-        kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
-        kafkaCluster.start();
+        kafkaContainer = new StrimziKafkaContainer()
+            .withKafkaConfigurationMap(Map.of(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), "false"));
+        kafkaContainer.start();
 
         setupKubeCluster();
-        setup(kafkaCluster);
+        setup(kafkaContainer);
 
         LOGGER.info("Using namespace {}", NAMESPACE);
-        startTopicOperator(kafkaCluster);
+        startTopicOperator(kafkaContainer);
     }
 
     @AfterAll
@@ -62,7 +63,7 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
         teardown(true);
         teardownKubeCluster();
         adminClient.close();
-        kafkaCluster.stop();
+        kafkaContainer.stop();
     }
 
     @AfterEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -36,7 +36,7 @@ public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
 
     @BeforeAll
     public void beforeAll() throws Exception {
-        kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
+        kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers());
         kafkaCluster.start();
 
         setupKubeCluster();
@@ -53,7 +53,7 @@ public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
     }
 
     @AfterEach
-    void afterEach() throws InterruptedException, ExecutionException, TimeoutException {
+    void afterEach() throws InterruptedException, TimeoutException {
         // clean-up KafkaTopic resources in Kubernetes
         clearKafkaTopics(true);
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -17,11 +17,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.lifecycle.Startable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -62,14 +62,8 @@ public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
         return 2;
     }
 
-    protected static Map<String, String> kafkaClusterConfig() {
-        Map<String, String> p = new HashMap<>();
-        p.put("zookeeper.connect", "zookeeper:2181");
-        return p;
-    }
-
     @Override
-    protected Map<String, String> topicOperatorConfig(StrimziKafkaCluster kafkaCluster) {
+    protected <T extends Startable> Map<String, String> topicOperatorConfig(T strimziContainer) {
         Map<String, String> m = super.topicOperatorConfig(kafkaCluster);
         m.put(Config.FULL_RECONCILIATION_INTERVAL_MS.key, "20000");
         return m;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -23,12 +22,13 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 
     @BeforeAll
     public void beforeAll() throws Exception {
-        kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
-        kafkaCluster.start();
+        kafkaContainer = new StrimziKafkaContainer()
+            .withKafkaConfigurationMap(Map.of(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "false"));
+        kafkaContainer.start();
 
         setupKubeCluster();
-        setup(kafkaCluster);
-        startTopicOperator(kafkaCluster);
+        setup(kafkaContainer);
+        startTopicOperator(kafkaContainer);
     }
 
     @AfterAll
@@ -36,7 +36,7 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
         teardown(false);
         teardownKubeCluster();
         adminClient.close();
-        kafkaCluster.stop();
+        kafkaContainer.stop();
     }
 
     @AfterEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.topic;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.test.container.StrimziKafkaCluster;
+import io.strimzi.test.container.StrimziKafkaContainer;
 import io.vertx.core.Future;
 import kafka.server.KafkaConfig$;
 import org.junit.jupiter.api.AfterAll;
@@ -19,7 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
-    protected static StrimziKafkaCluster kafkaCluster;
+    protected static StrimziKafkaContainer kafkaContainer;
 
     @BeforeAll
     public void beforeAll() throws Exception {
@@ -42,17 +42,6 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
     @AfterEach
     public void afterEach() throws InterruptedException, TimeoutException, ExecutionException {
         clearKafkaTopics(false);
-    }
-
-    protected static int numKafkaBrokers() {
-        return 1;
-    }
-
-    protected static Map<String, String> kafkaClusterConfig() {
-        Map<String, String> p = new HashMap<>();
-        p.put(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "false");
-        p.put("zookeeper.connect", "zookeeper:2181");
-        return p;
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicStoreUpgradeTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicStoreUpgradeTest.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import io.apicurio.registry.utils.ConcurrentUtil;
 import io.strimzi.operator.topic.zk.Zk;
-import io.strimzi.test.container.StrimziKafkaCluster;
+import io.strimzi.test.container.StrimziKafkaContainer;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(VertxExtension.class)
 public class TopicStoreUpgradeTest {
     private static final Map<String, String> MANDATORY_CONFIG;
-    private static StrimziKafkaCluster cluster;
+    private static StrimziKafkaContainer kafkaContainer;
 
     static {
         MANDATORY_CONFIG = new HashMap<>();
@@ -120,16 +120,13 @@ public class TopicStoreUpgradeTest {
     public static void before() throws Exception {
         vertx = Vertx.vertx();
 
-        Map<String, String> config = new HashMap<>();
-        config.put("zookeeper.connect", "zookeeper:2181");
+        kafkaContainer = new StrimziKafkaContainer();
+        kafkaContainer.start();
 
-        cluster = new StrimziKafkaCluster(1, 1, config);
-        cluster.start();
+        MANDATORY_CONFIG.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaContainer.getBootstrapServers());
+        MANDATORY_CONFIG.put(Config.ZOOKEEPER_CONNECT.key, kafkaContainer.getInternalZooKeeperConnect());
 
-        MANDATORY_CONFIG.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, cluster.getBootstrapServers());
-        MANDATORY_CONFIG.put(Config.ZOOKEEPER_CONNECT.key, cluster.getZookeeper().getHost() + ":" + cluster.getZookeeper().getFirstMappedPort());
-
-        ZkClient zkc = new ZkClient(cluster.getZookeeper().getHost() + ":" + cluster.getZookeeper().getFirstMappedPort());
+        ZkClient zkc = new ZkClient(kafkaContainer.getInternalZooKeeperConnect());
         try {
             zkc.create("/strimzi", null, CreateMode.PERSISTENT);
             zkc.create("/strimzi/topics", null, CreateMode.PERSISTENT);
@@ -140,7 +137,7 @@ public class TopicStoreUpgradeTest {
 
     @AfterAll
     public static void after() {
-        cluster.stop();
+        kafkaContainer.stop();
         vertx.close();
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/AbstractAdminApiOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/AbstractAdminApiOperatorIT.java
@@ -43,12 +43,13 @@ public abstract class AbstractAdminApiOperatorIT<T, S extends Collection<String>
     @BeforeAll
     public static void beforeAll() {
         vertx = Vertx.vertx();
-        Map<String, String> additionalConfiguration = Map.of(
-            "authorizer.class.name", "kafka.security.authorizer.AclAuthorizer",
-            "super.users", "User:ANONYMOUS");
+
         kafkaContainer = new StrimziKafkaContainer()
             .withBrokerId(1)
-            .withKafkaConfigurationMap(additionalConfiguration);
+            .withKafkaConfigurationMap(
+                Map.of(
+                "authorizer.class.name", "kafka.security.authorizer.AclAuthorizer",
+                "super.users", "User:ANONYMOUS"));
         kafkaContainer.start();
 
         Properties p = new Properties();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR optimizing ITs, where we used unnecessary three nodes Kafka clusters. I replaced ∀ them to use single-node ∧ thus reducing preparation time 👌🦥. Moreover it resolves this issue [1].

❗️ Before merging this PR we need to release test-container `0.101.0`.

[1] - https://github.com/strimzi/strimzi-kafka-operator/issues/6367

### Checklist

- [x] Make sure all tests pass