### PR TITLE
[systemtest] Test clients exchange - backup, bridge, connect, cruisecontrol and dump packages

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -61,6 +61,14 @@ public interface Constants {
     int GLOBAL_RECONCILIATION_COUNT = (int) ((RECONCILIATION_INTERVAL / GLOBAL_POLL_INTERVAL) + GLOBAL_STABILITY_OFFSET_COUNT);
 
     /**
+     * Scraper pod labels
+     */
+    String SCRAPER_LABEL_KEY = "user-test-app";
+    String SCRAPER_LABEL_VALUE = "scraper";
+
+    String SCRAPER_NAME = "scraper";
+
+    /**
      * Constants for Kafka clients labels
      */
     String KAFKA_CLIENTS_LABEL_KEY = "user-test-app";
@@ -365,8 +373,10 @@ public interface Constants {
     String TOPIC_KEY = "TOPIC_NAME";
     String STREAM_TOPIC_KEY = "STREAM_TOPIC_NAME";
     String KAFKA_CLIENTS_KEY = "KAFKA_CLIENTS_NAME";
+    String SCRAPER_KEY = "SCRAPER_NAME";
     String PRODUCER_KEY = "PRODUCER_NAME";
     String CONSUMER_KEY = "CONSUMER_NAME";
+    String USER_NAME_KEY = "USER_NAME";
     String KAFKA_CLIENTS_POD_KEY = "KAFKA_CLIENTS_POD_NAME";
     String KAFKA_TRACING_CLIENT_KEY = "KAFKA_TRACING_CLIENT";
     String KAFKA_SELECTOR = "KAFKA_SELECTOR";

--- a/systemtest/src/main/java/io/strimzi/systemtest/enums/DeploymentTypes.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/enums/DeploymentTypes.java
@@ -11,4 +11,5 @@ public enum DeploymentTypes {
     OlmClusterOperator,
     KafkaClients,
     DrainCleaner,
+    Scraper,
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
@@ -168,7 +168,7 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
      */
     public static void allowNetworkPolicySettingsForResource(ExtensionContext extensionContext, HasMetadata resource, String deploymentName) {
         LabelSelector labelSelector = new LabelSelectorBuilder()
-            .addToMatchLabels(Constants.KAFKA_CLIENTS_LABEL_KEY, Constants.KAFKA_CLIENTS_LABEL_VALUE)
+            .addToMatchLabels(Constants.SCRAPER_LABEL_KEY, Constants.SCRAPER_LABEL_VALUE)
             .build();
 
         final String namespaceName = StUtils.isParallelNamespaceTest(extensionContext) && !Environment.isNamespaceRbacScope() ?

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -25,6 +25,7 @@ final public class TestStorage {
 
     private static final String PRODUCER = "hello-world-producer";
     private static final String CONSUMER = "hello-world-consumer";
+    private static final String USER = "user";
     private static final String CLUSTER_NAME_PREFIX = "my-cluster-";
     private static final Random RANDOM = new Random();
 
@@ -34,8 +35,10 @@ final public class TestStorage {
     private String topicName;
     private String streamsTopicTargetName;
     private String kafkaClientsName;
+    private String scraperName;
     private String producerName;
     private String consumerName;
+    private String userName;
     private LabelSelector kafkaSelector;
     private LabelSelector zkSelector;
 
@@ -50,8 +53,10 @@ final public class TestStorage {
         this.topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.streamsTopicTargetName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.kafkaClientsName = clusterName + "-" + Constants.KAFKA_CLIENTS;
+        this.scraperName = clusterName + "-" + Constants.SCRAPER_NAME;
         this.producerName = clusterName + "-" + PRODUCER;
         this.consumerName = clusterName  + "-" + CONSUMER;
+        this.userName = clusterName + "-" + USER;
         this.kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
         this.zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
 
@@ -60,8 +65,10 @@ final public class TestStorage {
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.TOPIC_KEY, this.topicName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.STREAM_TOPIC_KEY, this.streamsTopicTargetName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.KAFKA_CLIENTS_KEY, this.kafkaClientsName);
+        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.SCRAPER_KEY, this.scraperName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PRODUCER_KEY, this.producerName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.CONSUMER_KEY, this.consumerName);
+        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.USER_NAME_KEY, this.userName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.KAFKA_SELECTOR, this.kafkaSelector);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.ZOOKEEPER_SELECTOR, this.zkSelector);
     }
@@ -90,12 +97,20 @@ final public class TestStorage {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.KAFKA_CLIENTS_KEY).toString();
     }
 
+    public String getScraperName() {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.SCRAPER_KEY).toString();
+    }
+
     public String getProducerName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.PRODUCER_KEY).toString();
     }
 
     public String getConsumerName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.CONSUMER_KEY).toString();
+    }
+
+    public String getUserName() {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.USER_NAME_KEY).toString();
     }
 
     public LabelSelector getKafkaSelector() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.templates.specific;
+
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.enums.DeploymentTypes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScraperTemplates {
+
+    private ScraperTemplates() { }
+
+    public static DeploymentBuilder scraperPod(String namespaceName, String podName) {
+        Map<String, String> label = new HashMap<>();
+
+        label.put(Constants.SCRAPER_LABEL_KEY, Constants.SCRAPER_LABEL_VALUE);
+        label.put(Constants.DEPLOYMENT_TYPE, DeploymentTypes.Scraper.name());
+
+        return new DeploymentBuilder()
+            .withNewMetadata()
+                .withName(podName)
+                .withLabels(label)
+                .withNamespace(namespaceName)
+            .endMetadata()
+            .withNewSpec()
+                .withNewSelector()
+                    .addToMatchLabels("app", podName)
+                    .addToMatchLabels(label)
+                .endSelector()
+                .withReplicas(1)
+                .withNewTemplate()
+                    .withNewMetadata()
+                        .addToLabels("app", podName)
+                        .addToLabels(label)
+                    .endMetadata()
+                    .withNewSpec()
+                        .withContainers(
+                            new ContainerBuilder()
+                                .withName(podName)
+                                .withImage("registry.access.redhat.com/ubi8/ubi:latest")
+                                .withCommand("sleep")
+                                .withArgs("infinity")
+                                .withImagePullPolicy(Environment.COMPONENTS_IMAGE_PULL_POLICY)
+                                .withResources(new ResourceRequirementsBuilder()
+                                    .addToRequests("memory", new Quantity("200M"))
+                                    .build())
+                                .build()
+                        )
+                        .endSpec()
+                .endTemplate()
+            .endSpec();
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -51,6 +51,17 @@ public class JobUtils {
     }
 
     /**
+     * Delete Jobs with wait
+     * @param namespace - name of the namespace
+     * @param names - job names
+     */
+    public static void deleteJobsWithWait(String namespace, String... names) {
+        for (String jobName : names) {
+            deleteJobWithWait(namespace, jobName);
+        }
+    }
+
+    /**
      * Wait for specific Job failure
      * @param jobName job name
      * @param timeout timeout in ms after which we assume that job failed

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
@@ -11,11 +11,13 @@ import static io.strimzi.test.TestUtils.USER_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
-import java.util.Map;
-
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.test.annotations.IsolatedSuite;
 import io.strimzi.test.annotations.IsolatedTest;
 import org.apache.logging.log4j.LogManager;
@@ -25,9 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
-import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.test.executor.Exec;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -36,40 +35,61 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 @Tag(INTERNAL_CLIENTS_USED)
 @IsolatedSuite
 public class ColdBackupScriptIsolatedST extends AbstractST {
+
     private static final Logger LOGGER = LogManager.getLogger(ColdBackupScriptIsolatedST.class);
 
     @BeforeAll
     void setUp() {
         clusterOperator.unInstall();
-        clusterOperator = clusterOperator.defaultInstallation().createInstallation().runInstallation();
+        clusterOperator = clusterOperator
+            .defaultInstallation()
+            .createInstallation()
+            .runInstallation();
     }
 
     @IsolatedTest
     void backupAndRestore(ExtensionContext context) {
         String clusterName = mapWithClusterNames.get(context.getDisplayName());
         String groupId = "my-group", newGroupId = "new-group";
+
+        String topicName = mapWithTestTopics.get(context.getDisplayName());
+        String producerName = clusterName + "-producer";
+        String consumerName = clusterName + "-consumer";
+
         int firstBatchSize = 100, secondBatchSize = 10;
         String backupFilePath = USER_PATH + "/target/" + clusterName + ".tgz";
 
         resourceManager.createResource(context, KafkaTemplates.kafkaPersistent(clusterName, 1, 1)
-                .editMetadata()
-                    .withNamespace(INFRA_NAMESPACE)
-                .endMetadata()
-                .build());
-        String clientsPodName = deployAndGetInternalClientsPodName(context);
-        InternalKafkaClient clients = buildInternalClients(context, clientsPodName, groupId, firstBatchSize);
+            .editMetadata()
+                .withNamespace(INFRA_NAMESPACE)
+            .endMetadata()
+            .build());
+
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+            .withNamespaceName(INFRA_NAMESPACE)
+            .withTopicName(topicName)
+            .withConsumerGroup(groupId)
+            .withMessageCount(firstBatchSize)
+            .build();
 
         // send messages and consume them
-        clients.sendMessagesPlain();
-        clients.receiveMessagesPlain();
+        resourceManager.createResource(context, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, INFRA_NAMESPACE, firstBatchSize);
 
         // save consumer group offsets
-        Map<String, String> offsetsBeforeBackup = clients.getCurrentOffsets();
-        assertThat("No offsets map before backup", offsetsBeforeBackup != null && offsetsBeforeBackup.size() > 0);
+        int offsetsBeforeBackup = KafkaUtils.getCurrentOffsets(KafkaResources.kafkaPodName(clusterName, 0), topicName, groupId);
+        assertThat("No offsets map before backup", offsetsBeforeBackup > 0);
 
         // send additional messages
-        clients.setMessageCount(secondBatchSize);
-        clients.sendMessagesPlain();
+        clients = new KafkaClientsBuilder(clients)
+            .withMessageCount(secondBatchSize)
+            .build();
+
+        resourceManager.createResource(context, clients.producerStrimzi());
+        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, firstBatchSize);
 
         // backup command
         LOGGER.info("Running backup procedure for {}/{}", INFRA_NAMESPACE, clusterName);
@@ -79,7 +99,11 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
         Exec.exec(Level.INFO, backupCommand);
 
         clusterOperator.unInstall();
-        clusterOperator = clusterOperator.defaultInstallation().createInstallation().runInstallation();
+
+        clusterOperator = clusterOperator
+            .defaultInstallation()
+            .createInstallation()
+            .runInstallation();
 
         // restore command
         LOGGER.info("Running restore procedure for {}/{}", INFRA_NAMESPACE, clusterName);
@@ -90,45 +114,28 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
 
         // check consumer group offsets
         KafkaUtils.waitForKafkaReady(clusterName);
-        clientsPodName = deployAndGetInternalClientsPodName(context);
-        clients = buildInternalClients(context, clientsPodName, groupId, secondBatchSize);
-        Map<String, String> offsetsAfterRestore = clients.getCurrentOffsets();
+
+        clients = new KafkaClientsBuilder(clients)
+            .withMessageCount(secondBatchSize)
+            .build();
+
+        int offsetsAfterRestore = KafkaUtils.getCurrentOffsets(KafkaResources.kafkaPodName(clusterName, 0), topicName, groupId);
         assertThat("Current consumer group offsets are not the same as before the backup", offsetsAfterRestore, is(offsetsBeforeBackup));
 
         // check consumer group recovery
-        assertThat("Consumer group is not able to recover after restore", clients.receiveMessagesPlain(), is(secondBatchSize));
+        resourceManager.createResource(context, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, secondBatchSize);
+        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         // check total number of messages
         int batchSize = firstBatchSize + secondBatchSize;
-        clients = clients.toBuilder()
-                .withConsumerGroupName(newGroupId)
+        clients = new KafkaClientsBuilder(clients)
+                .withConsumerGroup(newGroupId)
                 .withMessageCount(batchSize)
                 .build();
-        assertThat("A new consumer group is not able to get all messages", clients.receiveMessagesPlain(), is(batchSize));
-    }
 
-    private String deployAndGetInternalClientsPodName(ExtensionContext context) {
-        final String kafkaClientsName = mapWithKafkaClientNames.get(context.getDisplayName());
-        resourceManager.createResource(context, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName)
-            .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
-            .endMetadata()
-            .build());
-        return ResourceManager.kubeClient().listPodsByPrefixInName(INFRA_NAMESPACE, kafkaClientsName).get(0).getMetadata().getName();
-    }
-
-    private InternalKafkaClient buildInternalClients(ExtensionContext context, String podName, String groupId, int batchSize) {
-        String clusterName = mapWithClusterNames.get(context.getDisplayName());
-        String topicName = mapWithTestTopics.get(context.getDisplayName());
-        InternalKafkaClient clients = new InternalKafkaClient.Builder()
-                .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
-                .withNamespaceName(INFRA_NAMESPACE)
-                .withUsingPodName(podName)
-                .withClusterName(clusterName)
-                .withTopicName(topicName)
-                .withConsumerGroupName(groupId)
-                .withMessageCount(batchSize)
-                .build();
-        return clients;
+        resourceManager.createResource(context, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, batchSize);
+        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -201,7 +201,7 @@ public class CruiseControlST extends AbstractST {
 
         resourceManager.createResource(extensionContext,  KafkaRebalanceTemplates.kafkaRebalance(clusterName)
             .editOrNewSpec()
-            .withExcludedTopics("excluded-.*")
+                .withExcludedTopics("excluded-.*")
             .endSpec()
             .build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -328,6 +328,6 @@ public class FeatureGatesIsolatedST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(zkSelector, zkReplicas, zkPods);
         RollingUpdateUtils.waitTillComponentHasRolled(kafkaSelector, kafkaReplicas, kafkaPods);
 
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, INFRA_NAMESPACE, messageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, INFRA_NAMESPACE, messageCount);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -205,7 +205,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, namespaceName, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, namespaceName, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -429,7 +429,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, namespaceName, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, namespaceName, continuousClientsMessageCount);
         // ##############################
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
@@ -165,7 +165,6 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicXName, INFRA_NAMESPACE).build());
         resourceManager.createResource(extensionContext, teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(teamAProducerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, teamAProducerName);
 
         String topicAName = TOPIC_A + "-" + clusterName;
 
@@ -208,7 +207,6 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
         LOGGER.info("Sending {} messages to broker with topic name {}", MESSAGE_COUNT, topicAName);
         resourceManager.createResource(extensionContext, teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(teamAProducerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, teamAProducerName);
 
         // team A client shouldn't be able to consume messages with wrong consumer group
 
@@ -272,7 +270,7 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, teamBOauthClientJob.producerStrimziOauthTls(oauthClusterName));
         resourceManager.createResource(extensionContext, teamBOauthClientJob.consumerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitTillContinuousClientsFinish(teamBProducerName, teamBConsumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientsSuccess(teamBProducerName, teamBConsumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
     }
 
     @Description("As a member of team A, I can write to topics starting with 'x-' and " +
@@ -462,7 +460,6 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(teamAProducerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, teamAProducerName);
 
         LOGGER.info("Adding the maxSecondsWithoutReauthentication to Kafka listener with OAuth authentication");
         KafkaResource.replaceKafkaResourceInSpecificNamespace(oauthClusterName, kafka -> {
@@ -552,7 +549,6 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(teamAProducerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, teamAProducerName);
 
         LOGGER.info("Changing back to the original settings and checking, if the producer will be successful");
 
@@ -567,7 +563,6 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, teamAOauthClientJob.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(teamAProducerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, teamAProducerName);
 
         LOGGER.info("Changing configuration of Kafka back to it's original form");
         KafkaResource.replaceKafkaResourceInSpecificNamespace(oauthClusterName, kafka -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -199,9 +199,6 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, oauthAudienceInternalClientJob.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(audienceConsumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, audienceProducerName);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, audienceConsumerName);
     }
 
     @ParallelTest
@@ -254,9 +251,6 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
         resourceManager.createResource(extensionContext, oauthInternalClientJob.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
     }
 
     @Description("As an oauth KafkaConnect, I should be able to sink messages from kafka broker topic.")
@@ -285,11 +279,9 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(extensionContext, clusterName, oauthClusterName, 1)
@@ -359,11 +351,9 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         String targetKafkaCluster = clusterName + "-target";
 
@@ -503,11 +493,9 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         String kafkaSourceClusterName = oauthClusterName;
         String kafkaTargetClusterName = clusterName + "-target";
@@ -656,11 +644,9 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
 
@@ -706,7 +692,6 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, kafkaBridgeClientJob.producerStrimziBridge());
         ClientUtils.waitForClientSuccess(bridgeProducerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, bridgeProducerName);
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
@@ -178,7 +178,6 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, oauthInternalClientChecksJob.producerStrimzi());
         // client should succeeded because we set to `clientScope=test` and also Kafka has `scope=test`
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
     }
 
     @IsolatedTest("Modification of shared Kafka cluster")

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
@@ -36,7 +36,6 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.vertx.core.cli.annotations.Description;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -130,11 +129,9 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, oauthClusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
@@ -207,11 +204,9 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, true, kafkaClientsName).build());
 
@@ -257,7 +252,6 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, kafkaBridgeClientJob.producerStrimziBridge());
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
     }
 
     @Description("As a oauth mirror maker, I am able to replicate topic data using using encrypted communication")
@@ -289,11 +283,9 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, producerName);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
 
         String targetKafkaCluster = oauthClusterName + "-target";
 
@@ -414,7 +406,6 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, kafkaOauthClientJob.consumerStrimziOauthTls(targetKafkaCluster));
 
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
-        JobUtils.deleteJobWithWait(INFRA_NAMESPACE, consumerName);
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationIsolatedST.java
@@ -90,9 +90,7 @@ public class ClusterOperationIsolatedST extends AbstractST {
             NodeUtils.cordonNode(node.getMetadata().getName(), true);
         });
 
-        producerNames.forEach(producerName -> ClientUtils.waitTillContinuousClientsFinish(producerName, consumerNames.get(producerName.indexOf(producerName)), NAMESPACE, continuousClientsMessageCount));
-        producerNames.forEach(producerName -> kubeClient().deleteJob(producerName));
-        consumerNames.forEach(consumerName -> kubeClient().deleteJob(consumerName));
+        producerNames.forEach(producerName -> ClientUtils.waitForClientsSuccess(producerName, consumerNames.get(producerName.indexOf(producerName)), NAMESPACE, continuousClientsMessageCount));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerIsolatedST.java
@@ -24,7 +24,6 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NodeUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -117,7 +116,7 @@ public class DrainCleanerIsolatedST extends AbstractST {
             RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(Constants.DRAIN_CLEANER_NAMESPACE, testStorage.getKafkaSelector(), replicas, kafkaPod);
         }
 
-        ClientUtils.waitTillContinuousClientsFinish(testStorage.getProducerName(), testStorage.getConsumerName(), Constants.DRAIN_CLEANER_NAMESPACE, 300);
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), Constants.DRAIN_CLEANER_NAMESPACE, 300);
     }
 
     @IsolatedTest
@@ -249,9 +248,7 @@ public class DrainCleanerIsolatedST extends AbstractST {
             RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(Constants.DRAIN_CLEANER_NAMESPACE, testStorage.getKafkaSelector(), replicas, kafkaPod);
         });
 
-        producerNames.forEach(producer -> ClientUtils.waitTillContinuousClientsFinish(producer, consumerNames.get(producerNames.indexOf(producer)), Constants.DRAIN_CLEANER_NAMESPACE, 300));
-        producerNames.forEach(producer -> KubeClusterResource.kubeClient().deleteJob(producer));
-        consumerNames.forEach(consumer -> KubeClusterResource.kubeClient().deleteJob(consumer));
+        producerNames.forEach(producer -> ClientUtils.waitForClientsSuccess(producer, consumerNames.get(producerNames.indexOf(producer)), Constants.DRAIN_CLEANER_NAMESPACE, 300));
     }
 
     @AfterEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -399,7 +399,7 @@ public class TracingST extends AbstractST {
         resourceManager.createResource(extensionContext, ((KafkaTracingClients) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(KAFKA_TRACING_CLIENT_KEY)).producerWithTracing());
         resourceManager.createResource(extensionContext, ((KafkaTracingClients) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(KAFKA_TRACING_CLIENT_KEY)).consumerWithTracing());
 
-        ClientUtils.waitTillContinuousClientsFinish(
+        ClientUtils.waitForClientsSuccess(
             storageMap.get(extensionContext).getProducerName(),
             storageMap.get(extensionContext).getConsumerName(),
             storageMap.get(extensionContext).getNamespaceName(), MESSAGE_COUNT);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -562,11 +562,8 @@ public class AbstractUpgradeST extends AbstractST {
             // ##############################
             // Validate that continuous clients finished successfully
             // ##############################
-            ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, namespace, continuousClientsMessageCount);
+            ClientUtils.waitForClientsSuccess(producerName, consumerName, namespace, continuousClientsMessageCount);
             // ##############################
-            // Delete jobs to make same names available for next upgrade run during chain upgrade
-            kubeClient().deleteJob(producerName);
-            kubeClient().deleteJob(consumerName);
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeIsolatedST.java
@@ -69,7 +69,7 @@ public class KafkaUpgradeDowngradeIsolatedST extends AbstractUpgradeST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -94,7 +94,7 @@ public class KafkaUpgradeDowngradeIsolatedST extends AbstractUpgradeST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -119,7 +119,7 @@ public class KafkaUpgradeDowngradeIsolatedST extends AbstractUpgradeST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -140,7 +140,7 @@ public class KafkaUpgradeDowngradeIsolatedST extends AbstractUpgradeST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitTillContinuousClientsFinish(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, INFRA_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static io.strimzi.systemtest.Constants.OLM_UPGRADE;
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -151,10 +150,6 @@ public class OlmUpgradeIsolatedST extends AbstractUpgradeST {
 
         ClientUtils.waitForClientSuccess(producerName, namespace, messageUpgradeCount);
         ClientUtils.waitForClientSuccess(consumerName, namespace, messageUpgradeCount);
-
-        // Delete jobs to make same names available for next upgrade
-        kubeClient().deleteJob(producerName);
-        kubeClient().deleteJob(consumerName);
 
         // Check errors in CO log
         assertNoCoErrorsLogged(0);


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR is first of few for test clients exchange.

List of changes: 
- add new `ScraperTemplate`, which contains deployment of, lets say, dummy pod. The main purpose of scraper pod is currently to do requests on APIs. But there should be more in the future.
- add `tls` and `scram-sha` methods to our clients.
- add scraper and user names to `TestStorage`
- use `TestStorage` in tests, that contain work with clients 
- add jobs deletion to `ClientUtils.waitForClientSuccess` and `ClientUtils.waitForClients.Success` - so we don't have to delete jobs in each test after completition
- delete `deleteJobWithWait` methods from few tests

### Checklist

- [x] Make sure all tests pass

