### PR TITLE
[MO] - [system test] -> Using 3 ZooKeeper replicas instead of 2

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -141,7 +141,6 @@ class KafkaST extends AbstractST {
         LinkedHashMap<String, String> envVarGeneral = new LinkedHashMap<>();
         envVarGeneral.put("TEST_ENV_1", "test.env.one");
         envVarGeneral.put("TEST_ENV_2", "test.env.two");
-
         LinkedHashMap<String, String> envVarUpdated = new LinkedHashMap<>();
         envVarUpdated.put("TEST_ENV_2", "updated.test.env.two");
         envVarUpdated.put("TEST_ENV_3", "test.env.three");
@@ -392,9 +391,9 @@ class KafkaST extends AbstractST {
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
             String kafkaConfiguration = kubeClient(namespaceName).getConfigMap(namespaceName, cmName).getData().get("server.config");
-            assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=2"));
-            assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=2"));
-            assertThat(kafkaConfiguration, containsString("default.replication.factor=2"));
+            assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=3"));
+            assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=3"));
+            assertThat(kafkaConfiguration, containsString("default.replication.factor=3"));
         }
 
         kafkaConfigurationFromPod = cmdKubeClient(namespaceName).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "cat", "/tmp/strimzi.properties").out();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -153,9 +153,9 @@ class KafkaST extends AbstractST {
         kafkaConfig.put("default.replication.factor", "1");
 
         Map<String, Object> updatedKafkaConfig = new HashMap<>();
-        updatedKafkaConfig.put("offsets.topic.replication.factor", "2");
-        updatedKafkaConfig.put("transaction.state.log.replication.factor", "2");
-        updatedKafkaConfig.put("default.replication.factor", "2");
+        updatedKafkaConfig.put("offsets.topic.replication.factor", "3");
+        updatedKafkaConfig.put("transaction.state.log.replication.factor", "3");
+        updatedKafkaConfig.put("default.replication.factor", "3");
 
         // Zookeeper Config
         Map<String, Object> zookeeperConfig = new HashMap<>();
@@ -179,7 +179,7 @@ class KafkaST extends AbstractST {
         final int updatedPeriodSeconds = 5;
         final int updatedFailureThreshold = 1;
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 2)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3)
             .editSpec()
                 .editKafka()
                     .withNewReadinessProbe()
@@ -204,7 +204,7 @@ class KafkaST extends AbstractST {
                     .endTemplate()
                 .endKafka()
                 .editZookeeper()
-                    .withReplicas(2)
+                    .withReplicas(3)
                     .withNewReadinessProbe()
                        .withInitialDelaySeconds(initialDelaySeconds)
                         .withTimeoutSeconds(timeoutSeconds)
@@ -294,7 +294,7 @@ class KafkaST extends AbstractST {
         checkKafkaConfiguration(namespaceName, kafkaStatefulSetName(clusterName), kafkaConfig, clusterName);
         checkSpecificVariablesInContainer(namespaceName, kafkaStatefulSetName(clusterName), "kafka", envVarGeneral);
 
-        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 2)) {
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
             String kafkaConfiguration = kubeClient().getConfigMap(namespaceName, cmName).getData().get("server.config");
             assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=1"));
             assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=1"));
@@ -379,8 +379,8 @@ class KafkaST extends AbstractST {
             entityOperatorSpec.getTemplate().getTlsSidecarContainer().setEnv(StUtils.createContainerEnvVarsFromMap(envVarUpdated));
         }, namespaceName);
 
-        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, zkSelector, 2, zkSnapshot);
-        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 2, kafkaSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, zkSelector, 3, zkSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaSnapshot);
         DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPod);
         KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
 
@@ -390,7 +390,7 @@ class KafkaST extends AbstractST {
         checkKafkaConfiguration(namespaceName, kafkaStatefulSetName(clusterName), updatedKafkaConfig, clusterName);
         checkSpecificVariablesInContainer(namespaceName, kafkaStatefulSetName(clusterName), "kafka", envVarUpdated);
 
-        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 2)) {
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
             String kafkaConfiguration = kubeClient(namespaceName).getConfigMap(namespaceName, cmName).getData().get("server.config");
             assertThat(kafkaConfiguration, containsString("offsets.topic.replication.factor=2"));
             assertThat(kafkaConfiguration, containsString("transaction.state.log.replication.factor=2"));
@@ -398,9 +398,9 @@ class KafkaST extends AbstractST {
         }
 
         kafkaConfigurationFromPod = cmdKubeClient(namespaceName).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "cat", "/tmp/strimzi.properties").out();
-        assertThat(kafkaConfigurationFromPod, containsString("offsets.topic.replication.factor=2"));
-        assertThat(kafkaConfigurationFromPod, containsString("transaction.state.log.replication.factor=2"));
-        assertThat(kafkaConfigurationFromPod, containsString("default.replication.factor=2"));
+        assertThat(kafkaConfigurationFromPod, containsString("offsets.topic.replication.factor=3"));
+        assertThat(kafkaConfigurationFromPod, containsString("transaction.state.log.replication.factor=3"));
+        assertThat(kafkaConfigurationFromPod, containsString("default.replication.factor=3"));
 
         LOGGER.info("Testing Zookeepers");
         checkReadinessLivenessProbe(namespaceName, zookeeperStatefulSetName(clusterName), "zookeeper", updatedInitialDelaySeconds, updatedTimeoutSeconds,

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.StrimziPodSetTest;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
@@ -53,6 +52,8 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 class RecoveryIsolatedST extends AbstractST {
 
     static String sharedClusterName;
+    private static final int KAFKA_REPLICAS = 3;
+    private static final int ZOOKEEPER_REPLICAS = 3;
 
     private static final Logger LOGGER = LogManager.getLogger(RecoveryIsolatedST.class);
 
@@ -87,7 +88,7 @@ class RecoveryIsolatedST extends AbstractST {
 
         LOGGER.info("Waiting for recovery {}", kafkaName);
         StUtils.waitForStrimziPodSetOrStatefulSetRecovery(kafkaName, kafkaUid);
-        StUtils.waitForStrimziPodSetOrStatefulSetAndPodsReady(kafkaName, 3);
+        StUtils.waitForStrimziPodSetOrStatefulSetAndPodsReady(kafkaName, KAFKA_REPLICAS);
     }
 
     @IsolatedTest("We need for each test case its own Cluster Operator")
@@ -104,7 +105,7 @@ class RecoveryIsolatedST extends AbstractST {
 
         LOGGER.info("Waiting for recovery {}", zookeeperName);
         StUtils.waitForStrimziPodSetOrStatefulSetRecovery(zookeeperName, zookeeperUid);
-        StUtils.waitForStrimziPodSetOrStatefulSetAndPodsReady(zookeeperName, 2);
+        StUtils.waitForStrimziPodSetOrStatefulSetAndPodsReady(zookeeperName, ZOOKEEPER_REPLICAS);
     }
 
     @IsolatedTest("We need for each test case its own Cluster Operator")
@@ -168,14 +169,7 @@ class RecoveryIsolatedST extends AbstractST {
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaMetricsConfig with cluster {}", sharedClusterName);
 
-        String kafkaMetricsConfigName;
-        if (Environment.isStrimziPodSetEnabled())   {
-            // For PodSets, we delete one of the per-broker config maps
-            kafkaMetricsConfigName = KafkaResources.kafkaPodName(sharedClusterName, 1);
-        } else {
-            kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(sharedClusterName);
-        }
-
+        String kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(sharedClusterName);
         String kafkaMetricsConfigUid = kubeClient().getConfigMapUid(kafkaMetricsConfigName);
 
         kubeClient().deleteConfigMap(kafkaMetricsConfigName);
@@ -270,7 +264,7 @@ class RecoveryIsolatedST extends AbstractST {
 
         KafkaResource.replaceKafkaResource(sharedClusterName, k -> k.getSpec().getKafka().setResources(resourceReq));
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(INFRA_NAMESPACE, kafkaSelector, 3);
+        RollingUpdateUtils.waitForComponentAndPodsReady(INFRA_NAMESPACE, kafkaSelector, KAFKA_REPLICAS);
         KafkaUtils.waitForKafkaReady(sharedClusterName);
     }
 
@@ -290,8 +284,8 @@ class RecoveryIsolatedST extends AbstractST {
         kafkaPodList.subList(0, kafkaPodList.size() - 1).forEach(pod -> kubeClient().deletePod(pod));
         zkPodList.subList(0, zkPodList.size() - 1).forEach(pod -> kubeClient().deletePod(pod));
 
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(kafkaName, 3);
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(zkName, 2);
+        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(kafkaName, KAFKA_REPLICAS);
+        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(zkName, ZOOKEEPER_REPLICAS);
         KafkaUtils.waitForKafkaReady(sharedClusterName);
     }
 
@@ -308,7 +302,7 @@ class RecoveryIsolatedST extends AbstractST {
         sharedClusterName = generateRandomNameOfKafka("recovery-cluster");
         String kafkaClientsName = Constants.KAFKA_CLIENTS + "-" + sharedClusterName;
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(sharedClusterName, 3, 2).build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(sharedClusterName, KAFKA_REPLICAS, ZOOKEEPER_REPLICAS).build());
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
         resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridge(sharedClusterName, KafkaResources.plainBootstrapAddress(sharedClusterName), 1).build());
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -53,7 +53,7 @@ class RecoveryIsolatedST extends AbstractST {
 
     static String sharedClusterName;
     private static final int KAFKA_REPLICAS = 3;
-    private static final int ZOOKEEPER_REPLICAS = 3;
+    private static final int ZOOKEEPER_REPLICAS = KAFKA_REPLICAS;
 
     private static final Logger LOGGER = LogManager.getLogger(RecoveryIsolatedST.class);
 
@@ -302,7 +302,7 @@ class RecoveryIsolatedST extends AbstractST {
         sharedClusterName = generateRandomNameOfKafka("recovery-cluster");
         String kafkaClientsName = Constants.KAFKA_CLIENTS + "-" + sharedClusterName;
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(sharedClusterName, KAFKA_REPLICAS, ZOOKEEPER_REPLICAS).build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(sharedClusterName, KAFKA_REPLICAS).build());
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
         resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridge(sharedClusterName, KafkaResources.plainBootstrapAddress(sharedClusterName), 1).build());
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -127,13 +127,7 @@ class SecurityST extends AbstractST {
 
         LOGGER.info("Running testCertificates {}", clusterName);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 2)
-                .editSpec()
-                    .editZookeeper()
-                        .withReplicas(2)
-                    .endZookeeper()
-                .endSpec()
-                .build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3).build());
 
         LOGGER.info("Check Kafka bootstrap certificate");
         String outputCertificate = SystemTestCertManager.generateOpenSslCommandByComponent(namespaceName, KafkaResources.tlsBootstrapAddress(clusterName), KafkaResources.bootstrapServiceName(clusterName),
@@ -149,7 +143,7 @@ class SecurityST extends AbstractST {
         List<String> kafkaPorts = new ArrayList<>(Arrays.asList("9091", "9093"));
         List<String> zkPorts = new ArrayList<>(Arrays.asList("2181", "3888"));
 
-        IntStream.rangeClosed(0, 1).forEach(podId -> {
+        IntStream.rangeClosed(0, 2).forEach(podId -> {
             String output;
 
             LOGGER.info("Checking certificates for podId {}", podId);


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes problem in RecoveryST, SecurityST ∧ KafkaST where we use 2 ZooKeeper replicas and replace them with 3 (using an even number of ZooKeeper rnodes is not recommended).

Eventually, the Kafka cluster is deployed but it took 8 minutes to do so...
```
recovery-cluster-1461276912-kafka-0         0/1     Running   0               28s
recovery-cluster-1461276912-kafka-1         0/1     Running   0               28s
recovery-cluster-1461276912-kafka-2         0/1     Running   0               28s
recovery-cluster-1461276912-zookeeper-0     1/1     Running   7 (3m42s ago)   10m
recovery-cluster-1461276912-zookeeper-1     1/1     Running   7 (3m42s ago)   10m
strimzi-cluster-operator-6499b64c6c-sfn9p   1/1     Running   0               10m
```
With this change, I eliminate such problems.

### Checklist

- [x] Make sure all tests pass