### PR TITLE
Use annotations to suppress Checkstyle warnings instead of the `suppressions.xml` file

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -8,57 +8,20 @@
 
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
 
-    <!-- cluster-operator -->
-    <suppress checks="ParameterNumber"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]ResourceUtils.java"/>
+    <!-- Use this file to suppress warnings only when absolutely needed:
+               * To suppress a bunch of class (for example generated code)
+               * To suppress warning we do not want for the whole project
+               * To suppress file-level warnings
+         In all other cases, you should use the annotations on the methods or classes affected by it. -->
 
-    <suppress checks="ParameterNumber"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]resource[/\\]ResourceOperatorSupplier.java"/>
-
-    <suppress checks="MethodLength|NPathComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]assembly[/\\]KafkaAssemblyOperatorTest.java"/>
-
-    <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]AbstractModel.java"/>
-
-    <suppress checks="ClassFanOutComplexity|JavaNCSS"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]assembly[/\\]KafkaAssemblyOperatorTest.java"/>
-
-    <suppress checks="ClassFanOutComplexity|NPathComplexity|CyclomaticComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]KafkaCluster.java"/>
-
-    <suppress checks="NPathComplexity|CyclomaticComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]operator[/\\]assembly[/\\]KafkaAssemblyOperator.java"/>
-
-    <suppress checks="NPathComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]ZookeeperCluster.java"/>
-
-    <suppress checks="NPathComplexity|CyclomaticComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]KafkaConnectCluster.java"/>
-
-    <suppress checks="NPathComplexity|CyclomaticComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]model[/\\]KafkaBridgeCluster.java"/>
-
-    <!-- topic operator -->
-    <suppress checks="NPathComplexity|CyclomaticComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]topic[/\\]TopicOperator.java"/>
-    
-    <suppress checks="NPathComplexity|CyclomaticComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]topic[/\\]TopicName.java"/>
-
-    <suppress checks="ClassFanOutComplexity"
-              files="io[/\\]strimzi[/\\]operator[/\\]topic[/\\]MockAdminClient.java"/>
-
-    <suppress checks="ClassDataAbstractionCoupling"
-              files="io[/\\]strimzi[/\\]operator[/\\]cluster[/\\]Main.java"/>
-
+    <!-- Generated classes which we do not edit -->
     <suppress checks=".*"
               files="io[/\\]strimzi[/\\]api[/\\]kafka[/\\]model[/\\].*(Builder|Fluent|FluentImpl)\.java"/>
-
-    <suppress checks="UnnecessaryParentheses"
-              files="io[/\\]strimzi[/\\].*"/>
-
     <suppress checks=".*"
               files="io[/\\]strimzi[/\\]systemtest[/\\]kafkaclients[/\\]internalClients[/\\].*(Builder|Fluent|FluentImpl)\.java"/>
+
+    <!-- Unnecessary parentheses sometimes make the code more readable -->
+    <suppress checks="UnnecessaryParentheses"
+              files="io[/\\]strimzi[/\\].*"/>
 
 </suppressions>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -112,6 +112,7 @@ import static java.util.Collections.emptyMap;
 /**
  * AbstractModel an abstract base model for all components of the {@code Kafka} custom resource
  */
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public abstract class AbstractModel {
 
     public static final String STRIMZI_CLUSTER_OPERATOR_NAME = "strimzi-cluster-operator";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -155,6 +155,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         this.logAndMetricsConfigMountPath = "/opt/strimzi/custom-config/";
     }
 
