### PR TITLE
[MO] - [system test] -> parallelism + OLM fixes

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -362,7 +362,6 @@ public interface Constants {
      */
     String NAMESPACE_KEY = "NAMESPACE_NAME";
     String PREPARE_OPERATOR_ENV_KEY = "PREPARE_OPERATOR_ENV";
-    String PARALLEL_CLASS_COUNT = "PARALLEL_CLASS_COUNT";
 
     /**
      * Auxiliary variable for cluster operator deployment

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -151,7 +151,6 @@ public class Environment {
     public static final String OLM_OPERATOR_DEPLOYMENT_NAME_DEFAULT = Constants.STRIMZI_DEPLOYMENT_NAME;
     public static final String OLM_SOURCE_NAME_DEFAULT = "community-operators";
     public static final String OLM_APP_BUNDLE_PREFIX_DEFAULT = "strimzi-cluster-operator";
-    public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.26.1";
     private static final boolean DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT = true;
     private static final ClusterOperatorInstallType CLUSTER_OPERATOR_INSTALL_TYPE_DEFAULT = ClusterOperatorInstallType.BUNDLE;
     private static final boolean LB_FINALIZERS_DEFAULT = false;
@@ -206,7 +205,7 @@ public class Environment {
     public static final String OLM_SOURCE_NAME = getOrDefault(OLM_SOURCE_NAME_ENV, OLM_SOURCE_NAME_DEFAULT);
     public static final String OLM_SOURCE_NAMESPACE = getOrDefault(OLM_SOURCE_NAMESPACE_ENV, OpenShift.OLM_SOURCE_NAMESPACE);
     public static final String OLM_APP_BUNDLE_PREFIX = getOrDefault(OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX_DEFAULT);
-    public static final String OLM_OPERATOR_LATEST_RELEASE_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, OLM_OPERATOR_VERSION_DEFAULT);
+    public static final String OLM_OPERATOR_LATEST_RELEASE_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, "");
     // NetworkPolicy variable
     public static final boolean DEFAULT_TO_DENY_NETWORK_POLICIES = getOrDefault(DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, Boolean::parseBoolean, DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT);
     // ClusterOperator installation type variable

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/TestExecutionWatcher.java
@@ -72,6 +72,7 @@ public class TestExecutionWatcher implements TestExecutionExceptionHandler, Life
 
         SuiteThreadController suiteThreadController = SuiteThreadController.getInstance();
         if (StUtils.isParallelSuite(extensionContext)) {
+            suiteThreadController.notifyParallelSuiteToAllowExecution(extensionContext);
             suiteThreadController.removeParallelSuite(extensionContext);
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -73,7 +73,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
                 + "io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH"),
         // This happen from time to time during CO startup, it doesn't influence CO behavior
         EXIT_ON_OUT_OF_MEMORY("ExitOnOutOfMemoryError"),
-        OPERATION_TIMEOUT("Util:[0-9]+ - Exceeded timeout of.*while waiting for.*"),
+        OPERATION_TIMEOUT("Util:[0-9]+ - Reconciliation #[0-9]+.*Exceeded timeout of.*while waiting for.*"),
         // This is ignored cause it's no real problem when this error appears, components are being created even after timeout
         RECONCILIATION_TIMEOUT("ERROR Abstract.*Operator:[0-9]+ - Reconciliation.*"),
         ASSEMBLY_OPERATOR_RECONCILIATION_TIMEOUT("ERROR .*AssemblyOperator:[0-9]+ - Reconciliation.*[fF]ailed.*"),

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/SuiteThreadController.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/SuiteThreadController.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -122,7 +121,7 @@ public class SuiteThreadController {
     }
 
     @SuppressFBWarnings(value = "SWL_SLEEP_WITH_LOCK_HELD")
-    public void waitUntilEntryIsOpen(ExtensionContext extensionContext) {
+    public synchronized void waitUntilEntryIsOpen(ExtensionContext extensionContext) {
         // other threads must wait until is open
         while (this.isOpen.get()) {
             LOGGER.debug("Suite {} is waiting to lock to be released.", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()));

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/SuiteThreadController.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/SuiteThreadController.java
@@ -201,16 +201,11 @@ public class SuiteThreadController {
         final String testCaseToWait = extensionContext.getDisplayName();
         waitingTestCases.add(testCaseToWait);
 
-        LOGGER.info("Here before? :D ");
-
         if (runningTestCasesInParallelCount.get() > maxTestSuitesInParallel) {
             LOGGER.debug("[{}] moved to the WaitZone, because current thread exceed maximum of allowed " +
                     "test cases in parallel. ({}/{})", testCaseToWait, runningTestCasesInParallelCount.get(),
                 maxTestSuitesInParallel);
         }
-
-        LOGGER.info("Here afer? :D ");
-
         while (!isRunningAllowedNumberTestInParallel()) {
             LOGGER.trace("{} is waiting to proceed with execution but current thread exceed maximum " +
                     "of allowed test cases in parallel. ({}/{})",

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/SuiteThreadController.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/SuiteThreadController.java
@@ -65,34 +65,34 @@ public class SuiteThreadController {
         waitingTestCases = new ArrayList<>();
     }
 
-    public synchronized void addParallelSuite(ExtensionContext extensionContext) {
+    public void addParallelSuite(ExtensionContext extensionContext) {
         LOGGER.debug("[{}] - Adding parallel suite: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), extensionContext.getDisplayName());
 
-        runningTestSuitesInParallelCount.set(runningTestSuitesInParallelCount.incrementAndGet());
+        runningTestSuitesInParallelCount.incrementAndGet();
 
         LOGGER.debug("[{}] - Parallel suites count: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), runningTestSuitesInParallelCount.get());
     }
 
-    public synchronized void addParallelTest(ExtensionContext extensionContext) {
+    public void addParallelTest(ExtensionContext extensionContext) {
         LOGGER.debug("[{}] - Adding parallel test: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), extensionContext.getDisplayName());
 
-        runningTestCasesInParallelCount.set(runningTestCasesInParallelCount.incrementAndGet());
+        runningTestCasesInParallelCount.incrementAndGet();
 
         LOGGER.debug("[{}] - Parallel test count: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), runningTestCasesInParallelCount.get());
     }
 
-    public synchronized void removeParallelSuite(ExtensionContext extensionContext) {
+    public void removeParallelSuite(ExtensionContext extensionContext) {
         LOGGER.debug("[{}] - Removing parallel suite: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), extensionContext.getDisplayName());
 
-        runningTestSuitesInParallelCount.set(runningTestSuitesInParallelCount.decrementAndGet());
+        runningTestSuitesInParallelCount.decrementAndGet();
 
         LOGGER.debug("[{}] - Parallel suites count: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), runningTestSuitesInParallelCount.get());
     }
 
-    public synchronized void removeParallelTest(ExtensionContext extensionContext) {
+    public void removeParallelTest(ExtensionContext extensionContext) {
         LOGGER.debug("[{}] - Removing parallel test: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), extensionContext.getDisplayName());
 
-        runningTestCasesInParallelCount.set(runningTestCasesInParallelCount.decrementAndGet());
+        runningTestCasesInParallelCount.decrementAndGet();
 
         LOGGER.debug("[{}] - Parallel test count: {}", StUtils.removePackageName(extensionContext.getRequiredTestClass().getName()), runningTestCasesInParallelCount.get());
     }
@@ -201,11 +201,16 @@ public class SuiteThreadController {
         final String testCaseToWait = extensionContext.getDisplayName();
         waitingTestCases.add(testCaseToWait);
 
+        LOGGER.info("Here before? :D ");
+
         if (runningTestCasesInParallelCount.get() > maxTestSuitesInParallel) {
             LOGGER.debug("[{}] moved to the WaitZone, because current thread exceed maximum of allowed " +
                     "test cases in parallel. ({}/{})", testCaseToWait, runningTestCasesInParallelCount.get(),
                 maxTestSuitesInParallel);
         }
+
+        LOGGER.info("Here afer? :D ");
+
         while (!isRunningAllowedNumberTestInParallel()) {
             LOGGER.trace("{} is waiting to proceed with execution but current thread exceed maximum " +
                     "of allowed test cases in parallel. ({}/{})",

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
@@ -134,6 +134,9 @@ public class TestSuiteNamespaceManager {
                 }
                 KubeClusterResource.getInstance().createNamespace(CollectorElement.createCollectorElement(testSuite), namespaceName);
                 NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceName));
+                if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+                    StUtils.copyImagePullSecret(namespaceName);
+                }
             }
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -173,7 +173,7 @@ public class SetupClusterOperator {
             clusterOperatorBuilder = clusterOperatorBuilder.withNamespace(Constants.INFRA_NAMESPACE);
             return clusterOperatorBuilder;
         // OLM cluster wide must use KubeClusterResource.getInstance().getDefaultOlmNamespace() namespace
-        } else if (Environment.isOlmInstall() && IS_OLM_CLUSTER_WIDE.test(this.namespaceInstallTo)) {
+        } else if (Environment.isOlmInstall() && IS_OLM_CLUSTER_WIDE.test(this.namespaceToWatch)) {
             clusterOperatorBuilder = clusterOperatorBuilder
                 .withNamespace(cluster.getDefaultOlmNamespace())
                 .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES);
@@ -213,6 +213,7 @@ public class SetupClusterOperator {
                         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
                     }
                     createClusterRoleBindings();
+                    bindingsNamespaces = namespaceInstallTo.equals(Constants.INFRA_NAMESPACE) ? Collections.singletonList(cluster.getDefaultOlmNamespace()) : bindingsNamespaces;
                     namespaceInstallTo = cluster.getDefaultOlmNamespace();
                     olmResource = new OlmResource(namespaceInstallTo);
                     olmResource.create(extensionContext, operationTimeout, reconciliationInterval);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -19,6 +19,7 @@ import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.enums.ClusterOperatorRBACType;
+import io.strimzi.systemtest.enums.OlmInstallationStrategy;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.kubernetes.ClusterRoleBindingResource;
 import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
@@ -229,6 +230,19 @@ public class SetupClusterOperator {
         olmInstallation();
         return this;
     }
+
+    public SetupClusterOperator runManualOlmInstallation(final String fromVersion, final String channelName) {
+        if (isClusterOperatorNamespaceNotCreated()) {
+            cluster.setNamespace(namespaceInstallTo);
+            cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
+            extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
+        }
+        olmResource = new OlmResource(this.namespaceInstallTo);
+        olmResource.create(this.namespaceInstallTo, OlmInstallationStrategy.Manual, fromVersion, channelName);
+
+        return this;
+    }
+
 
     private void bundleInstallation() {
         LOGGER.info("Install ClusterOperator via Yaml bundle");

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -173,7 +173,7 @@ public class SetupClusterOperator {
             clusterOperatorBuilder = clusterOperatorBuilder.withNamespace(Constants.INFRA_NAMESPACE);
             return clusterOperatorBuilder;
         // OLM cluster wide must use KubeClusterResource.getInstance().getDefaultOlmNamespace() namespace
-        } else if (Environment.isOlmInstall() && IS_OLM_CLUSTER_WIDE.test(this.namespaceToWatch)) {
+        } else if (Environment.isOlmInstall() && !Environment.isNamespaceRbacScope()) {
             clusterOperatorBuilder = clusterOperatorBuilder
                 .withNamespace(cluster.getDefaultOlmNamespace())
                 .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -60,8 +60,9 @@ public class OlmResource implements SpecificResourceType {
         this.clusterOperator(this.namespace, operationTimeout, reconciliationInterval);
     }
 
-    public void create(OlmInstallationStrategy olmInstallationStrategy, String fromVersion) {
-        this.clusterOperator(this.namespace, olmInstallationStrategy, fromVersion);
+    public void create(final String namespaceName, OlmInstallationStrategy olmInstallationStrategy, String fromVersion) {
+        this.namespace = namespaceName;
+        this.clusterOperator(namespaceName, olmInstallationStrategy, fromVersion);
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -278,7 +278,7 @@ public class OlmResource implements SpecificResourceType {
         ResourceManager.cmdKubeClient().exec("delete", "subscriptions", "-l", "app=strimzi", "-n", namespace);
         ResourceManager.cmdKubeClient().exec("delete", "operatorgroups", "-l", "app=strimzi", "-n", namespace);
         ResourceManager.cmdKubeClient().exec(false, "delete", "csv", csvName, "-n", namespace);
-        DeploymentUtils.waitForDeploymentDeletion(deploymentName);
+        DeploymentUtils.waitForDeploymentDeletion(namespace, deploymentName);
     }
 
     private static void waitFor(String deploymentName, String namespace, int replicas) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -217,7 +217,7 @@ public class OlmResource implements SpecificResourceType {
      * Upgrade cluster operator by obtaining new install plan, which was not used and also approves installation by
      * changing the install plan YAML
      */
-    public static void upgradeClusterOperator() {
+    public void upgradeClusterOperator() {
         if (kubeClient().listPodsByPrefixInName(ResourceManager.getCoDeploymentName()).size() == 0) {
             throw new RuntimeException("We can not perform upgrade! Cluster operator pod is not present.");
         }
@@ -325,5 +325,9 @@ public class OlmResource implements SpecificResourceType {
 
     public static Map<String, Boolean> getClosedMapInstallPlan() {
         return CLOSED_MAP_INSTALL_PLAN;
+    }
+
+    public void setDeploymentName(String deploymentName) {
+        this.deploymentName = deploymentName;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -275,10 +275,14 @@ public class OlmResource implements SpecificResourceType {
     }
 
     private static void deleteOlm(String deploymentName, String namespace, String csvName) {
-        ResourceManager.cmdKubeClient().exec("delete", "subscriptions", "-l", "app=strimzi", "-n", namespace);
-        ResourceManager.cmdKubeClient().exec("delete", "operatorgroups", "-l", "app=strimzi", "-n", namespace);
-        ResourceManager.cmdKubeClient().exec(false, "delete", "csv", csvName, "-n", namespace);
-        DeploymentUtils.waitForDeploymentDeletion(namespace, deploymentName);
+        if (ResourceManager.kubeClient().getDeployment(namespace, deploymentName) != null) {
+            ResourceManager.cmdKubeClient().exec("delete", "subscriptions", "-l", "app=strimzi", "-n", namespace);
+            ResourceManager.cmdKubeClient().exec("delete", "operatorgroups", "-l", "app=strimzi", "-n", namespace);
+            ResourceManager.cmdKubeClient().exec(false, "delete", "csv", csvName, "-n", namespace);
+            DeploymentUtils.waitForDeploymentDeletion(namespace, deploymentName);
+        } else {
+            LOGGER.info("Cluster Operator: {} is already deleted in namespace: {}", deploymentName, namespace);
+        }
     }
 
     private static void waitFor(String deploymentName, String namespace, int replicas) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
@@ -31,12 +31,12 @@ public class KeycloakUtils {
 
     private KeycloakUtils() {}
 
-    public static void deployKeycloak(String namespace) {
-        LOGGER.info("Prepare Keycloak in namespace: {}", namespace);
+    public static void deployKeycloak(final String deploymentNamespace, final String watchNamespace) {
+        LOGGER.info("Prepare Keycloak Operator in namespace: {} with watching namespace: {}", deploymentNamespace, watchNamespace);
 
         // This is needed because from time to time the first try fails on Azure
         TestUtils.waitFor("Keycloak instance readiness", Constants.KEYCLOAK_DEPLOYMENT_POLL, Constants.KEYCLOAK_DEPLOYMENT_TIMEOUT, () -> {
-            ExecResult result = Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_PREPARE_SCRIPT, namespace, getValidKeycloakVersion());
+            ExecResult result = Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_PREPARE_SCRIPT, deploymentNamespace, getValidKeycloakVersion(), watchNamespace);
 
             if (!result.out().contains("All realms were successfully imported")) {
                 LOGGER.info("Errors occurred during Keycloak install: {}", result.err());
@@ -45,12 +45,12 @@ public class KeycloakUtils {
             return  true;
         });
 
-        LOGGER.info("Keycloak in namespace {} is ready", namespace);
+        LOGGER.info("Keycloak in namespace {} is ready", deploymentNamespace);
     }
 
-    public static void deleteKeycloak(String namespace) {
-        LOGGER.info("Teardown Keycloak in namespace: {}", namespace);
-        Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT, namespace, getValidKeycloakVersion());
+    public static void deleteKeycloak(final String deploymentNamespace, final String watchNamespace) {
+        LOGGER.info("Teardown Keycloak Operator in namespace: {} with watching namespace: {}", deploymentNamespace, watchNamespace);
+        Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT, deploymentNamespace, getValidKeycloakVersion(), watchNamespace);
     }
 
     /**

--- a/systemtest/src/main/resources/olm/subscription.yaml
+++ b/systemtest/src/main/resources/olm/subscription.yaml
@@ -10,7 +10,7 @@ spec:
   source: ${OLM_SOURCE_NAME}
   sourceNamespace: ${OLM_SOURCE_NAMESPACE}
   startingCSV: ${OLM_APP_BUNDLE_PREFIX}.v${OLM_OPERATOR_VERSION}
-  channel: stable
+  channel: ${OLM_CHANNEL}
   installPlanApproval: ${OLM_INSTALL_PLAN_APPROVAL}
   config:
     env:

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -620,16 +620,15 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     private final void beforeAllMustExecute(ExtensionContext extensionContext) {
+        if (StUtils.isParallelSuite(extensionContext)) {
+            parallelSuiteController.addParallelSuite(extensionContext);
+            parallelSuiteController.waitUntilAllowedNumberTestSuitesInParallel(extensionContext);
+        }
         try {
-            clusterOperator = SetupClusterOperator.getInstanceHolder();
-        } finally {
-            if (StUtils.isParallelSuite(extensionContext)) {
-                parallelSuiteController.addParallelSuite(extensionContext);
-                parallelSuiteController.waitUntilAllowedNumberTestSuitesInParallel(extensionContext);
-            }
             // (optional) create additional namespace/namespaces for test suites if needed
+            // in case `Terminating` issue with namespace we have to execute finally block
             testSuiteNamespaceManager.createAdditionalNamespaces(extensionContext);
-
+        } finally {
             if (StUtils.isIsolatedSuite(extensionContext)) {
                 cluster.setNamespace(Constants.INFRA_NAMESPACE);
                 // wait for parallel suites are done
@@ -639,6 +638,7 @@ public abstract class AbstractST implements TestSeparator {
             } else if (StUtils.isParallelSuite(extensionContext) && Environment.isNamespaceRbacScope()) {
                 cluster.setNamespace(Constants.INFRA_NAMESPACE);
             }
+            clusterOperator = SetupClusterOperator.getInstanceHolder();
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -673,8 +673,15 @@ public abstract class AbstractST implements TestSeparator {
     void tearDownTestCase(ExtensionContext extensionContext) throws Exception {
         LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
         LOGGER.debug("[{} - After Each] - Clean up after test", StUtils.removePackageName(this.getClass().getName()));
-        afterEachMayOverride(extensionContext);
-        afterEachMustExecute(extensionContext);
+        // try with finally is needed because in worst case possible if the Cluster is unable to delete namespaces, which
+        // results in `Timeout after 480000 ms waiting for Namespace namespace-136 removal` it throws WaitException and
+        // does not proceed with the next method (i.e., afterEachMustExecute()). This ensures that if such problem happen
+        // it will always execute the second method.
+        try {
+            afterEachMayOverride(extensionContext);
+        } finally {
+            afterEachMustExecute(extensionContext);
+        }
     }
 
     @AfterAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
@@ -16,9 +16,9 @@ import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
 import io.strimzi.test.annotations.IsolatedTest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/dump/LogDumpScriptIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/dump/LogDumpScriptIsolatedST.java
@@ -17,7 +17,7 @@ import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -75,7 +75,6 @@ import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.GLOBAL_TIMEOUT;
-import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.METRICS;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
@@ -220,7 +219,7 @@ public class MetricsIsolatedST extends AbstractST {
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
             .withUsingPodName(kafkaClientsPodName)
             .withTopicName(kafkaExporterTopic)
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withClusterName(metricsClusterName)
             .withMessageCount(5000)
             .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
@@ -232,7 +231,7 @@ public class MetricsIsolatedST extends AbstractST {
         );
 
         kafkaExporterMetricsData = collector.toBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withComponentType(ComponentType.KafkaExporter)
             .build()
             .collectMetricsFromPods();
@@ -256,21 +255,21 @@ public class MetricsIsolatedST extends AbstractST {
 
     @ParallelTest
     void testKafkaExporterDifferentSetting() throws InterruptedException, ExecutionException, IOException {
-        LabelSelector exporterSelector = kubeClient().getDeploymentSelectors(INFRA_NAMESPACE, KafkaExporterResources.deploymentName(metricsClusterName));
-        String runScriptContent = getExporterRunScript(kubeClient().listPods(INFRA_NAMESPACE, exporterSelector).get(0).getMetadata().getName());
+        LabelSelector exporterSelector = kubeClient().getDeploymentSelectors(clusterOperator.getDeploymentNamespace(), KafkaExporterResources.deploymentName(metricsClusterName));
+        String runScriptContent = getExporterRunScript(kubeClient().listPods(clusterOperator.getDeploymentNamespace(), exporterSelector).get(0).getMetadata().getName());
         assertThat("Exporter starting script has wrong setting than it's specified in CR", runScriptContent.contains("--group.filter=\".*\""));
         assertThat("Exporter starting script has wrong setting than it's specified in CR", runScriptContent.contains("--topic.filter=\".*\""));
 
-        Map<String, String> kafkaExporterSnapshot = DeploymentUtils.depSnapshot(INFRA_NAMESPACE, KafkaExporterResources.deploymentName(metricsClusterName));
+        Map<String, String> kafkaExporterSnapshot = DeploymentUtils.depSnapshot(clusterOperator.getDeploymentNamespace(), KafkaExporterResources.deploymentName(metricsClusterName));
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(metricsClusterName, k -> {
             k.getSpec().getKafkaExporter().setGroupRegex("my-group.*");
             k.getSpec().getKafkaExporter().setTopicRegex(topicName);
-        }, INFRA_NAMESPACE);
+        }, clusterOperator.getDeploymentNamespace());
 
-        DeploymentUtils.waitTillDepHasRolled(INFRA_NAMESPACE, KafkaExporterResources.deploymentName(metricsClusterName), 1, kafkaExporterSnapshot);
+        DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), KafkaExporterResources.deploymentName(metricsClusterName), 1, kafkaExporterSnapshot);
 
-        runScriptContent = getExporterRunScript(kubeClient().listPods(INFRA_NAMESPACE, exporterSelector).get(0).getMetadata().getName());
+        runScriptContent = getExporterRunScript(kubeClient().listPods(clusterOperator.getDeploymentNamespace(), exporterSelector).get(0).getMetadata().getName());
         assertThat("Exporter starting script has wrong setting than it's specified in CR", runScriptContent.contains("--group.filter=\"my-group.*\""));
         assertThat("Exporter starting script has wrong setting than it's specified in CR", runScriptContent.contains("--topic.filter=\"" + topicName + "\""));
     }
@@ -409,7 +408,7 @@ public class MetricsIsolatedST extends AbstractST {
 
         // Attach consumer before producer
         BridgeClients kafkaBridgeClientJob = new BridgeClientsBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withProducerName(producerName)
             .withConsumerName(consumerName)
             .withBootstrapAddress(KafkaBridgeResources.serviceName(BRIDGE_CLUSTER))
@@ -451,7 +450,7 @@ public class MetricsIsolatedST extends AbstractST {
     @Tag(ACCEPTANCE)
     void testCruiseControlMetrics() {
 
-        String cruiseControlMetrics = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, "/metrics");
+        String cruiseControlMetrics = CruiseControlUtils.callApi(clusterOperator.getDeploymentNamespace(), CruiseControlUtils.SupportedHttpMethods.GET, "/metrics");
 
         Matcher regex = Pattern.compile("^([^#].*)\\s+([^\\s]*)$", Pattern.MULTILINE).matcher(cruiseControlMetrics);
 
@@ -597,7 +596,7 @@ public class MetricsIsolatedST extends AbstractST {
         reasonMessage = "none";
         assertResourceStateMetricInTopicOperator(topicName, reasonMessage, 1.0, toMetrics);
 
-        cluster.setNamespace(INFRA_NAMESPACE);
+        cluster.setNamespace(clusterOperator.getDeploymentNamespace());
     }
 
     private String getExporterRunScript(String podName) throws InterruptedException, ExecutionException, IOException {
@@ -605,7 +604,7 @@ public class MetricsIsolatedST extends AbstractST {
         command.add("cat");
         command.add("/tmp/run.sh");
         ArrayList<String> executableCommand = new ArrayList<>();
-        executableCommand.addAll(Arrays.asList(cmdKubeClient().toString(), "exec", podName, "-n", INFRA_NAMESPACE, "--"));
+        executableCommand.addAll(Arrays.asList(cmdKubeClient().toString(), "exec", podName, "-n", clusterOperator.getDeploymentNamespace(), "--"));
         executableCommand.addAll(command);
 
         Exec exec = new Exec();
@@ -656,22 +655,22 @@ public class MetricsIsolatedST extends AbstractST {
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
         clusterOperator.unInstall();
         clusterOperator = clusterOperator.defaultInstallation()
-            .withWatchingNamespaces(INFRA_NAMESPACE + "," + SECOND_NAMESPACE)
-            .withBindingsNamespaces(Arrays.asList(INFRA_NAMESPACE, SECOND_NAMESPACE))
+            .withWatchingNamespaces(clusterOperator.getDeploymentNamespace() + "," + SECOND_NAMESPACE)
+            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), SECOND_NAMESPACE))
             .createInstallation()
             .runInstallation();
 
-        final String firstKafkaClientsName = INFRA_NAMESPACE + "-" + Constants.KAFKA_CLIENTS;
+        final String firstKafkaClientsName = clusterOperator.getDeploymentNamespace() + "-" + Constants.KAFKA_CLIENTS;
         final String secondKafkaClientsName = SECOND_NAMESPACE + "-" + Constants.KAFKA_CLIENTS;
 
-        cluster.setNamespace(INFRA_NAMESPACE);
+        cluster.setNamespace(clusterOperator.getDeploymentNamespace());
 
         // create resources without wait to deploy them simultaneously
         resourceManager.createResource(extensionContext, false,
             // kafka with cruise control and metrics
             KafkaTemplates.kafkaWithMetricsAndCruiseControlWithMetrics(metricsClusterName, 3, 3)
                 .editMetadata()
-                    .withNamespace(INFRA_NAMESPACE)
+                    .withNamespace(clusterOperator.getDeploymentNamespace())
                 .endMetadata()
                 .editOrNewSpec()
                     .editEntityOperator()
@@ -685,7 +684,7 @@ public class MetricsIsolatedST extends AbstractST {
                 .endSpec()
                 .build(),
             KafkaTemplates.kafkaWithMetrics(SECOND_CLUSTER, SECOND_NAMESPACE, 1, 1).build(),
-            KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, firstKafkaClientsName).build(),
+            KafkaClientsTemplates.kafkaClients(clusterOperator.getDeploymentNamespace(), false, firstKafkaClientsName).build(),
             KafkaClientsTemplates.kafkaClients(SECOND_NAMESPACE, false, secondKafkaClientsName).build()
         );
 
@@ -693,7 +692,7 @@ public class MetricsIsolatedST extends AbstractST {
         resourceManager.synchronizeResources(extensionContext);
 
         resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridgeWithMetrics(BRIDGE_CLUSTER, metricsClusterName, KafkaResources.plainBootstrapAddress(metricsClusterName), 1).build());
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, SECOND_NAMESPACE, INFRA_NAMESPACE).build());
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2WithMetrics(MIRROR_MAKER_CLUSTER, metricsClusterName, SECOND_CLUSTER, 1, SECOND_NAMESPACE, clusterOperator.getDeploymentNamespace()).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(metricsClusterName, topicName, 7, 2).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(metricsClusterName, kafkaExporterTopic, 7, 2).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(metricsClusterName, bridgeTopic).build());
@@ -701,7 +700,7 @@ public class MetricsIsolatedST extends AbstractST {
         resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(metricsClusterName, KafkaUserUtils.generateRandomNameOfKafkaUser()).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnectWithMetrics(metricsClusterName, 1).build());
 
-        kafkaClientsPodName = ResourceManager.kubeClient().listPodsByPrefixInName(INFRA_NAMESPACE, firstKafkaClientsName).get(0).getMetadata().getName();
+        kafkaClientsPodName = ResourceManager.kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), firstKafkaClientsName).get(0).getMetadata().getName();
 
         // Allow connections from clients to operators pods when NetworkPolicies are set to denied by default
         NetworkPolicyResource.allowNetworkPolicySettingsForClusterOperator(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -251,192 +251,192 @@ class MirrorMaker2IsolatedST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
     void testMirrorMaker2TlsAndTlsClientAuth(ExtensionContext extensionContext) throws Exception {
-//        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-//        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-//        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-//        String kafkaClusterSourceName = clusterName + "-source";
-//        String kafkaClusterTargetName = clusterName + "-target";
-//        String topicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
-//        String topicSourceNameMirrored = kafkaClusterSourceName + "." + topicName;
-//        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
-//        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
-//        String kafkaUserSourceName = clusterName + "-my-user-source";
-//        String kafkaUserTargetName = clusterName + "-my-user-target";
-//
-//        // Deploy source kafka with tls listener and mutual tls auth
-//        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
-//            .editSpec()
-//                .editKafka()
-//                    .withListeners(new GenericKafkaListenerBuilder()
-//                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-//                            .withPort(9093)
-//                            .withType(KafkaListenerType.INTERNAL)
-//                            .withTls(true)
-//                            .withAuth(new KafkaListenerAuthenticationTls())
-//                            .build())
-//                .endKafka()
-//            .endSpec()
-//            .build());
-//
-//        // Deploy target kafka with tls listener and mutual tls auth
-//        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
-//            .editSpec()
-//                .editKafka()
-//                    .withListeners(new GenericKafkaListenerBuilder()
-//                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-//                            .withPort(9093)
-//                            .withType(KafkaListenerType.INTERNAL)
-//                            .withTls(true)
-//                            .withAuth(new KafkaListenerAuthenticationTls())
-//                            .build())
-//                .endKafka()
-//            .endSpec()
-//            .build());
-//
-//        // Deploy topic
-//        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
-//        // Create Kafka user
-//        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build();
-//        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build();
-//
-//        resourceManager.createResource(extensionContext, userSource);
-//        resourceManager.createResource(extensionContext, userTarget);
-//        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, userSource, userTarget).build());
-//
-//        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-//
-//        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
-//        String topicTestName1 = baseTopic + "-test-1";
-//        String topicTestName2 = baseTopic + "-test-2";
-//
-//        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
-//        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterTargetName, topicTestName2).build());
-//
-//        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-//            .withUsingPodName(kafkaClientsPodName)
-//            .withTopicName(topicTestName1)
-//            .withNamespaceName(namespaceName)
-//            .withClusterName(kafkaClusterSourceName)
-//            .withKafkaUsername(userSource.getMetadata().getName())
-//            .withMessageCount(messagesCount)
-//            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-//            .build();
-//
-//        // Check brokers availability
-//        ClientUtils.waitUntilProducerAndConsumerSuccessfullySendAndReceiveMessages(extensionContext, internalKafkaClient);
-//
-//        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-//            topicTestName2, kafkaClusterTargetName, userTarget.getMetadata().getName());
-//
-//        internalKafkaClient = internalKafkaClient.toBuilder()
-//            .withClusterName(kafkaClusterTargetName)
-//            .withTopicName(topicTestName2)
-//            .withKafkaUsername(userTarget.getMetadata().getName())
-//            .build();
-//
-//        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-//            topicTestName2, kafkaClusterTargetName, messagesCount);
-//        internalKafkaClient.checkProducedAndConsumedMessages(
-//            internalKafkaClient.sendMessagesTls(),
-//            internalKafkaClient.receiveMessagesTls()
-//        );
-//
-//        // Initialize CertSecretSource with certificate and secret names for source
-//        CertSecretSource certSecretSource = new CertSecretSource();
-//        certSecretSource.setCertificate("ca.crt");
-//        certSecretSource.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterSourceName));
-//
-//        // Initialize CertSecretSource with certificate and secret names for target
-//        CertSecretSource certSecretTarget = new CertSecretSource();
-//        certSecretTarget.setCertificate("ca.crt");
-//        certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
-//
-//        // Deploy Mirror Maker 2.0 with tls listener and mutual tls auth
-//        KafkaMirrorMaker2ClusterSpec sourceClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-//                .withAlias(kafkaClusterSourceName)
-//                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
-//                .withNewKafkaClientAuthenticationTls()
-//                    .withNewCertificateAndKey()
-//                        .withSecretName(kafkaUserSourceName)
-//                        .withCertificate("user.crt")
-//                        .withKey("user.key")
-//                    .endCertificateAndKey()
-//                .endKafkaClientAuthenticationTls()
-//                .withNewTls()
-//                    .withTrustedCertificates(certSecretSource)
-//                .endTls()
-//                .build();
-//
-//        KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-//                .withAlias(kafkaClusterTargetName)
-//                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
-//                .withNewKafkaClientAuthenticationTls()
-//                    .withNewCertificateAndKey()
-//                        .withSecretName(kafkaUserTargetName)
-//                        .withCertificate("user.crt")
-//                        .withKey("user.key")
-//                    .endCertificateAndKey()
-//                .endKafkaClientAuthenticationTls()
-//                .withNewTls()
-//                    .withTrustedCertificates(certSecretTarget)
-//                .endTls()
-//                .addToConfig("config.storage.replication.factor", -1)
-//                .addToConfig("offset.storage.replication.factor", -1)
-//                .addToConfig("status.storage.replication.factor", -1)
-//                .build();
-//
-//        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
-//            .editSpec()
-//                .withClusters(sourceClusterWithTlsAuth, targetClusterWithTlsAuth)
-//                .editFirstMirror()
-//                    .withTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
-//                .endMirror()
-//            .endSpec()
-//            .build());
-//
-//        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-//            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
-//
-//        internalKafkaClient = internalKafkaClient.toBuilder()
-//            .withTopicName(topicSourceName)
-//            .withClusterName(kafkaClusterSourceName)
-//            .withKafkaUsername(userSource.getMetadata().getName())
-//            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-//            .build();
-//
-//        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-//            topicSourceName, kafkaClusterSourceName, messagesCount);
-//        int sent = internalKafkaClient.sendMessagesTls();
-//
-//        LOGGER.info("Receiving messages from - topic {}, cluster {} and message count of {}",
-//            topicSourceName, kafkaClusterSourceName, messagesCount);
-//        internalKafkaClient.checkProducedAndConsumedMessages(
-//            sent,
-//            internalKafkaClient.receiveMessagesTls()
-//        );
-//
-//        LOGGER.info("Now setting topic to {}, cluster to {} and user to {} - the messages should be mirrored",
-//            topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
-//
-//        internalKafkaClient = internalKafkaClient.toBuilder()
-//            .withTopicName(topicTargetName)
-//            .withClusterName(kafkaClusterTargetName)
-//            .withKafkaUsername(userTarget.getMetadata().getName())
-//            .build();
-//
-//        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
-//        internalKafkaClient.checkProducedAndConsumedMessages(
-//            sent,
-//            internalKafkaClient.receiveMessagesTls()
-//        );
-//        LOGGER.info("Messages successfully mirrored");
-//
-//        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
-//        assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
-//        assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
-//
-//        mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicSourceNameMirrored).get();
-//        assertThat(mirroredTopic, nullValue());
+        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String kafkaClusterSourceName = clusterName + "-source";
+        String kafkaClusterTargetName = clusterName + "-target";
+        String topicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
+        String topicSourceNameMirrored = kafkaClusterSourceName + "." + topicName;
+        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
+        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
+        String kafkaUserSourceName = clusterName + "-my-user-source";
+        String kafkaUserTargetName = clusterName + "-my-user-target";
+
+        // Deploy source kafka with tls listener and mutual tls auth
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                            .withPort(9093)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(true)
+                            .withAuth(new KafkaListenerAuthenticationTls())
+                            .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        // Deploy target kafka with tls listener and mutual tls auth
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                            .withPort(9093)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(true)
+                            .withAuth(new KafkaListenerAuthenticationTls())
+                            .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        // Deploy topic
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
+        // Create Kafka user
+        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build();
+        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build();
+
+        resourceManager.createResource(extensionContext, userSource);
+        resourceManager.createResource(extensionContext, userTarget);
+        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, userSource, userTarget).build());
+
+        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
+
+        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
+        String topicTestName1 = baseTopic + "-test-1";
+        String topicTestName2 = baseTopic + "-test-2";
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterTargetName, topicTestName2).build());
+
+        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+            .withUsingPodName(kafkaClientsPodName)
+            .withTopicName(topicTestName1)
+            .withNamespaceName(namespaceName)
+            .withClusterName(kafkaClusterSourceName)
+            .withKafkaUsername(userSource.getMetadata().getName())
+            .withMessageCount(messagesCount)
+            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .build();
+
+        // Check brokers availability
+        ClientUtils.waitUntilProducerAndConsumerSuccessfullySendAndReceiveMessages(extensionContext, internalKafkaClient);
+
+        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
+            topicTestName2, kafkaClusterTargetName, userTarget.getMetadata().getName());
+
+        internalKafkaClient = internalKafkaClient.toBuilder()
+            .withClusterName(kafkaClusterTargetName)
+            .withTopicName(topicTestName2)
+            .withKafkaUsername(userTarget.getMetadata().getName())
+            .build();
+
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            topicTestName2, kafkaClusterTargetName, messagesCount);
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            internalKafkaClient.sendMessagesTls(),
+            internalKafkaClient.receiveMessagesTls()
+        );
+
+        // Initialize CertSecretSource with certificate and secret names for source
+        CertSecretSource certSecretSource = new CertSecretSource();
+        certSecretSource.setCertificate("ca.crt");
+        certSecretSource.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterSourceName));
+
+        // Initialize CertSecretSource with certificate and secret names for target
+        CertSecretSource certSecretTarget = new CertSecretSource();
+        certSecretTarget.setCertificate("ca.crt");
+        certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
+
+        // Deploy Mirror Maker 2.0 with tls listener and mutual tls auth
+        KafkaMirrorMaker2ClusterSpec sourceClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias(kafkaClusterSourceName)
+                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+                .withNewKafkaClientAuthenticationTls()
+                    .withNewCertificateAndKey()
+                        .withSecretName(kafkaUserSourceName)
+                        .withCertificate("user.crt")
+                        .withKey("user.key")
+                    .endCertificateAndKey()
+                .endKafkaClientAuthenticationTls()
+                .withNewTls()
+                    .withTrustedCertificates(certSecretSource)
+                .endTls()
+                .build();
+
+        KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias(kafkaClusterTargetName)
+                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+                .withNewKafkaClientAuthenticationTls()
+                    .withNewCertificateAndKey()
+                        .withSecretName(kafkaUserTargetName)
+                        .withCertificate("user.crt")
+                        .withKey("user.key")
+                    .endCertificateAndKey()
+                .endKafkaClientAuthenticationTls()
+                .withNewTls()
+                    .withTrustedCertificates(certSecretTarget)
+                .endTls()
+                .addToConfig("config.storage.replication.factor", -1)
+                .addToConfig("offset.storage.replication.factor", -1)
+                .addToConfig("status.storage.replication.factor", -1)
+                .build();
+
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
+            .editSpec()
+                .withClusters(sourceClusterWithTlsAuth, targetClusterWithTlsAuth)
+                .editFirstMirror()
+                    .withTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
+                .endMirror()
+            .endSpec()
+            .build());
+
+        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
+            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
+
+        internalKafkaClient = internalKafkaClient.toBuilder()
+            .withTopicName(topicSourceName)
+            .withClusterName(kafkaClusterSourceName)
+            .withKafkaUsername(userSource.getMetadata().getName())
+            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .build();
+
+        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+            topicSourceName, kafkaClusterSourceName, messagesCount);
+        int sent = internalKafkaClient.sendMessagesTls();
+
+        LOGGER.info("Receiving messages from - topic {}, cluster {} and message count of {}",
+            topicSourceName, kafkaClusterSourceName, messagesCount);
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            sent,
+            internalKafkaClient.receiveMessagesTls()
+        );
+
+        LOGGER.info("Now setting topic to {}, cluster to {} and user to {} - the messages should be mirrored",
+            topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
+
+        internalKafkaClient = internalKafkaClient.toBuilder()
+            .withTopicName(topicTargetName)
+            .withClusterName(kafkaClusterTargetName)
+            .withKafkaUsername(userTarget.getMetadata().getName())
+            .build();
+
+        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
+        internalKafkaClient.checkProducedAndConsumedMessages(
+            sent,
+            internalKafkaClient.receiveMessagesTls()
+        );
+        LOGGER.info("Messages successfully mirrored");
+
+        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
+        assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
+        assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
+
+        mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicSourceNameMirrored).get();
+        assertThat(mirroredTopic, nullValue());
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -251,192 +251,192 @@ class MirrorMaker2IsolatedST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
     void testMirrorMaker2TlsAndTlsClientAuth(ExtensionContext extensionContext) throws Exception {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String topicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicSourceNameMirrored = kafkaClusterSourceName + "." + topicName;
-        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
-        String kafkaUserSourceName = clusterName + "-my-user-source";
-        String kafkaUserTargetName = clusterName + "-my-user-target";
-
-        // Deploy source kafka with tls listener and mutual tls auth
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
-            .editSpec()
-                .editKafka()
-                    .withListeners(new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationTls())
-                            .build())
-                .endKafka()
-            .endSpec()
-            .build());
-
-        // Deploy target kafka with tls listener and mutual tls auth
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
-            .editSpec()
-                .editKafka()
-                    .withListeners(new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationTls())
-                            .build())
-                .endKafka()
-            .endSpec()
-            .build());
-
-        // Deploy topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
-        // Create Kafka user
-        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build();
-        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build();
-
-        resourceManager.createResource(extensionContext, userSource);
-        resourceManager.createResource(extensionContext, userTarget);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, userSource, userTarget).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicTestName1 = baseTopic + "-test-1";
-        String topicTestName2 = baseTopic + "-test-2";
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterTargetName, topicTestName2).build());
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicTestName1)
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .build();
-
-        // Check brokers availability
-        ClientUtils.waitUntilProducerAndConsumerSuccessfullySendAndReceiveMessages(extensionContext, internalKafkaClient);
-
-        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-            topicTestName2, kafkaClusterTargetName, userTarget.getMetadata().getName());
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .withTopicName(topicTestName2)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            topicTestName2, kafkaClusterTargetName, messagesCount);
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            internalKafkaClient.sendMessagesTls(),
-            internalKafkaClient.receiveMessagesTls()
-        );
-
-        // Initialize CertSecretSource with certificate and secret names for source
-        CertSecretSource certSecretSource = new CertSecretSource();
-        certSecretSource.setCertificate("ca.crt");
-        certSecretSource.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterSourceName));
-
-        // Initialize CertSecretSource with certificate and secret names for target
-        CertSecretSource certSecretTarget = new CertSecretSource();
-        certSecretTarget.setCertificate("ca.crt");
-        certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
-
-        // Deploy Mirror Maker 2.0 with tls listener and mutual tls auth
-        KafkaMirrorMaker2ClusterSpec sourceClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-                .withAlias(kafkaClusterSourceName)
-                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
-                .withNewKafkaClientAuthenticationTls()
-                    .withNewCertificateAndKey()
-                        .withSecretName(kafkaUserSourceName)
-                        .withCertificate("user.crt")
-                        .withKey("user.key")
-                    .endCertificateAndKey()
-                .endKafkaClientAuthenticationTls()
-                .withNewTls()
-                    .withTrustedCertificates(certSecretSource)
-                .endTls()
-                .build();
-
-        KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-                .withAlias(kafkaClusterTargetName)
-                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
-                .withNewKafkaClientAuthenticationTls()
-                    .withNewCertificateAndKey()
-                        .withSecretName(kafkaUserTargetName)
-                        .withCertificate("user.crt")
-                        .withKey("user.key")
-                    .endCertificateAndKey()
-                .endKafkaClientAuthenticationTls()
-                .withNewTls()
-                    .withTrustedCertificates(certSecretTarget)
-                .endTls()
-                .addToConfig("config.storage.replication.factor", -1)
-                .addToConfig("offset.storage.replication.factor", -1)
-                .addToConfig("status.storage.replication.factor", -1)
-                .build();
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
-            .editSpec()
-                .withClusters(sourceClusterWithTlsAuth, targetClusterWithTlsAuth)
-                .editFirstMirror()
-                    .withTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
-                .endMirror()
-            .endSpec()
-            .build());
-
-        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            topicSourceName, kafkaClusterSourceName, messagesCount);
-        int sent = internalKafkaClient.sendMessagesTls();
-
-        LOGGER.info("Receiving messages from - topic {}, cluster {} and message count of {}",
-            topicSourceName, kafkaClusterSourceName, messagesCount);
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            sent,
-            internalKafkaClient.receiveMessagesTls()
-        );
-
-        LOGGER.info("Now setting topic to {}, cluster to {} and user to {} - the messages should be mirrored",
-            topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetName)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            sent,
-            internalKafkaClient.receiveMessagesTls()
-        );
-        LOGGER.info("Messages successfully mirrored");
-
-        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
-        assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
-        assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
-
-        mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicSourceNameMirrored).get();
-        assertThat(mirroredTopic, nullValue());
+//        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
+//        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+//        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+//        String kafkaClusterSourceName = clusterName + "-source";
+//        String kafkaClusterTargetName = clusterName + "-target";
+//        String topicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
+//        String topicSourceNameMirrored = kafkaClusterSourceName + "." + topicName;
+//        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
+//        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
+//        String kafkaUserSourceName = clusterName + "-my-user-source";
+//        String kafkaUserTargetName = clusterName + "-my-user-target";
+//
+//        // Deploy source kafka with tls listener and mutual tls auth
+//        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+//            .editSpec()
+//                .editKafka()
+//                    .withListeners(new GenericKafkaListenerBuilder()
+//                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+//                            .withPort(9093)
+//                            .withType(KafkaListenerType.INTERNAL)
+//                            .withTls(true)
+//                            .withAuth(new KafkaListenerAuthenticationTls())
+//                            .build())
+//                .endKafka()
+//            .endSpec()
+//            .build());
+//
+//        // Deploy target kafka with tls listener and mutual tls auth
+//        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+//            .editSpec()
+//                .editKafka()
+//                    .withListeners(new GenericKafkaListenerBuilder()
+//                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+//                            .withPort(9093)
+//                            .withType(KafkaListenerType.INTERNAL)
+//                            .withTls(true)
+//                            .withAuth(new KafkaListenerAuthenticationTls())
+//                            .build())
+//                .endKafka()
+//            .endSpec()
+//            .build());
+//
+//        // Deploy topic
+//        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
+//        // Create Kafka user
+//        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build();
+//        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build();
+//
+//        resourceManager.createResource(extensionContext, userSource);
+//        resourceManager.createResource(extensionContext, userTarget);
+//        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, userSource, userTarget).build());
+//
+//        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
+//
+//        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
+//        String topicTestName1 = baseTopic + "-test-1";
+//        String topicTestName2 = baseTopic + "-test-2";
+//
+//        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
+//        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterTargetName, topicTestName2).build());
+//
+//        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
+//            .withUsingPodName(kafkaClientsPodName)
+//            .withTopicName(topicTestName1)
+//            .withNamespaceName(namespaceName)
+//            .withClusterName(kafkaClusterSourceName)
+//            .withKafkaUsername(userSource.getMetadata().getName())
+//            .withMessageCount(messagesCount)
+//            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+//            .build();
+//
+//        // Check brokers availability
+//        ClientUtils.waitUntilProducerAndConsumerSuccessfullySendAndReceiveMessages(extensionContext, internalKafkaClient);
+//
+//        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
+//            topicTestName2, kafkaClusterTargetName, userTarget.getMetadata().getName());
+//
+//        internalKafkaClient = internalKafkaClient.toBuilder()
+//            .withClusterName(kafkaClusterTargetName)
+//            .withTopicName(topicTestName2)
+//            .withKafkaUsername(userTarget.getMetadata().getName())
+//            .build();
+//
+//        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+//            topicTestName2, kafkaClusterTargetName, messagesCount);
+//        internalKafkaClient.checkProducedAndConsumedMessages(
+//            internalKafkaClient.sendMessagesTls(),
+//            internalKafkaClient.receiveMessagesTls()
+//        );
+//
+//        // Initialize CertSecretSource with certificate and secret names for source
+//        CertSecretSource certSecretSource = new CertSecretSource();
+//        certSecretSource.setCertificate("ca.crt");
+//        certSecretSource.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterSourceName));
+//
+//        // Initialize CertSecretSource with certificate and secret names for target
+//        CertSecretSource certSecretTarget = new CertSecretSource();
+//        certSecretTarget.setCertificate("ca.crt");
+//        certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
+//
+//        // Deploy Mirror Maker 2.0 with tls listener and mutual tls auth
+//        KafkaMirrorMaker2ClusterSpec sourceClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
+//                .withAlias(kafkaClusterSourceName)
+//                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+//                .withNewKafkaClientAuthenticationTls()
+//                    .withNewCertificateAndKey()
+//                        .withSecretName(kafkaUserSourceName)
+//                        .withCertificate("user.crt")
+//                        .withKey("user.key")
+//                    .endCertificateAndKey()
+//                .endKafkaClientAuthenticationTls()
+//                .withNewTls()
+//                    .withTrustedCertificates(certSecretSource)
+//                .endTls()
+//                .build();
+//
+//        KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
+//                .withAlias(kafkaClusterTargetName)
+//                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+//                .withNewKafkaClientAuthenticationTls()
+//                    .withNewCertificateAndKey()
+//                        .withSecretName(kafkaUserTargetName)
+//                        .withCertificate("user.crt")
+//                        .withKey("user.key")
+//                    .endCertificateAndKey()
+//                .endKafkaClientAuthenticationTls()
+//                .withNewTls()
+//                    .withTrustedCertificates(certSecretTarget)
+//                .endTls()
+//                .addToConfig("config.storage.replication.factor", -1)
+//                .addToConfig("offset.storage.replication.factor", -1)
+//                .addToConfig("status.storage.replication.factor", -1)
+//                .build();
+//
+//        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
+//            .editSpec()
+//                .withClusters(sourceClusterWithTlsAuth, targetClusterWithTlsAuth)
+//                .editFirstMirror()
+//                    .withTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
+//                .endMirror()
+//            .endSpec()
+//            .build());
+//
+//        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
+//            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
+//
+//        internalKafkaClient = internalKafkaClient.toBuilder()
+//            .withTopicName(topicSourceName)
+//            .withClusterName(kafkaClusterSourceName)
+//            .withKafkaUsername(userSource.getMetadata().getName())
+//            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+//            .build();
+//
+//        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
+//            topicSourceName, kafkaClusterSourceName, messagesCount);
+//        int sent = internalKafkaClient.sendMessagesTls();
+//
+//        LOGGER.info("Receiving messages from - topic {}, cluster {} and message count of {}",
+//            topicSourceName, kafkaClusterSourceName, messagesCount);
+//        internalKafkaClient.checkProducedAndConsumedMessages(
+//            sent,
+//            internalKafkaClient.receiveMessagesTls()
+//        );
+//
+//        LOGGER.info("Now setting topic to {}, cluster to {} and user to {} - the messages should be mirrored",
+//            topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
+//
+//        internalKafkaClient = internalKafkaClient.toBuilder()
+//            .withTopicName(topicTargetName)
+//            .withClusterName(kafkaClusterTargetName)
+//            .withKafkaUsername(userTarget.getMetadata().getName())
+//            .build();
+//
+//        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
+//        internalKafkaClient.checkProducedAndConsumedMessages(
+//            sent,
+//            internalKafkaClient.receiveMessagesTls()
+//        );
+//        LOGGER.info("Messages successfully mirrored");
+//
+//        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
+//        assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
+//        assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
+//
+//        mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicSourceNameMirrored).get();
+//        assertThat(mirroredTopic, nullValue());
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/SingleNamespaceIsolatedST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.olm;
 
 import io.strimzi.systemtest.annotations.IsolatedSuite;
-import io.strimzi.systemtest.resources.operator.specific.OlmResource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -13,6 +12,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Collections;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
@@ -81,10 +82,16 @@ public class SingleNamespaceIsolatedST extends OlmAbstractST {
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
-        cluster.setNamespace(NAMESPACE);
-        cluster.createNamespace(NAMESPACE);
+        // delete shared ClusterOperator
+        clusterOperator.unInstall();
+        clusterOperator = clusterOperator.defaultInstallation()
+            .withNamespace(NAMESPACE)
+            .withWatchingNamespaces(NAMESPACE)
+            .withBindingsNamespaces(Collections.singletonList(NAMESPACE))
+            .createInstallation()
+            // run always OLM installation
+            .runOlmInstallation();
 
-        olmResource = new OlmResource(NAMESPACE);
-        olmResource.create(extensionContext);
+        cluster.setNamespace(NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -115,46 +115,46 @@ class UserST extends AbstractST {
     @ParallelTest
     @Tag(ACCEPTANCE)
     void testUpdateUser(ExtensionContext extensionContext) {
-//        String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
-//
-//        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(namespace, userClusterName, userName).build());
-//
-//        String kafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(userName));
-//        assertThat(kafkaUserSecret, hasJsonPath("$.data['ca.crt']", notNullValue()));
-//        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.crt']", notNullValue()));
-//        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.key']", notNullValue()));
-//        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.name", equalTo(userName)));
-//        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
-//
-//        KafkaUser kUser = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get();
-//        String kafkaUserAsJson = TestUtils.toJsonString(kUser);
-//
-//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
-//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
-//        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo(Constants.TLS_LISTENER_DEFAULT_NAME)));
-//
-//        long observedGeneration = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get().getStatus().getObservedGeneration();
-//
-//        KafkaUserResource.replaceUserResourceInSpecificNamespace(userName, ku -> {
-//            ku.getMetadata().setResourceVersion(null);
-//            ku.getSpec().setAuthentication(new KafkaUserScramSha512ClientAuthentication());
-//        }, namespace);
-//
-//        KafkaUserUtils.waitForKafkaUserIncreaseObserverGeneration(namespace, observedGeneration, userName);
-//        KafkaUserUtils.waitForKafkaUserCreation(namespace, userName);
-//
-//        String anotherKafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(namespace, userName));
-//
-//        assertThat(anotherKafkaUserSecret, hasJsonPath("$.data.password", notNullValue()));
-//
-//        kUser = Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).withName(userName).get();
-//        kafkaUserAsJson = TestUtils.toJsonString(kUser);
-//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
-//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
-//        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo("scram-sha-512")));
-//
-//        Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).delete(kUser);
-//        KafkaUserUtils.waitForKafkaUserDeletion(userName);
+        String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
+
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(namespace, userClusterName, userName).build());
+
+        String kafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(userName));
+        assertThat(kafkaUserSecret, hasJsonPath("$.data['ca.crt']", notNullValue()));
+        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.crt']", notNullValue()));
+        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.key']", notNullValue()));
+        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.name", equalTo(userName)));
+        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
+
+        KafkaUser kUser = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get();
+        String kafkaUserAsJson = TestUtils.toJsonString(kUser);
+
+        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
+        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
+        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo(Constants.TLS_LISTENER_DEFAULT_NAME)));
+
+        long observedGeneration = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get().getStatus().getObservedGeneration();
+
+        KafkaUserResource.replaceUserResourceInSpecificNamespace(userName, ku -> {
+            ku.getMetadata().setResourceVersion(null);
+            ku.getSpec().setAuthentication(new KafkaUserScramSha512ClientAuthentication());
+        }, namespace);
+
+        KafkaUserUtils.waitForKafkaUserIncreaseObserverGeneration(namespace, observedGeneration, userName);
+        KafkaUserUtils.waitForKafkaUserCreation(namespace, userName);
+
+        String anotherKafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(namespace, userName));
+
+        assertThat(anotherKafkaUserSecret, hasJsonPath("$.data.password", notNullValue()));
+
+        kUser = Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).withName(userName).get();
+        kafkaUserAsJson = TestUtils.toJsonString(kUser);
+        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
+        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
+        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo("scram-sha-512")));
+
+        Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).delete(kUser);
+        KafkaUserUtils.waitForKafkaUserDeletion(userName);
     }
 
     @Tag(SCALABILITY)
@@ -549,10 +549,10 @@ class UserST extends AbstractST {
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
-//        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
-//            .editMetadata()
-//                .withNamespace(namespace)
-//            .endMetadata()
-//            .build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
+            .editMetadata()
+                .withNamespace(namespace)
+            .endMetadata()
+            .build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -115,46 +115,46 @@ class UserST extends AbstractST {
     @ParallelTest
     @Tag(ACCEPTANCE)
     void testUpdateUser(ExtensionContext extensionContext) {
-        String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
-
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(namespace, userClusterName, userName).build());
-
-        String kafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(userName));
-        assertThat(kafkaUserSecret, hasJsonPath("$.data['ca.crt']", notNullValue()));
-        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.crt']", notNullValue()));
-        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.key']", notNullValue()));
-        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.name", equalTo(userName)));
-        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
-
-        KafkaUser kUser = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get();
-        String kafkaUserAsJson = TestUtils.toJsonString(kUser);
-
-        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
-        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
-        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo(Constants.TLS_LISTENER_DEFAULT_NAME)));
-
-        long observedGeneration = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get().getStatus().getObservedGeneration();
-
-        KafkaUserResource.replaceUserResourceInSpecificNamespace(userName, ku -> {
-            ku.getMetadata().setResourceVersion(null);
-            ku.getSpec().setAuthentication(new KafkaUserScramSha512ClientAuthentication());
-        }, namespace);
-
-        KafkaUserUtils.waitForKafkaUserIncreaseObserverGeneration(namespace, observedGeneration, userName);
-        KafkaUserUtils.waitForKafkaUserCreation(namespace, userName);
-
-        String anotherKafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(namespace, userName));
-
-        assertThat(anotherKafkaUserSecret, hasJsonPath("$.data.password", notNullValue()));
-
-        kUser = Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).withName(userName).get();
-        kafkaUserAsJson = TestUtils.toJsonString(kUser);
-        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
-        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
-        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo("scram-sha-512")));
-
-        Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).delete(kUser);
-        KafkaUserUtils.waitForKafkaUserDeletion(userName);
+//        String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
+//
+//        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(namespace, userClusterName, userName).build());
+//
+//        String kafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(userName));
+//        assertThat(kafkaUserSecret, hasJsonPath("$.data['ca.crt']", notNullValue()));
+//        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.crt']", notNullValue()));
+//        assertThat(kafkaUserSecret, hasJsonPath("$.data['user.key']", notNullValue()));
+//        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.name", equalTo(userName)));
+//        assertThat(kafkaUserSecret, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
+//
+//        KafkaUser kUser = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get();
+//        String kafkaUserAsJson = TestUtils.toJsonString(kUser);
+//
+//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
+//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
+//        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo(Constants.TLS_LISTENER_DEFAULT_NAME)));
+//
+//        long observedGeneration = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(userName).get().getStatus().getObservedGeneration();
+//
+//        KafkaUserResource.replaceUserResourceInSpecificNamespace(userName, ku -> {
+//            ku.getMetadata().setResourceVersion(null);
+//            ku.getSpec().setAuthentication(new KafkaUserScramSha512ClientAuthentication());
+//        }, namespace);
+//
+//        KafkaUserUtils.waitForKafkaUserIncreaseObserverGeneration(namespace, observedGeneration, userName);
+//        KafkaUserUtils.waitForKafkaUserCreation(namespace, userName);
+//
+//        String anotherKafkaUserSecret = TestUtils.toJsonString(kubeClient(namespace).getSecret(namespace, userName));
+//
+//        assertThat(anotherKafkaUserSecret, hasJsonPath("$.data.password", notNullValue()));
+//
+//        kUser = Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).withName(userName).get();
+//        kafkaUserAsJson = TestUtils.toJsonString(kUser);
+//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(userName)));
+//        assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
+//        assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo("scram-sha-512")));
+//
+//        Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).delete(kUser);
+//        KafkaUserUtils.waitForKafkaUserDeletion(userName);
     }
 
     @Tag(SCALABILITY)
@@ -549,10 +549,10 @@ class UserST extends AbstractST {
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
-            .editMetadata()
-                .withNamespace(namespace)
-            .endMetadata()
-            .build());
+//        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
+//            .editMetadata()
+//                .withNamespace(namespace)
+//            .endMetadata()
+//            .build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -127,7 +127,7 @@ public class OauthAbstractST extends AbstractST {
         // this is need for cluster-wide OLM (creating `infra-namespace` for Keycloak)
         // Keycloak do not support cluster-wide namespace and thus we need it to deploy in non-OLM cluster wide namespace
         // (f.e., our `infra-namespace`)
-        if (kubeClient().getNamespace(namespace) != null) {
+        if (kubeClient().getNamespace(Constants.INFRA_NAMESPACE) == null) {
             cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), Constants.INFRA_NAMESPACE);
         }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloak;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
@@ -685,7 +686,7 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
     @AfterAll
     void tearDown(ExtensionContext extensionContext) throws Exception {
         // delete keycloak before namespace
-        KeycloakUtils.deleteKeycloak(INFRA_NAMESPACE);
+        KeycloakUtils.deleteKeycloak(Constants.INFRA_NAMESPACE, clusterOperator.getDeploymentNamespace());
         // delete namespace etc.
         super.afterAllMayOverride(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -798,7 +798,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
     @AfterAll
     void tearDown(ExtensionContext extensionContext) throws Exception {
         // delete keycloak before namespace
-        KeycloakUtils.deleteKeycloak(INFRA_NAMESPACE);
+        KeycloakUtils.deleteKeycloak(Constants.INFRA_NAMESPACE, clusterOperator.getDeploymentNamespace());
         // delete namespace etc.
         super.afterAllMayOverride(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelTest;
@@ -278,7 +279,7 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
     @AfterAll
     void tearDown(ExtensionContext extensionContext) throws Exception {
         // delete keycloak before namespace
-        KeycloakUtils.deleteKeycloak(INFRA_NAMESPACE);
+        KeycloakUtils.deleteKeycloak(Constants.INFRA_NAMESPACE, clusterOperator.getDeploymentNamespace());
         // delete namespace etc.
         super.afterAllMayOverride(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
@@ -52,7 +52,6 @@ import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.HTTP_BRIDGE_DEFAULT_PORT;
-import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
@@ -82,10 +81,10 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
 
         KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withProducerName(producerName)
             .withConsumerName(consumerName)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
@@ -97,10 +96,10 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .build();
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
     }
 
     @Description("As an oauth KafkaConnect, I am able to sink messages from kafka broker topic using encrypted communication.")
@@ -113,10 +112,10 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
 
         KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withProducerName(producerName)
             .withConsumerName(consumerName)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
@@ -128,17 +127,17 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .build();
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, oauthClusterName + "-" + Constants.KAFKA_CLIENTS).build());
+        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(clusterOperator.getDeploymentNamespace(), false, oauthClusterName + "-" + Constants.KAFKA_CLIENTS).build());
 
         String defaultKafkaClientsPodName =
-                ResourceManager.kubeClient().listPodsByPrefixInName(INFRA_NAMESPACE, oauthClusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
+                ResourceManager.kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), oauthClusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
 
-        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(extensionContext, clusterName, INFRA_NAMESPACE, oauthClusterName, 1)
+        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(extensionContext, clusterName, clusterOperator.getDeploymentNamespace(), oauthClusterName, 1)
             .editSpec()
                 .withConfig(connectorConfig)
                 .addToConfig("key.converter.schemas.enable", false)
@@ -169,13 +168,13 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .endSpec()
             .build());
 
-        String kafkaConnectPodName = kubeClient(INFRA_NAMESPACE).listPods(INFRA_NAMESPACE, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+        String kafkaConnectPodName = kubeClient(clusterOperator.getDeploymentNamespace()).listPods(clusterOperator.getDeploymentNamespace(), clusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 
-        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(INFRA_NAMESPACE, kafkaConnectPodName);
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(clusterOperator.getDeploymentNamespace(), kafkaConnectPodName);
 
-        KafkaConnectorUtils.createFileSinkConnector(INFRA_NAMESPACE, defaultKafkaClientsPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(clusterName, INFRA_NAMESPACE, 8083));
+        KafkaConnectorUtils.createFileSinkConnector(clusterOperator.getDeploymentNamespace(), defaultKafkaClientsPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(clusterName, clusterOperator.getDeploymentNamespace(), 8083));
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(INFRA_NAMESPACE, kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(clusterOperator.getDeploymentNamespace(), kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
     }
 
     @Description("As a oauth bridge, i am able to send messages to bridge endpoint using encrypted communication")
@@ -188,10 +187,10 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
 
         KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withProducerName(producerName)
             .withConsumerName(consumerName)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
@@ -203,16 +202,16 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .build();
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, true, kafkaClientsName).build());
+        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(clusterOperator.getDeploymentNamespace(), true, kafkaClientsName).build());
 
         resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridge(oauthClusterName, KafkaResources.tlsBootstrapAddress(oauthClusterName), 1)
             .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
+                .withNamespace(clusterOperator.getDeploymentNamespace())
             .endMetadata()
             .editSpec()
                 .withNewTls()
@@ -247,11 +246,11 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .withPort(HTTP_BRIDGE_DEFAULT_PORT)
             .withDelayMs(1000)
             .withPollInterval(1000)
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .build();
 
         resourceManager.createResource(extensionContext, kafkaBridgeClientJob.producerStrimziBridge());
-        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
     }
 
     @Description("As a oauth mirror maker, I am able to replicate topic data using using encrypted communication")
@@ -267,10 +266,10 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
 
         KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withProducerName(producerName)
             .withConsumerName(consumerName)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(oauthClusterName))
@@ -282,16 +281,16 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .build();
 
         resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthTls(oauthClusterName));
-        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
         String targetKafkaCluster = oauthClusterName + "-target";
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(targetKafkaCluster, 1, 1)
             .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
+                .withNamespace(clusterOperator.getDeploymentNamespace())
             .endMetadata()
             .editSpec()
                 .editKafka()
@@ -322,7 +321,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(oauthClusterName, oauthClusterName, targetKafkaCluster,
             ClientUtils.generateRandomConsumerGroup(), 1, true)
                 .editMetadata()
-                    .withNamespace(INFRA_NAMESPACE)
+                    .withNamespace(clusterOperator.getDeploymentNamespace())
                 .endMetadata()
                 .editSpec()
                     .withNewConsumer()
@@ -379,19 +378,19 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
                 .endSpec()
                 .build());
 
-        String mirrorMakerPodName = kubeClient().listPodsByPrefixInName(INFRA_NAMESPACE, KafkaMirrorMakerResources.deploymentName(oauthClusterName)).get(0).getMetadata().getName();
-        String kafkaMirrorMakerLogs = kubeClient().logsInSpecificNamespace(INFRA_NAMESPACE, mirrorMakerPodName);
+        String mirrorMakerPodName = kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), KafkaMirrorMakerResources.deploymentName(oauthClusterName)).get(0).getMetadata().getName();
+        String kafkaMirrorMakerLogs = kubeClient().logsInSpecificNamespace(clusterOperator.getDeploymentNamespace(), mirrorMakerPodName);
 
         assertThat(kafkaMirrorMakerLogs,
             not(containsString("keytool error: java.io.FileNotFoundException: /opt/kafka/consumer-oauth-certs/**/* (No such file or directory)")));
 
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(INFRA_NAMESPACE, oauthClusterName, USER_NAME).build());
-        KafkaUserUtils.waitForKafkaUserCreation(INFRA_NAMESPACE, USER_NAME);
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(clusterOperator.getDeploymentNamespace(), oauthClusterName, USER_NAME).build());
+        KafkaUserUtils.waitForKafkaUserCreation(clusterOperator.getDeploymentNamespace(), USER_NAME);
 
         LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", targetKafkaCluster);
 
         KafkaOauthClients kafkaOauthClientJob = new KafkaOauthClientsBuilder()
-            .withNamespaceName(INFRA_NAMESPACE)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withProducerName(producerName)
             .withConsumerName(consumerName)
             .withClientUserName(USER_NAME)
@@ -405,7 +404,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, kafkaOauthClientJob.consumerStrimziOauthTls(targetKafkaCluster));
 
-        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
     }
 
     @ParallelTest
@@ -415,7 +414,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
         String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, INFRA_NAMESPACE).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
 
         keycloakInstance.setIntrospectionEndpointUri("https://" + keycloakInstance.getHttpsUri() + "/auth/realms/internal/protocol/openid-connect/token/introspect");
         String introspectionKafka = oauthClusterName + "-intro";
@@ -427,7 +426,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(introspectionKafka, 1)
             .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
+                .withNamespace(clusterOperator.getDeploymentNamespace())
             .endMetadata()
             .editSpec()
                 .editKafka()
@@ -454,7 +453,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .build());
 
         KafkaOauthClients oauthInternalClientIntrospectionJob = new KafkaOauthClientsBuilder()
