### PR TITLE
ST: Add sanity profile for system tests

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -306,6 +306,14 @@
         </profile>
 
         <profile>
+            <id>sanity</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>sanity</groups>
+            </properties>
+        </profile>
+
+        <profile>
             <id>bridge</id>
             <properties>
                 <skipTests>false</skipTests>

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -192,6 +192,11 @@ public interface Constants {
     String SMOKE = "smoke";
 
     /**
+     * Tag for sanity tests
+     */
+    String SANITY = "sanity";
+
+    /**
      * Tag for tests, which results are not 100% reliable on all testing environments.
      */
     String FLAKY = "flaky";

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -79,6 +79,7 @@ import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.systemtest.Constants.SMOKE;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
@@ -152,6 +153,7 @@ class ConnectIsolatedST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @Tag(SANITY)
     @Tag(SMOKE)
     @Tag(INTERNAL_CLIENTS_USED)
     void testKafkaConnectAndPausedConnectorWithFileSinkPlugin(ExtensionContext extensionContext) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -48,6 +48,7 @@ import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.Constants.STRIMZI_DEPLOYMENT_NAME;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -134,6 +135,7 @@ public class CruiseControlST extends AbstractST {
     }
 
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
+    @Tag(SANITY)
     @Tag(ACCEPTANCE)
     void testCruiseControlWithRebalanceResourceAndRefreshAnnotation(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -72,6 +72,7 @@ import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.security.SystemTestCertManager.exportToPemFiles;
 import static io.strimzi.systemtest.security.SystemTestCertManager.generateIntermediateCaCertAndKey;
 import static io.strimzi.systemtest.security.SystemTestCertManager.generateEndEntityCertAndKey;
@@ -672,6 +673,7 @@ public class ListenersST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @Tag(SANITY)
     @Tag(ACCEPTANCE)
     @Tag(LOADBALANCER_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
@@ -1092,6 +1094,7 @@ public class ListenersST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @Tag(SANITY)
     @Tag(ACCEPTANCE)
     @Tag(EXTERNAL_CLIENTS_USED)
     @Tag(INTERNAL_CLIENTS_USED)

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -80,6 +80,7 @@ import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.METRICS;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -91,6 +92,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag(SANITY)
+@Tag(ACCEPTANCE)
 @Tag(REGRESSION)
 @Tag(METRICS)
 @Tag(CRUISE_CONTROL)
@@ -174,7 +177,6 @@ public class MetricsIsolatedST extends AbstractST {
     }
 
     @ParallelTest
-    @Tag(ACCEPTANCE)
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testKafkaConnectRequests() {
@@ -214,7 +216,6 @@ public class MetricsIsolatedST extends AbstractST {
     }
 
     @IsolatedTest
-    @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
     void testKafkaExporterDataAfterExchange(ExtensionContext extensionContext) {
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
@@ -276,7 +277,6 @@ public class MetricsIsolatedST extends AbstractST {
     }
 
     @ParallelTest
-    @Tag(ACCEPTANCE)
     void testClusterOperatorMetrics(ExtensionContext extensionContext) {
         clusterOperatorMetricsData = collector.toBuilder()
             .withNamespaceName(clusterOperator.getDeploymentNamespace())
@@ -329,7 +329,6 @@ public class MetricsIsolatedST extends AbstractST {
     }
 
     @ParallelTest
-    @Tag(ACCEPTANCE)
     void testUserOperatorMetrics() {
         userOperatorMetricsData = collector.toBuilder()
             .withComponentType(ComponentType.UserOperator)
@@ -351,7 +350,6 @@ public class MetricsIsolatedST extends AbstractST {
     }
 
     @ParallelTest
-    @Tag(ACCEPTANCE)
     void testTopicOperatorMetrics() {
         topicOperatorMetricsData = collector.toBuilder()
             .withComponentType(ComponentType.TopicOperator)
@@ -378,7 +376,6 @@ public class MetricsIsolatedST extends AbstractST {
     @ParallelTest
     @Tag(MIRROR_MAKER2)
     @Tag(CONNECT_COMPONENTS)
-    @Tag(ACCEPTANCE)
     void testMirrorMaker2Metrics() {
         kafkaMirrorMaker2MetricsData = collector.toBuilder()
             .withComponentName(MIRROR_MAKER_CLUSTER)
@@ -397,7 +394,6 @@ public class MetricsIsolatedST extends AbstractST {
 
     @ParallelTest
     @Tag(BRIDGE)
-    @Tag(ACCEPTANCE)
     void testKafkaBridgeMetrics(ExtensionContext extensionContext) {
         String producerName = "bridge-producer";
         String consumerName = "bridge-consumer";
@@ -448,7 +444,6 @@ public class MetricsIsolatedST extends AbstractST {
     }
 
     @ParallelTest
-    @Tag(ACCEPTANCE)
     void testCruiseControlMetrics() {
 
         String cruiseControlMetrics = CruiseControlUtils.callApi(INFRA_NAMESPACE, CruiseControlUtils.SupportedHttpMethods.GET, "/metrics");

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -95,6 +95,7 @@ import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
+import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.security.SystemTestCertManager.STRIMZI_INTERMEDIATE_CA;
 import static io.strimzi.systemtest.security.SystemTestCertManager.convertPrivateKeyToPKCS8File;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -211,6 +212,7 @@ class SecurityST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @Tag(SANITY)
     @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds new profile `sanity` to system tests. It includes tests, which verify the core functionality of Strimzi + some additional features under 1h of execution time.

### Checklist

- [x] Make sure all tests pass

