### PR TITLE
Fix JMXTrans ConfigMap and logging

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -73,7 +73,7 @@ public class JmxTrans extends AbstractModel {
     private boolean isDeployed;
     private boolean isJmxAuthenticated;
     private String configMapName;
-    private String clusterName;
+    private final String clusterName;
     private String loggingLevel;
 
     protected List<ContainerEnvVar> templateContainerEnvVars;
@@ -98,20 +98,10 @@ public class JmxTrans extends AbstractModel {
         this.name = JmxTransResources.deploymentName(cluster);
         this.clusterName = cluster;
         this.replicas = 1;
-        this.readinessPath = "/metrics";
-        this.livenessPath = "/metrics";
         this.readinessProbeOptions = READINESS_PROBE_OPTIONS;
-
-        this.mountPath = "/var/lib/kafka";
-
-        this.logAndMetricsConfigVolumeName = "kafka-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/usr/share/jmxtrans/conf/";
-
-        // Metrics must be enabled as JmxTrans is all about gathering JMX metrics from the Kafka brokers and pushing it to remote sources.
-        this.isMetricsEnabled = true;
     }
 
-    public static JmxTrans fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
+    public static JmxTrans fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly) {
         JmxTrans result = null;
         JmxTransSpec spec = kafkaAssembly.getSpec().getJmxTrans();
         if (spec != null) {
@@ -129,7 +119,7 @@ public class JmxTrans extends AbstractModel {
                 result.isJmxAuthenticated = true;
             }
 
-            result.loggingLevel = spec.getLogLevel() == null ? "" : spec.getLogLevel();
+            result.loggingLevel = spec.getLogLevel() == null ? "INFO" : spec.getLogLevel();
 
             result.setResources(spec.getResources());
 
@@ -236,20 +226,18 @@ public class JmxTrans extends AbstractModel {
     }
 
     public List<Volume> getVolumes() {
-        List<Volume> volumes = new ArrayList<>(3);
+        List<Volume> volumes = new ArrayList<>(2);
 
         volumes.add(createTempDirVolume());
         volumes.add(VolumeUtils.createConfigMapVolume(JMXTRANS_VOLUME_NAME, configMapName));
-        volumes.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, KafkaCluster.metricAndLogConfigsName(clusterName)));
 
         return volumes;
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        List<VolumeMount> volumeMountList = new ArrayList<>(3);
+        List<VolumeMount> volumeMountList = new ArrayList<>(2);
 
         volumeMountList.add(createTempDirVolumeMount());
-        volumeMountList.add(VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
         volumeMountList.add(VolumeUtils.createVolumeMount(JMXTRANS_VOLUME_NAME, JMX_FILE_PATH));
         return volumeMountList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -4459,7 +4459,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Future<ReconciliationState> getJmxTransDescription() {
             try {
                 int numOfBrokers = kafkaCluster.getReplicas();
-                this.jmxTrans = JmxTrans.fromCrd(reconciliation, kafkaAssembly, versions);
+                this.jmxTrans = JmxTrans.fromCrd(reconciliation, kafkaAssembly);
                 if (this.jmxTrans != null) {
                     this.jmxTransConfigMap = jmxTrans.generateJmxTransConfigMap(kafkaAssembly.getSpec().getJmxTrans(), numOfBrokers);
                     this.jmxTransDeployment = jmxTrans.generateDeployment(imagePullPolicy, imagePullSecrets);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -28,7 +28,6 @@ import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.template.JmxTransOutputDefinitionTemplateBuilder;
 import io.strimzi.api.kafka.model.template.JmxTransQueryTemplateBuilder;
-import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.components.JmxTransOutputWriter;
 import io.strimzi.operator.cluster.model.components.JmxTransQueries;
@@ -58,15 +57,12 @@ import static org.hamcrest.Matchers.hasProperty;
 
 @ParallelSuite
 public class JmxTransTest {
-    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private final String namespace = "test";
     private final String cluster = "foo";
     private final int replicas = 3;
     private final String image = "image";
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
-    private final Map<String, Object> metricsCm = singletonMap("animal", "wombat");
-    private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String metricsCMName = "metrics-cm";
     private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics(AbstractModel.ANCILLARY_CM_KEY_METRICS, metricsCMName);
     private final Map<String, Object> configuration = singletonMap("foo", "bar");
@@ -95,7 +91,7 @@ public class JmxTransTest {
             .endSpec()
             .build();
 
-    private final JmxTrans jmxTrans = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
+    private final JmxTrans jmxTrans = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly);
 
     @ParallelTest
     public void testOutputDefinitionWriterDeserialization() {
@@ -257,7 +253,7 @@ public class JmxTransTest {
                     .endJmxTrans()
                 .endSpec()
                 .build();
-        JmxTrans jmxTrans = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
+        JmxTrans jmxTrans = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource);
 
         // Check Deployment
         Deployment dep = jmxTrans.generateDeployment(null, null);
@@ -312,7 +308,7 @@ public class JmxTransTest {
                 .endSpec()
                 .build();
 
-        List<EnvVar> envVars = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS).getEnvVars();
+        List<EnvVar> envVars = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource).getEnvVars();
 
         assertThat("Failed to correctly set container environment variable: " + testEnvOneKey,
                 envVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
@@ -347,7 +343,7 @@ public class JmxTransTest {
                 .endSpec()
                 .build();
 
-        List<EnvVar> envVars = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS).getEnvVars();
+        List<EnvVar> envVars = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource).getEnvVars();
 
         assertThat("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
                 envVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
@@ -379,7 +375,7 @@ public class JmxTransTest {
                 .endSpec()
                 .build();
 
-        JmxTrans jmxTrans = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
+        JmxTrans jmxTrans = JmxTrans.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource);
         assertThat(jmxTrans.templateContainerSecurityContext, is(securityContext));
 
         Deployment deployment = jmxTrans.generateDeployment(null, null);

--- a/docker-images/jmxtrans/Dockerfile
+++ b/docker-images/jmxtrans/Dockerfile
@@ -28,6 +28,7 @@ RUN mkdir -p /usr/share/jmxtrans/lib/ \
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY jmxtrans_readiness_check.sh /opt/jmx/
+COPY logback.xml ${JMXTRANS_HOME}/conf/
 
 #####
 # Add NC

--- a/docker-images/jmxtrans/docker-entrypoint.sh
+++ b/docker-images/jmxtrans/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set +x
 
 EXEC="-jar $JAR_FILE -e -j $JSON_DIR -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR $ADDITIONAL_JARS_OPTS"
 GC_OPTS="-Xms${HEAP_SIZE}m -Xmx${HEAP_SIZE}m -XX:PermSize=${PERM_SIZE}m -XX:MaxPermSize=${MAX_PERM_SIZE}m"
-JMXTRANS_OPTS="$JMXTRANS_OPTS -Dlog4j2.configurationFile=file:///${JMXTRANS_HOME}/conf/log4j2.properties"
+JMXTRANS_OPTS="$JMXTRANS_OPTS -Dlogback.configurationFile=file:///${JMXTRANS_HOME}/conf/logback.xml"
 
 if [ -n "${KAFKA_JMX_USERNAME}" ]; then
   JMXTRANS_OPTS="$JMXTRANS_OPTS -Dkafka.username=${KAFKA_JMX_USERNAME} -Dkafka.password=${KAFKA_JMX_PASSWORD}"

--- a/docker-images/jmxtrans/logback.xml
+++ b/docker-images/jmxtrans/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration debug="false">
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="com.googlecode.jmxtrans" level="${JMXTRANS_LOGGING_LEVEL}"/>
+    <root level="info">
+        <appender-ref ref="console" />
+    </root>
+</configuration>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fix 2 bugs in the JMX Trans deployment:
* For some reason, it was loading the broker configuration and metrics map. That meant it didn't worked with StrimziPodSets where the config map doesn't exist anymore. The Config Map did not seemed to be used anymore -> the only file whcih was seemingly loaded from the ConfigMap mounting point was the `log4j2.properties` file -> but there is no such file in the config map. Even if it for some reasons was expected to use the broker logging configuration, it would be just Log4j1 `log4j.properties`.
* The logging did not worked. The `logLevel` field from the `Kafka` CR is passed through environment variable. But it was not used anywhere and did not seemed to work. Also - as described above - instead of configuring the Logback configuration used by JMXTrans, it was pointing it to non-existent Log4j2 configuration file. Since the logging configuration was nto there, Logback tried to log into file by default which was throwing errors into the STDOUT log because it was unable to write the log to disk due to missing permissions.

This PR removed the broker config map from the deployment. And it also adds a new basic `logback.xml` file which enabled only STDOUT logging. It also uses the existing environment variable to configure the log level.

As part of this PR I also deleted several fields whihc were set despite not being used for anything.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally