### PR TITLE
Added test about removing expired CA certificates

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -209,8 +209,7 @@ public abstract class Ca {
         this.clock = Clock.systemUTC();
     }
 
-    /** test **/
-    protected void setClock(Clock clock) {
+    /* test */ protected void setClock(Clock clock) {
         this.clock = clock;
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -102,7 +102,6 @@ public abstract class Ca {
     private final PasswordGenerator passwordGenerator;
     protected final Reconciliation reconciliation;
     private Clock clock;
-    private static final ZoneId UTC = ZoneId.of("UTC");
 
     /**
      * Set the {@code strimzi.io/force-renew} annotation on the given {@code caCert} if the given {@code caKey} has

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -29,6 +29,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.chrono.IsoChronology;
@@ -100,6 +101,8 @@ public abstract class Ca {
 
     private final PasswordGenerator passwordGenerator;
     protected final Reconciliation reconciliation;
+    private Clock clock;
+    private static final ZoneId UTC = ZoneId.of("UTC");
 
     /**
      * Set the {@code strimzi.io/force-renew} annotation on the given {@code caCert} if the given {@code caKey} has
@@ -203,6 +206,12 @@ public abstract class Ca {
         this.generateCa = generateCa;
         this.policy = policy == null ? CertificateExpirationPolicy.RENEW_CERTIFICATE : policy;
         this.renewalType = RenewalType.NOOP;
+        this.clock = Clock.systemUTC();
+    }
+
+    /** test **/
+    protected void setClock(Clock clock) {
+        this.clock = clock;
     }
 
     private static void delete(Reconciliation reconciliation, File file) {
@@ -798,7 +807,7 @@ public abstract class Ca {
             try {
                 X509Certificate cert = x509Certificate(Base64.getDecoder().decode(certText));
                 Instant expiryDate = cert.getNotAfter().toInstant();
-                remove = expiryDate.isBefore(Instant.now());
+                remove = expiryDate.isBefore(clock.instant());
                 if (remove) {
                     LOGGER.debugCr(reconciliation, "The certificate (data.{}) in Secret expired {}; removing it",
                             certName.replace(".", "\\."), expiryDate);


### PR DESCRIPTION
This PR adds a test for checking that a CA certificate is removed when it expires.
In order to do that, it adds a new `Clock` field to the `Ca` class to make it possible to "mock" the time as it can be already done within the `OpenSslCertManager`. By default, it's going to use UTC system clock.
For passing a specific `Clock` instance for testing, I just added a `setClock` method and not extending the constructor.