### PR TITLE
Update the API links to point to Kube 1.23 docs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -221,7 +221,7 @@
                                 <argument>io.strimzi.crdgenerator.DocGenerator</argument>
                                 <argument>--linker</argument>
                                 <argument>io.strimzi.crdgenerator.KubeLinker</argument>
-                                <argument>https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/</argument>
+                                <argument>https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/</argument>
                                 <argument>modules/appendix_crds.adoc</argument>
                                 <argument>io.strimzi.api.kafka.model.Kafka</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaConnect</argument>

--- a/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSetSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSetSpec.java
@@ -34,7 +34,7 @@ public class StrimziPodSetSpec extends Spec {
     @Description("Selector is a label query which matches all the pods managed by this `StrimziPodSet`. " +
             "Only `matchLabels` is supported. " +
             "If `matchExpressions` is set, it will be ignored.")
-    @KubeLink(group = "meta", version = "v1", kind = "LabelSelector")
+    @KubeLink(group = "meta", version = "v1", kind = "labelselector")
     @JsonProperty(required = true)
     public LabelSelector getSelector() {
         return selector;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -164,7 +164,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
 
     @Description("The pod's HostAliases. " +
             "HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.")
-    @KubeLink(group = "core", version = "v1", kind = "HostAlias")
+    @KubeLink(group = "core", version = "v1", kind = "hostalias")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<HostAlias> getHostAliases() {
         return hostAliases;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Crd.java
@@ -113,7 +113,7 @@ public @interface Crd {
 
             /**
              * The scale subresource of a custom resources that this is the definition for.
-             * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#customresourcesubresourcescale-v1beta1-apiextensions-k8s-io">Kubernetes 1.18 API documtation</a>
+             * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#customresourcesubresourcescale-v1beta1-apiextensions-k8s-io">Kubernetes 1.23 API documtation</a>
              */
             @interface Scale {
                 String apiVersion() default "all";

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -85,10 +85,10 @@ include::../api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc[leveloffset=+1]
 |xref:type-JvmOptions-{context}[`JvmOptions`]
 |jmxOptions           1.2+<.<a|JMX Options for Kafka brokers.
 |xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
-|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |metricsConfig        1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
 |logging              1.2+<.<a|Logging configuration for Kafka. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
@@ -132,10 +132,10 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`]
 |configuration       1.2+<.<a|Additional listener configuration.
 |xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaListenerConfiguration`]
-|networkPolicyPeers  1.2+<.<a|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io[external documentation for networking.k8s.io/v1 networkpolicypeer].
+|networkPolicyPeers  1.2+<.<a|List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#networkpolicypeer-v1-networking-k8s-io[external documentation for networking.k8s.io/v1 networkpolicypeer].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io[NetworkPolicyPeer] array
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#networkpolicypeer-v1-networking-k8s-io[NetworkPolicyPeer] array
 |====
 
 [id='type-KafkaListenerAuthenticationTls-{context}']
@@ -777,10 +777,10 @@ Used in: xref:type-ExternalLogging-{context}[`ExternalLogging`], xref:type-JmxPr
 [options="header"]
 |====
 |Property                |Description
-|configMapKeyRef  1.2+<.<a|Reference to the key in the ConfigMap containing the configuration. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
+|configMapKeyRef  1.2+<.<a|Reference to the key in the ConfigMap containing the configuration. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[ConfigMapKeySelector]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapkeyselector-v1-core[ConfigMapKeySelector]
 |====
 
 [id='type-InlineLogging-{context}']
@@ -921,40 +921,40 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 |Property                              |Description
 |metadata                       1.2+<.<a|Metadata applied to the resource.
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|imagePullSecrets               1.2+<.<a|List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[external documentation for core/v1 localobjectreference].
+|imagePullSecrets               1.2+<.<a|List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[external documentation for core/v1 localobjectreference].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[LocalObjectReference] array
-|securityContext                1.2+<.<a|Configures pod-level security attributes and common container settings. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core[external documentation for core/v1 podsecuritycontext].
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[LocalObjectReference] array
+|securityContext                1.2+<.<a|Configures pod-level security attributes and common container settings. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core[external documentation for core/v1 podsecuritycontext].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core[PodSecurityContext]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core[PodSecurityContext]
 |terminationGracePeriodSeconds  1.2+<.<a|The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds.
 |integer
-|affinity                       1.2+<.<a|The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[external documentation for core/v1 affinity].
+|affinity                       1.2+<.<a|The pod's affinity rules. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#affinity-v1-core[external documentation for core/v1 affinity].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core[Affinity]
-|tolerations                    1.2+<.<a|The pod's tolerations. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[external documentation for core/v1 toleration].
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#affinity-v1-core[Affinity]
+|tolerations                    1.2+<.<a|The pod's tolerations. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[external documentation for core/v1 toleration].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core[Toleration] array
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[Toleration] array
 |priorityClassName              1.2+<.<a|The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.
 |string
 |schedulerName                  1.2+<.<a|The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.
 |string
-|hostAliases                    1.2+<.<a|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[external documentation for core/v1 HostAlias].
+|hostAliases                    1.2+<.<a|The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#hostalias-v1-core[external documentation for core/v1 hostalias].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#HostAlias-v1-core[HostAlias] array
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#hostalias-v1-core[HostAlias] array
 |tmpDirSizeLimit                1.2+<.<a|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
 |string
 |enableServiceLinks             1.2+<.<a|Indicates whether information about services should be injected into Pod's environment variables.
 |boolean
-|topologySpreadConstraints      1.2+<.<a|The pod's topology spread constraints. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[external documentation for core/v1 topologyspreadconstraint].
+|topologySpreadConstraints      1.2+<.<a|The pod's topology spread constraints. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core[external documentation for core/v1 topologyspreadconstraint].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
 |====
 
 [id='type-InternalServiceTemplate-{context}']
@@ -1027,10 +1027,10 @@ include::../api/io.strimzi.api.kafka.model.template.ContainerTemplate.adoc[level
 |Property                |Description
 |env              1.2+<.<a|Environment variables which should be applied to the container.
 |xref:type-ContainerEnvVar-{context}[`ContainerEnvVar`] array
-|securityContext  1.2+<.<a|Security context for the container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core[external documentation for core/v1 securitycontext].
+|securityContext  1.2+<.<a|Security context for the container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core[external documentation for core/v1 securitycontext].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core[SecurityContext]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core[SecurityContext]
 |====
 
 [id='type-ContainerEnvVar-{context}']
@@ -1080,10 +1080,10 @@ include::../api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc[leveloffset
 |xref:type-JvmOptions-{context}[`JvmOptions`]
 |jmxOptions      1.2+<.<a|JMX Options for Zookeeper nodes.
 |xref:type-KafkaJmxOptions-{context}[`KafkaJmxOptions`]
-|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |metricsConfig   1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
 |logging         1.2+<.<a|Logging configuration for ZooKeeper. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
@@ -1172,10 +1172,10 @@ include::../api/io.strimzi.api.kafka.model.EntityTopicOperatorSpec.adoc[leveloff
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe                  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|resources                       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources                       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |topicMetadataMaxAttempts        1.2+<.<a|The number of attempts at getting topic metadata.
 |integer
 |logging                         1.2+<.<a|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
@@ -1214,10 +1214,10 @@ include::../api/io.strimzi.api.kafka.model.EntityUserOperatorSpec.adoc[leveloffs
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe                  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|resources                       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources                       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |logging                         1.2+<.<a|Logging configuration. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |jvmOptions                      1.2+<.<a|JVM Options for pods.
@@ -1248,10 +1248,10 @@ include::../api/io.strimzi.api.kafka.model.TlsSidecar.adoc[leveloffset=+1]
 |string (one of [emerg, debug, crit, err, alert, warning, notice, info])
 |readinessProbe  1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |====
 
 [id='type-EntityOperatorTemplate-{context}']
@@ -1312,10 +1312,10 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |tlsSidecar      1.2+<.<a|TLS sidecar configuration.
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
-|resources       1.2+<.<a|CPU and memory resources to reserve for the Cruise Control container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve for the Cruise Control container. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |livenessProbe   1.2+<.<a|Pod liveness checking for the Cruise Control container.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe  1.2+<.<a|Pod readiness checking for the Cruise Control container.
@@ -1395,10 +1395,10 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |kafkaQueries       1.2+<.<a|Queries to send to the Kafka brokers to define what data should be read from each broker. For more information on these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate` schema reference].
 |xref:type-JmxTransQueryTemplate-{context}[`JmxTransQueryTemplate`] array
-|resources          1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources          1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |template           1.2+<.<a|Template for JmxTrans resources.
 |xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`]
 |====
@@ -1477,10 +1477,10 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |topicRegex           1.2+<.<a|Regular expression to specify which topics to collect. Default value is `.*`.
 |string
-|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |logging              1.2+<.<a|Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`.
 |string
 |enableSaramaLogging  1.2+<.<a|Enable Sarama logging, a Go client library used by the Kafka Exporter.
@@ -1633,10 +1633,10 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |config                 1.2+<.<a|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
-|resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |livenessProbe          1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe         1.2+<.<a|Pod readiness checking.
@@ -1972,14 +1972,14 @@ Used in: xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`
 [options="header"]
 |====
 |Property                |Description
-|configMapKeyRef  1.2+<.<a|Reference to a key in a ConfigMap. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
+|configMapKeyRef  1.2+<.<a|Reference to a key in a ConfigMap. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapkeyselector-v1-core[external documentation for core/v1 configmapkeyselector].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapkeyselector-v1-core[ConfigMapKeySelector]
-|secretKeyRef     1.2+<.<a|Reference to a key in a Secret. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapkeyselector-v1-core[ConfigMapKeySelector]
+|secretKeyRef     1.2+<.<a|Reference to a key in a Secret. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[SecretKeySelector]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[SecretKeySelector]
 |====
 
 [id='type-ExternalConfigurationVolumeSource-{context}']
@@ -1991,16 +1991,16 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 [options="header"]
 |====
 |Property          |Description
-|configMap  1.2+<.<a|Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapvolumesource-v1-core[external documentation for core/v1 configmapvolumesource].
+|configMap  1.2+<.<a|Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapvolumesource-v1-core[external documentation for core/v1 configmapvolumesource].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
 |name       1.2+<.<a|Name of the volume which will be added to the Kafka Connect pods.
 |string
-|secret     1.2+<.<a|Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1-core[external documentation for core/v1 secretvolumesource].
+|secret     1.2+<.<a|Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretvolumesource-v1-core[external documentation for core/v1 secretvolumesource].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1-core[SecretVolumeSource]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretvolumesource-v1-core[SecretVolumeSource]
 |====
 
 [id='type-Build-{context}']
@@ -2021,10 +2021,10 @@ include::../api/io.strimzi.api.kafka.model.connect.build.Build.adoc[leveloffset=
 |Property          |Description
 |output     1.2+<.<a|Configures where should the newly built image be stored. Required. The type depends on the value of the `output.type` property within the given object, which must be one of [docker, imagestream].
 |xref:type-DockerOutput-{context}[`DockerOutput`], xref:type-ImageStreamOutput-{context}[`ImageStreamOutput`]
-|resources  1.2+<.<a|CPU and memory resources to reserve for the build. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources  1.2+<.<a|CPU and memory resources to reserve for the build. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |plugins    1.2+<.<a|List of connector plugins which should be added to the Kafka Connect. Required.
 |xref:type-Plugin-{context}[`Plugin`] array
 |====
@@ -2380,10 +2380,10 @@ Used in: xref:type-Password-{context}[`Password`]
 [options="header"]
 |====
 |Property             |Description
-|secretKeyRef  1.2+<.<a|Selects a key of a Secret in the resource's namespace. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
+|secretKeyRef  1.2+<.<a|Selects a key of a Secret in the resource's namespace. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core[SecretKeySelector]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[SecretKeySelector]
 |====
 
 [id='type-KafkaUserAuthorizationSimple-{context}']
@@ -2608,10 +2608,10 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerSpec.adoc[leveloffset
 |xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`]
 |producer        1.2+<.<a|Configuration of target cluster.
 |xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
-|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources       1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |whitelist       1.2+<.<a|*The `whitelist` property has been deprecated, and should now be configured using `spec.include`.* List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas.
 |string
 |include         1.2+<.<a|List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas.
@@ -2779,10 +2779,10 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 |xref:type-KafkaBridgeConsumerSpec-{context}[`KafkaBridgeConsumerSpec`]
 |producer          1.2+<.<a|Kafka producer related configuration.
 |xref:type-KafkaBridgeProducerSpec-{context}[`KafkaBridgeProducerSpec`]
-|resources         1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources         1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |jvmOptions        1.2+<.<a|**Currently not supported** JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
 |logging           1.2+<.<a|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
@@ -3020,10 +3020,10 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array
 |mirrors                1.2+<.<a|Configuration of the MirrorMaker 2.0 connectors.
 |xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2MirrorSpec`] array
-|resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core[ResourceRequirements]
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |livenessProbe          1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe         1.2+<.<a|Pod readiness checking.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -72,7 +72,7 @@
 :K8sMeaningOfMemory: link:https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory[Meaning of memory^]
 :K8sManagingComputingResources: link:https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers^]
 :K8sLivenessReadinessProbes: link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Configure Liveness and Readiness Probes^]
-:K8sNetworkPolicyPeerAPI: link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io[NetworkPolicyPeer API reference^]
+:K8sNetworkPolicyPeerAPI: link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#networkpolicypeer-v1-networking-k8s-io[NetworkPolicyPeer API reference^]
 :K8sImagePullPolicies: link:https://kubernetes.io/docs/concepts/containers/images/#updating-images[Disruptions^]
 :K8sCRDs: link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/[Extend the Kubernetes API with CustomResourceDefinitions^]
 :K8sResizingPersistentVolumesUsingKubernetes: link:https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/[Resizing Persistent Volumes using Kubernetes^]


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates the links to the Kubeetes API reference to point to Kube 1.23 instead of 1.18 which is not available anymore.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally