### PR TITLE
`StrimziPodSet` reconciliation only switch

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -767,7 +767,8 @@ public class ResourceUtils {
                 featureGates,
                 10,
                 10_000,
-                30);
+                30,
+                false);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfigRolesOnly(KafkaVersion.Lookup versions, long operationTimeoutMs) {
@@ -788,7 +789,8 @@ public class ResourceUtils {
                 "",
                 10,
                 10_000,
-                30);
+                30,
+                false);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions, long operationTimeoutMs) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -445,7 +445,8 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 "",
                 10,
                 10_000,
-                30);
+                30,
+                false);
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_19), certManager, passwordGenerator,
                 supplier, config);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -941,7 +941,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 "",
                 10,
                 10_000,
-                30);
+                30,
+                false);
 
         kcrao = new KafkaRebalanceAssemblyOperator(Vertx.vertx(), pfa, supplier, config);
 

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -204,6 +204,10 @@ Set this environment variable to `false` to disable network policy generation. Y
 `STRIMZI_DNS_CACHE_TTL` :: Optional, default `30`.
 Number of seconds to cache successful name lookups in local DNS resolver. Any negative value means cache forever. Zero means do not cache. This can be useful to avoid connection errors due to long caching policies being applied.
 
+`STRIMZI_POD_SET_RECONCILIATION_ONLY` :: Optional, default `false`.
+When set to `true`, the Cluster Operator will reconcile only the `StrimziPodSet` resources and any changes to the other custom resources (`Kafka`, `KafkaConnect`, and so on) will be ignored.
+This mode is useful to ensure that your Pods will be recreated if needed, but no other changes happen to your clusters.
+
 `STRIMZI_FEATURE_GATES`:: Optional.
 Enables or disables features and functionality controlled by xref:ref-operator-cluster-feature-gates-{context}[feature gates].
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the [`StrimziPodSets`-only reconciliation switch](https://github.com/strimzi/proposals/blob/main/031-statefulset-removal.md#strimzipodsets-only-switch) as defined in the Strimzi Proposal 031. 

With StatefulSets, users can switch off the Cluster Operator and the Kubernetes StatefulSet controller will still manage the pods, recreate them etc. But with StrimziPodsSets, it is not easy to just _switch-off_ the operator because it also manages the pods. this switch allows to disable the reconciliation of all the `Kafka*` custom resources, but still manage the Pods based on the existing StrimziPodSet resources.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally