### PR TITLE
Fixed needs for overwrite on pause reconcile annotation

### DIFF
--- a/documentation/modules/security/proc-replacing-your-own-private-keys.adoc
+++ b/documentation/modules/security/proc-replacing-your-own-private-keys.adoc
@@ -213,7 +213,7 @@ To resume the `Kafka` custom resource reconciliation, set the `pause-reconciliat
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl annotate Kafka _NAME-OF-CUSTOM-RESOURCE_ strimzi.io/pause-reconciliation="false"
+kubectl annotate --overwrite Kafka _NAME-OF-CUSTOM-RESOURCE_ strimzi.io/pause-reconciliation="false"
 ----
 +
 You can also do the same by removing the `pause-reconciliation` annotation.


### PR DESCRIPTION
This trivial PR adds the `--overwrite` option to the annotate command to unpause reconcile during the CA private key replacement. It's needed because the annotation is already in place from previous steps.