### PR TITLE
Extend the maintenance windows support to user certificates as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Increase the size of the `/tmp` volumes to 5Mi to allow unpacking of compression libraries
 * Use `/healthz` endpoint for Kafka Exporter health checks
 * Update Jackson Library to 2.12.6
+* Renew user certificates in User Operator only during maintenance windows
 
 ## 0.28.0
 

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -106,25 +106,6 @@
             <artifactId>certificate-manager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz</artifactId>
-            <exclusions>
-                <!-- We just depend on the CronExpression class, not all of quartz's deps -->
-                <exclusion>
-                    <groupId>com.mchange</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.mchange</groupId>
-                    <artifactId>mchange-commons-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.zaxxer</groupId>
-                    <artifactId>HikariCP-java7</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -45,23 +45,18 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
-import org.quartz.CronExpression;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TimeZone;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 
@@ -69,7 +64,6 @@ import static java.util.Collections.emptyMap;
  * ModelUtils is a utility class that holds generic static helper functions
  * These are generally to be used within the classes that extend the AbstractModel class
  */
-@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class ModelUtils {
 
     private ModelUtils() {}
@@ -740,40 +734,6 @@ public class ModelUtils {
                             && owner.getName().equals(o.getName())
                             && owner.getUid().equals(o.getUid()));
         } else {
-            return false;
-        }
-    }
-
-    /**
-     * Checks whether maintenance time window is satisfied or not
-     *
-     * @param reconciliation        Reconciliation marker
-     * @param maintenanceWindows    List of maintenance windows
-     * @param dateSupplier          Date supplier
-     *
-     * @return                      True if we are in a maintenance window or if no maintenance windows are defined. False otherwise.
-     */
-    public static boolean isMaintenanceTimeWindowsSatisfied(Reconciliation reconciliation, List<String> maintenanceWindows, Supplier<Date> dateSupplier) {
-        String currentCron = null;
-        try {
-            boolean isSatisfiedBy = maintenanceWindows == null || maintenanceWindows.isEmpty();
-            if (!isSatisfiedBy) {
-                Date date = dateSupplier.get();
-                for (String cron : maintenanceWindows) {
-                    currentCron = cron;
-                    CronExpression cronExpression = new CronExpression(cron);
-                    // the user defines the cron expression in "UTC/GMT" timezone but CO pod
-                    // can be running on a different one, so setting it on the cron expression
-                    cronExpression.setTimeZone(TimeZone.getTimeZone("GMT"));
-                    if (cronExpression.isSatisfiedBy(date)) {
-                        isSatisfiedBy = true;
-                        break;
-                    }
-                }
-            }
-            return isSatisfiedBy;
-        } catch (ParseException e) {
-            LOGGER.warnCr(reconciliation, "The provided maintenance time windows list contains {} which is not a valid cron expression", currentCron);
             return false;
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -708,7 +708,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 reconciliation.namespace(), reconciliation.name(), caLabels.toMap(),
                                 clusterCaCertLabels, clusterCaCertAnnotations,
                                 clusterCaConfig != null && !clusterCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,
-                                ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
+                                Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
 
                         CertificateAuthority clientsCaConfig = kafkaAssembly.getSpec().getClientsCa();
 
@@ -726,7 +726,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         clientsCa.createRenewOrReplace(reconciliation.namespace(), reconciliation.name(),
                                 caLabels.toMap(), emptyMap(), emptyMap(),
                                 clientsCaConfig != null && !clientsCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,
-                                ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
+                                Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
 
                         List<Future> secretReconciliations = new ArrayList<>(2);
 
@@ -1759,7 +1759,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").<ReconciliationState>executeBlocking(
                 future -> {
                     try {
-                        zkCluster.generateCertificates(kafkaAssembly, clusterCa, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
+                        zkCluster.generateCertificates(kafkaAssembly, clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
                         future.complete(this);
                     } catch (Throwable e) {
                         future.fail(e);
@@ -2794,7 +2794,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     try {
                         kafkaCluster.generateCertificates(kafkaAssembly,
                                 clusterCa, kafkaBootstrapDnsName, kafkaBrokerDnsNames,
-                                ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
+                                Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
                         future.complete(this);
                     } catch (Throwable e) {
                         future.fail(e);
@@ -4087,7 +4087,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityTopicOperatorSecret(Supplier<Date> dateSupplier) {
-            return updateCertificateSecretWithDiff(EntityTopicOperator.secretName(name), entityOperator == null || entityOperator.getTopicOperator() == null ? null : entityOperator.getTopicOperator().generateSecret(clusterCa, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier)))
+            return updateCertificateSecretWithDiff(EntityTopicOperator.secretName(name), entityOperator == null || entityOperator.getTopicOperator() == null ? null : entityOperator.getTopicOperator().generateSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier)))
                     .map(changed -> {
                         existingEntityTopicOperatorCertsChanged = changed;
                         return this;
@@ -4095,7 +4095,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> entityUserOperatorSecret(Supplier<Date> dateSupplier) {
-            return updateCertificateSecretWithDiff(EntityUserOperator.secretName(name), entityOperator == null || entityOperator.getUserOperator() == null ? null : entityOperator.getUserOperator().generateSecret(clusterCa, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier)))
+            return updateCertificateSecretWithDiff(EntityUserOperator.secretName(name), entityOperator == null || entityOperator.getUserOperator() == null ? null : entityOperator.getUserOperator().generateSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier)))
                     .map(changed -> {
                         existingEntityUserOperatorCertsChanged = changed;
                         return this;
@@ -4148,7 +4148,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> cruiseControlSecret(Supplier<Date> dateSupplier) {
-            return updateCertificateSecretWithDiff(CruiseControl.secretName(name), cruiseControl == null ? null : cruiseControl.generateSecret(kafkaAssembly, clusterCa, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier)))
+            return updateCertificateSecretWithDiff(CruiseControl.secretName(name), cruiseControl == null ? null : cruiseControl.generateSecret(kafkaAssembly, clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier)))
                     .map(changed -> {
                         existingCruiseControlCertsChanged = changed;
                         return this;
@@ -4338,7 +4338,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
             Secret secret = ModelUtils.buildSecret(reconciliation, clusterCa, clusterCa.clusterOperatorSecret(), namespace,
                     ClusterOperator.secretName(name), "cluster-operator", "cluster-operator",
-                    labels, ownerRef, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
+                    labels, ownerRef, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, getMaintenanceTimeWindows(), dateSupplier));
 
             return withVoid(secretOperations.reconcile(reconciliation, namespace, ClusterOperator.secretName(name),
                     secret));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -16,6 +16,7 @@ import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
@@ -122,7 +123,7 @@ public class KafkaExporterReconciler {
                     .compose(oldSecret -> {
                         return secretOperator
                                 .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.secretName(reconciliation.name()),
-                                        kafkaExporter.generateSecret(clusterCa, ModelUtils.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, dateSupplier)))
+                                        kafkaExporter.generateSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, dateSupplier)))
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred

--- a/documentation/modules/configuring/con-configuring-user-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-user-operator.adoc
@@ -29,7 +29,7 @@ The `logging` property configures the logging of the User Operator.
 For more details, see xref:property-topic-operator-logging-reference[].
 
 `secretPrefix`::
-The `secretPrefix` property adds a prefix to the name of all Secrets created from the KafkaUser resource. For example, `STRIMZI_SECRET_PREFIX=kafka-` would prefix all Secret names with `kafka-`. So a KafkaUser named `my-user` would create a Secret named `kafka-my-user`.
+The `secretPrefix` property adds a prefix to the name of all Secrets created from the KafkaUser resource. For example, `secretPrefix: kafka-` would prefix all Secret names with `kafka-`. So a KafkaUser named `my-user` would create a Secret named `kafka-my-user`.
 
 .Example User Operator configuration
 [source,yaml,subs=attributes+]

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -75,6 +75,8 @@ spec:
               value: "kafka-"
             - name: STRIMZI_ACLS_ADMIN_API_SUPPORTED <14>
               value: "true"
+            - name: STRIMZI_MAINTENANCE_TIME_WINDOWS <15>
+              value: '* * 8-10 * * ?;* * 14-15 * * ?'
 ----
 <1> The Kubernetes namespace for the User Operator to watch for `KafkaUser` resources. Only one namespace can be specified.
 <2>  The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
@@ -99,7 +101,7 @@ The default is `30` days to initiate certificate renewal before the old certific
 When set to `false`, the User Operator will reject all resources with `simple` authorization ACL rules.
 This helps to avoid unnecessary exceptions in the Kafka cluster logs.
 The default is `true`.
-
+<15> (Optional) Semi-colon separated list of Cron Expressions defining the maintenance time windows during which the expiring user certificates will be renewed.
 
 . If you are using TLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.
 Otherwise, go to the next step.

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -94,6 +94,25 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <exclusions>
+                <!-- We just depend on the CronExpression class, not all of quartz's deps -->
+                <exclusion>
+                    <groupId>com.mchange</groupId>
+                    <artifactId>c3p0</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.mchange</groupId>
+                    <artifactId>mchange-commons-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP-java7</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -32,6 +32,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -220,7 +221,9 @@ public class KafkaUserOperator extends AbstractOperator<KafkaUser, KafkaUserSpec
                             clientsCaKeySecret,
                             userSecret,
                             config.getClientsCaValidityDays(),
-                            config.getClientsCaRenewalDays()
+                            config.getClientsCaRenewalDays(),
+                            config.getMaintenanceWindows(),
+                            KafkaUserOperator::dateSupplier
                     );
 
                     return Future.succeededFuture();
@@ -317,5 +320,9 @@ public class KafkaUserOperator extends AbstractOperator<KafkaUser, KafkaUserSpec
     @Override
     protected KafkaUserStatus createStatus() {
         return new KafkaUserStatus();
+    }
+
+    private static Date dateSupplier()  {
+        return new Date();
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -37,15 +37,15 @@ public class ResourceUtils {
     public static final String CA_KEY_NAME = NAME + "-key";
     public static final String PASSWORD = "my-password";
 
-    public static UserOperatorConfig createUserOperatorConfig(Map<String, String> labels, boolean aclsAdminApiSupported, String scramShaPassworldLength) {
+    public static UserOperatorConfig createUserOperatorConfig(Map<String, String> labels, boolean aclsAdminApiSupported, String scramShaPasswordLength) {
         Map<String, String> envVars = new HashMap<>(4);
         envVars.put(UserOperatorConfig.STRIMZI_NAMESPACE, NAMESPACE);
         envVars.put(UserOperatorConfig.STRIMZI_LABELS, labels.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")));
         envVars.put(UserOperatorConfig.STRIMZI_CA_CERT_SECRET_NAME, CA_CERT_NAME);
         envVars.put(UserOperatorConfig.STRIMZI_CA_KEY_SECRET_NAME, CA_KEY_NAME);
         envVars.put(UserOperatorConfig.STRIMZI_ACLS_ADMIN_API_SUPPORTED, Boolean.toString(aclsAdminApiSupported));
-        if (!scramShaPassworldLength.equals("12")) {
-            envVars.put(UserOperatorConfig.STRIMZI_SCRAM_SHA_PASSWORD_LENGTH, scramShaPassworldLength);
+        if (!scramShaPasswordLength.equals("12")) {
+            envVars.put(UserOperatorConfig.STRIMZI_SCRAM_SHA_PASSWORD_LENGTH, scramShaPasswordLength);
         }
 
         return UserOperatorConfig.fromMap(envVars);

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -10,9 +10,11 @@ import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -53,6 +55,7 @@ public class UserOperatorConfigTest {
         assertThat(config.getClientsCaRenewalDays(), is(10));
         assertThat(config.isAclsAdminApiSupported(), is(false));
         assertThat(config.getScramPasswordLength(), is(20));
+        assertThat(config.getMaintenanceWindows(), is(nullValue()));
     }
 
     @Test
@@ -149,5 +152,23 @@ public class UserOperatorConfigTest {
 
         UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
         assertThat(config.isAclsAdminApiSupported(), is(UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED));
+    }
+
+    @Test
+    public void testMaintenanceTimeWindows()    {
+        Map<String, String> envVars = new HashMap<>(UserOperatorConfigTest.envVars);
+
+        envVars.put(UserOperatorConfig.STRIMZI_MAINTENANCE_TIME_WINDOWS, "* * 8-10 * * ?;* * 14-15 * * ?");
+
+        UserOperatorConfig config = UserOperatorConfig.fromMap(envVars);
+        assertThat(config.getMaintenanceWindows(), is(List.of("* * 8-10 * * ?", "* * 14-15 * * ?")));
+    }
+
+    @Test
+    public void testParseMaintenanceTimeWindows()    {
+        assertThat(UserOperatorConfig.parseMaintenanceTimeWindows("* * 8-10 * * ?;* * 14-15 * * ?"), is(List.of("* * 8-10 * * ?", "* * 14-15 * * ?")));
+        assertThat(UserOperatorConfig.parseMaintenanceTimeWindows("* * 8-10 * * ?"), is(List.of("* * 8-10 * * ?")));
+        assertThat(UserOperatorConfig.parseMaintenanceTimeWindows(null), is(nullValue()));
+        assertThat(UserOperatorConfig.parseMaintenanceTimeWindows(""), is(nullValue()));
     }
 }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelCertificateHandlingTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.model;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
+import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.operator.user.ResourceUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KafkaUserModelCertificateHandlingTest {
+    // Certificate used for expiration tests where actual expiration is needed. This certificate expires on 27th March 2023.
+    // But with correct configuration or renewal days before expiration, it can be used to trigger expiration,
+    private final static String USER_CRT_FOR_EXPIRATION_TEST = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIECTCCAfGgAwIBAgIUAw8AFcPvJkD5ijYTuT5KBt6sUX4wDQYJKoZIhvcNAQEN\n" +
+            "BQAwLTETMBEGA1UECgwKaW8uc3RyaW16aTEWMBQGA1UEAwwNY2xpZW50cy1jYSB2\n" +
+            "MDAeFw0yMjAzMjcxNTQyNTBaFw0yMzAzMjcxNTQyNTBaMA8xDTALBgNVBAMMBHVz\n" +
+            "ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8cpNdaHYyZuPJ2p1I\n" +
+            "2LpEN5nwrE6Bys79ITbfwj+C12O5wyLp+n0VNr/7DPZUQP71vwWDdSmrP2gW6OSV\n" +
+            "EOb40mjLvRSRRDrcowNXL6NlV+tzd7QuNgBilWssBfpvBGYHsux7dA7Qf+DGv/Wp\n" +
+            "Wqw31ybPk5NqQXzRjJ+6xVLjERlLuIGy0s4XsO4Grfuwa1Le40KVoHNR+BRft+H6\n" +
+            "wajKnUP/j0hJHOgYmYNeuB6Aw8T49HctKJzay/b/0Jud1Vre3/cS4l5EyKpq1H3l\n" +
+            "DWPShSY0CdcvmVkSoqRJeRbqeRrUrAdzWtOIXVBuI9SonAov5RHBtaX+rZldALZD\n" +
+            "o3FrAgMBAAGjPzA9MB0GA1UdDgQWBBTO8o3wkH+x7WSJNO9Gi316f5SBADAMBgNV\n" +
+            "HRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIFoDANBgkqhkiG9w0BAQ0FAAOCAgEAjGBr\n" +
+            "wBlL2Bxcqo8BbRsLtQyRjiOtG+K0gniMAJaX5T6zUxPouzw4fkz+FMlyU+/SGYHt\n" +
+            "wDKhe6pNqls5If884i2R/Vkl4PpX1WMi1BewzdENIGkQFKzjRQd/yCKqlW2+QaNM\n" +
+            "H+u+K5l6yxyZ0FWH5pf7XVMpgs8MI/0Hq1349Lh56Ekcna8MZNxg1wBjMQzSrv9U\n" +
+            "QUV7ITOCt4ghYsUx3gaoehLt9lXnnNWCW7o/7VcZEfxV1Cr6pm+cgfvqS+sTeb8E\n" +
+            "xxlIVuwhVuT6kxzepjEceXrletj66aITAZlg3xPQwzw3jYX354HXkmpDox2KvcLK\n" +
+            "xKhBfbqbEZbI/kVKZF6XQEWmflnz/kiy1hTfHBNRuOTu/pHb4LHXW0b4qUcljxRR\n" +
+            "412HUn/OTulvqtU9pQi442+KzxFX+bm6mQwO95eZbte8omK5EzWZkvop6CjT4V9a\n" +
+            "Rnb2PLgqNCSBkp4XhR77bdWI8y569y+lcMckj6xK2ct1OGNpudClkd0oeUb/MZnT\n" +
+            "4ebFTZY24EM5LNmWXaR6RVmbg0Xc1kSR8DqUzTaNA2s8lbtQId4yvzxOP5Lkcq/G\n" +
+            "dJl3QtzbWBWFW2bU8MHZ2bUQsmw0RtmTg9tDMCHLAH+9Mw7yMWsEg5iX0H7hnwJA\n" +
+            "T/DiI+A2t2dGukf5qfzqgiXkq4XqM6+p0zY1Cv0=\n" +
+            "-----END CERTIFICATE-----\n";
+
+    private final Secret clientsCaCert = ResourceUtils.createClientsCaCertSecret();
+    private final Secret clientsCaKey = ResourceUtils.createClientsCaKeySecret();
+    private final CertManager mockCertManager = new MockCertManager();
+    private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
+
+    @Test
+    public void testNewUser()    {
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, () -> new Date());
+
+        assertThat(model.generateNewCertificateCalled, is(1));
+        assertThat(model.reuseCertificateCalled, is(0));
+    }
+
+    @Test
+    public void testExistingUserWithIncompleteSecret()    {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withData(Map.of("password", Base64.getEncoder().encodeToString("123456".getBytes(StandardCharsets.UTF_8))))
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 365, 30, null, () -> new Date());
+
+        assertThat(model.generateNewCertificateCalled, is(1));
+        assertThat(model.reuseCertificateCalled, is(0));
+    }
+
+    @Test
+    public void testExistingUserWithCompleteSecretButOldCa()    {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withData(Map.of("ca.crt", Base64.getEncoder().encodeToString("Some old CA public key".getBytes(StandardCharsets.UTF_8)),
+                        "user.crt", Base64.getEncoder().encodeToString("User public key".getBytes(StandardCharsets.UTF_8)),
+                        "user.key", Base64.getEncoder().encodeToString("User private key".getBytes(StandardCharsets.UTF_8))))
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 365, 30, null, () -> new Date());
+
+        assertThat(model.generateNewCertificateCalled, is(1));
+        assertThat(model.reuseCertificateCalled, is(0));
+    }
+
+    @Test
+    public void testExistingUserWithCompleteSecret()    {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withData(Map.of("ca.crt", clientsCaCert.getData().get("ca.crt"),
+                        "user.crt", Base64.getEncoder().encodeToString("User public key".getBytes(StandardCharsets.UTF_8)),
+                        "user.key", Base64.getEncoder().encodeToString("User private key".getBytes(StandardCharsets.UTF_8))))
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 365, 30, null, () -> new Date());
+
+        assertThat(model.generateNewCertificateCalled, is(0));
+        assertThat(model.reuseCertificateCalled, is(1));
+    }
+
+    @Test
+    public void testExistingUserWithExpiringCertWithoutMaintenanceWindows()    {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withData(Map.of("ca.crt", clientsCaCert.getData().get("ca.crt"),
+                        "user.crt", Base64.getEncoder().encodeToString(USER_CRT_FOR_EXPIRATION_TEST.getBytes(StandardCharsets.UTF_8)),
+                        "user.key", Base64.getEncoder().encodeToString("User private key".getBytes(StandardCharsets.UTF_8))))
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 1000, 500, null, () -> new Date());
+
+        assertThat(model.generateNewCertificateCalled, is(1));
+        assertThat(model.reuseCertificateCalled, is(0));
+    }
+
+    @Test
+    public void testExistingUserWithExpiringCertInMaintenanceWindow()    {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withData(Map.of("ca.crt", clientsCaCert.getData().get("ca.crt"),
+                        "user.crt", Base64.getEncoder().encodeToString(USER_CRT_FOR_EXPIRATION_TEST.getBytes(StandardCharsets.UTF_8)),
+                        "user.key", Base64.getEncoder().encodeToString("User private key".getBytes(StandardCharsets.UTF_8))))
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 1000, 500, List.of("* * 8-10 * * ?", "* * 14-15 * * ?"), () -> Date.from(Instant.parse("2018-11-26T09:00:00Z")));
+
+        assertThat(model.generateNewCertificateCalled, is(1));
+        assertThat(model.reuseCertificateCalled, is(0));
+    }
+
+    @Test
+    public void testExistingUserWithExpiringCertOutsideOfMaintenanceWindow()    {
+        Secret userSecret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(ResourceUtils.NAME)
+                    .withNamespace(ResourceUtils.NAMESPACE)
+                .endMetadata()
+                .withData(Map.of("ca.crt", clientsCaCert.getData().get("ca.crt"),
+                        "user.crt", Base64.getEncoder().encodeToString(USER_CRT_FOR_EXPIRATION_TEST.getBytes(StandardCharsets.UTF_8)),
+                        "user.key", Base64.getEncoder().encodeToString("User private key".getBytes(StandardCharsets.UTF_8))))
+                .build();
+
+        MockKafkaUserModel model = new MockKafkaUserModel();
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userSecret, 1000, 500, List.of("* * 8-10 * * ?", "* * 14-15 * * ?"), () -> Date.from(Instant.parse("2018-11-26T11:55:00Z")));
+
+        assertThat(model.generateNewCertificateCalled, is(0));
+        assertThat(model.reuseCertificateCalled, is(1));
+    }
+
+    class MockKafkaUserModel extends KafkaUserModel {
+        public int reuseCertificateCalled = 0;
+        public int generateNewCertificateCalled = 0;
+
+        protected MockKafkaUserModel() {
+            super(ResourceUtils.NAMESPACE, ResourceUtils.NAME, Labels.EMPTY, null);
+        }
+
+        @Override
+        CertAndKey generateNewCertificate(Reconciliation reconciliation, Ca clientsCa) {
+            generateNewCertificateCalled++;
+            return null;
+        }
+
+        @Override
+        CertAndKey reuseCertificate(Reconciliation reconciliation, Ca clientsCa, Secret userSecret) {
+            reuseCertificateCalled++;
+            return null;
+        }
+    }
+}

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 
@@ -136,7 +137,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecret()    {
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, () -> new Date());
         Secret generatedSecret = model.generateSecret();
 
         assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
@@ -160,7 +161,7 @@ public class KafkaUserModelTest {
     public void testGenerateSecretWithPrefix()    {
         String secretPrefix = "strimzi-";
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, secretPrefix, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, () -> new Date());
         Secret generatedSecret = model.generateSecret();
 
         assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
@@ -197,7 +198,7 @@ public class KafkaUserModelTest {
                 .build();
 
         KafkaUserModel model = KafkaUserModel.fromCrd(userWithTemplate, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, () -> new Date());
         Secret generatedSecret = model.generateSecret();
 
         assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
@@ -221,7 +222,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecretGeneratesCertificateWhenNoSecretExistsProvidedByUser()    {
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, () -> new Date());
         Secret generated = model.generateSecret();
 
         assertThat(new String(model.decodeFromSecret(generated, "ca.crt")), is("clients-ca-crt"));
@@ -246,22 +247,22 @@ public class KafkaUserModelTest {
                 .build();
 
         InvalidCertificateException e = assertThrows(InvalidCertificateException.class, () -> {
-            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, null, clientsCaKey, null, 365, 30);
+            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, null, clientsCaKey, null, 365, 30, null, () -> new Date());
         });
         assertThat(e.getMessage(), is("The Clients CA Cert Secret is missing"));
 
         e = assertThrows(InvalidCertificateException.class, () -> {
-            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, null, null, 365, 30);
+            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, null, null, 365, 30, null, () -> new Date());
         });
         assertThat(e.getMessage(), is("The Clients CA Key Secret is missing"));
 
         e = assertThrows(InvalidCertificateException.class, () -> {
-            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, emptySecret, clientsCaKey, null, 365, 30);
+            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, emptySecret, clientsCaKey, null, 365, 30, null, () -> new Date());
         });
         assertThat(e.getMessage(), is("The Clients CA Cert Secret is missing the ca.crt file"));
 
         e = assertThrows(InvalidCertificateException.class, () -> {
-            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, emptySecret, null, 365, 30);
+            model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, emptySecret, null, 365, 30, null, () -> new Date());
         });
         assertThat(e.getMessage(), is("The Clients CA Key Secret is missing the ca.key file"));
     }
@@ -276,7 +277,7 @@ public class KafkaUserModelTest {
         clientsCaKeySecret.getData().put("ca.key", Base64.getEncoder().encodeToString("different-clients-ca-key".getBytes()));
 
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCertSecret, clientsCaKeySecret, userCert, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCertSecret, clientsCaKeySecret, userCert, 365, 30, null, () -> new Date());
         Secret generatedSecret = model.generateSecret();
 
         assertThat(new String(model.decodeFromSecret(generatedSecret, "ca.crt")),  is("different-clients-ca-crt"));
@@ -294,7 +295,7 @@ public class KafkaUserModelTest {
         Secret userCert = ResourceUtils.createUserSecretTls();
 
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userCert, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userCert, 365, 30, null, () -> new Date());
         Secret generatedSecret = model.generateSecret();
 
         // These values match those in ResourceUtils.createUserSecretTls()
@@ -312,7 +313,7 @@ public class KafkaUserModelTest {
     public void testGenerateSecretGeneratesCertificateWithExistingScramSha()    {
         Secret userCert = ResourceUtils.createUserSecretScramSha();
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userCert, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, userCert, 365, 30, null, () -> new Date());
         Secret generated = model.generateSecret();
 
         assertThat(new String(model.decodeFromSecret(generated, "ca.crt")),  is("clients-ca-crt"));
@@ -328,7 +329,7 @@ public class KafkaUserModelTest {
     @Test
     public void testGenerateSecretGeneratesKeyStoreWhenOldVersionSecretExists() {
         KafkaUserModel model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, () -> new Date());
         Secret oldSecret = model.generateSecret();
 
         // remove keystore and password to simulate a Secret from a previous version
@@ -336,7 +337,7 @@ public class KafkaUserModelTest {
         oldSecret.getData().remove("user.password");
 
         model = KafkaUserModel.fromCrd(tlsUser, UserOperatorConfig.DEFAULT_SECRET_PREFIX, UserOperatorConfig.DEFAULT_STRIMZI_ACLS_ADMIN_API_SUPPORTED);
-        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, oldSecret, 365, 30);
+        model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, oldSecret, 365, 30, null, () -> new Date());
         Secret generatedSecret = model.generateSecret();
 
         assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The [maintenance windows](https://strimzi.io/docs/operators/latest/full/configuring.html#assembly-maintenance-time-windows-str) are currently used for the followinf operations:
* Renewal of the Clients CA
* Renewal of the ClusterCA
* Renewal of the server certificates

But they are not applied to the user certificates. So what can happen is for example the following scenarion:
* Clients CA is expiring (i.e. it is in the renewal period)
* Due to the maintenance window, its renewal might be postponed
* Many user certificates might ne expiring at that point as well (e.g. because they were created during the previous renewal so are expiring at the same time as the Clients CA)
* Because the User Operator ignores the maintenance windows, it will renew the user certificates. But becaue the Clients CA renewal was postponed due to maintenance window, it will actually renew the user certificate with the old CA.
* Later, when the operator gets into maintenance window it renews the Clients CA. And that in turn triggers yet another renewal of the user certificates.

To avoid this slightly chaotic and unpredictable situation, this PR extends the use of the maintenance windows to the User Operator. The configuration is passed to it as a environment variable and it is used during the certificate renewal.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md