### PR TITLE
Add Mirror Maker 2 security examples

### DIFF
--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -1,0 +1,322 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-source-cluster
+spec:
+  kafka:
+    version: 3.1.0
+    replicas: 1
+    listeners:
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication:
+          type: scram-sha-512
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.1"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-target-cluster
+spec:
+  kafka:
+    version: 3.1.0
+    replicas: 1
+    listeners:
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication:
+          type: scram-sha-512
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.1"
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 100Gi
+          deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    userOperator: {}
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: my-source-user
+  labels:
+    strimzi.io/cluster: my-source-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # MirrorSourceConnector
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: Create
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: DescribeConfigs
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: Write
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Read
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: DescribeConfigs
+      # MirrorCheckpointConnector
+      - resource:
+          type: cluster
+        operation: Describe
+      - resource: # Needed for every group for which offsets are synced
+          type: group
+          name: "*"
+        operation: Describe
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: Read
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: my-target-user
+  labels:
+    strimzi.io/cluster: my-target-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Underlying Kafka Connects internal topics used to store configuration, offsets or status
+      - resource:
+          type: group
+          name: mirrormaker2-cluster
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Describe
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: DescribeConfigs
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Write
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Create
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Describe
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: DescribeConfigs
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Write
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Create
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Write
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Describe
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: DescribeConfigs
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Create
+      # MirrorSourceConnector
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Create
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Alter
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: AlterConfigs
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Write
+      # MirrorCheckpointConnector
+      - resource:
+          type: cluster
+        operation: Describe
+      - resource:
+          type: topic
+          name: my-source-cluster.checkpoints.internal
+        operation: Create
+      - resource:
+          type: topic
+          name: my-source-cluster.checkpoints.internal
+        operation: Describe
+      - resource:
+          type: topic
+          name: my-source-cluster.checkpoints.internal
+        operation: Write
+      - resource: # Needed for every group for which the offset is synced
+          type: group
+          name: "*"
+        operation: Read
+      - resource: # Needed for every group for which the offset is synced
+          type: group
+          name: "*"
+        operation: Describe
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Read
+      # MirrorHeartbeatConnector
+      - resource:
+          type: topic
+          name: heartbeats
+        operation: Create
+      - resource:
+          type: topic
+          name: heartbeats
+        operation: Describe
+      - resource:
+          type: topic
+          name: heartbeats
+        operation: Write
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker-2
+spec:
+  version: 3.1.0
+  replicas: 1
+  connectCluster: "my-target-cluster"
+  clusters:
+    - alias: "my-source-cluster"
+      bootstrapServers: my-source-cluster-kafka-bootstrap:9093
+      tls:
+        trustedCertificates:
+          - secretName: my-source-cluster-cluster-ca-cert
+            certificate: ca.crt
+      authentication:
+        type: scram-sha-512
+        username: my-source-user
+        passwordSecret:
+          secretName: my-source-user
+          password: password
+    - alias: "my-target-cluster"
+      bootstrapServers: my-target-cluster-kafka-bootstrap:9093
+      tls:
+        trustedCertificates:
+          - secretName: my-target-cluster-cluster-ca-cert
+            certificate: ca.crt
+      authentication:
+        type: scram-sha-512
+        username: my-target-user
+        passwordSecret:
+          secretName: my-target-user
+          password: password
+      config:
+        # -1 means it will use the default replication factor configured in the broker
+        config.storage.replication.factor: -1
+        offset.storage.replication.factor: -1
+        status.storage.replication.factor: -1
+  mirrors:
+    - sourceCluster: "my-source-cluster"
+      targetCluster: "my-target-cluster"
+      sourceConnector:
+        config:
+          replication.factor: 1
+          offset-syncs.topic.replication.factor: 1
+          sync.topic.acls.enabled: "false"
+      heartbeatConnector:
+        config:
+          heartbeats.topic.replication.factor: 1
+      checkpointConnector:
+        config:
+          checkpoints.topic.replication.factor: 1
+          sync.group.offsets.enabled: "true"
+      topicsPattern: ".*"
+      groupsPattern: ".*"

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -1,0 +1,322 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-source-cluster
+spec:
+  kafka:
+    version: 3.1.0
+    replicas: 1
+    listeners:
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication:
+          type: tls
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.1"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-target-cluster
+spec:
+  kafka:
+    version: 3.1.0
+    replicas: 1
+    listeners:
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication:
+          type: tls
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.1"
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 100Gi
+          deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    userOperator: {}
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: my-source-user
+  labels:
+    strimzi.io/cluster: my-source-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # MirrorSourceConnector
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: Create
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: DescribeConfigs
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: Write
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Read
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: DescribeConfigs
+      # MirrorCheckpointConnector
+      - resource:
+          type: cluster
+        operation: Describe
+      - resource: # Needed for every group for which offsets are synced
+          type: group
+          name: "*"
+        operation: Describe
+      - resource: # Not needed if offset-syncs.topic.location=target
+          type: topic
+          name: mm2-offset-syncs.my-target-cluster.internal
+        operation: Read
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: my-target-user
+  labels:
+    strimzi.io/cluster: my-target-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Underlying Kafka Connects internal topics used to store configuration, offsets or status
+      - resource:
+          type: group
+          name: mirrormaker2-cluster
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Describe
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: DescribeConfigs
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Write
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-configs
+        operation: Create
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Describe
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: DescribeConfigs
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Write
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-status
+        operation: Create
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Read
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Write
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Describe
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: DescribeConfigs
+      - resource:
+          type: topic
+          name: mirrormaker2-cluster-offsets
+        operation: Create
+      # MirrorSourceConnector
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Create
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Alter
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: AlterConfigs
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Write
+      # MirrorCheckpointConnector
+      - resource:
+          type: cluster
+        operation: Describe
+      - resource:
+          type: topic
+          name: my-source-cluster.checkpoints.internal
+        operation: Create
+      - resource:
+          type: topic
+          name: my-source-cluster.checkpoints.internal
+        operation: Describe
+      - resource:
+          type: topic
+          name: my-source-cluster.checkpoints.internal
+        operation: Write
+      - resource: # Needed for every group for which the offset is synced
+          type: group
+          name: "*"
+        operation: Read
+      - resource: # Needed for every group for which the offset is synced
+          type: group
+          name: "*"
+        operation: Describe
+      - resource: # Needed for every topic which is mirrored
+          type: topic
+          name: "*"
+        operation: Read
+      # MirrorHeartbeatConnector
+      - resource:
+          type: topic
+          name: heartbeats
+        operation: Create
+      - resource:
+          type: topic
+          name: heartbeats
+        operation: Describe
+      - resource:
+          type: topic
+          name: heartbeats
+        operation: Write
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker-2
+spec:
+  version: 3.1.0
+  replicas: 1
+  connectCluster: "my-target-cluster"
+  clusters:
+    - alias: "my-source-cluster"
+      bootstrapServers: my-source-cluster-kafka-bootstrap:9093
+      tls:
+        trustedCertificates:
+          - secretName: my-source-cluster-cluster-ca-cert
+            certificate: ca.crt
+      authentication:
+        type: tls
+        certificateAndKey:
+          secretName: my-source-user
+          certificate: user.crt
+          key: user.key
+    - alias: "my-target-cluster"
+      bootstrapServers: my-target-cluster-kafka-bootstrap:9093
+      tls:
+        trustedCertificates:
+          - secretName: my-target-cluster-cluster-ca-cert
+            certificate: ca.crt
+      authentication:
+        type: tls
+        certificateAndKey:
+          secretName: my-target-user
+          certificate: user.crt
+          key: user.key
+      config:
+        # -1 means it will use the default replication factor configured in the broker
+        config.storage.replication.factor: -1
+        offset.storage.replication.factor: -1
+        status.storage.replication.factor: -1
+  mirrors:
+    - sourceCluster: "my-source-cluster"
+      targetCluster: "my-target-cluster"
+      sourceConnector:
+        config:
+          replication.factor: 1
+          offset-syncs.topic.replication.factor: 1
+          sync.topic.acls.enabled: "false"
+      heartbeatConnector:
+        config:
+          heartbeats.topic.replication.factor: 1
+      checkpointConnector:
+        config:
+          checkpoints.topic.replication.factor: 1
+          sync.group.offsets.enabled: "true"
+      topicsPattern: ".*"
+      groupsPattern: ".*"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds Mirror Maker 2 example to the security examples. It uses AuthN / AuthZ including the list of ACLs.