### PR TITLE
Fix schellcheck compatibility with v0.8+

### DIFF
--- a/tools/prerequisites-check.sh
+++ b/tools/prerequisites-check.sh
@@ -24,17 +24,17 @@ IFS="." read -r -a YQ_ARRAY <<< "$YQ_VERSION"
 
 yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 4.2.1 or above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
 
-if [[ YQ_ARRAY[0] -lt 4  ]]; then
+if [[ ${YQ_ARRAY[0]} -lt 4  ]]; then
   echo -e "$yq_err_msg"
   exit 1
 fi
 
-if [[ YQ_ARRAY[0] -eq 4  ]] && [[ YQ_ARRAY[1] -lt 2 ]]; then
+if [[ ${YQ_ARRAY[0]} -eq 4  ]] && [[ ${YQ_ARRAY[1]} -lt 2 ]]; then
   echo -e "$yq_err_msg"
   exit 1
 fi
 
-if [[ YQ_ARRAY[0] -eq 4  ]] && [[ YQ_ARRAY[1] -eq 2 ]] && [[ YQ_ARRAY[2] -lt 1 ]]; then
+if [[ ${YQ_ARRAY[0]} -eq 4  ]] && [[ ${YQ_ARRAY[1]} -eq 2 ]] && [[ ${YQ_ARRAY[2]} -lt 1 ]]; then
   echo -e "$yq_err_msg"
-  exit 1 
+  exit 1
 fi


### PR DESCRIPTION
No $ and no {} breaks condition check with shellcheck 0.8.0 version.

Signed-off-by: Ales Justin <ales.justin@gmail.com>
