### PR TITLE
Make `DirectoryConfigProvider` example more realistic

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc
@@ -181,7 +181,7 @@ In this example, a `Secret` contains TLS truststore and keystore user credential
 apiVersion: v1
 kind: Secret
 metadata:
-  name: mysecret
+  name: my-user
   labels:
     strimzi.io/kind: KafkaUser
     strimzi.io/cluster: my-cluster
@@ -214,9 +214,12 @@ spec:
   #...
   externalConfiguration:
     volumes:
-      - name: connector-config
+      - name: cluster-ca
         secret:
-          secretName: mysecret
+          secretName: my-cluster-cluster-ca-cert
+      - name: my-user
+        secret:
+          secretName: my-user
 ----
 <1> The `DirectoryConfigProvider` provides values from files in a directory. The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
 
@@ -237,10 +240,12 @@ spec:
   class: io.debezium.connector.mysql.MySqlConnector
   tasksMax: 2
   config:
-    security.protocol: SSL
-    ssl.truststore.type: PEM
-    ssl.truststore.location: "${directory:/opt/kafka/external-configuration/connector-config:ca.crt}"
-    ssl.keystore.type: PEM
-    ssl.keystore.location: "${directory:/opt/kafka/external-configuration/connector-config:user.key}"
+    # ...
+    database.history.producer.security.protocol: SSL
+    database.history.producer.ssl.truststore.type: PEM
+    database.history.producer.ssl.truststore.certificates: "${directory:/opt/kafka/external-configuration/cluster-ca:ca.crt}"
+    database.history.producer.ssl.keystore.type: PEM
+    database.history.producer.ssl.keystore.certificate.chain: "${directory:/opt/kafka/external-configuration/my-user:user.crt}"
+    database.history.producer.ssl.keystore.key: "${directory:/opt/kafka/external-configuration/my-user:user.key}"
     #...
 ----


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The example of how to use the `DirectoryConfigProvider` needs ot be improved a bit:
* It refers to Strimzi KafkaUser secret, but it does not follow its structure and content
* It uses the `DirectoryConfigProvider` to load PEM files. But it is using the wrong options (`ssl.truststore.location` / `ssl.keystore.location`) which would not work in reality.

This PR tries to make the example a bit more realistic both from the Strimzi as well as from Debezium perspective.

This fix is based on #6533 

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging