### PR TITLE
Filter forbidden options in KafkaConnector configurations

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -27,7 +27,8 @@ import java.util.Map;
 @EqualsAndHashCode
 public abstract class AbstractConnectorSpec extends Spec {
     private static final long serialVersionUID = 1L;
-    private static final String FORBIDDEN_PARAMETERS = "connector.class, tasks.max";
+
+    public static final String FORBIDDEN_PARAMETERS = "connector.class, tasks.max";
 
     private Integer tasksMax;
     private Boolean pause;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectorConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectorConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.AbstractConnectorSpec;
+import io.strimzi.operator.common.Reconciliation;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class for handling KafkaConnector configuration passed by the user
+ */
+public class KafkaConnectorConfiguration extends AbstractConfiguration {
+    private static final List<String> FORBIDDEN_PREFIXES;
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
+    private static final Map<String, String> DEFAULTS;
+
+    static {
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(AbstractConnectorSpec.FORBIDDEN_PARAMETERS);
+        FORBIDDEN_PREFIX_EXCEPTIONS = List.of();
+        DEFAULTS = new HashMap<>(0);
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param reconciliation  The reconciliation
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
+    public KafkaConnectorConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -42,6 +42,7 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.model.KafkaConnectorConfiguration;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -49,8 +50,8 @@ import io.strimzi.operator.common.AbstractOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Operator;
-import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
@@ -74,7 +75,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -194,7 +194,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         case ADDED:
                         case DELETED:
                         case MODIFIED:
-                            Future<Void> f;
                             if (connectName != null) {
                                 // Check whether a KafkaConnect exists
                                 connectOperator.resourceOperator.getAsync(connectNamespace, connectName)
@@ -470,7 +469,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     /**
      * Try to get the current connector config. If the connector does not exist, or its config differs from the 
      * {@code connectorSpec}'s, then call
-     * {@link #createOrUpdateConnector(Reconciliation, String, KafkaConnectApi, String, KafkaConnectorSpec)}
+     * {@link #createOrUpdateConnector(Reconciliation, String, KafkaConnectApi, String, KafkaConnectorSpec, KafkaConnectorConfiguration)}
      * otherwise, just return the connectors current state.
      * @param reconciliation The reconciliation.
      * @param host The REST API host.
@@ -482,10 +481,12 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      */
     protected Future<ConnectorStatusAndConditions> maybeCreateOrUpdateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
                                                                                 String connectorName, KafkaConnectorSpec connectorSpec, CustomResource resource) {
+        KafkaConnectorConfiguration desiredConfig = new KafkaConnectorConfiguration(reconciliation, connectorSpec.getConfig().entrySet());
+
         return apiClient.getConnectorConfig(reconciliation, new BackOff(200L, 2, 6), host, port, connectorName).compose(
-            config -> {
-                if (!needsReconfiguring(reconciliation, connectorName, connectorSpec, config)) {
-                    LOGGER.debugCr(reconciliation, "Connector {} exists and has desired config, {}=={}", connectorName, connectorSpec.getConfig(), config);
+            currentConfig -> {
+                if (!needsReconfiguring(reconciliation, connectorName, connectorSpec, desiredConfig.asOrderedProperties().asMap(), currentConfig)) {
+                    LOGGER.debugCr(reconciliation, "Connector {} exists and has desired config, {}=={}", connectorName, desiredConfig.asOrderedProperties().asMap(), currentConfig);
                     return apiClient.status(reconciliation, host, port, connectorName)
                         .compose(status -> pauseResume(reconciliation, host, apiClient, connectorName, connectorSpec, status))
                         .compose(ignored -> maybeRestartConnector(reconciliation, host, apiClient, connectorName, resource, new ArrayList<>()))
@@ -495,8 +496,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                 .compose(createConnectorStatusAndConditions(conditions)))
                         .compose(status -> updateConnectorTopics(reconciliation, host, apiClient, connectorName, status));
                 } else {
-                    LOGGER.debugCr(reconciliation, "Connector {} exists but does not have desired config, {}!={}", connectorName, connectorSpec.getConfig(), config);
-                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec)
+                    LOGGER.debugCr(reconciliation, "Connector {} exists but does not have desired config, {}!={}", connectorName, desiredConfig.asOrderedProperties().asMap(), currentConfig);
+                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec, desiredConfig)
                         .compose(createConnectorStatusAndConditions())
                         .compose(status -> updateConnectorTopics(reconciliation, host, apiClient, connectorName, status));
                 }
@@ -505,7 +506,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 if (error instanceof ConnectRestException
                         && ((ConnectRestException) error).getStatusCode() == 404) {
                     LOGGER.debugCr(reconciliation, "Connector {} does not exist", connectorName);
-                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec)
+                    return createOrUpdateConnector(reconciliation, host, apiClient, connectorName, connectorSpec, desiredConfig)
                         .compose(createConnectorStatusAndConditions())
                         .compose(status -> updateConnectorTopics(reconciliation, host, apiClient, connectorName, status));
                 } else {
@@ -516,28 +517,27 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
     private boolean needsReconfiguring(Reconciliation reconciliation, String connectorName,
                                        KafkaConnectorSpec connectorSpec,
-                                       Map<String, String> actual) {
-        Map<String, String> desired = new HashMap<>(connectorSpec.getConfig().size());
+                                       Map<String, String> desiredConfig,
+                                       Map<String, String> actualConfig) {
         // The actual which comes from Connect API includes tasks.max, connector.class and name,
         // which connectorSpec.getConfig() does not
         if (connectorSpec.getTasksMax() != null) {
-            desired.put("tasks.max", connectorSpec.getTasksMax().toString());
+            desiredConfig.put("tasks.max", connectorSpec.getTasksMax().toString());
         }
-        desired.put("name", connectorName);
-        desired.put("connector.class", connectorSpec.getClassName());
-        for (Map.Entry<String, Object> entry : connectorSpec.getConfig().entrySet()) {
-            desired.put(entry.getKey(), entry.getValue() != null ? entry.getValue().toString() : null);
-        }
+        desiredConfig.put("name", connectorName);
+        desiredConfig.put("connector.class", connectorSpec.getClassName());
+
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debugCr(reconciliation, "Desired: {}", new TreeMap<>(desired));
-            LOGGER.debugCr(reconciliation, "Actual:  {}", new TreeMap<>(actual));
+            LOGGER.debugCr(reconciliation, "Desired configuration for connector {}: {}", connectorName, new TreeMap<>(desiredConfig));
+            LOGGER.debugCr(reconciliation, "Actual configuration for connector {}:  {}", connectorName, new TreeMap<>(actualConfig));
         }
-        return !desired.equals(actual);
+
+        return !desiredConfig.equals(actualConfig);
     }
 
     protected Future<Map<String, Object>> createOrUpdateConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
-                                                                  String connectorName, KafkaConnectorSpec connectorSpec) {
-        return apiClient.createOrUpdatePutRequest(reconciliation, host, port, connectorName, asJson(reconciliation, connectorSpec))
+                                                                  String connectorName, KafkaConnectorSpec connectorSpec, KafkaConnectorConfiguration desiredConfig) {
+        return apiClient.createOrUpdatePutRequest(reconciliation, host, port, connectorName, asJson(connectorSpec, desiredConfig))
             .compose(ignored -> apiClient.statusWithBackOff(reconciliation, new BackOff(200L, 2, 10), host, port,
                     connectorName))
             .compose(status -> pauseResume(reconciliation, host, apiClient, connectorName, connectorSpec, status))
@@ -770,19 +770,11 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
     }
 
-    protected JsonObject asJson(Reconciliation reconciliation, KafkaConnectorSpec spec) {
+    protected JsonObject asJson(KafkaConnectorSpec spec, KafkaConnectorConfiguration desiredConfig) {
         JsonObject connectorConfigJson = new JsonObject();
-        if (spec.getConfig() != null) {
-            for (Map.Entry<String, Object> cf : spec.getConfig().entrySet()) {
-                String name = cf.getKey();
-                if ("connector.class".equals(name)
-                        || "tasks.max".equals(name)) {
-                    // TODO include resource namespace and name in this message
-                    LOGGER.warnCr(reconciliation, "Configuration parameter {} in KafkaConnector.spec.config will be ignored and the value from KafkaConnector.spec will be used instead",
-                            name);
-                }
-                connectorConfigJson.put(name, cf.getValue());
-            }
+
+        for (Map.Entry<String, String> cf : desiredConfig.asOrderedProperties().asMap().entrySet()) {
+            connectorConfigJson.put(cf.getKey(), cf.getValue());
         }
 
         if (spec.getTasksMax() != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -301,7 +301,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                                 .build();                      
 
                         prepareMirrorMaker2ConnectorConfig(reconciliation, mirror, clusterMap.get(sourceClusterAlias), clusterMap.get(targetClusterAlias), connectorSpec, mirrorMaker2Cluster);
-                        LOGGER.debugCr(reconciliation, "creating/updating connector {} config: {}", connectorName, asJson(reconciliation, connectorSpec).toString());
+                        LOGGER.debugCr(reconciliation, "creating/updating connector {} config: {}", connectorName, connectorSpec.getConfig());
                         return reconcileMirrorMaker2Connector(reconciliation, mirrorMaker2, apiClient, host, connectorName, connectorSpec, mirrorMaker2Status);
                     })
                     .collect(Collectors.toList()))


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The connector operator currently does not properly handle the forbidden properties:
* They are defined in the API class, but never used to filter the options, just for docs
* The forbidden options are actually filtered / overwritten before aplying the configuration to Connect, but it has its own definition of the forbidden fields
* The forbidden options are not properly filtered when the operator decides if connector configuration needs to be updated or not. This causes unnecessary connector updates and connector reloades when the forbidden options are used as described in #6438 

One of the problems here is that the Connector operator does not use the shared Configuration classes used everywhere else. This PR uses it for the connectors as well. That ensures the forbidden options are filtered in the same way as for the other configurations. The configuration class also does the warnings of forbidden configuration options automatically.

This should close #6438 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging