### PR TITLE
[MO] - rbac collector edge case fix

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -145,7 +145,7 @@ public class LogCollector {
         // it's not test suite but test case, and we are gonna collect logs
         if (!this.collectorElement.getTestMethodName().isEmpty()) {
             // @ParallelSuite -> this is generated namespace but we collect logs only iff STRIMZI_RBAC_SCOPE=CLUSTER
-            // because when e we run STRIMZI_RBAC_SCOPE=NAMESPACE mode we use one namespace (i.e., clusterOperatorNamespace).
+            // because when we run STRIMZI_RBAC_SCOPE=NAMESPACE mode we use one namespace (i.e., clusterOperatorNamespace).
             if (StUtils.isParallelSuite(extensionContext.getParent().get()) && !Environment.isNamespaceRbacScope()) {
                 // @IsolatedTest or @ParallelTest or @ParallelNamespaceTest -> are executed in that generated namespace
                 if (StUtils.isIsolatedTest(extensionContext) ||

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.annotations.ParallelTest;
@@ -143,9 +144,9 @@ public class LogCollector {
 
         // it's not test suite but test case, and we are gonna collect logs
         if (!this.collectorElement.getTestMethodName().isEmpty()) {
-            // fetch test suite extensionContext
-            // @ParallelSuite -> this is generated namespace
-            if (StUtils.isParallelSuite(extensionContext.getParent().get())) {
+            // @ParallelSuite -> this is generated namespace but we collect logs only iff STRIMZI_RBAC_SCOPE=CLUSTER
+            // because when e we run STRIMZI_RBAC_SCOPE=NAMESPACE mode we use one namespace (i.e., clusterOperatorNamespace).
+            if (StUtils.isParallelSuite(extensionContext.getParent().get()) && !Environment.isNamespaceRbacScope()) {
                 // @IsolatedTest or @ParallelTest or @ParallelNamespaceTest -> are executed in that generated namespace
                 if (StUtils.isIsolatedTest(extensionContext) ||
                     StUtils.isParallelTest(extensionContext) ||


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes the edge case for collecting logs when we use `RBAC=NAMESPACE`. The current implementation line ([156](https://github.com/strimzi/strimzi-kafka-operator/compare/main...see-quick:fix-rbac-scope-collecting-logs?expand=1#diff-ec5e66aebd68442ff335612c7007ba4e3950625678a53d225b841179b5c1a83bL156)) could produce NPE because if something bad happens in `@ParallelSuite`. When we set `RBAC` to `NAMESPACE` it does not create an additional namespace for @ParallelSuite and thus such line ([156](https://github.com/strimzi/strimzi-kafka-operator/compare/main...see-quick:fix-rbac-scope-collecting-logs?expand=1#diff-ec5e66aebd68442ff335612c7007ba4e3950625678a53d225b841179b5c1a83bL156))) will produce NPE. 

### Checklist

- [x] Make sure all tests pass