### PR TITLE
Add Admin client connection count to Kafka Connect Grafana dashboard

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-connect.json
@@ -1001,6 +1001,12 @@
           "interval": "",
           "legendFormat": "#producer connections",
           "refId": "B"
+        },
+        {
+          "expr": "sum(kafka_admin_client_connection_count{strimzi_io_kind=~\"KafkaConnect.*\",strimzi_io_cluster=\"$strimzi_connect_cluster_name\"})",
+          "legendFormat": "#admin connections",
+          "interval": "",
+          "refId": "C"
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Kafka Connect Grafana dashboard has currently a chart with consumer and producer connection counts. But Connect uses also Admin Client connections. This PR adds the admin connection count to the chart as well.

![Screenshot 2022-02-28 at 20 42 15](https://user-images.githubusercontent.com/5658439/156048854-43fdbd6f-39a4-4c01-8c36-3cf268fb4e89.png)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Supply screenshots for visual changes, such as Grafana dashboards

