### PR TITLE
[MO] - [system test] -> optimize parallel execution using test class ordering

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/OrderTestClasses.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/OrderTestClasses.java
@@ -1,0 +1,82 @@
+package io.strimzi.systemtest.listeners;
+
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.utils.StUtils;
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+
+import java.util.Collections;
+import java.util.Comparator;
+
+/**
+ * Provides an order of the test classes using {@code ClassDescriptorComparator}. The {@link io.strimzi.systemtest.annotations.ParallelSuite}
+ * has highest priority. On the other hand {@link io.strimzi.systemtest.annotations.IsolatedSuite} has the lowest one.
+ * The reason why ordering is beneficial for execution is that many threads, which are spawned by {@link java.util.concurrent.ForkJoinPool}
+ * are blocked by {@link io.strimzi.systemtest.annotations.IsolatedSuite}. Completely re-ordering these tests, where first
+ * we execute {@link io.strimzi.systemtest.annotations.ParallelSuite} would mean that we eliminate such problem and thus
+ * utilize it.
+ *
+ * For instance here is the run completely re-order of such test run. {@link io.strimzi.systemtest.annotations.IsolatedSuite}
+ * are the last one to execute.
+ *
+ *  Following testclasses are selected for run:
+ *  -> io.strimzi.systemtest.cruisecontrol.CruiseControlST
+ *  -> io.strimzi.systemtest.cruisecontrol.CruiseControlConfigurationST
+ *  -> io.strimzi.systemtest.cruisecontrol.CruiseControlApiST
+ *  -> io.strimzi.systemtest.kafka.listeners.ListenersST
+ *  -> io.strimzi.systemtest.kafka.listeners.MultipleListenersST
+ *  -> io.strimzi.systemtest.kafka.ConfigProviderST
+ *  -> io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfSharedST
+ *  -> io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfST
+ *  -> io.strimzi.systemtest.kafka.KafkaST
+ *  -> io.strimzi.systemtest.bridge.HttpBridgeTlsST
+ *  -> io.strimzi.systemtest.bridge.HttpBridgeScramShaST
+ *  -> io.strimzi.systemtest.mirrormaker.MirrorMakerIsolatedST
+ *  -> io.strimzi.systemtest.mirrormaker.MirrorMaker2IsolatedST
+ *  -> io.strimzi.systemtest.connect.ConnectIsolatedST
+ *  -> io.strimzi.systemtest.connect.ConnectBuilderIsolatedST
+ *  -> io.strimzi.systemtest.bridge.HttpBridgeIsolatedST
+ *  -> io.strimzi.systemtest.metrics.MetricsIsolatedST
+ *  -> io.strimzi.systemtest.metrics.JmxIsolatedST
+ *
+ */
+public class OrderTestClasses implements ClassOrderer {
+
+    private class ClassDescriptorComparator implements Comparator<ClassDescriptor> {
+
+        @Override
+        public int compare(ClassDescriptor classDescriptor, ClassDescriptor t1) {
+            return compareTo(classDescriptor, t1);
+        }
+
+        /**
+         * Helper method, for comparing two {@code ClassDescriptor} objects. This is achieved by {@link io.strimzi.systemtest.annotations.IsolatedSuite}
+         * annotation where such test suite has low priority.
+         *
+         * @param classDescriptor the first {@link ClassDescriptor} to be compared
+         * @param otherDescriptor the other {@link ClassDescriptor} to be compared
+         * @return 0 if classDescriptorName == otherDescriptorName or both descriptor has {@link io.strimzi.systemtest.annotations.IsolatedSuite};
+         * -1 if classDescriptor does not contain {@link io.strimzi.systemtest.annotations.IsolatedSuite} and thus is &lt; otherDescriptorName;
+         * 1 if classDescriptor contains {@link io.strimzi.systemtest.annotations.IsolatedSuite} and thus is &gt; otherDescriptorName.
+         */
+        private int compareTo(ClassDescriptor classDescriptor, ClassDescriptor otherDescriptor) {
+            final String classDescriptorName = classDescriptor.getTestClass().getName();
+            final String otherDescriptorName = otherDescriptor.getTestClass().getName();
+
+            if (StUtils.isIsolatedSuite(classDescriptor) && !StUtils.isIsolatedSuite(otherDescriptor)) {
+                return 1;
+            } else if (!StUtils.isIsolatedSuite(classDescriptor) && StUtils.isIsolatedSuite(otherDescriptor)) {
+                return -1;
+            } else {
+                // Both has @ParallelSuites or @IsolatedSuite
+                return 0;
+            }
+        }
+    }
+
+    @Override
+    public void orderClasses(ClassOrdererContext context) {
+        Collections.sort(context.getClassDescriptors(), new ClassDescriptorComparator());
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/OrderTestSuites.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/OrderTestSuites.java
@@ -1,6 +1,9 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.systemtest.listeners;
 
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.utils.StUtils;
 import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
@@ -10,12 +13,25 @@ import java.util.Collections;
 import java.util.Comparator;
 
 /**
- * Provides an order of the test classes using {@code ClassDescriptorComparator}. The {@link io.strimzi.systemtest.annotations.ParallelSuite}
- * has highest priority. On the other hand {@link io.strimzi.systemtest.annotations.IsolatedSuite} has the lowest one.
- * The reason why ordering is beneficial for execution is that many threads, which are spawned by {@link java.util.concurrent.ForkJoinPool}
- * are blocked by {@link io.strimzi.systemtest.annotations.IsolatedSuite}. Completely re-ordering these tests, where first
- * we execute {@link io.strimzi.systemtest.annotations.ParallelSuite} would mean that we eliminate such problem and thus
- * utilize it.
+ * Provides an order of the test classes using {@code ClassDescriptorComparator}. Naturally, the {@link io.strimzi.systemtest.annotations.ParallelSuite}
+ * has the highest priority, and on the other hand, {@link io.strimzi.systemtest.annotations.IsolatedSuite} has the lowest one.
+ * That means that test classes that contain {@link io.strimzi.systemtest.annotations.IsolatedSuite} will be executed last.
+ * The reason why ordering is beneficial for execution is that {@link io.strimzi.systemtest.annotations.IsolatedSuite} may
+ * block many threads, which {@link java.util.concurrent.ForkJoinPool} spawns (using a work-stealing algorithm).
+ * In the scenario where we have the following test plan:
+ *
+ *      1. @ParallelSuite
+ *      2. @ParallelSuite
+ *      3. @IsolatedSuite
+ *      4. @IsolatedSuite
+ *      5. @ParallelSuite
+ *      6. @ParallelSuite
+ *
+ * We configure fixed class-wide parallelism using only three threads. Meaning that the first two threads will run in parallel,
+ * but the third one must way until these two threads complete their execution. If the first {@link io.strimzi.systemtest.annotations.ParallelSuite}
+ * completes its execution, this thread gets assigned the following test class, {@link io.strimzi.systemtest.annotations.IsolatedSuite}
+ * (Thread will be waiting for the second thread to finish its execution). This is not an optimal execution path.
+ * Instead, we re-order such test classes before TestEngine runs them and eliminate blocked threads.
  *
  * For instance here is the run completely re-order of such test run. {@link io.strimzi.systemtest.annotations.IsolatedSuite}
  * are the last one to execute.
@@ -41,13 +57,13 @@ import java.util.Comparator;
  *  -> io.strimzi.systemtest.metrics.JmxIsolatedST
  *
  */
-public class OrderTestClasses implements ClassOrderer {
+public class OrderTestSuites implements ClassOrderer {
 
     private class ClassDescriptorComparator implements Comparator<ClassDescriptor> {
 
         @Override
-        public int compare(ClassDescriptor classDescriptor, ClassDescriptor t1) {
-            return compareTo(classDescriptor, t1);
+        public int compare(ClassDescriptor classDescriptor, ClassDescriptor otherDescriptor) {
+            return compareTo(classDescriptor, otherDescriptor);
         }
 
         /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/OrderTestSuites.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/OrderTestSuites.java
@@ -37,24 +37,24 @@ import java.util.Comparator;
  * are the last one to execute.
  *
  *  Following testclasses are selected for run:
- *  -> io.strimzi.systemtest.cruisecontrol.CruiseControlST
- *  -> io.strimzi.systemtest.cruisecontrol.CruiseControlConfigurationST
- *  -> io.strimzi.systemtest.cruisecontrol.CruiseControlApiST
- *  -> io.strimzi.systemtest.kafka.listeners.ListenersST
- *  -> io.strimzi.systemtest.kafka.listeners.MultipleListenersST
- *  -> io.strimzi.systemtest.kafka.ConfigProviderST
- *  -> io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfSharedST
- *  -> io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfST
- *  -> io.strimzi.systemtest.kafka.KafkaST
- *  -> io.strimzi.systemtest.bridge.HttpBridgeTlsST
- *  -> io.strimzi.systemtest.bridge.HttpBridgeScramShaST
- *  -> io.strimzi.systemtest.mirrormaker.MirrorMakerIsolatedST
- *  -> io.strimzi.systemtest.mirrormaker.MirrorMaker2IsolatedST
- *  -> io.strimzi.systemtest.connect.ConnectIsolatedST
- *  -> io.strimzi.systemtest.connect.ConnectBuilderIsolatedST
- *  -> io.strimzi.systemtest.bridge.HttpBridgeIsolatedST
- *  -> io.strimzi.systemtest.metrics.MetricsIsolatedST
- *  -> io.strimzi.systemtest.metrics.JmxIsolatedST
+ *  -&lt; io.strimzi.systemtest.cruisecontrol.CruiseControlST
+ *  -&lt; io.strimzi.systemtest.cruisecontrol.CruiseControlConfigurationST
+ *  -&lt; io.strimzi.systemtest.cruisecontrol.CruiseControlApiST
+ *  -&lt; io.strimzi.systemtest.kafka.listeners.ListenersST
+ *  -&lt; io.strimzi.systemtest.kafka.listeners.MultipleListenersST
+ *  -&lt; io.strimzi.systemtest.kafka.ConfigProviderST
+ *  -&lt; io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfSharedST
+ *  -&lt; io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfST
+ *  -&lt; io.strimzi.systemtest.kafka.KafkaST
+ *  -&lt; io.strimzi.systemtest.bridge.HttpBridgeTlsST
+ *  -&lt; io.strimzi.systemtest.bridge.HttpBridgeScramShaST
+ *  -&lt; io.strimzi.systemtest.mirrormaker.MirrorMakerIsolatedST
+ *  -&lt; io.strimzi.systemtest.mirrormaker.MirrorMaker2IsolatedST
+ *  -&lt; io.strimzi.systemtest.connect.ConnectIsolatedST
+ *  -&lt; io.strimzi.systemtest.connect.ConnectBuilderIsolatedST
+ *  -&lt; io.strimzi.systemtest.bridge.HttpBridgeIsolatedST
+ *  -&lt; io.strimzi.systemtest.metrics.MetricsIsolatedST
+ *  -&lt; io.strimzi.systemtest.metrics.JmxIsolatedST
  *
  */
 public class OrderTestSuites implements ClassOrderer {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -376,7 +376,7 @@ public class StUtils {
 
     /**
      * Checking if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelTest}
-     * @param extensionContext context of the test case
+     * @param annotationHolder context of the test case
      * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelTest},
      * otherwise false
      */

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -32,11 +32,13 @@ import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,12 +64,23 @@ public class StUtils {
 
     private static final Pattern VERSION_IMAGE_PATTERN = Pattern.compile("(?<version>[0-9.]+)=(?<image>[^\\s]*)");
 
-    private static final BiFunction<String, ExtensionContext, Boolean> CONTAINS_ANNOTATION =
-        (annotationName, extensionContext) -> Arrays.stream(extensionContext.getElement().get().getAnnotations()).filter(
-            annotation -> annotation.annotationType().getName()
-                .toLowerCase(Locale.ENGLISH)
-                // more than one because in some cases the TestSuite can inherit the annotation
-                .contains(annotationName)).count() >= 1;
+    private static final BiFunction<String, Object, Boolean> CONTAINS_ANNOTATION =
+        (annotationName, annotationHolder) -> {
+            Annotation[] annotations;
+            if (annotationHolder instanceof ExtensionContext) {
+                annotations = ((ExtensionContext) annotationHolder).getElement().get().getAnnotations();
+            } else if (annotationHolder instanceof ClassDescriptor) {
+                annotations = ((ClassDescriptor) annotationHolder).getTestClass().getAnnotations();
+            } else {
+                throw new RuntimeException("Using type: " + annotationHolder + " which is not supported!");
+            }
+            return Arrays.stream(annotations).filter(
+                annotation -> annotation.annotationType().getName()
+                    .toLowerCase(Locale.ENGLISH)
+                    // more than one because in some cases the TestSuite can inherit the annotation
+                    .contains(annotationName)).count() >= 1;
+
+        };
 
     private StUtils() { }
 
@@ -367,48 +380,48 @@ public class StUtils {
      * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelTest},
      * otherwise false
      */
-    public static boolean isParallelTest(ExtensionContext extensionContext) {
-        return CONTAINS_ANNOTATION.apply(Constants.PARALLEL_TEST, extensionContext);
+    public static boolean isParallelTest(Object annotationHolder) {
+        return CONTAINS_ANNOTATION.apply(Constants.PARALLEL_TEST, annotationHolder);
     }
 
     /**
      * Checking if test case contains annotation {@link io.strimzi.systemtest.annotations.IsolatedTest}
-     * @param extensionContext context of the test case
+     * @param annotationHolder context of the test case
      * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.IsolatedTest},
      * otherwise false
      */
-    public static boolean isIsolatedTest(ExtensionContext extensionContext) {
-        return CONTAINS_ANNOTATION.apply(Constants.ISOLATED_TEST, extensionContext);
+    public static boolean isIsolatedTest(Object annotationHolder) {
+        return CONTAINS_ANNOTATION.apply(Constants.ISOLATED_TEST, annotationHolder);
     }
 
     /**
      * Checking if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelNamespaceTest}
-     * @param extensionContext context of the test case
+     * @param annotationHolder context of the test case
      * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelNamespaceTest},
      * otherwise false
      */
-    public static boolean isParallelNamespaceTest(ExtensionContext extensionContext) {
-        return CONTAINS_ANNOTATION.apply(Constants.PARALLEL_NAMESPACE, extensionContext);
+    public static boolean isParallelNamespaceTest(Object annotationHolder) {
+        return CONTAINS_ANNOTATION.apply(Constants.PARALLEL_NAMESPACE, annotationHolder);
     }
 
     /**
      * Checking if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelSuite}
-     * @param extensionContext context of the test case
+     * @param annotationHolder context of the test case
      * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.ParallelSuite},
      * otherwise false
      */
-    public static boolean isParallelSuite(ExtensionContext extensionContext) {
-        return CONTAINS_ANNOTATION.apply(Constants.PARALLEL_SUITE, extensionContext);
+    public static boolean isParallelSuite(Object annotationHolder) {
+        return CONTAINS_ANNOTATION.apply(Constants.PARALLEL_SUITE, annotationHolder);
     }
 
     /**
      * Checking if test case contains annotation {@link io.strimzi.systemtest.annotations.IsolatedSuite}
-     * @param extensionContext context of the test case
+     * @param annotationHolder context of the test case
      * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.IsolatedSuite},
      * otherwise false
      */
-    public static boolean isIsolatedSuite(ExtensionContext extensionContext) {
-        return CONTAINS_ANNOTATION.apply(Constants.ISOLATED_SUITE, extensionContext);
+    public static boolean isIsolatedSuite(Object annotationHolder) {
+        return CONTAINS_ANNOTATION.apply(Constants.ISOLATED_SUITE, annotationHolder);
     }
 
     /**

--- a/systemtest/src/test/resources/junit-platform.properties
+++ b/systemtest/src/test/resources/junit-platform.properties
@@ -7,3 +7,4 @@ junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
 junit.jupiter.execution.parallel.config.fixed.parallelism=1
 junit.platform.output.capture.maxBuffer=true
+junit.jupiter.testclass.order.default=io.strimzi.systemtest.listeners.OrderTestClasses

--- a/systemtest/src/test/resources/junit-platform.properties
+++ b/systemtest/src/test/resources/junit-platform.properties
@@ -7,4 +7,4 @@ junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
 junit.jupiter.execution.parallel.config.fixed.parallelism=1
 junit.platform.output.capture.maxBuffer=true
-junit.jupiter.testclass.order.default=io.strimzi.systemtest.listeners.OrderTestClasses
+junit.jupiter.testclass.order.default=io.strimzi.systemtest.listeners.OrderTestSuites


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds order in test classes, which optimize our execution path during parallelization and eliminate (blocking threads).

#### Detailed description:

**ClassDescriptorComparator**

Provides an order of the test classes using {`ClassDescriptorComparator`}. Naturally, the {`io.strimzi.systemtest.annotations.ParallelSuite`} has the highest priority, and on the other hand, {`io.strimzi.systemtest.annotations.IsolatedSuite`} has the lowest one. That means that test classes that contain {`io.strimzi.systemtest.annotations.IsolatedSuite`} will be executed last. The reason why ordering is beneficial for execution is that {`io.strimzi.systemtest.annotations.IsolatedSuite`} may block many threads, which {`java.util.concurrent.ForkJoinPool`} spawns (using a `work-stealing algorithm`). In the scenario where we have the following test plan:

1.  @ParallelSuite
2. @ParallelSuite
3. @IsolatedSuite
4. @IsolatedSuite
5. @ParallelSuite
6. @ParallelSuite

We configure fixed class-wide parallelism using only three threads. Meaning that the first two threads will run in parallel, but the third one must way until these two threads complete their execution. If the first {`io.strimzi.systemtest.annotations.ParallelSuite`} completes its execution, this thread gets assigned the following test class, {`io.strimzi.systemtest.annotations.IsolatedSuite`} (Thread will be waiting for the second thread to finish its execution). This is not an optimal execution path.  Instead, we re-order such test classes before TestEngine runs them and eliminate blocked threads. For instance here is the run completely re-order of such a test run. {`io.strimzi.systemtest.annotations.IsolatedSuite`} are the last one to execute.

```java
 Following testclasses are selected for run:
 -> io.strimzi.systemtest.cruisecontrol.CruiseControlST
 -> io.strimzi.systemtest.cruisecontrol.CruiseControlConfigurationST
 -> io.strimzi.systemtest.cruisecontrol.CruiseControlApiST
 -> io.strimzi.systemtest.kafka.listeners.ListenersST
 -> io.strimzi.systemtest.kafka.listeners.MultipleListenersST
 -> io.strimzi.systemtest.kafka.ConfigProviderST
 -> io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfSharedST
 -> io.strimzi.systemtest.kafka.dynamicconfiguration.DynamicConfST
 -> io.strimzi.systemtest.kafka.KafkaST
 -> io.strimzi.systemtest.bridge.HttpBridgeTlsST
 -> io.strimzi.systemtest.bridge.HttpBridgeScramShaST
 -> io.strimzi.systemtest.mirrormaker.MirrorMakerIsolatedST
 -> io.strimzi.systemtest.mirrormaker.MirrorMaker2IsolatedST
 -> io.strimzi.systemtest.connect.ConnectIsolatedST
 -> io.strimzi.systemtest.connect.ConnectBuilderIsolatedST
 -> io.strimzi.systemtest.bridge.HttpBridgeIsolatedST
 -> io.strimzi.systemtest.metrics.MetricsIsolatedST
 -> io.strimzi.systemtest.metrics.JmxIsolatedST
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


