### PR TITLE
Fix logging configuration in the Cluster Operator

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -20,20 +20,16 @@ data:
     rootLogger.level = {{ default .Values.logLevel .Values.logLevelOverride }}
     rootLogger.appenderRefs = stdout
     rootLogger.appenderRef.console.ref = STDOUT
-    rootLogger.additivity = false
 
     # Kafka AdminClient logging is a bit noisy at INFO level
     logger.kafka.name = org.apache.kafka
     logger.kafka.level = WARN
-    logger.kafka.additivity = false
 
     # Zookeeper is very verbose even on INFO level -> We set it to WARN by default
     logger.zookeepertrustmanager.name = org.apache.zookeeper
     logger.zookeepertrustmanager.level = WARN
-    logger.zookeepertrustmanager.additivity = false
 
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
-    logger.netty.additivity = false
     {{- end }}

--- a/packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -17,19 +17,15 @@ data:
     rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
     rootLogger.appenderRefs = stdout
     rootLogger.appenderRef.console.ref = STDOUT
-    rootLogger.additivity = false
 
     # Kafka AdminClient logging is a bit noisy at INFO level
     logger.kafka.name = org.apache.kafka
     logger.kafka.level = WARN
-    logger.kafka.additivity = false
 
     # Zookeeper is very verbose even on INFO level -> We set it to WARN by default
     logger.zookeepertrustmanager.name = org.apache.zookeeper
     logger.zookeepertrustmanager.level = WARN
-    logger.zookeepertrustmanager.additivity = false
 
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
-    logger.netty.additivity = false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Cluster Operator logging configuration has several special loggers for Kafka, ZooKeeper and Netty which have some custom logging level configured. This is because on INFO level, they were quite noisy. However, for some reason, all these loggers disabled `additivity`. That means that these loggers did not inherit the appenders from their parents and in our case they were essentially without any appenders. So whatever they logged, it never showed up in the log.

This PR removes `additivity` configuration (which defaults to `true` if not set). With that, they inherit the standard output appender and log properly into the standard output. By default, the logs shown in the logs should not change. But the WARN and ERROR logs from these classes should not how up properly in the log.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally