### PR TITLE
Increase the temporary volume size to 5Mi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.29.0
 
+* Increase the size of the `/tmp` volumes to 5Mi to allow unpacking of compression libraries
 * Use `/healthz` endpoint for Kafka Exporter health checks
 
 ## 0.28.0

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -185,9 +185,9 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     }
 
     @Pattern(Constants.MEMORY_REGEX)
-    @DefaultValue("1Mi")
+    @DefaultValue("5Mi")
     @Description("Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). " +
-            "Default value is `1Mi`.")
+            "Default value is `5Mi`.")
     public String getTmpDirSizeLimit() {
         return tmpDirSizeLimit;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -152,6 +152,7 @@ public abstract class AbstractModel {
      */
     /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME = "strimzi-tmp";
     /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH = "/tmp";
+    /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE = "5Mi";
 
     /**
      * Annotation on PVCs storing the original configuration
@@ -1801,7 +1802,7 @@ public abstract class AbstractModel {
     }
 
     protected Volume createTempDirVolume(String volumeName) {
-        return VolumeUtils.createEmptyDirVolume(volumeName, templateTmpDirSizeLimit == null ? "1Mi" : templateTmpDirSizeLimit, "Memory");
+        return VolumeUtils.createEmptyDirVolume(volumeName, templateTmpDirSizeLimit == null ? STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE : templateTmpDirSizeLimit, "Memory");
     }
 
     protected VolumeMount createTempDirVolumeMount() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -213,7 +213,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_TLS), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         checkOwnerReference(kbc.createOwnerReference(), dep);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -538,7 +538,7 @@ public class KafkaClusterTest {
         assertThat(containers.get(0).getPorts().get(1).getProtocol(), is("TCP"));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         if (cm.getSpec().getKafka().getRack() != null) {
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1684,7 +1684,7 @@ public class KafkaConnectClusterTest {
         assertThat(AbstractModel.containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         checkOwnerReference(kc.createOwnerReference(), dep);
         checkRack(dep, resource);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -298,7 +298,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(AbstractModel.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TLS), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         checkOwnerReference(kmm2.createOwnerReference(), dep);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -271,7 +271,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getStrategy().getRollingUpdate().getMaxUnavailable().getIntVal(), is(Integer.valueOf(0)));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         checkOwnerReference(mm.createOwnerReference(), dep);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPodSetTest.java
@@ -160,7 +160,7 @@ public class KafkaPodSetTest {
             assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
             assertThat(pod.getSpec().getVolumes().stream()
                     .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-                    .findFirst().orElse(null).getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+                    .findFirst().orElse(null).getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
             assertThat(pod.getSpec().getContainers().size(), is(1));
             assertThat(pod.getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds(), is(5));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -407,7 +407,7 @@ public class ZookeeperClusterTest {
         assertThat(containers.get(0).getVolumeMounts().get(4).getMountPath(), is(ZookeeperCluster.ZOOKEEPER_CLUSTER_CA_VOLUME_MOUNT));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
     }
 
     // TODO test volume claim templates

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
@@ -148,7 +148,7 @@ public class ZookeeperPodSetTest {
             assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
             assertThat(pod.getSpec().getVolumes().stream()
                     .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-                    .findFirst().orElse(null).getEmptyDir().getSizeLimit(), is(new Quantity("1Mi")));
+                    .findFirst().orElse(null).getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
             assertThat(pod.getSpec().getContainers().size(), is(1));
             assertThat(pod.getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds(), is(5));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -947,7 +947,7 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
-|tmpDirSizeLimit                1.2+<.<a|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+|tmpDirSizeLimit                1.2+<.<a|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
 |string
 |enableServiceLinks             1.2+<.<a|Indicates whether information about services should be injected into Pod's environment variables.
 |boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1238,7 +1238,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -2355,7 +2355,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -3429,7 +3429,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -4383,7 +4383,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -5186,7 +5186,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -5773,7 +5773,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -789,7 +789,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1465,7 +1465,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -950,7 +950,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -814,7 +814,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -883,7 +883,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1559,7 +1559,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `1Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1623,7 +1623,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -2919,7 +2919,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -4158,7 +4158,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -5224,7 +5224,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -6145,7 +6145,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -6778,7 +6778,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -888,7 +888,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services
@@ -1625,7 +1625,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1106,7 +1106,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -913,7 +913,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1015,7 +1015,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services
@@ -1752,7 +1752,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When compression is used to compress / uncompress the messages, Kafka relies on compression libraries which make use of natively compiled binaries. It turns out these libraries are unpacked into the `/tmp` directory. And when using something like Zstd which is over 1MB in size, it does not fit into the available space and it fails:

```
2022-02-25 20:07:52,875 ERROR [ReplicaManager broker=0] Error processing append operation on partition my-source-cluster.my-topic-0 (kafka.server.ReplicaManager) [data-plane-kafka-request-handler-1]
org.apache.kafka.common.KafkaException: java.lang.ExceptionInInitializerError: Cannot unpack libzstd-jni-1.5.0-4: No space left on device
	at org.apache.kafka.common.compress.ZstdFactory.wrapForOutput(ZstdFactory.java:45)
	at org.apache.kafka.common.record.CompressionType$5.wrapForOutput(CompressionType.java:122)
	at org.apache.kafka.common.record.MemoryRecordsBuilder.<init>(MemoryRecordsBuilder.java:140)
	at org.apache.kafka.common.record.MemoryRecordsBuilder.<init>(MemoryRecordsBuilder.java:160)
	at org.apache.kafka.common.record.MemoryRecordsBuilder.<init>(MemoryRecordsBuilder.java:198)
	at org.apache.kafka.common.record.MemoryRecords.builder(MemoryRecords.java:593)
	at kafka.log.LogValidator$.buildRecordsAndAssignOffsets(LogValidator.scala:513)
	at kafka.log.LogValidator$.validateMessagesAndAssignOffsetsCompressed(LogValidator.scala:466)
	at kafka.log.LogValidator$.validateMessagesAndAssignOffsets(LogValidator.scala:112)
	at kafka.log.UnifiedLog.append(UnifiedLog.scala:802)
	at kafka.log.UnifiedLog.appendAsLeader(UnifiedLog.scala:718)
	at kafka.cluster.Partition.$anonfun$appendRecordsToLeader$1(Partition.scala:1057)
	at kafka.cluster.Partition.appendRecordsToLeader(Partition.scala:1045)
	at kafka.server.ReplicaManager.$anonfun$appendToLocalLog$6(ReplicaManager.scala:924)
	at scala.collection.StrictOptimizedMapOps.map(StrictOptimizedMapOps.scala:28)
	at scala.collection.StrictOptimizedMapOps.map$(StrictOptimizedMapOps.scala:27)
	at scala.collection.mutable.HashMap.map(HashMap.scala:35)
	at kafka.server.ReplicaManager.appendToLocalLog(ReplicaManager.scala:912)
	at kafka.server.ReplicaManager.appendRecords(ReplicaManager.scala:583)
	at kafka.server.KafkaApis.handleProduceRequest(KafkaApis.scala:658)
	at kafka.server.KafkaApis.handle(KafkaApis.scala:169)
	at kafka.server.KafkaRequestHandler.run(KafkaRequestHandler.scala:75)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ExceptionInInitializerError: Cannot unpack libzstd-jni-1.5.0-4: No space left on device
	at java.base/java.io.FileOutputStream.writeBytes(Native Method)
	at java.base/java.io.FileOutputStream.write(FileOutputStream.java:354)
	at com.github.luben.zstd.util.Native.load(Native.java:110)
	at com.github.luben.zstd.util.Native.load(Native.java:55)
	at com.github.luben.zstd.ZstdOutputStreamNoFinalizer.<clinit>(ZstdOutputStreamNoFinalizer.java:18)
	at org.apache.kafka.common.compress.ZstdFactory.wrapForOutput(ZstdFactory.java:43)
	... 22 more
```

Users can increase the size in templates, but this sounds like something what should work out of the box. This PR increase the size of the `/tmp` volume to `5Mi` which should fit all the native binaries with some reserve and should make it easier to use compression without any changes.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md