### PR TITLE
Fix client rack-awareness in Kafka Connect

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
@@ -131,5 +131,5 @@ ${TLS_AUTH_CONFIGURATION}
 ${SASL_AUTH_CONFIGURATION}
 
 # Additional configuration
-client.rack=${STRIMZI_RACK_ID}
+consumer.client.rack=${STRIMZI_RACK_ID}
 EOF


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like the client rack-awareness (consuming from closest replica instead of leader replica) does nto work when only the `client.rack` option is set. This option seems to affect the internal Connect consumers from the herder. But not the consumer from the connector. To apply it to connectors, it needs to be `consumer.client.rack`.

This PR should to fix it. It follows the logic that Connect it self should probably consume from leader (more up-to-date control data) and only the connectors should use the rack-awareness for the data they are processing. So this PR sets only `consumer.client.rack`.

This should close #6492

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging