### PR TITLE
Update Kaniko to 1.8.0 and Maven Builder to 1.11

### DIFF
--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.7.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.8.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.10
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
 
 USER root
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kaniko executor to new version 1.8.0 and the Maven builder to 1.11. The new version should have support for additional platforms if/when needed.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally