### PR TITLE
Try to improve the default memory configuration of the operators

### DIFF
--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -23,6 +23,11 @@ JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 # Deny illegal access option is supported only on Java 9 and higher
 JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
 
+# Default memory options used when the user didn't configured any of these options, we set the defaults
+if [[ "$JAVA_OPTS" != *"MinRAMPercentage"* && "$JAVA_OPTS" != *"MaxRAMPercentage"* && "$JAVA_OPTS" != *"InitialRAMPercentage"* ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=20 -XX:InitialRAMPercentage=10"
+fi
+
 # Disable FIPS if needed
 if [ "$FIPS_MODE" = "disabled" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Dcom.redhat.fips=false"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

I spent some time trying to tune the way the operators use the memory to make it run OoM less often. So far my finding is that using the following options seems to significantly reduce the number of restarts: `-XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=20 -XX:InitialRAMPercentage=10`. The `RAMPercentage` options were chosen over `-Xm*` options since they should better scale with the container resources. I'm not 100% sure how efficient this will be since with the default resources (384Mi) a big chunk of the memory is consumed by things such as CodeHeap etc.

This PR adds it to all 3 operators as the new default. It is set only when none of these options is configured by the user. This might seem a bit weird. However, it seemed to be the best way how to combine the existing JAVA_OPTS` values based by the user to the CO with the options from the `jvmOptions` sections in the KAfka CR for TO and UO. If anyone has any more elegant idea how to integrate it, I'm open to suggestions.

One worry is that it is quite hard to test this in various environments. My observation is based on my long-running environment with 1 Kafka cluster, 1 Connect cluster, 6 connectors, 4 users and 32 topics. It is hard to guarantee that these values won't make things worse for some other users. In any case, users can override these values if needed.

This should (hopefully) resolve #4471 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging