### PR TITLE
Per-broker configuration with Kafka PodSets

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -9,6 +9,15 @@
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
 
     <!-- cluster-operator -->
+
+    <!-- KafkaAssemblyOperator is relatively big at this point because lot of methods have copies for StatefulSets and
+         for StrimziPodSets. Once StatefulSet support is dropped, a lot of the logic will be removed again and the file
+         should be smaller again. Then we should be able to remove this suppression.
+         (This suppresses the File level warning which cannot be suppressed using annotation inside the class)
+         -->
+    <suppress checks="JavaNCSS"
+              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]assembly[/\\]KafkaAssemblyOperator.java"/>
+
     <suppress checks="ParameterNumber"
               files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]ResourceUtils.java"/>
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -497,11 +497,16 @@ public abstract class AbstractModel {
     }
 
     /**
-     * @param logging The Logging to parse.
-     * @param externalCm The external ConfigMap, used if Logging is an instance of ExternalLogging
-     * @return The logging properties as a String in log4j/2 properties file format.
+     * Generates the logging configuration as a String. The configuration is generated based on the default logging
+     * configuration files from resources, the (optional) inline logging configuration from the custom resource
+     * and the (optional) external logging configuration in a user-provided ConfigMap.
+     *
+     * @param logging       The logging configuration from the custom resource
+     * @param externalCm    The user-provided ConfigMap with custom Log4j / Log4j2 file
+     *
+     * @return              String with the Log4j / Log4j2 properties used for configuration
      */
-    public String parseLogging(Logging logging, ConfigMap externalCm) {
+    public String loggingConfiguration(Logging logging, ConfigMap externalCm) {
         if (logging instanceof InlineLogging) {
             InlineLogging inlineLogging = (InlineLogging) logging;
             OrderedProperties newSettings = getDefaultLogConfig();
@@ -583,16 +588,18 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Generates a metrics and logging ConfigMap according to configured defaults.
+     * Generates a metrics and logging ConfigMap according to configured defaults. This is used with most operands, but
+     * not all of them. Kafka brokers have own methods in the KafkaCluster class. So does the Bridge. And Kafka Exporter
+     * has no metrics or logging ConfigMap at all.
      *
      * @param metricsAndLogging The external CMs
      * @return The generated ConfigMap.
      */
     public ConfigMap generateMetricsAndLogConfigMap(MetricsAndLogging metricsAndLogging) {
         Map<String, String> data = new HashMap<>(2);
-        data.put(getAncillaryConfigMapKeyLogConfig(), parseLogging(getLogging(), metricsAndLogging.getLoggingCm()));
+        data.put(getAncillaryConfigMapKeyLogConfig(), loggingConfiguration(getLogging(), metricsAndLogging.getLoggingCm()));
         if (getMetricsConfigInCm() != null) {
-            String parseResult = parseMetrics(metricsAndLogging.getMetricsCm());
+            String parseResult = metricsConfiguration(metricsAndLogging.getMetricsCm());
             if (parseResult != null) {
                 this.setMetricsEnabled(true);
                 data.put(ANCILLARY_CM_KEY_METRICS, parseResult);
@@ -601,7 +608,14 @@ public abstract class AbstractModel {
         return createConfigMap(ancillaryConfigMapName, data);
     }
 
-    protected String parseMetrics(ConfigMap externalCm) {
+    /**
+     * Generates Prometheus metrics configuration based on the JMXExporter configuration from the user-provided ConfigMap.
+     *
+     * @param externalCm    ConfigMap with the JMX Prometheus configuration YAML
+     *
+     * @return              String with JSON formatted metrics configuration
+     */
+    public String metricsConfiguration(ConfigMap externalCm) {
         if (getMetricsConfigInCm() != null) {
             if (getMetricsConfigInCm() instanceof JmxPrometheusExporterMetrics) {
                 if (externalCm == null) {
@@ -611,7 +625,7 @@ public abstract class AbstractModel {
                 } else {
                     String data = externalCm.getData().get(((JmxPrometheusExporterMetrics) getMetricsConfigInCm()).getValueFrom().getConfigMapKeyRef().getKey());
                     if (data == null) {
-                        LOGGER.warnCr(reconciliation, "ConfigMap {} does not contain specified key {}. Metrics disabled.", ((JmxPrometheusExporterMetrics) getMetricsConfigInCm()).getValueFrom().getConfigMapKeyRef().getName(),
+                        LOGGER.warnCr(reconciliation, "ConfigMap {} does not contain specified key {}.", ((JmxPrometheusExporterMetrics) getMetricsConfigInCm()).getValueFrom().getConfigMapKeyRef().getName(),
                                 ((JmxPrometheusExporterMetrics) getMetricsConfigInCm()).getValueFrom().getConfigMapKeyRef().getKey());
                         throw new InvalidResourceException("ConfigMap " + ((JmxPrometheusExporterMetrics) getMetricsConfigInCm()).getValueFrom().getConfigMapKeyRef().getName()
                                 + " does not contain specified key " + ((JmxPrometheusExporterMetrics) getMetricsConfigInCm()).getValueFrom().getConfigMapKeyRef().getKey() + ".");
@@ -970,11 +984,15 @@ public abstract class AbstractModel {
     }
 
     protected ConfigMap createConfigMap(String name, Map<String, String> data) {
+        return createConfigMap(name, labels.toMap(), data);
+    }
+
+    protected ConfigMap createConfigMap(String name, Map<String, String> labels, Map<String, String> data) {
         return new ConfigMapBuilder()
                 .withNewMetadata()
                     .withName(name)
                     .withNamespace(namespace)
-                    .withLabels(labels.toMap())
+                    .withLabels(labels)
                     .withOwnerReferences(createOwnerReference())
                 .endMetadata()
                 .withData(data)
@@ -1136,22 +1154,24 @@ public abstract class AbstractModel {
     /**
      * Creates the StrimziPodSet with the Pods which currently correspond to the existing StatefulSet pods.
      *
-     * @param replicas          Defines how many pods should be generated and stored in this StrimziPodSet
-     * @param setAnnotations    Map with annotations which should be set on the StrimziPodSet
-     * @param podAnnotations    Map with annotation which should be set on the Pods
-     * @param volumes           Function which returns a list of volumes which should be used by the Pod and its containers
-     * @param affinity          Affinity rules for the pods
-     * @param initContainers    List of init containers which should be used in the pods
-     * @param containers        List of containers which should be used in the pods
-     * @param imagePullSecrets  List of image pull secrets with container registry credentials
-     * @param isOpenShift       Flag to specify whether we are on OpenShift or not
+     * @param replicas                  Defines how many pods should be generated and stored in this StrimziPodSet
+     * @param setAnnotations            Map with annotations which should be set on the StrimziPodSet
+     * @param podAnnotationsProvider    Function which provides annotation map for a specific Pod. A function is used
+     *                                  instead of providing a map because in some cases, each pod might have different
+     *                                  annotations. So they need to be generated per-pod.
+     * @param volumes                   Function which returns a list of volumes which should be used by the Pod and its containers
+     * @param affinity                  Affinity rules for the pods
+     * @param initContainers            List of init containers which should be used in the pods
+     * @param containers                List of containers which should be used in the pods
+     * @param imagePullSecrets          List of image pull secrets with container registry credentials
+     * @param isOpenShift               Flag to specify whether we are on OpenShift or not
      *
-     * @return                  Generated StrimziPodSet with all pods
+     * @return                          Generated StrimziPodSet with all pods
      */
     protected StrimziPodSet createPodSet(
             int replicas,
             Map<String, String> setAnnotations,
-            Map<String, String> podAnnotations,
+            Function<Integer, Map<String, String>> podAnnotationsProvider,
             Function<String, List<Volume>> volumes,
             Affinity affinity,
             List<Container> initContainers,
@@ -1165,7 +1185,7 @@ public abstract class AbstractModel {
             Pod pod = createStatefulPod(
                     name,
                     podName,
-                    podAnnotations,
+                    podAnnotationsProvider.apply(i),
                     volumes.apply(podName),
                     affinity,
                     initContainers,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -550,7 +550,7 @@ public class ZookeeperCluster extends AbstractModel {
         return createPodSet(
             replicas,
             Collections.singletonMap(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage)),
-            podAnnotations,
+            (brokerId) -> podAnnotations,
             podName -> getPodSetVolumes(podName, isOpenShift),
             getMergedAffinity(),
             getInitContainers(imagePullPolicy),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -127,7 +127,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
         if (useStrimziPodSets) {
             CrdOperator<KubernetesClient, StrimziPodSet, StrimziPodSetList> mockPodSetOps = supplier.strimziPodSetOperator;
             when(mockPodSetOps.getAsync(any(), eq(zkCluster.getName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, null)));
-            when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, null)));
+            when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null)));
 
             StatefulSetOperator mockStsOps = supplier.stsOperations;
             when(mockStsOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(null));
@@ -224,7 +224,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
                 return Future.succeededFuture(zkPodSet);
             });
             when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenAnswer(i -> {
-                StrimziPodSet kafkaPodSet = kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, null);
+                StrimziPodSet kafkaPodSet = kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
                 kafkaPodSet.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true");
                 return Future.succeededFuture(kafkaPodSet);
             });
@@ -334,7 +334,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
         if (useStrimziPodSets) {
             CrdOperator<KubernetesClient, StrimziPodSet, StrimziPodSetList> mockPodSetOps = supplier.strimziPodSetOperator;
             when(mockPodSetOps.getAsync(any(), eq(zkCluster.getName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, null)));
-            when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, null)));
+            when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null)));
 
             StatefulSetOperator mockStsOps = supplier.stsOperations;
             when(mockStsOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(null));
@@ -452,7 +452,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
             when(mockPodSetOps.getAsync(any(), eq(zkCluster.getName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, null)));
             when(mockPodSetOps.deleteAsync(any(), any(), eq(zkCluster.getName()), anyBoolean())).thenReturn(Future.succeededFuture());
             when(mockPodSetOps.reconcile(any(), any(), eq(zkCluster.getName()), any())).thenReturn(Future.succeededFuture());
-            when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, null)));
+            when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null)));
             when(mockPodSetOps.deleteAsync(any(), any(), eq(kafkaCluster.getName()), anyBoolean())).thenReturn(Future.succeededFuture());
             when(mockPodSetOps.reconcile(any(), any(), eq(kafkaCluster.getName()), any())).thenReturn(Future.succeededFuture());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -123,7 +123,6 @@ import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -654,16 +653,16 @@ public class KafkaAssemblyOperatorTest {
         ArgumentCaptor<String> logNameCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.reconcile(any(), anyString(), logNameCaptor.capture(), logCaptor.capture())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
 
-        ConfigMap metricsCm = kafkaCluster.generateAncillaryConfigMap(new MetricsAndLogging(metricsCM, null), emptySet(), emptySet(), false);
+        ConfigMap metricsCm = kafkaCluster.generateSharedConfigurationConfigMap(new MetricsAndLogging(metricsCM, null), Map.of(), Map.of(), false);
         when(mockCmOps.getAsync(kafkaNamespace, KafkaCluster.metricAndLogConfigsName(kafkaName))).thenReturn(Future.succeededFuture(metricsCm));
         when(mockCmOps.getAsync(kafkaNamespace, metricsCMName)).thenReturn(Future.succeededFuture(metricsCM));
         when(mockCmOps.getAsync(kafkaNamespace, differentMetricsCMName)).thenReturn(Future.succeededFuture(metricsCM));
-
         when(mockCmOps.getAsync(anyString(), eq(JmxTrans.jmxTransConfigName(kafkaName)))).thenReturn(
             Future.succeededFuture(new ConfigMapBuilder()
                     .withNewMetadata().withResourceVersion("123").endMetadata()
                     .build())
         );
+        when(mockCmOps.listAsync(kafkaNamespace, kafkaCluster.getSelectorLabels())).thenReturn(Future.succeededFuture(List.of()));
 
         ArgumentCaptor<Route> routeCaptor = ArgumentCaptor.forClass(Route.class);
         ArgumentCaptor<String> routeNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -975,7 +974,7 @@ public class KafkaAssemblyOperatorTest {
                 .endMetadata()
                 .withData(singletonMap("metrics-config.yml", ""))
                 .build();
-        ConfigMap metricsAndLoggingCm = originalKafkaCluster.generateAncillaryConfigMap(new MetricsAndLogging(metricsCm, null), emptySet(), emptySet(), false);
+        ConfigMap metricsAndLoggingCm = originalKafkaCluster.generateSharedConfigurationConfigMap(new MetricsAndLogging(metricsCm, null), Map.of(), Map.of(), false);
         when(mockCmOps.get(clusterNamespace, KafkaCluster.metricAndLogConfigsName(clusterName))).thenReturn(metricsAndLoggingCm);
         when(mockCmOps.getAsync(clusterNamespace, KafkaCluster.metricAndLogConfigsName(clusterName))).thenReturn(Future.succeededFuture(metricsAndLoggingCm));
 
@@ -992,7 +991,7 @@ public class KafkaAssemblyOperatorTest {
                 .withNamespace(clusterNamespace)
                 .endMetadata()
                 .withData(singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG,
-                        updatedKafkaCluster.parseLogging(LOG_KAFKA_CONFIG, null)))
+                        updatedKafkaCluster.loggingConfiguration(LOG_KAFKA_CONFIG, null)))
                 .build();
         when(mockCmOps.get(clusterNamespace, KafkaCluster.metricAndLogConfigsName(clusterName))).thenReturn(logCm);
 
@@ -1001,11 +1000,12 @@ public class KafkaAssemblyOperatorTest {
                 .withNamespace(clusterNamespace)
                 .endMetadata()
                 .withData(singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG,
-                        updatedZookeeperCluster.parseLogging(LOG_ZOOKEEPER_CONFIG, null)))
+                        updatedZookeeperCluster.loggingConfiguration(LOG_ZOOKEEPER_CONFIG, null)))
                 .build();
         when(mockCmOps.get(clusterNamespace, ZookeeperCluster.zookeeperMetricAndLogConfigsName(clusterName))).thenReturn(zklogsCm);
         when(mockCmOps.getAsync(clusterNamespace, metricsCMName)).thenReturn(Future.succeededFuture(metricsCM));
         when(mockCmOps.getAsync(clusterNamespace, differentMetricsCMName)).thenReturn(Future.succeededFuture(metricsCM));
+        when(mockCmOps.listAsync(clusterNamespace, updatedKafkaCluster.getSelectorLabels())).thenReturn(Future.succeededFuture(List.of()));
 
         // Mock pod ops
         when(mockPodOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.common.BackOff;
+import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.PodOperator;
@@ -583,9 +584,23 @@ public class KafkaRollerTest {
                                    Function<Integer, ForceableProblem> getConfigsException,
                                    Function<Integer, Future<Boolean>> canRollFn,
                                   int... controllers) {
-            super(new Reconciliation("test", "Kafka", stsNamespace(), clusterName()), KafkaRollerTest.vertx, podOps, 500, 1000,
-                () -> new BackOff(10L, 2, 4),
-                    sts.getSpec().getReplicas(), clusterCaCertSecret, coKeySecret, "", "", KafkaVersionTestUtils.getLatestVersion(), true);
+            super(
+                    new Reconciliation("test", "Kafka", stsNamespace(), clusterName()),
+                    KafkaRollerTest.vertx,
+                    podOps,
+                    500,
+                    1000,
+                    () -> new BackOff(10L, 2, 4),
+                    sts.getSpec().getReplicas(),
+                    clusterCaCertSecret,
+                    coKeySecret,
+                    new DefaultAdminClientProvider(),
+                    brokerId -> "",
+                    "",
+                    KafkaVersionTestUtils.getLatestVersion(),
+                    true
+            );
+
             this.controllers = controllers;
             this.controllerCall = 0;
             Objects.requireNonNull(acOpenException);

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -39,7 +39,11 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 - Service account used by the Kafka pods.
 - PodDisruptionBudget configured for the Kafka brokers.
 
-`_cluster-name_-kafka-_idx_`:: Pods created by the Kafka StatefulSet or StrimziPodSet.
+`_cluster-name_-kafka-_idx_`:: Name given to the following Kafka resources:
++
+- Pods created by the Kafka StatefulSet or StrimziPodSet.
+- ConfigMap with Kafka broker configuration (if the xref:ref-operator-use-strimzi-pod-sets-feature-gate-{context}[UseStrimziPodSets feature gate] is enabled).
+
 `_cluster-name_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
 `_cluster-name_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients connecting from within the Kubernetes cluster.
 `_cluster-name_-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled. The old service name will be used for backwards compatibility when the listener name is `external` and port is `9094`.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.ContainerEnvVarBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.crd.StrimziPodSetResource;
@@ -629,5 +630,28 @@ public class StUtils {
 
     public static Map<String, String> getStrimziPodSetOrStatefulSetMatchLabels(String resourceName, boolean isSpsEnabled) {
         return getStrimziPodSetOrStatefulSetMatchLabels(kubeClient().getNamespace(), resourceName, isSpsEnabled);
+    }
+
+    /**
+     * Returns a list of names of ConfigMaps with broker configuration files. For StatefulSets, the list has only one
+     * item with the shared ConfigMap. For StrimziPodSets, it should be a ConfigMap per broker.
+     *
+     * @param kafkaClusterName  Name of the Kafka cluster
+     * @param replicas          Number of Kafka replicas
+     *
+     * @return                  List with ConfigMaps containing the configuration
+     */
+    public static List<String> getKafkaConfigurationConfigMaps(String kafkaClusterName, int replicas)    {
+        List<String> cmNames = new ArrayList<>(replicas);
+
+        if (Environment.isStrimziPodSetEnabled())   {
+            for (int i = 0; i < replicas; i++)  {
+                cmNames.add(KafkaResources.kafkaPodName(kafkaClusterName, i));
+            }
+        } else {
+            cmNames.add(KafkaResources.kafkaMetricsAndLogConfigMapName(kafkaClusterName));
+        }
+
+        return cmNames;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -294,10 +294,12 @@ class KafkaST extends AbstractST {
         checkKafkaConfiguration(namespaceName, kafkaStatefulSetName(clusterName), kafkaConfig, clusterName);
         checkSpecificVariablesInContainer(namespaceName, kafkaStatefulSetName(clusterName), "kafka", envVarGeneral);
 
-        String kafkaConfiguration = kubeClient().getConfigMap(namespaceName, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName)).getData().get("server.config");
-        assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=1"));
-        assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=1"));
-        assertThat(kafkaConfiguration, containsString("default.replication.factor=1"));
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 2)) {
+            String kafkaConfiguration = kubeClient().getConfigMap(namespaceName, cmName).getData().get("server.config");
+            assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=1"));
+            assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=1"));
+            assertThat(kafkaConfiguration, containsString("default.replication.factor=1"));
+        }
 
         String kafkaConfigurationFromPod = cmdKubeClient(namespaceName).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "cat", "/tmp/strimzi.properties").out();
         assertThat(kafkaConfigurationFromPod, containsString("offsets.topic.replication.factor=1"));
@@ -388,10 +390,12 @@ class KafkaST extends AbstractST {
         checkKafkaConfiguration(namespaceName, kafkaStatefulSetName(clusterName), updatedKafkaConfig, clusterName);
         checkSpecificVariablesInContainer(namespaceName, kafkaStatefulSetName(clusterName), "kafka", envVarUpdated);
 
-        kafkaConfiguration = kubeClient(namespaceName).getConfigMap(namespaceName, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName)).getData().get("server.config");
-        assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=2"));
-        assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=2"));
-        assertThat(kafkaConfiguration, containsString("default.replication.factor=2"));
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 2)) {
+            String kafkaConfiguration = kubeClient(namespaceName).getConfigMap(namespaceName, cmName).getData().get("server.config");
+            assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=2"));
+            assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=2"));
+            assertThat(kafkaConfiguration, containsString("default.replication.factor=2"));
+        }
 
         kafkaConfigurationFromPod = cmdKubeClient(namespaceName).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "cat", "/tmp/strimzi.properties").out();
         assertThat(kafkaConfigurationFromPod, containsString("offsets.topic.replication.factor=2"));
@@ -1040,6 +1044,7 @@ class KafkaST extends AbstractST {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+        final int kafkaReplicas = 3;
         final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         Map<String, String> labels = new HashMap<>();
@@ -1049,7 +1054,7 @@ class KafkaST extends AbstractST {
         labels.put(labelKeys[0], labelValues[0]);
         labels.put(labelKeys[1], labelValues[1]);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 1)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, kafkaReplicas, 1)
             .editMetadata()
                 .withLabels(labels)
             .endMetadata()
@@ -1110,13 +1115,15 @@ class KafkaST extends AbstractST {
 
         verifyPresentLabels(labels, service.getMetadata().getLabels());
 
-        LOGGER.info("Waiting for kafka config map labels changed {}", labels);
-        ConfigMapUtils.waitForConfigMapLabelsChange(namespaceName, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName), labels);
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, kafkaReplicas)) {
+            LOGGER.info("Waiting for Kafka ConfigMap {} in namespace {} to have new labels: {}", cmName, namespaceName, labels);
+            ConfigMapUtils.waitForConfigMapLabelsChange(namespaceName, cmName, labels);
 
-        LOGGER.info("Verifying kafka labels via config maps");
-        ConfigMap configMap = kubeClient(namespaceName).getConfigMap(namespaceName, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName));
+            LOGGER.info("Verifying Kafka labels on ConfigMap {} in namespace {}", cmName, namespaceName);
+            ConfigMap configMap = kubeClient(namespaceName).getConfigMap(namespaceName, cmName);
 
-        verifyPresentLabels(labels, configMap.getMetadata().getLabels());
+            verifyPresentLabels(labels, configMap.getMetadata().getLabels());
+        }
 
         LOGGER.info("Waiting for kafka stateful set labels changed {}", labels);
         StUtils.waitForStatefulSetOrStrimziPodSetLabelsChange(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName), labels);
@@ -1154,12 +1161,15 @@ class KafkaST extends AbstractST {
 
         verifyNullLabels(labelKeys, service);
 
-        LOGGER.info("Verifying kafka labels via config maps");
-        ConfigMapUtils.waitForConfigMapLabelsDeletion(namespaceName, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName), labelKeys[0], labelKeys[1], labelKeys[2]);
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, kafkaReplicas)) {
+            LOGGER.info("Waiting for Kafka ConfigMap {} in namespace {} to have labels removed: {}", cmName, namespaceName, labelKeys);
+            ConfigMapUtils.waitForConfigMapLabelsDeletion(namespaceName, cmName, labelKeys[0], labelKeys[1], labelKeys[2]);
 
-        configMap = kubeClient(namespaceName).getConfigMap(namespaceName, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName));
+            LOGGER.info("Verifying Kafka labels on ConfigMap {} in namespace {}", cmName, namespaceName);
+            ConfigMap configMap = kubeClient(namespaceName).getConfigMap(namespaceName, cmName);
 
-        verifyNullLabels(labelKeys, configMap);
+            verifyNullLabels(labelKeys, configMap);
+        }
 
         LOGGER.info("Waiting for kafka stateful set labels changed {}", labels);
         StUtils.waitForStatefulSetOrStrimziPodSetLabelsDeletion(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName), labelKeys[0], labelKeys[1], labelKeys[2]);
@@ -1652,14 +1662,16 @@ class KafkaST extends AbstractST {
         LOGGER.info("Checking kafka configuration");
         List<Pod> pods = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, podNamePrefix);
 
-        Properties properties = configMap2Properties(kubeClient(namespaceName).getConfigMap(namespaceName, clusterName + "-kafka-config"));
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, pods.size())) {
+            Properties properties = configMap2Properties(kubeClient(namespaceName).getConfigMap(namespaceName, cmName));
 
-        for (Map.Entry<String, Object> property : config.entrySet()) {
-            String key = property.getKey();
-            Object val = property.getValue();
+            for (Map.Entry<String, Object> property : config.entrySet()) {
+                String key = property.getKey();
+                Object val = property.getValue();
 
-            assertThat(properties.keySet().contains(key), is(true));
-            assertThat(properties.getProperty(key), is(val));
+                assertThat(properties.keySet().contains(key), is(true));
+                assertThat(properties.getProperty(key), is(val));
+            }
         }
 
         for (Pod pod: pods) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -215,7 +215,10 @@ class LogSettingST extends AbstractST {
         resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(namespace, LOG_SETTING_CLUSTER_NAME, userName).build());
 
         LOGGER.info("Checking if Kafka, Zookeeper, TO and UO of cluster:{} has log level set properly", LOG_SETTING_CLUSTER_NAME);
-        assertThat("Kafka's log level is set properly", checkLoggersLevel(namespace, KAFKA_LOGGERS, kafkaMap), is(true));
+        StUtils.getKafkaConfigurationConfigMaps(LOG_SETTING_CLUSTER_NAME, 3)
+                .forEach(cmName -> {
+                    assertThat("Kafka's log level is set properly", checkLoggersLevel(namespace, KAFKA_LOGGERS, cmName), is(true));
+                });
         assertThat("Zookeeper's log level is set properly", checkLoggersLevel(namespace, ZOOKEEPER_LOGGERS, zookeeperMap), is(true));
         assertThat("Topic operator's log level is set properly", checkLoggersLevel(namespace, OPERATORS_LOGGERS, topicOperatorMap), is(true));
         assertThat("User operator's log level is set properly", checkLoggersLevel(namespace, OPERATORS_LOGGERS, userOperatorMap), is(true));

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.StrimziPodSetTest;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
@@ -167,7 +168,14 @@ class RecoveryIsolatedST extends AbstractST {
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaMetricsConfig with cluster {}", sharedClusterName);
 
-        String kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(sharedClusterName);
+        String kafkaMetricsConfigName;
+        if (Environment.isStrimziPodSetEnabled())   {
+            // For PodSets, we delete one of the per-broker config maps
+            kafkaMetricsConfigName = KafkaResources.kafkaPodName(sharedClusterName, 1);
+        } else {
+            kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(sharedClusterName);
+        }
+
         String kafkaMetricsConfigUid = kubeClient().getConfigMapUid(kafkaMetricsConfigName);
 
         kubeClient().deleteConfigMap(kafkaMetricsConfigName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerIsolatedST.java
@@ -28,6 +28,7 @@ import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.StatefulSetTest;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -74,6 +75,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class KafkaRollerIsolatedST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaRollerIsolatedST.class);
 
+    // When using StrimziPodSets, Kafka pods are not all rolled when scaling up or down.
+    // This test needs to be updated to support StrimziPodSets as well
+    //             => https://github.com/strimzi/strimzi-kafka-operator/issues/6493
+    @StatefulSetTest
     @ParallelNamespaceTest
     void testKafkaRollsWhenTopicIsUnderReplicated(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, we have a single configuration generated for all Kafka brokers. It is the same for all of them with the exception of some replaceable values which are replaced using `envsubst` only in the running broker container. This does not allow us to configure each broker separately to for example give it a separate role (e.g. Kraft controller versus broker etc.). It also means that all brokers need to be rolled  when scaling up / down because some parts of the config change. It will be also limiting once we possibly have different node pools with different Kafka configurations.

This PR changes how the Kafka brokers are configured when using StrimziPodSets. It uses a new per-broker configuration file from its own ConfigMap. It also reduces the way `envsubst` are used in the containers. It now passes only secrets (e.g. OAuth client secrets) and things not known up-front (Rack-id, Node port hostnames) as placeholders. All other information is already filled in in the config file including broker ID or advertised hostnames (with the exception of node port hostnames) and ports.

Long term, this should allow us to have different configuration per-broker which is important for example for Kraft. But already this PR provides some improvements such as reduced number of rolled pods when scaling Kafka up/down or listener address changes for some brokers. (In these situations for StatefulSet we always have to roll all brokers)

When StatefulSets are used, everything works as before. Unlike StrimziPodSets, StatefulSets use the same ConfigMap for all brokers. If we would generate into it different records with per-broker configuration, we would face risks that for bigger clusters, we run out of the available space in the ConfigMap. So I decided to not attempt anything like that. With StrimziPodSets, each broker has its own ConfigMap so this risk is not an issue.

Changes to some of the STs about rolling update during scale-up/down are too complex to change in this PR. They are disabled for now for StrimziPodSets and will be fixed as part of #6493.

This resolves #1211 and resolves #4913.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging