### PR TITLE
Separate Kafka Exporter reconciliation from `KafkaAssemblyOperator` class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -40,22 +40,28 @@ import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.KafkaUpgradeException;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
+import org.quartz.CronExpression;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 
@@ -63,6 +69,7 @@ import static java.util.Collections.emptyMap;
  * ModelUtils is a utility class that holds generic static helper functions
  * These are generally to be used within the classes that extend the AbstractModel class
  */
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class ModelUtils {
 
     private ModelUtils() {}
@@ -735,5 +742,50 @@ public class ModelUtils {
         } else {
             return false;
         }
+    }
+
+    /**
+     * Checks whether maintenance time window is satisfied or not
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param maintenanceWindows    List of maintenance windows
+     * @param dateSupplier          Date supplier
+     *
+     * @return                      True if we are in a maintenance window or if no maintenance windows are defined. False otherwise.
+     */
+    public static boolean isMaintenanceTimeWindowsSatisfied(Reconciliation reconciliation, List<String> maintenanceWindows, Supplier<Date> dateSupplier) {
+        String currentCron = null;
+        try {
+            boolean isSatisfiedBy = maintenanceWindows == null || maintenanceWindows.isEmpty();
+            if (!isSatisfiedBy) {
+                Date date = dateSupplier.get();
+                for (String cron : maintenanceWindows) {
+                    currentCron = cron;
+                    CronExpression cronExpression = new CronExpression(cron);
+                    // the user defines the cron expression in "UTC/GMT" timezone but CO pod
+                    // can be running on a different one, so setting it on the cron expression
+                    cronExpression.setTimeZone(TimeZone.getTimeZone("GMT"));
+                    if (cronExpression.isSatisfiedBy(date)) {
+                        isSatisfiedBy = true;
+                        break;
+                    }
+                }
+            }
+            return isSatisfiedBy;
+        } catch (ParseException e) {
+            LOGGER.warnCr(reconciliation, "The provided maintenance time windows list contains {} which is not a valid cron expression", currentCron);
+            return false;
+        }
+    }
+
+    /**
+     * Extracts the CA generation from the CA
+     *
+     * @param ca    CA from which the generation should be extracted
+     *
+     * @return      CA generation or the initial generation if no generation is set
+     */
+    public static int caCertGeneration(Ca ca) {
+        return Annotations.intAnnotation(ca.caCertSecret(), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, Ca.INIT_GENERATION);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.cluster.model.ClusterCa;
+import io.strimzi.operator.cluster.model.ImagePullPolicy;
+import io.strimzi.operator.cluster.model.KafkaExporter;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
+import io.vertx.core.Future;
+
+import java.util.Date;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Class used for reconciliation of Kafka Exporter. This class contains both the steps of the Kafka Exporter
+ * reconciliation pipeline and is also used to store the state between them.
+ */
+public class KafkaExporterReconciler {
+    private final Reconciliation reconciliation;
+    private final long operationTimeoutMs;
+    private final KafkaExporter kafkaExporter;
+    private final ClusterCa clusterCa;
+    private final List<String> maintenanceWindows;
+
+    private final DeploymentOperator deploymentOperator;
+    private final SecretOperator secretOperator;
+    private final ServiceAccountOperator serviceAccountOperator;
+
+    private boolean existingKafkaExporterCertsChanged = false;
+
+    /**
+     * Constructs the Kafka Exporter reconciler
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param operationTimeoutMs        Timeout for Kubernetes operations
+     * @param kafkaAssembly             The Kafka custom resource
+     * @param versions                  The supported Kafka versions
+     * @param clusterCa                 The Cluster CA instance
+     * @param deploymentOperator        The Deployment operator for working with Kubernetes Deployments
+     * @param secretOperator            The Secret operator for working with Kubernetes Secrets
+     * @param serviceAccountOperator    The Service Account operator for working with Kubernetes Service Accounts
+     */
+    public KafkaExporterReconciler(
+            Reconciliation reconciliation,
+            long operationTimeoutMs,
+            Kafka kafkaAssembly,
+            KafkaVersion.Lookup versions,
+            ClusterCa clusterCa,
+            DeploymentOperator deploymentOperator,
+            SecretOperator secretOperator,
+            ServiceAccountOperator serviceAccountOperator
+    ) {
+        this.reconciliation = reconciliation;
+        this.operationTimeoutMs = operationTimeoutMs;
+        this.kafkaExporter = KafkaExporter.fromCrd(reconciliation, kafkaAssembly, versions);
+        this.clusterCa = clusterCa;
+        this.maintenanceWindows = kafkaAssembly.getSpec().getMaintenanceTimeWindows();
+
+        this.deploymentOperator = deploymentOperator;
+        this.secretOperator = secretOperator;
+        this.serviceAccountOperator = serviceAccountOperator;
+    }
+
+    /**
+     * The main reconciliation method which triggers the whole reconciliation pipeline. This is the method which is
+     * expected to be called from the outside to trigger the reconciliation.
+     *
+     * @param isOpenShift       Flag indicating whether we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  List of Image pull secrets
+     * @param dateSupplier      Date supplier for checking maintenance windows
+     *
+     * @return                  Future which completes when the reconciliation completes
+     */
+    public Future<Void> reconcile(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets, Supplier<Date> dateSupplier)    {
+        return kafkaExporterServiceAccount()
+                .compose(i -> kafkaExporterSecret(dateSupplier))
+                .compose(i -> kafkaExporterDeployment(isOpenShift, imagePullPolicy, imagePullSecrets))
+                .compose(i -> kafkaExporterReady());
+    }
+
+    /**
+     * Manages the Kafka Exporter Service Account.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    private Future<Void> kafkaExporterServiceAccount() {
+        return serviceAccountOperator
+                .reconcile(
+                        reconciliation,
+                        reconciliation.namespace(),
+                        KafkaExporter.containerServiceAccountName(reconciliation.name()),
+                        kafkaExporter != null ? kafkaExporter.generateServiceAccount() : null
+                ).map((Void) null);
+    }
+
+    /**
+     * Manages the Kafka Exporter Secret with certificates.
+     *
+     * @param dateSupplier  Date supplier for checking maintenance windows for updating the certificates
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    private Future<Void> kafkaExporterSecret(Supplier<Date> dateSupplier) {
+        if (kafkaExporter != null) {
+            return secretOperator.getAsync(reconciliation.namespace(), KafkaExporter.secretName(reconciliation.name()))
+                    .compose(oldSecret -> {
+                        return secretOperator
+                                .reconcile(reconciliation, reconciliation.namespace(), KafkaExporter.secretName(reconciliation.name()),
+                                        kafkaExporter.generateSecret(clusterCa, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, dateSupplier)))
+                                .compose(patchResult -> {
+                                    if (patchResult instanceof ReconcileResult.Patched) {
+                                        // The secret is patched and some changes to the existing certificates actually occurred
+                                        existingKafkaExporterCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
+                                    } else {
+                                        existingKafkaExporterCertsChanged = false;
+                                    }
+
+                                    return Future.succeededFuture();
+                                });
+                    });
+        } else {
+            return secretOperator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaExporter.secretName(reconciliation.name()), null)
+                    .map((Void) null);
+        }
+    }
+
+    /**
+     * Manages the Kafka Exporter deployment.
+     *
+     * @param isOpenShift       Flag indicating whether we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  List of Image pull secrets
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    private Future<Void> kafkaExporterDeployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
+        if (kafkaExporter != null) {
+            Deployment deployment = kafkaExporter.generateDeployment(isOpenShift, imagePullPolicy, imagePullSecrets);
+            int caCertGeneration = ModelUtils.caCertGeneration(this.clusterCa);
+            Annotations.annotations(deployment.getSpec().getTemplate()).put(
+                    Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
+
+            return deploymentOperator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaExporter.kafkaExporterName(reconciliation.name()), deployment)
+                    .compose(patchResult -> {
+                        if (patchResult instanceof ReconcileResult.Noop)   {
+                            // Deployment needs ot be rolled because the certificate secret changed
+                            if (existingKafkaExporterCertsChanged) {
+                                return kafkaExporterRollingUpdate();
+                            }
+                        }
+
+                        // No need to roll, we patched the deployment (and it will roll itself) or we created a new one
+                        return Future.succeededFuture();
+                    });
+        } else  {
+            return deploymentOperator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaExporter.kafkaExporterName(reconciliation.name()), null)
+                    .map((Void) null);
+        }
+    }
+
+    /**
+     * Triggers the rolling update of the Kafka Exporter. This is used to trigger the roll when the certificates change.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    private Future<Void> kafkaExporterRollingUpdate() {
+        return deploymentOperator.rollingUpdate(reconciliation, reconciliation.namespace(), KafkaExporter.kafkaExporterName(reconciliation.name()), operationTimeoutMs);
+    }
+
+    /**
+     * Waits for the Kafka Exporter deployment to finish any rolling and get ready.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    private Future<Void> kafkaExporterReady() {
+        if (kafkaExporter != null) {
+            return deploymentOperator.waitForObserved(reconciliation, reconciliation.namespace(), KafkaExporter.kafkaExporterName(reconciliation.name()), 1_000, operationTimeoutMs)
+                    .compose(i -> deploymentOperator.readiness(reconciliation, reconciliation.namespace(), KafkaExporter.kafkaExporterName(reconciliation.name()), 1_000, operationTimeoutMs));
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -311,18 +311,7 @@ public class KafkaExporterTest {
                 kafkaStorage, zkStorage, kafkaLogJson, zooLogJson, null, null);
         KafkaExporter ke = KafkaExporter.fromCrd(new Reconciliation("test", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()), resource, VERSIONS);
 
-        assertThat(ke.generateDeployment(true, null, null), is(nullValue()));
-        assertThat(ke.generateSecret(null, true), is(nullValue()));
-    }
-
-    @ParallelTest
-    public void testGenerateDeploymentWhenDisabled()   {
-        Kafka resource = ResourceUtils.createKafka(namespace, cluster, replicas, image,
-                healthDelay, healthTimeout, jmxMetricsConfig, kafkaConfig, zooConfig,
-                kafkaStorage, zkStorage, kafkaLogJson, zooLogJson, null, null);
-        KafkaExporter ke = KafkaExporter.fromCrd(new Reconciliation("test", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()), resource, VERSIONS);
-
-        assertThat(ke.generateDeployment(true, null, null), is(nullValue()));
+        assertThat(ke, is(nullValue()));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `KafkaAssemblyOperator` class is currently very monolithic. It contains the reconciliation steps and state for all sub-components which are part of the Kafka custom resource. This PR tries to peel-off Kafka Exporter reconciliation and the state these steps use.

This does not do much on its own, but it seems fairly easy and it reduces the `KafkaAssemblyOperator` footprint. It should make it a bit more clear which parts of the state Kafka Exporter actually needs, it should make it easier to edit the Kafka Exporter recocniliation and if needed it should also make it easier to test it (this PR does not add any new tests - the testing is currently done through the `KafkaAssemblyOperator` testing. But if / when needed, it can be tested separately).

If this is accepted, I think we can similarly handle also the JMXTrans, Cruise Control and EntityOperator reconciliation. It might be much harder to use this to separate ZooKeeper and Kafka.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally