### PR TITLE
docs: describe compute resources config

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 The Cluster Operator is responsible for deploying and managing Apache Kafka clusters within a Kubernetes cluster.
 
-The procedures in this section describe how to deploy the Cluster Operator to _watch_ one of the following:
+The procedures in this section describe how to deploy the Cluster Operator to watch one of the following:
 
 ** xref:deploying-cluster-operator-{context}[A single namespace]
 ** xref:deploying-cluster-operator-to-watch-multiple-namespaces-{context}[Multiple namespaces]

--- a/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
@@ -8,9 +8,8 @@
 [role="_abstract"]
 The Cluster Operator is responsible for deploying and managing Apache Kafka clusters within a Kubernetes cluster.
 
-The procedures in this section show:
+The procedures in this section describe how to deploy the Cluster Operator to _watch_ one of the following:
 
-* How to deploy the Cluster Operator to _watch_:
 ** xref:deploying-cluster-operator-{context}[A single namespace]
 ** xref:deploying-cluster-operator-to-watch-multiple-namespaces-{context}[Multiple namespaces]
 ** xref:deploying-cluster-operator-to-watch-whole-cluster-{context}[All namespaces]

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -1,6 +1,5 @@
 // This assembly is included in:
 //
-// assembly-getting-started.adoc
 // deploying/assembly-deploy-tasks.adoc
 
 [id="deploy-create-cluster_{context}"]

--- a/documentation/assemblies/deploying/assembly-deploy-kafka-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-cluster.adoc
@@ -7,7 +7,7 @@
 
 Apache Kafka is an open-source distributed publish-subscribe messaging system for fault-tolerant real-time data feeds.
 
-The procedures in this section show:
+The procedures in this section describe the following:
 
 * How to use the Cluster Operator to deploy:
 ** xref:deploying-kafka-cluster-{context}[An _ephemeral_ or _persistent_ Kafka cluster]

--- a/documentation/modules/deploying/con-deploy-options-scope.adoc
+++ b/documentation/modules/deploying/con-deploy-options-scope.adoc
@@ -34,13 +34,11 @@ Strimzi supports additional deployment options to monitor your deployment.
 
 == CPU and memory resource limits and requests
 
-By default, the Strimzi deployment does not specify requests and limits for CPU and memory resources.
-It's important for Kafka to have enough of these resources to run properly, but not more than they need if they are sharing resources.
-If you don't set limits, a container could use all the available memory.
+By default, the Strimzi Cluster Operator does not specify requests and limits for CPU and memory resources for any operands it deploys.
 
-The amount of resources to reserve depends on the specific requirements of the deployment.
-The number of producers and consumers has an impact, as does the size of messages.
-You might monitor data throughput and other metrics to get an idea of the resources needed.
+Having sufficient resources is important for applications like Kafka to be stable and deliver good performance.
 
-You can set resource requests and limits for each container in a pod.
-If you want to set requests and limits, you link:{BookURLUsing}#con-common-configuration-resources-reference[add resources configuration to Strimzi custom resources].
+The right amount of resources you should use depends on the specific requirements and use-cases.
+
+You should consider configuring the CPU and memory resources.
+You can set resource requests and limits for each container in the link:{BookURLUsing}#con-common-configuration-resources-reference[Strimzi custom resources].

--- a/documentation/modules/deploying/con-deploy-options-scope.adoc
+++ b/documentation/modules/deploying/con-deploy-options-scope.adoc
@@ -31,3 +31,16 @@ Strimzi supports additional deployment options to monitor your deployment.
 * Extract metrics and monitor Kafka components by xref:assembly-metrics-setup-str[deploying Prometheus and Grafana with your Kafka cluster].
 * Extract additional metrics, particularly related to monitoring consumer lag, by xref:proc-metrics-kafka-deploy-options-{context}[deploying Kafka Exporter with your Kafka cluster].
 * Track messages end-to-end by link:{BookURLUsing}#assembly-distributed-tracing-str[setting up distributed tracing^].
+
+== CPU and memory resource limits and requests
+
+By default, the Strimzi deployment does not specify requests and limits for CPU and memory resources.
+It's important for Kafka to have enough of these resources to run properly, but not more than they need if they are sharing resources.
+If you don't set limits, a container could use all the available memory.
+
+The amount of resources to reserve depends on the specific requirements of the deployment.
+The number of producers and consumers has an impact, as does the size of messages.
+You might monitor data throughput and other metrics to get an idea of the resources needed.
+
+You can set resource requests and limits for each container in a pod.
+If you want to set requests and limits, you link:{BookURLUsing}#con-common-configuration-resources-reference[add resources configuration to Strimzi custom resources].

--- a/documentation/modules/deploying/con-deploy-prereqs.adoc
+++ b/documentation/modules/deploying/con-deploy-prereqs.adoc
@@ -5,10 +5,10 @@
 [id='deploy-prereqs-{context}']
 = Deployment prerequisites
 
-To deploy Strimzi, make sure that:
+To deploy Strimzi, you'll need the following:
 
 ifdef::Downloading[]
-* A Kubernetes {KubernetesVersion} cluster is available.
+* A Kubernetes {KubernetesVersion} cluster.
 +
 If you do not have access to a Kubernetes cluster, you can install Strimzi with xref:deploy-kubernetes-{context}[_Minikube_].
 * The `kubectl` command-line tool is installed and configured to connect to the running cluster.
@@ -38,7 +38,7 @@ For example, the `oc` equivalent of `kubectl taint` is `oc adm taint`.
 
 endif::Downloading[]
 ifndef::Downloading[]
-* An OpenShift {OpenShiftVersion} cluster is available.
+* An OpenShift {OpenShiftVersion} cluster.
 +
 Strimzi is based on Strimzi {StrimziVersion}.
 

--- a/documentation/modules/deploying/con-deploy-prereqs.adoc
+++ b/documentation/modules/deploying/con-deploy-prereqs.adoc
@@ -5,7 +5,7 @@
 [id='deploy-prereqs-{context}']
 = Deployment prerequisites
 
-To deploy Strimzi, you'll need the following:
+To deploy Strimzi, you will need the following:
 
 ifdef::Downloading[]
 * A Kubernetes {KubernetesVersion} cluster.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updates the _Deploying_ guide
Adds a section to _Configuring a deployment_  that provides information on configuring cpu and memory resources, and why it might be required.  Links to the [resources](https://strimzi.io/docs/operators/in-development/configuring.html#con-common-configuration-resources-reference) section in the _Configuring_ guide for more information.

Plus, few small edits from review.

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

