### PR TITLE
Update Keycloak patch on s390x Jenkins pipeline

### DIFF
--- a/.jenkins/scripts/build_keycloak_opa-s390x.sh
+++ b/.jenkins/scripts/build_keycloak_opa-s390x.sh
@@ -2,8 +2,8 @@
 
 eval $(minikube docker-env)
 
-sed -i 's#kubectl apply -n \${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/\${KEYCLOAK_VERSION}/deploy/operator.yaml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/\${KEYCLOAK_VERSION}/deploy/operator.yaml | sed "s\#Always\#IfNotPresent\#g" | kubectl apply -n \${NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
-sed -i 's#kubectl delete -n \${NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/\${KEYCLOAK_VERSION}/deploy/operator.yaml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/\${KEYCLOAK_VERSION}/deploy/operator.yaml | sed "s\#Always\#IfNotPresent\#g" | kubectl delete -n \${NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
+sed -i 's#kubectl apply -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/\${KEYCLOAK_VERSION}/deploy/operator.yaml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/\${KEYCLOAK_VERSION}/deploy/operator.yaml | sed "s\#Always\#IfNotPresent\#g" | kubectl apply -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
+sed -i 's#kubectl delete -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/\${KEYCLOAK_VERSION}/deploy/operator.yaml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/\${KEYCLOAK_VERSION}/deploy/operator.yaml | sed "s\#Always\#IfNotPresent\#g" | kubectl delete -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
 sed -i '/.*openpolicyagent\/opa.*/ a \          imagePullPolicy: IfNotPresent' systemtest/src/test/resources/opa/opa.yaml 
 
 docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/keycloak-15.0.2.tar.gz


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

_Please describe your pull request_

Since PR #6468 has replaced variable name `NAMESPACE` with `KEYCLOAK_OPERATOR_NAMESPACE` in Keycloak related scripts, this PR is to update the variable name in Keycloak patch for s390x Jenkins scripts accordingly.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