-                .withNamespaceName(INFRA_NAMESPACE)
+                .withNamespaceName(clusterOperator.getDeploymentNamespace())
                 .withProducerName(producerName)
                 .withConsumerName(consumerName)
                 .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(introspectionKafka))
@@ -466,15 +465,15 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
                 .build();
 
         resourceManager.createResource(extensionContext, oauthInternalClientIntrospectionJob.producerStrimziOauthTls(introspectionKafka));
-        ClientUtils.waitForClientSuccess(producerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
 
         resourceManager.createResource(extensionContext, oauthInternalClientIntrospectionJob.consumerStrimziOauthTls(introspectionKafka));
-        ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
     }
 
     @BeforeAll
     void setUp(ExtensionContext extensionContext) {
-        super.setupCoAndKeycloak(extensionContext, INFRA_NAMESPACE);
+        super.setupCoAndKeycloak(extensionContext, clusterOperator.getDeploymentNamespace());
 
         keycloakInstance.setRealm("internal", true);
 
@@ -482,7 +481,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(oauthClusterName, 3)
             .editMetadata()
-                .withNamespace(INFRA_NAMESPACE)
+                .withNamespace(clusterOperator.getDeploymentNamespace())
             .endMetadata()
             .editSpec()
                 .editKafka()
@@ -491,13 +490,13 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
             .endSpec()
             .build());
 
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(INFRA_NAMESPACE, oauthClusterName, OAUTH_CLIENT_NAME).build());
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(clusterOperator.getDeploymentNamespace(), oauthClusterName, OAUTH_CLIENT_NAME).build());
     }
 
     @AfterAll
     void tearDown(ExtensionContext extensionContext) throws Exception {
         // delete keycloak before namespace
-        KeycloakUtils.deleteKeycloak(INFRA_NAMESPACE);
+        KeycloakUtils.deleteKeycloak(clusterOperator.getDeploymentNamespace());
         // delete namespace etc.
         super.afterAllMayOverride(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
@@ -496,7 +496,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
     @AfterAll
     void tearDown(ExtensionContext extensionContext) throws Exception {
         // delete keycloak before namespace
-        KeycloakUtils.deleteKeycloak(clusterOperator.getDeploymentNamespace());
+        KeycloakUtils.deleteKeycloak(Constants.INFRA_NAMESPACE, clusterOperator.getDeploymentNamespace());
         // delete namespace etc.
         super.afterAllMayOverride(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/ClusterOperationIsolatedST.java
@@ -15,7 +15,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NodeUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartIsolatedST.java
@@ -15,7 +15,7 @@ import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
@@ -44,7 +44,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.specific.BridgeUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -100,51 +100,51 @@ public class TracingST extends AbstractST {
     @Tag(ACCEPTANCE)
     void testProducerConsumerStreamsService(ExtensionContext extensionContext) {
         // Current implementation of Jaeger deployment and test parallelism does not allow to run this test with STRIMZI_RBAC_SCOPE=NAMESPACE`
-//        assumeFalse(Environment.isNamespaceRbacScope());
-//
-//        resourceManager.createResource(extensionContext,
-//            KafkaTemplates.kafkaEphemeral(
-//                storageMap.get(extensionContext).getClusterName(), 3, 1).build());
-//
-//        resourceManager.createResource(extensionContext,
-//            KafkaTopicTemplates.topic(storageMap.get(extensionContext).getClusterName(),
-//                storageMap.get(extensionContext).getTopicName())
-//            .editSpec()
-//                .withReplicas(3)
-//                .withPartitions(12)
-//            .endSpec()
-//            .build());
-//
-//        resourceManager.createResource(extensionContext,
-//            KafkaTopicTemplates.topic(storageMap.get(extensionContext).getClusterName(),
-//                storageMap.get(extensionContext).retrieveFromTestStorage(Constants.STREAM_TOPIC_KEY).toString())
-//            .editSpec()
-//                .withReplicas(3)
-//                .withPartitions(12)
-//            .endSpec()
-//            .build());
-//
-//        resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).producerWithTracing());
-//
-//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
-//            JAEGER_PRODUCER_SERVICE,
-//            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
-//            JAEGER_QUERY_SERVICE);
-//
-//        resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).consumerWithTracing());
-//
-//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
-//            JAEGER_CONSUMER_SERVICE,
-//            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
-//            JAEGER_QUERY_SERVICE);
-//
-//        resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).kafkaStreamsWithTracing());
+        assumeFalse(Environment.isNamespaceRbacScope());
 
-//        TODO: Disabled because of issue with Streams API and tracing. Uncomment this after fix. https://github.com/strimzi/strimzi-kafka-operator/issues/5680
-//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
-//            JAEGER_KAFKA_STREAMS_SERVICE,
-//            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
-//            JAEGER_QUERY_SERVICE);
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(
+                storageMap.get(extensionContext).getClusterName(), 3, 1).build());
+
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(storageMap.get(extensionContext).getClusterName(),
+                storageMap.get(extensionContext).getTopicName())
+            .editSpec()
+                .withReplicas(3)
+                .withPartitions(12)
+            .endSpec()
+            .build());
+
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(storageMap.get(extensionContext).getClusterName(),
+                storageMap.get(extensionContext).retrieveFromTestStorage(Constants.STREAM_TOPIC_KEY).toString())
+            .editSpec()
+                .withReplicas(3)
+                .withPartitions(12)
+            .endSpec()
+            .build());
+
+        resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).producerWithTracing());
+
+        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
+            JAEGER_PRODUCER_SERVICE,
+            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
+            JAEGER_QUERY_SERVICE);
+
+        resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).consumerWithTracing());
+
+        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
+            JAEGER_CONSUMER_SERVICE,
+            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
+            JAEGER_QUERY_SERVICE);
+
+        resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).kafkaStreamsWithTracing());
+
+        TODO: Disabled because of issue with Streams API and tracing. Uncomment this after fix. https://github.com/strimzi/strimzi-kafka-operator/issues/5680
+        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
+            JAEGER_KAFKA_STREAMS_SERVICE,
+            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
+            JAEGER_QUERY_SERVICE);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -539,40 +539,40 @@ public class TracingST extends AbstractST {
 
     @BeforeEach
     void createTestResources(ExtensionContext extensionContext) {
-//        TestStorage testStorage = new TestStorage(extensionContext, namespace);
-//
-//        storageMap.put(extensionContext, testStorage);
-//
-//        deployJaegerInstance(extensionContext, storageMap.get(extensionContext).getNamespaceName());
-//
-//        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(storageMap.get(extensionContext).getNamespaceName(), false, storageMap.get(extensionContext).getKafkaClientsName()).build());
-//
-//        testStorage.addToTestStorage(Constants.KAFKA_CLIENTS_POD_KEY, kubeClient(storageMap.get(extensionContext).getNamespaceName()).listPodsByPrefixInName(storageMap.get(extensionContext).getKafkaClientsName()).get(0).getMetadata().getName());
-//
-//        storageMap.put(extensionContext, testStorage);
-//
-//        final KafkaTracingClients kafkaTracingClient = new KafkaTracingClientsBuilder()
-//            .withNamespaceName(storageMap.get(extensionContext).getNamespaceName())
-//            .withProducerName(storageMap.get(extensionContext).getProducerName())
-//            .withConsumerName(storageMap.get(extensionContext).getConsumerName())
-//            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(storageMap.get(extensionContext).getClusterName()))
-//            .withTopicName(storageMap.get(extensionContext).getTopicName())
-//            .withStreamsTopicTargetName(storageMap.get(extensionContext).retrieveFromTestStorage(Constants.STREAM_TOPIC_KEY).toString())
-//            .withMessageCount(MESSAGE_COUNT)
-//            .withJaegerServiceProducerName(JAEGER_PRODUCER_SERVICE)
-//            .withJaegerServiceConsumerName(JAEGER_CONSUMER_SERVICE)
-//            .withJaegerServiceStreamsName(JAEGER_KAFKA_STREAMS_SERVICE)
-//            .withJaegerServerAgentName(JAEGER_AGENT_NAME)
-//            .build();
-//
-//        testStorage.addToTestStorage(Constants.KAFKA_TRACING_CLIENT_KEY, kafkaTracingClient);
-//
-//        storageMap.put(extensionContext, testStorage);
+        TestStorage testStorage = new TestStorage(extensionContext, namespace);
+
+        storageMap.put(extensionContext, testStorage);
+
+        deployJaegerInstance(extensionContext, storageMap.get(extensionContext).getNamespaceName());
+
+        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(storageMap.get(extensionContext).getNamespaceName(), false, storageMap.get(extensionContext).getKafkaClientsName()).build());
+
+        testStorage.addToTestStorage(Constants.KAFKA_CLIENTS_POD_KEY, kubeClient(storageMap.get(extensionContext).getNamespaceName()).listPodsByPrefixInName(storageMap.get(extensionContext).getKafkaClientsName()).get(0).getMetadata().getName());
+
+        storageMap.put(extensionContext, testStorage);
+
+        final KafkaTracingClients kafkaTracingClient = new KafkaTracingClientsBuilder()
+            .withNamespaceName(storageMap.get(extensionContext).getNamespaceName())
+            .withProducerName(storageMap.get(extensionContext).getProducerName())
+            .withConsumerName(storageMap.get(extensionContext).getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(storageMap.get(extensionContext).getClusterName()))
+            .withTopicName(storageMap.get(extensionContext).getTopicName())
+            .withStreamsTopicTargetName(storageMap.get(extensionContext).retrieveFromTestStorage(Constants.STREAM_TOPIC_KEY).toString())
+            .withMessageCount(MESSAGE_COUNT)
+            .withJaegerServiceProducerName(JAEGER_PRODUCER_SERVICE)
+            .withJaegerServiceConsumerName(JAEGER_CONSUMER_SERVICE)
+            .withJaegerServiceStreamsName(JAEGER_KAFKA_STREAMS_SERVICE)
+            .withJaegerServerAgentName(JAEGER_AGENT_NAME)
+            .build();
+
+        testStorage.addToTestStorage(Constants.KAFKA_TRACING_CLIENT_KEY, kafkaTracingClient);
+
+        storageMap.put(extensionContext, testStorage);
     }
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) throws IOException {
-//        // deployment of the jaeger
-//        deployJaegerOperator(extensionContext);
+        // deployment of the jaeger
+        deployJaegerOperator(extensionContext);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -140,11 +140,11 @@ public class TracingST extends AbstractST {
 
         resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).kafkaStreamsWithTracing());
 
-        TODO: Disabled because of issue with Streams API and tracing. Uncomment this after fix. https://github.com/strimzi/strimzi-kafka-operator/issues/5680
-        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
-            JAEGER_KAFKA_STREAMS_SERVICE,
-            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
-            JAEGER_QUERY_SERVICE);
+//        TODO: Disabled because of issue with Streams API and tracing. Uncomment this after fix. https://github.com/strimzi/strimzi-kafka-operator/issues/5680
+//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
+//            JAEGER_KAFKA_STREAMS_SERVICE,
+//            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.KAFKA_CLIENTS_POD_KEY).toString(),
+//            JAEGER_QUERY_SERVICE);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -31,7 +31,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.test.executor.Exec;
 import io.strimzi.test.executor.ExecResult;
 import io.vertx.core.json.JsonArray;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeIsolatedST.java
@@ -18,7 +18,7 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
@@ -17,7 +17,7 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.OlmUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
@@ -91,7 +91,7 @@ public class OlmUpgradeIsolatedST extends AbstractUpgradeST {
         // 2. Approve installation
         //   a) get name of install-plan
         //   b) approve installation
-        clusterOperator.runManualOlmInstallation(fromVersion, "amq-streams-2.0.x");
+        clusterOperator.runManualOlmInstallation(fromVersion, "strimzi-0.27.x");
 
         String url = testParameters.getString("urlFrom");
         File dir = FileUtils.downloadAndUnzip(url);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
@@ -6,7 +6,7 @@ package io.strimzi.systemtest.upgrade;
 
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -18,7 +18,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import org.apache.logging.log4j.LogManager;

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
@@ -18,7 +18,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -192,7 +192,7 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
         clusterOperator.unInstall();
         clusterOperator = clusterOperator.defaultInstallation()
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
-            .withBindingsNamespaces(Arrays.asList(Constants.INFRA_NAMESPACE, SECOND_NAMESPACE, THIRD_NAMESPACE))
+            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), SECOND_NAMESPACE, THIRD_NAMESPACE))
             .createInstallation()
             .runInstallation();
 

--- a/systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
+++ b/systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
@@ -1,72 +1,72 @@
 #!/usr/bin/env bash
 
-NAMESPACE=$1
-
+KEYCLOAK_OPERATOR_NAMESPACE=$1
 KEYCLOAK_VERSION=$2
+KEYCLOAK_INSTANCE_NAMESPACE=$3
 
 SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Generate keycloak secret"
 mkdir -p /tmp/keycloak
 openssl req  -nodes -new -x509  -keyout /tmp/keycloak/keycloak.key -out /tmp/keycloak/keycloak.crt -subj '/CN=keycloak'
-kubectl create secret -n ${NAMESPACE} generic sso-x509-https-secret --from-file=tls.crt=/tmp/keycloak/keycloak.crt --from-file=tls.key=/tmp/keycloak/keycloak.key
+kubectl create secret -n ${KEYCLOAK_OPERATOR_NAMESPACE} generic sso-x509-https-secret --from-file=tls.crt=/tmp/keycloak/keycloak.crt --from-file=tls.key=/tmp/keycloak/keycloak.key
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Deploy Keycloak Operator"
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/service_account.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role_binding.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role.yaml
-curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role_binding.yaml | sed "s#namespace: .*#namespace: ${NAMESPACE}#g" | kubectl apply  -n ${NAMESPACE} -f -
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakclients_crd.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloaks_crd.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakusers_crd.yaml
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/operator.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/service_account.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role_binding.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role.yaml
+curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role_binding.yaml | sed "s#namespace: .*#namespace: ${KEYCLOAK_OPERATOR_NAMESPACE}#g" | kubectl apply  -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f -
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakclients_crd.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloaks_crd.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakusers_crd.yaml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/operator.yaml
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Deploy Keycloak instance"
-kubectl apply -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/examples/keycloak/keycloak.yaml
+kubectl apply -n ${KEYCLOAK_INSTANCE_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/examples/keycloak/keycloak.yaml
 
 # This is needed to avoid race condition when pods are not created yet before waiting for pods condition
-PODS=$(kubectl get pods -n ${NAMESPACE})
+PODS=$(kubectl get pods -n ${KEYCLOAK_OPERATOR_NAMESPACE})
 RETRY=12
 while [[ ${PODS} != *"keycloak-0"* && ${RETRY} -gt 0 ]]
 do
 	echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") keycloak-0 does not exists! Going to check it in 5 seconds (${RETRY})"
 	sleep 5
-	PODS=$(kubectl get po -n ${NAMESPACE})
+	PODS=$(kubectl get po -n ${KEYCLOAK_OPERATOR_NAMESPACE})
 	((RETRY-=1))
 done
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Wait for Keycloak Operator readiness"
-kubectl wait deployment/keycloak-operator --for=condition=available --timeout=90s -n ${NAMESPACE}
+kubectl wait deployment/keycloak-operator --for=condition=available --timeout=90s -n ${KEYCLOAK_OPERATOR_NAMESPACE}
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Wait for Keycloak readiness"
-kubectl wait pod/keycloak-0 --for=condition=containersready --timeout=300s -n ${NAMESPACE}
+kubectl wait pod/keycloak-0 --for=condition=containersready --timeout=300s -n ${KEYCLOAK_INSTANCE_NAMESPACE}
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Copy realm scripts"
-kubectl cp  -n ${NAMESPACE} ${SCRIPT_PATH}/create_realm.sh keycloak-0:/tmp/create_realm.sh
-kubectl cp  -n ${NAMESPACE} ${SCRIPT_PATH}/create_realm_authorization.sh keycloak-0:/tmp/create_realm_authorization.sh
-kubectl cp  -n ${NAMESPACE} ${SCRIPT_PATH}/create_realm_scope_audience.sh keycloak-0:/tmp/create_realm_scope_audience.sh
+kubectl cp  -n ${KEYCLOAK_INSTANCE_NAMESPACE} ${SCRIPT_PATH}/create_realm.sh keycloak-0:/tmp/create_realm.sh
+kubectl cp  -n ${KEYCLOAK_INSTANCE_NAMESPACE} ${SCRIPT_PATH}/create_realm_authorization.sh keycloak-0:/tmp/create_realm_authorization.sh
+kubectl cp  -n ${KEYCLOAK_INSTANCE_NAMESPACE} ${SCRIPT_PATH}/create_realm_scope_audience.sh keycloak-0:/tmp/create_realm_scope_audience.sh
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Get Admin password"
-PASSWORD=$(kubectl get secret -n ${NAMESPACE} credential-example-keycloak -o=jsonpath='{.data.ADMIN_PASSWORD}' | base64 -d)
-USERNAME=$(kubectl get secret -n ${NAMESPACE} credential-example-keycloak -o=jsonpath='{.data.ADMIN_USERNAME}' | base64 -d)
+PASSWORD=$(kubectl get secret -n ${KEYCLOAK_INSTANCE_NAMESPACE} credential-example-keycloak -o=jsonpath='{.data.ADMIN_PASSWORD}' | base64 -d)
+USERNAME=$(kubectl get secret -n ${KEYCLOAK_INSTANCE_NAMESPACE} credential-example-keycloak -o=jsonpath='{.data.ADMIN_USERNAME}' | base64 -d)
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Import realms - USER:${USERNAME} - PASS:${PASSWORD}"
-AUTHENTICATION_REALM_OUTPUT=$(kubectl exec keycloak-0 -n ${NAMESPACE} -- /tmp/create_realm.sh ${USERNAME} ${PASSWORD} localhost:8443)
+AUTHENTICATION_REALM_OUTPUT=$(kubectl exec keycloak-0 -n ${KEYCLOAK_INSTANCE_NAMESPACE} -- /tmp/create_realm.sh ${USERNAME} ${PASSWORD} localhost:8443)
 echo ${AUTHENTICATION_REALM_OUTPUT}
 if [[ ${AUTHENTICATION_REALM_OUTPUT} == *"Realm wasn't imported!"* ]]; then
   echo "[ERROR] $(date -u +"%Y-%m-%d %H:%M:%S") Authentication realm wasn't imported!"
   exit 1
 fi
 
-AUTHORIZATION_REALM_OUTPUT=$(kubectl exec keycloak-0 -n ${NAMESPACE} -- /tmp/create_realm_authorization.sh ${USERNAME} ${PASSWORD} localhost:8443)
+AUTHORIZATION_REALM_OUTPUT=$(kubectl exec keycloak-0 -n ${KEYCLOAK_INSTANCE_NAMESPACE} -- /tmp/create_realm_authorization.sh ${USERNAME} ${PASSWORD} localhost:8443)
 if [[ ${AUTHORIZATION_REALM_OUTPUT} == *"Realm wasn't imported!"* ]]; then
   echo "[ERROR] $(date -u +"%Y-%m-%d %H:%M:%S") Authorization realm wasn't imported!"
   exit 1
 fi
 
-SCOPE_AUDIENCE_REALM_OUTPUT=$(kubectl exec keycloak-0 -n ${NAMESPACE} -- /tmp/create_realm_scope_audience.sh ${USERNAME} ${PASSWORD} localhost:8443)
+SCOPE_AUDIENCE_REALM_OUTPUT=$(kubectl exec keycloak-0 -n ${KEYCLOAK_INSTANCE_NAMESPACE} -- /tmp/create_realm_scope_audience.sh ${USERNAME} ${PASSWORD} localhost:8443)
 if [[ ${SCOPE_AUDIENCE_REALM_OUTPUT} == *"Realm wasn't imported!"* ]]; then
   echo "[ERROR] $(date -u +"%Y-%m-%d %H:%M:%S") Scope & audience realm wasn't imported!"
   exit 1

--- a/systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
+++ b/systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-NAMESPACE=$1
-
+KEYCLOAK_OPERATOR_NAMESPACE=$1
 KEYCLOAK_VERSION=$2
+KEYCLOAK_INSTANCE_NAMESPACE=$3
 
 SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Delete Keycloak & Keycloak Operator"
-kubectl delete -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/examples/keycloak/keycloak.yaml
-kubectl delete -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/operator.yaml
+kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/examples/keycloak/keycloak.yaml
+kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/operator.yaml
 kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakusers_crd.yaml
 kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloaks_crd.yaml
 kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakclients_crd.yaml
@@ -16,6 +16,6 @@ kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_V
 kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
 kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role.yaml
 kubectl delete -f https://raw.githubusercontent.com/keycloak/keycloak-operator/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role_binding.yaml
-kubectl delete -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role.yaml
-kubectl delete -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role_binding.yaml
-kubectl delete -n ${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/service_account.yaml
+kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role.yaml
+kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role_binding.yaml
+kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/service_account.yaml


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR fixes a few things related to the OLM installation with namespace handling in the deletion or installation process. Moreover, it fixes one problem with class-wide parallelization related to bad annotation (which locks the entire execution and
 results in a deadlock situation). Also removing unnecessary invocation of method `set()` because AtomicInteger holds a reference to its value and thus do not need to assign it. Additionally, there is no need to annotate methods such as adding or removing test cases and test suites with synchronized because `incrementAndGet` is an atomic operation (more here -> https://docs.oracle.com/javase/specs/jls/se10/html/jls-8.html#jls-8.3.1.4). 


### Checklist

- [x] Make sure all tests pass