+    @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static KafkaBridgeCluster fromCrd(Reconciliation reconciliation, KafkaBridge kafkaBridge, KafkaVersion.Lookup versions) {
 
         KafkaBridgeCluster kafkaBridgeCluster = new KafkaBridgeCluster(reconciliation, kafkaBridge);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -98,7 +98,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static io.strimzi.operator.cluster.model.CruiseControl.CRUISE_CONTROL_METRIC_REPORTER;
 
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class KafkaCluster extends AbstractModel {
     protected static final String APPLICATION_NAME = "kafka";
 
@@ -362,7 +362,7 @@ public class KafkaCluster extends AbstractModel {
         return fromCrd(reconciliation, kafkaAssembly, versions, null, 0);
     }
 
-    @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:JavaNCSS"})
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "checkstyle:MethodLength", "checkstyle:JavaNCSS"})
     public static KafkaCluster fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly, KafkaVersion.Lookup versions, Storage oldStorage, int oldReplicas) {
         KafkaSpec kafkaSpec = kafkaAssembly.getSpec();
         KafkaClusterSpec kafkaClusterSpec = kafkaSpec.getKafka();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -195,6 +195,7 @@ public class KafkaConnectCluster extends AbstractModel {
      * from the instantiation of the (subclass of) KafkaConnectCluster,
      * thus permitting reuse of the setter-calling code for subclasses.
      */
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     protected static <C extends KafkaConnectCluster> C fromSpec(Reconciliation reconciliation,
                                                                 KafkaConnectSpec spec,
                                                                 KafkaVersion.Lookup versions,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -237,7 +237,7 @@ public class ZookeeperCluster extends AbstractModel {
         return fromCrd(reconciliation, kafkaAssembly, versions, null, 0);
     }
 
-    @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:CyclomaticComplexity"})
+    @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     public static ZookeeperCluster fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly, KafkaVersion.Lookup versions, Storage oldStorage, int oldReplicas) {
         ZookeeperCluster zk = new ZookeeperCluster(reconciliation, kafkaAssembly);
         zk.setOwnerReference(kafkaAssembly);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -598,6 +598,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * Within both the secrets the current certificate is stored under the key {@code ca.crt}
          * and the current key is stored under the key {@code ca.key}.
          */
+        @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
         Future<ReconciliationState> reconcileCas(Supplier<Date> dateSupplier) {
             Labels selectorLabels = Labels.EMPTY.withStrimziKind(reconciliation.kind()).withStrimziCluster(reconciliation.name());
             Labels caLabels = Labels.generateDefaultLabels(kafkaAssembly, Labels.APPLICATION_NAME, AbstractModel.STRIMZI_CLUSTER_OPERATOR_NAME);
@@ -999,6 +1000,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          *
          * @return
          */
+        @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
         Future<ReconciliationState> prepareVersionChange() {
             if (versionChange.isNoop()) {
                 LOGGER.debugCr(reconciliation, "{}: No Kafka version change", reconciliation);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -139,6 +139,7 @@ public class ResourceOperatorSupplier {
                 zlf);
     }
 
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
                                     RouteOperator routeOperations,
                                     StatefulSetOperator stsOperations,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -349,6 +349,7 @@ public class ResourceUtils {
                 .build();
     }
 
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
     public static Kafka createKafka(String namespace, String name, int replicas,
                                     String image, int healthDelay, int healthTimeout,
                                     MetricsConfig metricsConfig,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -141,6 +141,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class KafkaAssemblyOperatorTest {
 
     public static final Map<String, Object> METRICS_CONFIG = new HashMap<>();
@@ -414,6 +415,7 @@ public class KafkaAssemblyOperatorTest {
         return pvcs;
     }
 
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "checkstyle:JavaNCSS", "checkstyle:MethodLength"})
     private void createCluster(VertxTestContext context, Kafka kafka, List<Secret> secrets) {
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
@@ -880,6 +882,7 @@ public class KafkaAssemblyOperatorTest {
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 
+    @SuppressWarnings({"checkstyle:NPathComplexity", "checkstyle:JavaNCSS", "checkstyle:MethodLength"})
     private void updateCluster(VertxTestContext context, Kafka originalAssembly, Kafka updatedAssembly) {
         KafkaCluster originalKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, originalAssembly, VERSIONS);
         KafkaCluster updatedKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, updatedAssembly, VERSIONS);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
@@ -59,6 +59,7 @@ class TopicName {
      * constructed (with invalid characters removed or changed) and a disambiguating hash is appended to that
      * prefix and the concatenation of the prefix and hash is returned.
      */
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     public ResourceName asKubeName() {
         ResourceName mname;
         if (ResourceName.isValidResourceName(this.name)) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -451,6 +451,7 @@ class TopicOperator {
      * When the given {@code action} is complete it must complete its argument future,
      * which will complete the returned future
      */
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     public Future<Void> executeWithTopicLockHeld(LogContext logContext, TopicName key, Reconciliation action) {
         String lockName = key.toString();
         int timeoutMs = 30 * 1_000;


### PR DESCRIPTION
### Type of change

- Task

### Description

For a long time, we prefer to use annotations directly in the Java code to suppress any Checkstyle warnings. But from the past, we had a bunch of different suppressions also in the `suppressions.xml`. Some of these were outdated now, but many still valid.

This PR transfers all suppressions where it is possible to annotations and leaves there only those which are a general => exclusion for the generated files or the `UnnecessaryParentheses` rule which we don't follow in favour of more readable code. This does not solve the problems from the warnings of course, but it should hopefully:
* Make sure we do not have suppressions for files which do not exist anymore
* Make the suppressions more visible since they are in the code and not in some XML file nobody looks into
* Make people consider their code when new warning is raised (since many of the annotations are on method level instead of file or class level and do not suppress warnings from new code in the same file / class)