### PR TITLE
Make the `RecoveryIsolatedST.testRecoveryFromKafkaMetricsConfigDeletion` test work with `StrimziPodSets`

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.StrimziPodSetTest;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
@@ -169,7 +170,14 @@ class RecoveryIsolatedST extends AbstractST {
         // kafka cluster already deployed
         LOGGER.info("Running deleteKafkaMetricsConfig with cluster {}", sharedClusterName);
 
-        String kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(sharedClusterName);
+        String kafkaMetricsConfigName;
+        if (Environment.isStrimziPodSetEnabled())   {
+            // For PodSets, we delete one of the per-broker config maps
+            kafkaMetricsConfigName = KafkaResources.kafkaPodName(sharedClusterName, 1);
+        } else {
+            kafkaMetricsConfigName = KafkaResources.kafkaMetricsAndLogConfigMapName(sharedClusterName);
+        }
+
         String kafkaMetricsConfigUid = kubeClient().getConfigMapUid(kafkaMetricsConfigName);
 
         kubeClient().deleteConfigMap(kafkaMetricsConfigName);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For whatever reason, #6529 reverted the changes which made the `RecoveryIsolatedST.testRecoveryFromKafkaMetricsConfigDeletion` test work with `StrimziPodSets`. This PR restores the original handling which deletes one of the per-pod ConfigMaps when StrimziPodSets are used.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally