### PR TITLE
[MO] - [system test] -> deployment resource not specifying namespace …

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -20,7 +20,7 @@ public class DeploymentResource implements ResourceType<Deployment> {
     }
     @Override
     public Deployment get(String namespace, String name) {
-        return ResourceManager.kubeClient().namespace(namespace).getDeployment(namespace, name);
+        return ResourceManager.kubeClient().getDeployment(namespace, name);
     }
     @Override
     public void create(Deployment resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -20,7 +20,7 @@ public class DeploymentResource implements ResourceType<Deployment> {
     }
     @Override
     public Deployment get(String namespace, String name) {
-        return ResourceManager.kubeClient().namespace(namespace).getDeployment(name);
+        return ResourceManager.kubeClient().namespace(namespace).getDeployment(namespace, name);
     }
     @Override
     public void create(Deployment resource) {


### PR DESCRIPTION
…when get

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes namespace handling in DeploymentResource, where in some edge cases the Kubernetes client could not get the resource in the correct namespace.

### Checklist

- [x] Make sure all tests pass