### PR TITLE
[MO] - [system test] -> MultipleListenersST route fix name 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Random;
 
+import static io.strimzi.operator.common.Util.sha1Prefix;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 
 /**
@@ -45,7 +46,7 @@ final public class TestStorage {
     public TestStorage(ExtensionContext extensionContext, String namespaceName) {
         this.extensionContext = extensionContext;
         this.namespaceName = StUtils.isParallelNamespaceTest(extensionContext) ? StUtils.getNamespaceBasedOnRbac(namespaceName, extensionContext) : namespaceName;
-        this.clusterName = CLUSTER_NAME_PREFIX + RANDOM.nextInt(Integer.MAX_VALUE);
+        this.clusterName = CLUSTER_NAME_PREFIX + sha1Prefix(String.valueOf(RANDOM.nextInt(Integer.MAX_VALUE)));
         this.topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.streamsTopicTargetName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.kafkaClientsName = clusterName + "-" + Constants.KAFKA_CLIENTS;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static io.strimzi.operator.common.Util.sha1Prefix;
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -594,7 +595,8 @@ public abstract class AbstractST implements TestSeparator {
             }
 
             LOGGER.info("Not first test we are gonna generate cluster name");
-            String clusterName = CLUSTER_NAME_PREFIX + new Random().nextInt(Integer.MAX_VALUE);
+
+            String clusterName = CLUSTER_NAME_PREFIX + sha1Prefix(String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
 
             mapWithClusterNames.put(testName, clusterName);
             mapWithTestTopics.put(testName, KafkaTopicUtils.generateRandomNameOfTopic());

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -110,7 +110,7 @@ public class MultipleListenersST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMultipleRoutes(ExtensionContext extensionContext) throws Exception {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String shortClusterNameForRoute = clusterName.substring(clusterName.length() - 10, clusterName.length());
+        final String shortClusterNameForRoute = clusterName.substring(0, clusterName.length() - 5);
 
         runListenersTest(extensionContext, testCases.get(KafkaListenerType.ROUTE), shortClusterNameForRoute);
     }
@@ -122,7 +122,7 @@ public class MultipleListenersST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMixtureOfExternalListeners(ExtensionContext extensionContext) throws Exception {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String shortClusterNameForRoute = clusterName.substring(clusterName.length() - 10, clusterName.length());
+        final String shortClusterNameForRoute = clusterName.substring(0, clusterName.length() - 5);
 
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 
@@ -144,7 +144,7 @@ public class MultipleListenersST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testCombinationOfEveryKindOfListener(ExtensionContext extensionContext) throws Exception {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String shortClusterNameForRoute = clusterName.substring(clusterName.length() - 10, clusterName.length());
+        final String shortClusterNameForRoute = clusterName.substring(0, clusterName.length() - 5);
 
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -109,9 +109,10 @@ public class MultipleListenersST extends AbstractST {
     @Tag(EXTERNAL_CLIENTS_USED)
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMultipleRoutes(ExtensionContext extensionContext) throws Exception {
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String shortClusterNameForRoute = clusterName.substring(clusterName.length() - 10, clusterName.length());
 
-        runListenersTest(extensionContext, testCases.get(KafkaListenerType.ROUTE), clusterName);
+        runListenersTest(extensionContext, testCases.get(KafkaListenerType.ROUTE), shortClusterNameForRoute);
     }
 
     @OpenShiftOnly
@@ -120,7 +121,8 @@ public class MultipleListenersST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMixtureOfExternalListeners(ExtensionContext extensionContext) throws Exception {
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String shortClusterNameForRoute = clusterName.substring(clusterName.length() - 10, clusterName.length());
 
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 
@@ -131,7 +133,7 @@ public class MultipleListenersST extends AbstractST {
         multipleDifferentListeners.addAll(nodeportListeners);
 
         // run ROUTE + NODEPORT listeners
-        runListenersTest(extensionContext, multipleDifferentListeners, clusterName);
+        runListenersTest(extensionContext, multipleDifferentListeners, shortClusterNameForRoute);
     }
 
     @OpenShiftOnly
@@ -141,7 +143,8 @@ public class MultipleListenersST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testCombinationOfEveryKindOfListener(ExtensionContext extensionContext) throws Exception {
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String shortClusterNameForRoute = clusterName.substring(clusterName.length() - 10, clusterName.length());
 
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 
@@ -156,7 +159,7 @@ public class MultipleListenersST extends AbstractST {
         multipleDifferentListeners.addAll(loadbalancersListeners);
 
         // run INTERNAL + NODEPORT + ROUTE + LOADBALANCER listeners
-        runListenersTest(extensionContext, multipleDifferentListeners, clusterName);
+        runListenersTest(extensionContext, multipleDifferentListeners, shortClusterNameForRoute);
     }
 
     private void runListenersTest(ExtensionContext extensionContext, List<GenericKafkaListener> listeners, String clusterName) throws Exception {

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -52,7 +52,6 @@ public class MultipleListenersST extends AbstractST {
     private Object lock = new Object();
 
     private final String namespace = testSuiteNamespaceManager.getMapOfAdditionalNamespaces().get(MultipleListenersST.class.getSimpleName()).stream().findFirst().get();
-
     // only 4 type of listeners
     private Map<KafkaListenerType, List<GenericKafkaListener>> testCases = new HashMap<>(4);
 
@@ -110,9 +109,8 @@ public class MultipleListenersST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMultipleRoutes(ExtensionContext extensionContext) throws Exception {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String shortClusterNameForRoute = clusterName.substring(0, clusterName.length() - 5);
 
-        runListenersTest(extensionContext, testCases.get(KafkaListenerType.ROUTE), shortClusterNameForRoute);
+        runListenersTest(extensionContext, testCases.get(KafkaListenerType.ROUTE), clusterName);
     }
 
     @OpenShiftOnly
@@ -122,7 +120,6 @@ public class MultipleListenersST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMixtureOfExternalListeners(ExtensionContext extensionContext) throws Exception {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String shortClusterNameForRoute = clusterName.substring(0, clusterName.length() - 5);
 
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 
@@ -133,7 +130,7 @@ public class MultipleListenersST extends AbstractST {
         multipleDifferentListeners.addAll(nodeportListeners);
 
         // run ROUTE + NODEPORT listeners
-        runListenersTest(extensionContext, multipleDifferentListeners, shortClusterNameForRoute);
+        runListenersTest(extensionContext, multipleDifferentListeners, clusterName);
     }
 
     @OpenShiftOnly
@@ -144,7 +141,6 @@ public class MultipleListenersST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testCombinationOfEveryKindOfListener(ExtensionContext extensionContext) throws Exception {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String shortClusterNameForRoute = clusterName.substring(0, clusterName.length() - 5);
 
         List<GenericKafkaListener> multipleDifferentListeners = new ArrayList<>();
 
@@ -159,7 +155,7 @@ public class MultipleListenersST extends AbstractST {
         multipleDifferentListeners.addAll(loadbalancersListeners);
 
         // run INTERNAL + NODEPORT + ROUTE + LOADBALANCER listeners
-        runListenersTest(extensionContext, multipleDifferentListeners, shortClusterNameForRoute);
+        runListenersTest(extensionContext, multipleDifferentListeners, clusterName);
     }
 
     private void runListenersTest(ExtensionContext extensionContext, List<GenericKafkaListener> listeners, String clusterName) throws Exception {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes problem when we create a route listener type inside the Kafka cluster. The problem is in the exceeding allowed
name length where this for instance `my-cluster-1169541598-kafka-route-bootstrap-multiple-listeners-st` is too large. I have to apply the `sha1Prefix` method for randomly generated numbers and thus eliminate such a problem (Thanks for the tip @scholzj). Locally tested works without facing this problem:

```java
2022-02-22 21:59:05 ERROR AbstractOperator:247 - Reconciliation #30(timer) Kafka(multiple-listeners-st/my-cluster-1169541598): createOrUpdate failed
java.lang.IllegalArgumentException: Invalid DNS name: my-cluster-1169541598-kafka-route-bootstrap-multiple-listeners-st.apps.morsak-aws.strimzi.app-services-dev.net
        at io.strimzi.certs.Subject$Builder.addDnsName(Subject.java:47) ~[io.strimzi.certificate-manager-0.29.0-SNAPSHOT.jar:0.29.0-SNAPSHOT]
        at io.strimzi.operator.cluster.model.ClusterCa.lambda$generateBrokerCerts$4(ClusterCa.java:215) ~[io.strimzi.cluster-operator-0.29.0-SNAPSHOT.jar:0.29.0-SNAPSHOT]
 ```

### Checklist

- [x] Make sure all tests pass