### PR TITLE
[MO] - [minor] -> bump up junit5 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <javax.json.version>1.1.4</javax.json.version>
         <rest-assured.version>4.4.0</rest-assured.version>
         <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
-        <jupiter.version>5.7.0</jupiter.version>
+        <jupiter.version>5.8.0</jupiter.version>
         <junit.platform.version>1.7.0</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,8 @@
         <javax.json.version>1.1.4</javax.json.version>
         <rest-assured.version>4.4.0</rest-assured.version>
         <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
-        <jupiter.version>5.8.0</jupiter.version>
-        <junit.platform.version>1.8.0</junit.platform.version>
+        <jupiter.version>5.8.2</jupiter.version>
+        <junit.platform.version>1.8.2</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <gson.version>2.8.2</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <rest-assured.version>4.4.0</rest-assured.version>
         <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
         <jupiter.version>5.8.0</jupiter.version>
-        <junit.platform.version>1.7.0</junit.platform.version>
+        <junit.platform.version>1.8.0</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <gson.version>2.8.2</gson.version>


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature

### Description

This PR updating version of the `JUnit 5 Jupiter` component to `5.8.2`. The reason why I want to change it is to use https://junit.org/junit5/docs/snapshot/api/org.junit.jupiter.api/org/junit/jupiter/api/ClassOrderer.html in the next PR. 

Update 1:

Also adding `<junit.platform.version>1.8.2</junit.platform.version>` because `Jupiter 5.8.2` depends on such version.

### Checklist

- [x] Make sure ∀ tests are passing