### PR TITLE
[DOC] Fix JSONPath for the listener bootstrap address in docs

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -230,9 +230,9 @@ You can retrieve this from the status of the `Kafka` resource.
 
 .Example command to retrieve the address and port for client connection
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
 
-NOTE: Listeners cannot be configured to use the ports set aside for interbroker communication (9091) and metrics (9404).
+NOTE: Listeners cannot be configured to use the ports set aside for interbroker communication (9090 and 9091) and metrics (9404).
 
 [id='property-listener-tls-{context}']
 === `tls`

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -230,7 +230,7 @@ You can retrieve this from the status of the `Kafka` resource.
 
 .Example command to retrieve the address and port for client connection
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
+kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
 
 NOTE: Listeners cannot be configured to use the ports set aside for interbroker communication (9090 and 9091) and metrics (9404).
 

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -139,7 +139,7 @@ NOTE: If you scale your Kafka cluster while using external listeners, it might t
 . Find the bootstrap address and port from the status of the `Kafka` resource.
 +
 [source,shell, subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}'
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}'
 +
 Use the bootstrap address in your Kafka client to connect to the Kafka cluster.
 

--- a/documentation/modules/managing/con-custom-resources-info.adoc
+++ b/documentation/modules/managing/con-custom-resources-info.adoc
@@ -94,32 +94,25 @@ when you are testing new Strimzi features.
 
 There are other values you can pass to the `-o` option.
 For example, by using `-o yaml` you get the output in YAML format.
-Usng `-o json` will return it as JSON.
+Using `-o json` will return it as JSON.
 
 You can see all the options in `kubectl get --help`.
 
 One of the most useful options is the {K8SJsonPath}, which allows you to pass JSONPath expressions to query the Kubernetes API.
 A JSONPath expression can extract or navigate specific parts of any resource.
 
-For example, you can use the JSONPath expression `{.status.listeners[?(@.type=="tls")].bootstrapServers}`
+For example, you can use the JSONPath expression `{.status.listeners[?(@.name=="tls")].bootstrapServers}`
 to get the bootstrap address from the status of the Kafka custom resource and use it in your Kafka clients.
 
-Here, the command finds the `bootstrapServers` value of the `tls` listeners.
+Here, the command finds the `bootstrapServers` value of the listener named `tls`:
 
 [source,shell]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.type=="tls")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="tls")].bootstrapServers}{"\n"}'
 
 my-cluster-kafka-bootstrap.myproject.svc:9093
 ----
 
-By changing the type condition to `@.type=="external"` or `@.type=="plain"` you can also get the address of the other Kafka listeners.
-
-[source,shell]
-----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
-
-192.168.1.247:9094
-----
+By changing the name condition you can also get the address of the other Kafka listeners.
 
 You can use `jsonpath` to extract any other property or group of properties from any custom resource.

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -53,7 +53,12 @@ The cluster CA certificate to verify the identity of the kafka brokers is also c
 . Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
++
+For example:
++
+[source,shell,subs=+quotes]
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
 
 . If TLS encryption is enabled, extract the public certificate of the broker certification authority.
 +

--- a/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-loadbalancers.adoc
@@ -53,7 +53,7 @@ The cluster CA certificate to verify the identity of the kafka brokers is also c
 . Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
+kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
 +
 For example:
 +

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -55,7 +55,12 @@ The cluster CA certificate to verify the identity of the kafka brokers is also c
 . Retrieve the bootstrap address you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
++
+For example:
++
+[source,shell,subs=+quotes]
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
 
 . If TLS encryption is enabled, extract the public certificate of the broker certification authority.
 +

--- a/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-nodeports.adoc
@@ -55,7 +55,7 @@ The cluster CA certificate to verify the identity of the kafka brokers is also c
 . Retrieve the bootstrap address you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
+kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
 +
 For example:
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -64,7 +64,12 @@ The cluster CA certificate to verify the identity of the kafka brokers is also c
 . Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.type=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
++
+For example:
++
+[source,shell,subs=+quotes]
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="listener1")].bootstrapServers}{"\n"}'
 
 . Extract the public certificate of the broker certification authority.
 +

--- a/documentation/modules/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/proc-accessing-kafka-using-routes.adoc
@@ -64,7 +64,7 @@ The cluster CA certificate to verify the identity of the kafka brokers is also c
 . Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _KAFKA-CLUSTER-NAME_ -o=jsonpath='{.status.listeners[?(@.name=="_LISTENER-NAME_")].bootstrapServers}{"\n"}'
+kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
 +
 For example:
 +


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The docs use JSON Path `kubectl` query to get the bootstrap address for Kafka listeners. But the JSON Path query seems to focus on the type. It also seems to use the `external` type in multiple places. That is not correct:
1) The type is not unique, so it might return multiple listener addresses (it is not uncommon to have for example two load balancer listeners - one for internal and one for external communication etc.)
2) There is no `external` type. The types are `internal`, `route`, `ingress`, `loadbalancer` or `nodeport`.

This PR updates the example commands to work based on the listener name instead. That uniquely identifies the listener, so it is better to get the right bootstrap address.