### PR TITLE
Use only one hash function everywhere

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
@@ -152,7 +152,7 @@ public class KafkaConnectDockerfile {
             artifactMap.entrySet().forEach(plugin -> {
                 plugin.getValue().forEach(mvn -> {
                     String repo = mvn.getRepository() == null ? MavenArtifact.DEFAULT_REPOSITORY : maybeAppendSlash(mvn.getRepository());
-                    String artifactHash = Util.sha1Prefix(mvn.getGroup() + "/" + mvn.getArtifact() + "/" + mvn.getVersion());
+                    String artifactHash = Util.hashStub(mvn.getGroup() + "/" + mvn.getArtifact() + "/" + mvn.getVersion());
                     String artifactDir = plugin.getKey() + "/" + artifactHash;
 
                     Cmd cmd = run("curl", "-L", "--create-dirs", "--output", "/tmp/" + artifactDir + "/pom.xml", assembleResourceUrl(repo, mvn, "pom"))
@@ -301,7 +301,7 @@ public class KafkaConnectDockerfile {
      */
     private void addJarArtifact(PrintWriter writer, String connectorPath, JarArtifact jar) {
         checkUrlIsPresent(jar);
-        String artifactHash = Util.sha1Prefix(jar.getUrl());
+        String artifactHash = Util.hashStub(jar.getUrl());
         String artifactDir = connectorPath + "/" + artifactHash;
         String artifactPath = artifactDir + "/" + artifactHash + ".jar";
         addUnmodifiedArtifact(writer, jar, artifactDir, artifactPath);
@@ -316,7 +316,7 @@ public class KafkaConnectDockerfile {
      */
     private void addOtherArtifact(PrintWriter writer, String connectorPath, OtherArtifact other) {
         checkUrlIsPresent(other);
-        String artifactHash = Util.sha1Prefix(other.getUrl());
+        String artifactHash = Util.hashStub(other.getUrl());
         String artifactDir = connectorPath + "/" + artifactHash;
         String fileName = other.getFileName() != null ? other.getFileName() : artifactHash;
         String artifactPath = artifactDir + "/" + fileName;
@@ -355,7 +355,7 @@ public class KafkaConnectDockerfile {
      */
     private void addTgzArtifact(PrintWriter writer, String connectorPath, TgzArtifact tgz) {
         checkUrlIsPresent(tgz);
-        String artifactHash = Util.sha1Prefix(tgz.getUrl());
+        String artifactHash = Util.hashStub(tgz.getUrl());
         String artifactDir = connectorPath + "/" + artifactHash;
         String archivePath = connectorPath + "/" + artifactHash + ".tgz";
 
@@ -384,7 +384,7 @@ public class KafkaConnectDockerfile {
      */
     private void addZipArtifact(PrintWriter writer, String connectorPath, ZipArtifact zip) {
         checkUrlIsPresent(zip);
-        String artifactHash = Util.sha1Prefix(zip.getUrl());
+        String artifactHash = Util.hashStub(zip.getUrl());
         String artifactDir = connectorPath + "/" + artifactHash;
         String archivePath = connectorPath + "/" + artifactHash + ".zip";
 
@@ -416,7 +416,7 @@ public class KafkaConnectDockerfile {
      */
     private void addMavenArtifact(PrintWriter writer, String connectorName, MavenArtifact mvn) {
         checkGavIsPresent(mvn);
-        String artifactHash = Util.sha1Prefix(mvn.getGroup() + "/" + mvn.getArtifact() + "/" + mvn.getVersion());
+        String artifactHash = Util.hashStub(mvn.getGroup() + "/" + mvn.getArtifact() + "/" + mvn.getVersion());
 
         Cmd run = run("/tmp/artifacts/" + connectorName + "/" + artifactHash, BASE_PLUGIN_PATH + connectorName + "/" + artifactHash);
         writer.append("COPY --from=downloadArtifacts ").println(run);
@@ -474,7 +474,7 @@ public class KafkaConnectDockerfile {
      * @return  Dockerfile hash stub
      */
     public String hashStub()    {
-        return Util.sha1Prefix(dockerfile);
+        return Util.hashStub(dockerfile);
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -7,10 +7,6 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +33,7 @@ import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.operator.common.Util;
 
 /**
  * Shared methods for working with Volume
@@ -461,7 +458,7 @@ public class VolumeUtils {
      */
     /*test*/ static String makeValidVolumeName(String originalName) {
         // SHA-1 hash is used for uniqueness
-        String digestStub = getVolumeNameHashStub(originalName);
+        String digestStub = Util.hashStub(originalName);
 
         // Special characters need to be replaced
         String newName = originalName
@@ -483,23 +480,6 @@ public class VolumeUtils {
 
         // Returned new fixed name with the hash at the end
         return newName.substring(0, i) + "-" + digestStub;
-    }
-
-    /**
-     * Gets the first 8 characters from a SHA-1 hash of a volume name
-     *
-     * @param name  Volume name
-     * @return      First 8 characters of the SHA-1 hash
-     */
-    private static String getVolumeNameHashStub(String name)   {
-        try {
-            MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
-            byte[] digest = sha1.digest(name.getBytes(StandardCharsets.US_ASCII));
-
-            return String.format("%040x", new BigInteger(1, digest)).substring(0, 8);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Failed to get volume name SHA-1 hash", e);
-        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -110,7 +110,7 @@ public class ConnectBuildOperator {
         }
 
         KafkaConnectDockerfile dockerfile = connectBuild.generateDockerfile();
-        String newBuildRevision = dockerfile.hashStub() + Util.sha1Prefix(connectBuild.getBuild().getOutput().getImage());
+        String newBuildRevision = dockerfile.hashStub() + Util.hashStub(connectBuild.getBuild().getOutput().getImage());
         ConfigMap dockerFileConfigMap = connectBuild.generateDockerfileConfigMap(dockerfile);
 
         if (newBuildRevision.equals(currentBuildRevision)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -126,7 +126,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(logAndMetricsConfigMap -> {
                     String logging = logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG);
                     annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH,
-                            Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                            Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     desiredLogging.set(logging);
                     return configMapOperations.reconcile(reconciliation, namespace, connect.getAncillaryConfigMapName(), logAndMetricsConfigMap);
                 })

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -154,7 +154,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(logAndMetricsConfigMap -> {
                     String logging = logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG);
                     annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH,
-                        Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                        Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     desiredLogging.set(logging);
                     return configMapOperations.reconcile(reconciliation, namespace, mirrorMaker2Cluster.getAncillaryConfigMapName(), logAndMetricsConfigMap);
                 })

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/PodRevision.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/PodRevision.java
@@ -34,7 +34,7 @@ public class PodRevision {
      */
     public static String getRevision(Reconciliation reconciliation, Pod pod) {
         try {
-            return Util.sha1Prefix(PodSetUtils.podToString(pod));
+            return Util.hashStub(PodSetUtils.podToString(pod));
         } catch (JsonProcessingException e) {
             LOGGER.warnCr(reconciliation, "Failed to get pod revision", e);
             throw new RuntimeException("Failed to get pod revision", e);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertTest.java
@@ -208,7 +208,7 @@ public class KafkaAssemblyOperatorCustomCertTest {
     }
 
     public String getTlsThumbprint()    {
-        return "{external=COWn2zWLZMhoewfrmSTfUeKlQPifBKekyXzjm2iGTuc=, tls=vjPd/D/f0/X3yqitf65yoUZbyeWnQU4cPDJGbr7GA7I=}";
+        return "{external=fc4c92a1, tls=d33fd102}";
     }
 
     public Secret getExternalSecret() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -189,7 +189,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 assertThat(dc.getMetadata().getName(), is(connect.getName()));
                 Map<String, String> annotations = new HashMap<>();
                 annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH,
-                                                         Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
+                                                         Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
                 annotations.put(Annotations.ANNO_STRIMZI_AUTH_HASH, "0");
                 assertThat(dc, is(connect.generateDeployment(annotations, true, null, null)));
 
@@ -456,7 +456,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
                 String loggingConfiguration = loggingCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG);
                 String dynamicallyUnmodifiableEntries = Util.getLoggingDynamicallyUnmodifiableEntries(loggingConfiguration);
-                String hashedLoggingConf = Util.stringHash(dynamicallyUnmodifiableEntries);
+                String hashedLoggingConf = Util.hashStub(dynamicallyUnmodifiableEntries);
                 Map<String, String> annotations = new HashMap<>();
                 annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH,
                                                          hashedLoggingConf);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -82,7 +82,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
     private static final String OUTPUT_IMAGE = "my-connect-build:latest";
-    private static final String OUTPUT_IMAGE_HASH_STUB = Util.sha1Prefix(OUTPUT_IMAGE);
+    private static final String OUTPUT_IMAGE_HASH_STUB = Util.hashStub(OUTPUT_IMAGE);
 
     protected static Vertx vertx;
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
@@ -608,7 +608,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
             Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.sha1Prefix(oldBuild.getBuild().getOutput().getImage()));
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.hashStub(oldBuild.getBuild().getOutput().getImage()));
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build-2@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
@@ -673,7 +673,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                     Deployment dep = capturedDeps.get(0);
                     assertThat(dep.getMetadata().getName(), is(connect.getName()));
                     assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build-2@sha256:blablabla"));
-                    assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                    assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.hashStub(build.getBuild().getOutput().getImage())));
 
                     // Verify ConfigMap
                     List<ConfigMap> capturedCms = dockerfileCaptor.getAllValues();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -82,7 +82,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
     private static final String OUTPUT_IMAGE = "my-connect-build:latest";
-    private static final String OUTPUT_IMAGE_HASH_STUB = Util.sha1Prefix(OUTPUT_IMAGE);
+    private static final String OUTPUT_IMAGE_HASH_STUB = Util.hashStub(OUTPUT_IMAGE);
 
     protected static Vertx vertx;
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
@@ -605,7 +605,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
             Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.sha1Prefix(oldBuild.getBuild().getOutput().getImage()));
+            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.hashStub(oldBuild.getBuild().getOutput().getImage()));
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build-2@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
@@ -680,7 +680,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                     Deployment dep = capturedDeps.get(0);
                     assertThat(dep.getMetadata().getName(), is(connect.getName()));
                     assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), is("my-connect-build-2@sha256:blablabla"));
-                    assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.sha1Prefix(build.getBuild().getOutput().getImage())));
+                    assertThat(Annotations.stringAnnotation(dep.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null), is(build.generateDockerfile().hashStub() + Util.hashStub(build.getBuild().getOutput().getImage())));
 
                     // Verify BuildConfig
                     List<BuildConfig> capturedBcs = buildConfigCaptor.getAllValues();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -168,7 +168,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(mirrorMaker2.getName()));
                 Map annotations = new HashMap();
-                annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
+                annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
                 assertThat(dc, is(mirrorMaker2.generateDeployment(annotations, true, null, null)));
 
                 // Verify PodDisruptionBudget
@@ -370,7 +370,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(compareTo.getName()));
                 Map<String, String> annotations = new HashMap();
-                annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG))));
+                annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG))));
                 assertThat(dc, is(compareTo.generateDeployment(annotations, true, null, null)));
 
                 // Verify PodDisruptionBudget
