### PR TITLE
Fix / Good to have change in the `proc-install-product` doc

### DIFF
--- a/documentation/modules/quickstart/proc-installing-product.adoc
+++ b/documentation/modules/quickstart/proc-installing-product.adoc
@@ -61,14 +61,6 @@ env:
   value: my-kafka-project
 # ...
 ----
-
-. Deploy the CRDs and role-based access control (RBAC) resources to manage the CRDs.
-+
-[source, shell, subs=+quotes ]
-----
-kubectl create -f install/cluster-operator/ -n kafka
-----
-
 . Give permission to the Cluster Operator to watch the `my-kafka-project` namespace.
 +
 --
@@ -83,3 +75,9 @@ kubectl create -f install/cluster-operator/031-RoleBinding-strimzi-cluster-opera
 --
 +
 The commands create role bindings that grant permission for the Cluster Operator to access the Kafka cluster.
+. Deploy the CRDs and role-based access control (RBAC) resources to manage the CRDs.
++
+[source, shell, subs=+quotes ]
+----
+kubectl create -f install/cluster-operator/ -n kafka
+----

--- a/documentation/modules/quickstart/proc-installing-product.adoc
+++ b/documentation/modules/quickstart/proc-installing-product.adoc
@@ -61,6 +61,7 @@ env:
   value: my-kafka-project
 # ...
 ----
+
 . Give permission to the Cluster Operator to watch the `my-kafka-project` namespace.
 +
 --
@@ -75,6 +76,7 @@ kubectl create -f install/cluster-operator/031-RoleBinding-strimzi-cluster-opera
 --
 +
 The commands create role bindings that grant permission for the Cluster Operator to access the Kafka cluster.
+
 . Deploy the CRDs and role-based access control (RBAC) resources to manage the CRDs.
 +
 [source, shell, subs=+quotes ]


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

_Select the type of your PR_

- Documentation

### Description

When we go through the steps of the `Install Strimzi` section, The 6th step deploys the cluster operator but the the cluster operator will keep failing as the permission for cluster operator to access kafka cluster is given in 7th step. This 
 makes the user thinks that its an error in strimzi since there is nothing mentioned about the error you will face after deploying in the 6th step . There was some issues which were pointing towards this confusion so its good to have the 7th step execute before the 6th step

Alternative :

Maybe we can add some extra lines which states that a user is supposed to get this error if they haven't executed the 7th step.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

