### PR TITLE
Updated slf4j and log4j versions to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <vertx.version>4.2.4</vertx.version>
         <vertx-junit5.version>4.2.4</vertx-junit5.version>
         <vertx.kafka.client>4.2.4</vertx.kafka.client>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.17.2</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson-core.version>2.11.3</fasterxml.jackson-core.version>
@@ -111,7 +111,7 @@
         <zookeeper.version>3.6.3</zookeeper.version>
         <mockito.version>2.28.2</mockito.version>
         <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <quartz.version>2.3.2</quartz.version>
         <jaeger.version>1.6.0</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>


### PR DESCRIPTION
### Type of change

_Bufixg - Security Vulnerability: Strimzi Operator_

### Description
During scanning of the official images from Strimzi few High severity vulnerabilities were seen.
Vulnerable component in the docker image is `/opt/strimzi/lib/org.slf4j.slf4j-api-1.7.25.jar:slf4j-api
1.7.26`

The details of the CVE can be read at : 
- Public [CVE-2018-8088](https://nvd.nist.gov/vuln/detail/CVE-2018-8088)
- non-Public [Sysdig VULNDB-175810] (https://us2.app.sysdig.com/secure/#/scanning/vulnerabilities/VULNDB-175810)

The fix was introduced in version `1.7.26` of `slf4j-api`.  

This fix also includes changes to mitigate CVE reported at - [Jackson Databind - 3328](https://github.com/FasterXML/jackson-databind/issues/3328)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