@@ -739,7 +739,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                     Deployment dc = capturedDc.get(0);
                     assertThat(dc.getMetadata().getName(), is(mirrorMaker2.getName()));
                     Map<String, String> annotations = new HashMap<>();
-                    annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
+                    annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
                     assertThat(dc, is(mirrorMaker2.generateDeployment(annotations, true, null, null)));
 
                     // Verify PodDisruptionBudget
@@ -834,7 +834,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                     Deployment dc = capturedDc.get(0);
                     assertThat(dc.getMetadata().getName(), is(mirrorMaker2.getName()));
                     Map annotations = new HashMap();
-                    annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.stringHash(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
+                    annotations.put(Annotations.ANNO_STRIMZI_LOGGING_DYNAMICALLY_UNCHANGEABLE_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(LOGGING_CONFIG)));
                     assertThat(dc, is(mirrorMaker2.generateDeployment(annotations, true, null, null)));
 
                     // Verify PodDisruptionBudget

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -410,31 +410,6 @@ public class Util {
     }
 
     /**
-     * Computes and returns a hash from the String
-     * @param toBeHashed String to be hashed
-     * @return hash
-     */
-    public static String stringHash(String toBeHashed)  {
-        try {
-            MessageDigest hashFunc = MessageDigest.getInstance("SHA");
-
-            byte[] hash = hashFunc.digest(toBeHashed.getBytes(StandardCharsets.UTF_8));
-
-            StringBuffer stringHash = new StringBuffer();
-
-            for (int i = 0; i < hash.length; i++) {
-                String hex = Integer.toHexString(0xff & hash[i]);
-                if (hex.length() == 1) stringHash.append('0');
-                stringHash.append(hex);
-            }
-
-            return stringHash.toString();
-        } catch (NoSuchAlgorithmException e)    {
-            throw new RuntimeException("Failed to create SHA MessageDigest instance");
-        }
-    }
-
-    /**
      * Method parses all dynamically unchangeable entries from the logging configuration.
      * @param loggingConfiguration logging configuration to be parsed
      * @return String containing all unmodifiable entries.
@@ -500,14 +475,26 @@ public class Util {
     /**
      * Gets the first 8 characters from a SHA-1 hash of the provided String
      *
-     * @param   toBeHashed   String for which the hash will be returned
+     * @param   toBeHashed  String for which the hash will be returned
+     *
      * @return              First 8 characters of the SHA-1 hash
      */
-    public static String sha1Prefix(String toBeHashed)   {
+    public static String hashStub(String toBeHashed)   {
+        return hashStub(toBeHashed.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    /**
+     * Gets the first 8 characters from a SHA-1 hash of the provided byte array
+     *
+     * @param   toBeHashed  Byte array for which the hash will be returned
+     *
+     * @return              First 8 characters of the SHA-1 hash
+     */
+    public static String hashStub(byte[] toBeHashed)   {
         try {
             // This is used to generate unique identifier which is not used for security => using SHA-1 is ok
             MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
-            byte[] digest = sha1.digest(toBeHashed.getBytes(StandardCharsets.US_ASCII));
+            byte[] digest = sha1.digest(toBeHashed);
 
             return String.format("%040x", new BigInteger(1, digest)).substring(0, 8);
         } catch (NoSuchAlgorithmException e) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Random;
 
-import static io.strimzi.operator.common.Util.sha1Prefix;
+import static io.strimzi.operator.common.Util.hashStub;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 
 /**
@@ -49,7 +49,7 @@ final public class TestStorage {
     public TestStorage(ExtensionContext extensionContext, String namespaceName) {
         this.extensionContext = extensionContext;
         this.namespaceName = StUtils.isParallelNamespaceTest(extensionContext) ? StUtils.getNamespaceBasedOnRbac(namespaceName, extensionContext) : namespaceName;
-        this.clusterName = CLUSTER_NAME_PREFIX + sha1Prefix(String.valueOf(RANDOM.nextInt(Integer.MAX_VALUE)));
+        this.clusterName = CLUSTER_NAME_PREFIX + hashStub(String.valueOf(RANDOM.nextInt(Integer.MAX_VALUE)));
         this.topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.streamsTopicTargetName = KafkaTopicUtils.generateRandomNameOfTopic();
         this.kafkaClientsName = clusterName + "-" + Constants.KAFKA_CLIENTS;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.common.Util.sha1Prefix;
+import static io.strimzi.operator.common.Util.hashStub;
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -596,7 +596,7 @@ public abstract class AbstractST implements TestSeparator {
 
             LOGGER.info("Not first test we are gonna generate cluster name");
 
-            String clusterName = CLUSTER_NAME_PREFIX + sha1Prefix(String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
+            String clusterName = CLUSTER_NAME_PREFIX + hashStub(String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
 
             mapWithClusterNames.put(testName, clusterName);
             mapWithTestTopics.put(testName, KafkaTopicUtils.generateRandomNameOfTopic());

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -469,7 +469,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         connectPodName = kubeClient().listPods(storage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         String fileName = getPluginFileNameFromConnectPod(connectPodName);
         assertNotEquals(fileName, ECHO_SINK_FILE_NAME);
-        assertEquals(fileName, Util.sha1Prefix(ECHO_SINK_JAR_URL));
+        assertEquals(fileName, Util.hashStub(ECHO_SINK_JAR_URL));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We use currently several utility methods to create hashes or hash stubs to track changes to different configurations and trigger rolling updates. This PR unifies them to use all the same function instead of multiple different ones.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally