### PR TITLE
[MO] - TopicOperatorIT using shared TO (execution time from ~30m -> 6m)

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -16,12 +16,10 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,27 +35,27 @@ public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
     protected static StrimziKafkaCluster kafkaCluster;
 
     @BeforeAll
-    public static void beforeAll() throws IOException {
+    public void beforeAll() throws Exception {
         kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
         kafkaCluster.start();
 
         setupKubeCluster();
+        setup(kafkaCluster);
+        startTopicOperator(kafkaCluster);
     }
 
     @AfterAll
-    public static void afterAll() {
+    public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
+        teardown(true);
         teardownKubeCluster();
+        adminClient.close();
         kafkaCluster.stop();
     }
 
-    @BeforeEach
-    public void beforeEach() throws Exception {
-        setup(kafkaCluster);
-    }
-
     @AfterEach
-    public void afterEach() throws InterruptedException, TimeoutException, ExecutionException {
-        teardown(true);
+    void afterEach() throws InterruptedException, ExecutionException, TimeoutException {
+        // clean-up KafkaTopic resources in Kubernetes
+        clearKafkaTopics(true);
     }
 
     protected static int numKafkaBrokers() {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -11,10 +11,8 @@ import kafka.server.KafkaConfig$;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -24,27 +22,26 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
     protected static StrimziKafkaCluster kafkaCluster;
 
     @BeforeAll
-    public static void beforeAll() throws IOException {
+    public void beforeAll() throws Exception {
         kafkaCluster = new StrimziKafkaCluster(numKafkaBrokers(), numKafkaBrokers(), kafkaClusterConfig());
         kafkaCluster.start();
 
         setupKubeCluster();
+        setup(kafkaCluster);
+        startTopicOperator(kafkaCluster);
     }
 
     @AfterAll
-    public static void afterAll() {
+    public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
+        teardown(false);
         teardownKubeCluster();
+        adminClient.close();
         kafkaCluster.stop();
-    }
-
-    @BeforeEach
-    public void beforeEach() throws Exception {
-        setup(kafkaCluster);
     }
 
     @AfterEach
     public void afterEach() throws InterruptedException, TimeoutException, ExecutionException {
-        teardown(false);
+        clearKafkaTopics(false);
     }
 
     protected static int numKafkaBrokers() {


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR refactoring TopicOperator integration tests. Specifically `TopicOperatorBaseIT` family. Two things, which has been done:
1. Move Kafka setup for ∀ test cases for each test suite (reduction time approximately *3 minutes* in total)
2. Move Deployment of Topic Operator to `@BeforeAll` making him sharable between test cases  (reduction time approximately *21 minutes* in total)

**Build pipeline - before**
<img width="736" alt="image" src="https://user-images.githubusercontent.com/30839163/154865499-f8afdd62-8835-426f-87b5-fa3df4411c56.png">

**Build pipeline - after**

<img width="700" alt="image" src="https://user-images.githubusercontent.com/30839163/154865808-647b0a70-efed-4c66-91be-7e04fe17800a.png">

### Checklist

- [x] Make sure all tests pass