### PR TITLE
Disable Cold Backup system tests when PodSets are enabled

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
@@ -13,6 +13,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import java.util.Map;
 
+import io.strimzi.systemtest.annotations.StatefulSetTest;
 import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
+@StatefulSetTest
 @IsolatedSuite
 public class ColdBackupScriptIsolatedST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(ColdBackupScriptIsolatedST.class);


### PR DESCRIPTION
### Type of change

- Task

### Description

The Cold backup tool currently doens't support the StrimziPodSets. It should be disabled when PodSets are used. This PR disables the ST -> issue #6471 tracks adding the support for Podsets to the script.

### Checklist

- [x] Reference relevant issue(s) and close them after merging