### PR TITLE
Drop Kaniko patch from Jenkins s390x scripts

### DIFF
--- a/.jenkins/Jenkinsfile-pr-s390x
+++ b/.jenkins/Jenkinsfile-pr-s390x
@@ -181,9 +181,8 @@ pipeline {
             }
             steps {
                 script {
-                    //The following 2 steps are temporary
+                    //The next step is temporary
                     lib.buildKeycloakAndOpa_s390x(env.WORKSPACE)
-                    lib.applys390xpatch(env.WORKSPACE)
                     lib.buildStrimziImages()
                     env.BUILD_DOCKER_IMAGE_STATUS = true
                     env.DOCKER_REGISTRY = sh(script: "kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'", returnStdout: true).trim() + ":80"

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -30,10 +30,6 @@ def buildKeycloakAndOpa_s390x(String workspace) {
     sh(script: "${workspace}/.jenkins/scripts/build_keycloak_opa-s390x.sh")
 }
 
-def applys390xpatch(String workspace) {
-    sh(script: "${workspace}/.jenkins/scripts/apply_s390x_patch.sh")
-}
-
 def buildStrimziImages() {
     sh(script: """
         eval \$(minikube docker-env)

--- a/.jenkins/scripts/apply_s390x_patch.sh
+++ b/.jenkins/scripts/apply_s390x_patch.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sed -i 's#v1.7.0#ff3ee40293cb943c4ffb70d808c4e8772189c7e1#g' docker-images/kaniko-executor/Makefile


### PR DESCRIPTION
Signed-off-by: Kun-Lu <kun.lu@ibm.com>

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

_Please describe your pull request_

Since PR #6494 has upgraded Kaniko to v1.8.0 which has s390x support, this PR is to drop Kaniko patch from Jenkins s390x scripts.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

