### PR TITLE
docs: describe tasksmax for mirrormaker

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
@@ -39,6 +39,9 @@ include::../../modules/configuring/con-config-mirrormaker2-replication.adoc[leve
 //Config for mirrormmaker connectors
 include::../../modules/configuring/con-config-mirrormaker2-connectors.adoc[leveloffset=+1]
 
+//Increasing the number of tasks
+include::../../modules/configuring/con-config-mirrormaker2-tasks-max.adoc[leveloffset=+1]
+
 //Handling of ACLs in replication
 include::../../modules/configuring/con-config-mirrormaker2-acls.adoc[leveloffset=+1]
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// assembly-config-mirrormaker2.adoc
+
+[id='con-mirrormaker-tasks-max-{context}']
+= Specifying a maximum number of tasks
+
+[role="_abstract"]
+Connectors create the tasks that are responsible for moving data in and out of Kafka.
+Each connector comprises one or more tasks that are distributed across a group of worker pods that run the tasks.
+
+Tasks run in parallel.
+If there are more tasks than workers, workers handle multiple tasks.
+
+You can specify the maximum number of connector tasks in your MirrorMaker configuration using the `tasksMax` property.
+Without specifying a maximum number of tasks, the default setting is a single task.
+If the infrastructure supports the processing overhead, increasing the number of tasks can improve throughput.
+
+.tasksMax configuration for a MirrorMaker connector
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaMirrorMaker2ApiVersion}
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker2
+spec:
+  # ...
+  mirrors:
+  - sourceCluster: "my-cluster-source"
+    targetCluster: "my-cluster-target"
+    sourceConnector:
+      tasksMax: 10
+  # ...    
+----
+
+For sink and source connectors, the maximum number of tasks that can run in parallel depends on a number of factors.
+Common factors include the connector configuration, the type of external system, the expected throughput, and the number of workers.
+A connector creates fewer than the maximum number of tasks if it cannot achieve the parallelism.
+For sink connectors, the maximum number of tasks possible is one for each partition consumed.
+
+Suppose a source connector is used to connect to a database as an external data source.
+The connector might determine the required number of tasks based on the number of tables in the database and the maximum allowable number of tasks.
+The source connector might create fewer tasks than the maximum allowed if it’s not possible or desirable to split the source data into so many tasks.

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -10,6 +10,8 @@ Connectors create the tasks that are responsible for moving data in and out of K
 Each connector comprises one or more tasks that are distributed across a group of worker pods that run the tasks.
 
 Tasks run in parallel.
+Workers are assigned one or more tasks.
+A single task is handled by one worker pod, so you don't need more worker pods than tasks.
 If there are more tasks than workers, workers handle multiple tasks.
 
 You can specify the maximum number of connector tasks in your MirrorMaker configuration using the `tasksMax` property.
@@ -30,7 +32,7 @@ spec:
     targetCluster: "my-cluster-target"
     sourceConnector:
       tasksMax: 10
-  # ...    
+  # ...
 ----
 
 For sink and source connectors, the maximum number of tasks that can run in parallel depends on a number of factors.

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -157,12 +157,12 @@ spec:
 ----
 <1> Use `KafkaConnect`.
 <2> Enables KafkaConnectors for the Kafka Connect cluster.
-<3> xref:con-common-configuration-replicas-reference[The number of replica nodes].
+<3> xref:con-common-configuration-replicas-reference[The number of replica nodes] for the workers that run tasks.
 <4> Authentication for the Kafka Connect cluster, using the xref:type-KafkaClientAuthenticationTls-reference[TLS mechanism], as shown here, using xref:type-KafkaClientAuthenticationOAuth-reference[OAuth bearer tokens], or a SASL-based xref:type-KafkaClientAuthenticationScramSha256-reference[SCRAM-SHA-256]/xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512] or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN] mechanism.
 By default, Kafka Connect connects to Kafka brokers using a plain text connection.
 <5> xref:con-common-configuration-bootstrap-reference[Bootstrap server] for connection to the Kafka Connect cluster.
 <6> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for the cluster. If certificates are stored in the same secret, it can be listed multiple times.
-<7> xref:property-kafka-connect-config-reference[Kafka Connect configuration] of _workers_ (not connectors).
+<7> xref:property-kafka-connect-config-reference[Kafka Connect configuration] of workers (not connectors).
 Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 <8> xref:type-Build-reference[Build configuration properties] for building a container image with connector plugins automatically.
 <9> (Required) Configuration of the container registry where new images are pushed.

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -186,7 +186,7 @@ spec:
             key: awsSecretAccessKey
 ----
 <1> The Kafka Connect and Mirror Maker 2.0 xref:type-KafkaConnectSpec-reference[version], which will always be the same.
-<2> xref:con-common-configuration-replicas-reference[The number of replica nodes].
+<2> xref:con-common-configuration-replicas-reference[The number of replica nodes] for the workers that run tasks.
 <3> xref:type-KafkaMirrorMaker2Spec-reference[Kafka cluster alias] for Kafka Connect, which must specify the *target* Kafka cluster. The Kafka cluster is used by Kafka Connect for its internal topics.
 <4> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Specification] for the Kafka clusters being synchronized.
 <5> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Cluster alias] for the source Kafka cluster.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds a new section to [Kafka MirrorMaker 2.0 cluster configuration](https://strimzi.io/docs/operators/in-development/configuring.html#assembly-mirrormaker-str) in the _configuring_ guide. The section provides some context to how and when you use the `tasksMax` property.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

