### PR TITLE
Remove the refresh annotation when CC is not enabled or Cluster label is missing/wrong.

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -724,9 +724,9 @@ public class KafkaRebalanceAssemblyOperator
                                                     KafkaRebalance kafkaRebalance,
                                                     KafkaRebalanceAnnotation rebalanceAnnotation,
                                                     RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
-        if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
-            // The user has fixed the error on the resource and want to 'refresh'
-            // This actually requests a new rebalance proposal
+
+        if (shouldRenewRebalance(kafkaRebalance, rebalanceAnnotation)) {
+            // CC is activated from the disabled state or the user has fixed the error on the resource and want to 'refresh'
             return onNew(reconciliation, host, apiClient, kafkaRebalance, rebalanceOptionsBuilder);
         } else {
             // Stay in the current NotReady state, returning null as next state
@@ -1083,11 +1083,13 @@ public class KafkaRebalanceAssemblyOperator
         String clusterName = kafkaRebalance.getMetadata().getLabels() == null ? null : kafkaRebalance.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         String clusterNamespace = kafkaRebalance.getMetadata().getNamespace();
         if (clusterName == null) {
-            LOGGER.warnCr(reconciliation, "Resource lacks label '{}': No cluster related to a possible rebalance.", Labels.STRIMZI_CLUSTER_LABEL);
-            return updateStatus(reconciliation, kafkaRebalance, new KafkaRebalanceStatus(),
-                    new InvalidResourceException("Resource lacks label '"
-                            + Labels.STRIMZI_CLUSTER_LABEL
-                            + "': No cluster related to a possible rebalance.")).mapEmpty();
+
+            String errorString = "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.";
+            LOGGER.warnCr(reconciliation, errorString);
+            KafkaRebalanceStatus status = new KafkaRebalanceStatus();
+            status.addCondition(StatusUtils.buildWarningCondition(CruiseControlIssues.clusterLabelMissing.getReason(), errorString));
+            return updateStatus(reconciliation, kafkaRebalance, status,
+                    new InvalidResourceException(errorString)).mapEmpty();
         }
 
         // Get associated Kafka cluster state
@@ -1104,10 +1106,12 @@ public class KafkaRebalanceAssemblyOperator
                         LOGGER.debugCr(reconciliation, "{} {} in namespace {} belongs to a Kafka cluster {} which does not match label selector {} and will be ignored", kind(), kafkaRebalance.getMetadata().getName(), clusterNamespace, clusterName, kafkaSelector.get().getMatchLabels());
                         return Future.succeededFuture();
                     } else if (kafka.getSpec().getCruiseControl() == null) {
-                        LOGGER.warnCr(reconciliation, "Kafka resource lacks 'cruiseControl' declaration : No deployed Cruise Control for doing a rebalance.");
-                        return updateStatus(reconciliation, kafkaRebalance, new KafkaRebalanceStatus(),
-                                new InvalidResourceException("Kafka resource lacks 'cruiseControl' declaration "
-                                        + ": No deployed Cruise Control for doing a rebalance.")).mapEmpty();
+                        String errorString = "Kafka resource lacks 'cruiseControl' declaration " + ": No deployed Cruise Control for doing a rebalance.";
+                        LOGGER.warnCr(reconciliation, errorString);
+                        KafkaRebalanceStatus status = new KafkaRebalanceStatus();
+                        status.addCondition(StatusUtils.buildWarningCondition(CruiseControlIssues.cruiseControlDisabled.getReason(), errorString));
+                        return updateStatus(reconciliation, kafkaRebalance, status,
+                                new InvalidResourceException(errorString)).mapEmpty();
                     }
 
                     if (kafka.getSpec().getKafka().getStorage() instanceof JbodStorage) {
@@ -1283,6 +1287,50 @@ public class KafkaRebalanceAssemblyOperator
     private boolean hasRebalanceAnnotation(KafkaRebalance kafkaRebalance) {
         return kafkaRebalance.getMetadata().getAnnotations() != null &&
                 kafkaRebalance.getMetadata().getAnnotations().containsKey(ANNO_STRIMZI_IO_REBALANCE);
+    }
+
+    private boolean shouldRenewRebalance(KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation) {
+        // check if refresh annotation applied or request are made when CC is not active
+        if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "ConnectException".equals(condition.getReason()))) {
+            return true;
+        } else {
+            return CruiseControlIssues.checkForMatch(kafkaRebalance.getStatus().getConditions());
+        }
+    }
+
+    /**
+     * Contains the issues that will be picked up in the periodic reconciliation, once corrected.
+     */
+    private enum CruiseControlIssues {
+
+        /**
+         * The Kafka cluster label is missing .
+         */
+        clusterLabelMissing("Cluster Label missing"),
+
+        /**
+         * Cruise Control was not declared in the Kafka Resource
+         */
+        cruiseControlDisabled("Cruise Control disabled");
+
+        public String getReason() {
+            return reason;
+        }
+
+        private final String reason;
+
+        CruiseControlIssues(String reason) {
+            this.reason = reason;
+        }
+
+        public static boolean checkForMatch(List<Condition> conditions) {
+            for (CruiseControlIssues issue : CruiseControlIssues.values()) {
+                if (conditions.stream().anyMatch(condition -> issue.getReason().equals(condition.getReason()))) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     private KafkaRebalanceState state(KafkaRebalance kafkaRebalance) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -8,8 +8,11 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.CruiseControlResources;
+import io.strimzi.api.kafka.model.CruiseControlSpec;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaTopicSpec;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
@@ -31,12 +34,14 @@ import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaRebalanceTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
@@ -159,16 +164,27 @@ public class CruiseControlST extends AbstractST {
     void testCruiseControlWithRebalanceResourceAndRefreshAnnotation(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3)
-            .editMetadata()
-            .withNamespace(namespace)
-            .endMetadata()
-            .build());
-        resourceManager.createResource(extensionContext, KafkaRebalanceTemplates.kafkaRebalance(clusterName)
-            .editMetadata()
-            .withNamespace(namespace)
-            .endMetadata()
-            .build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3)
+                .editMetadata()
+                    .withNamespace(namespace)
+                .endMetadata()
+                .build());
+        resourceManager.createResource(extensionContext, false,  KafkaRebalanceTemplates.kafkaRebalance(clusterName)
+                .editMetadata()
+                    .withNamespace(namespace)
+                .endMetadata()
+                .build());
+
+        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
+
+        KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(namespace, clusterName, KafkaRebalanceState.NotReady);
+
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(namespace, kafkaSelector);
+
+        // Cruise Control spec is now enabled
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> kafka.getSpec().setCruiseControl(new CruiseControlSpec()), namespace);
+
+        RollingUpdateUtils.waitTillComponentHasRolled(namespace, kafkaSelector, 3, kafkaPods);
 
         KafkaRebalanceUtils.doRebalancingProcess(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND, namespace, clusterName), namespace, clusterName);
 


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

- Task

### Description

This PR address the issue mentioned in #3636. This removes the use of refresh annotation when we apply KR and CC is not enabled or the cluster label is missing/wrong.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

