### PR TITLE
Add support for Kafka 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.29.0
 
+* Add support for Apache Kafka 3.0.1
 * Increase the size of the `/tmp` volumes to 5Mi to allow unpacking of compression libraries
 * Use `/healthz` endpoint for Kafka Exporter health checks
 * Update Jackson Library to 2.12.6

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.0.x/pom.xml
@@ -340,11 +340,35 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.12.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.12.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- END: To avoid conflicts between Jackson 2.12 used by Kafka and 2.13 used by Fabric8, we have to exclude these libraries and include the right versions -->
         <!-- EnvVar Configuration Provider for Apache Kafka -->

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -340,11 +340,35 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.12.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.12.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- END: To avoid conflicts between Jackson 2.12 used by Kafka and 2.13 used by Fabric8, we have to exclude these libraries and include the right versions -->
         <!-- EnvVar Configuration Provider for Apache Kafka -->

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -7,6 +7,7 @@
 |Kafka
 a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.0.0
+* {DockerOrg}/kafka:{DockerTag}-kafka-3.0.1
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.1.0
 
 a|

--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -7,5 +7,6 @@
 |=================
 |Kafka version |Interbroker protocol version |Log message format version| ZooKeeper version
 | 3.0.0 | 3.0 | 3.0 | 3.6.3
+| 3.0.1 | 3.0 | 3.0 | 3.6.3
 | 3.1.0 | 3.1 | 3.1 | 3.6.3
 |=================

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -156,6 +156,15 @@
   third-party-libs: 3.0.x
   supported: true
   default: false
+- version: 3.0.1
+  format: 3.0
+  protocol: 3.0
+  url: https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz
+  checksum: D949FA4BE7B601A9B482AE1C7861135A5DA007362C4C1C9C218BDCA94C45E918527E56738361AEDC6B6DFB7ABF02B1AA8110C7BC622CC2379B8A2EE557E5756F
+  zookeeper: 3.6.3
+  third-party-libs: 3.0.x
+  supported: true
+  default: false
 - version: 3.1.0
   format: 3.1
   protocol: 3.1

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -16,17 +16,21 @@
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
                 3.0.0={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-3.0.0
+                3.0.1={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-3.0.1
                 3.1.0={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-3.1.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
                 3.0.0={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-3.0.0
+                3.0.1={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-3.0.1
                 3.1.0={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-3.1.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |                 
                 3.0.0={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-3.0.0
+                3.0.1={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-3.0.1
                 3.1.0={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-3.1.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
                 3.0.0={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-3.0.0
+                3.0.1={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-3.0.1
                 3.1.0={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-3.1.0
 {{- end -}}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -58,18 +58,22 @@ spec:
             - name: STRIMZI_KAFKA_IMAGES
               value: |
                 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0
+                3.0.1=quay.io/strimzi/kafka:latest-kafka-3.0.1
                 3.1.0=quay.io/strimzi/kafka:latest-kafka-3.1.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0
+                3.0.1=quay.io/strimzi/kafka:latest-kafka-3.0.1
                 3.1.0=quay.io/strimzi/kafka:latest-kafka-3.1.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
                 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0
+                3.0.1=quay.io/strimzi/kafka:latest-kafka-3.0.1
                 3.1.0=quay.io/strimzi/kafka:latest-kafka-3.1.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0
+                3.0.1=quay.io/strimzi/kafka:latest-kafka-3.0.1
                 3.1.0=quay.io/strimzi/kafka:latest-kafka-3.1.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: quay.io/strimzi/operator:latest


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for Kafka 3.0.1. To avoid dependency conflict, I also had to update the 3rd party libs to exclude some more Jackson libraries.

_(This PR is currently draft based on the RC)_

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md