### PR TITLE
 Refactored and fixed the mechanism for paused reconciliations

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -363,6 +363,17 @@ public class KafkaRebalanceAssemblyOperator
 
         LOGGER.infoCr(reconciliation, "Rebalance action from state [{}]", currentState);
 
+        if (Annotations.isReconciliationPausedWithAnnotation(kafkaRebalance)) {
+            // we need to do this check again because it was triggered by a watcher
+            KafkaRebalanceStatus status = new KafkaRebalanceStatus();
+
+            Set<Condition> unknownAndDeprecatedConditions = validate(reconciliation, kafkaRebalance);
+            unknownAndDeprecatedConditions.add(StatusUtils.getPausedCondition());
+            status.setConditions(new ArrayList<>(unknownAndDeprecatedConditions));
+
+            return updateStatus(reconciliation, kafkaRebalance, status, null).compose(i -> Future.succeededFuture());
+        }
+
         if (kafkaRebalance.getSpec().isRebalanceDisk() && !usingJbodStorage) {
             String error = "Cannot set rebalanceDisk=true for Kafka clusters with a non-JBOD storage config. " +
                 "Intra-broker balancing only applies to Kafka deployments that use JBOD storage with multiple disks.";
@@ -374,9 +385,6 @@ public class KafkaRebalanceAssemblyOperator
 
         return computeNextStatus(reconciliation, host, apiClient, kafkaRebalance, currentState, rebalanceAnnotation, rebalanceOptionsBuilder)
            .compose(desiredStatusAndMap -> {
-               if (Annotations.isReconciliationPausedWithAnnotation(kafkaRebalance)) {
-                   return updateStatus(reconciliation, kafkaRebalance, desiredStatusAndMap.status, null).compose(i -> Future.succeededFuture());
-               }
                // More events related to resource modification might be queued with a stale state. (potentially updated by the rebalance holding the lock)
                // Due to possible long rebalancing operations that take the lock for the entire period,
                // do a new get to retrieve the current resource state.
@@ -448,7 +456,7 @@ public class KafkaRebalanceAssemblyOperator
                 // Rebalance Complete
                 return onReady(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
             case ReconciliationPaused:
-                return onReconciliationPaused(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
+                return onReconciliationPaused(reconciliation, host, apiClient, kafkaRebalance, rebalanceOptionsBuilder);
             case NotReady:
                 // Error case
                 return onNotReady(reconciliation, host, apiClient, kafkaRebalance, rebalanceAnnotation, rebalanceOptionsBuilder);
@@ -731,13 +739,8 @@ public class KafkaRebalanceAssemblyOperator
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> onReconciliationPaused(Reconciliation reconciliation,
                                                                              String host, CruiseControlApi apiClient,
                                                                              KafkaRebalance kafkaRebalance,
-                                                                             KafkaRebalanceAnnotation rebalanceAnnotation,
                                                                              RebalanceOptions.RebalanceOptionsBuilder rebalanceOptionsBuilder) {
-        if (Annotations.isReconciliationPausedWithAnnotation(kafkaRebalance)) {
-            Set<Condition> unknownAndDeprecatedConditions = validate(reconciliation, kafkaRebalance);
-            unknownAndDeprecatedConditions.add(StatusUtils.getPausedCondition());
-            return configMapOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName()).compose(loadmap -> Future.succeededFuture(new MapAndStatus<>(loadmap, buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), unknownAndDeprecatedConditions))));
-        }
+
         return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder);
     }
 
@@ -1118,7 +1121,7 @@ public class KafkaRebalanceAssemblyOperator
                                             // cluster rebalance is new or it is in one of the others states
                                             if (kafkaRebalanceStatus == null) {
                                                 currentState = KafkaRebalanceState.New;
-                                            } else if (kafkaRebalanceStatus.getConditions().stream().filter(cond -> "ReconciliationPaused".equals(cond.getType())).findAny().isPresent()) {
+                                            } else if (kafkaRebalanceStatus.getConditions().stream().filter(cond -> KafkaRebalanceState.ReconciliationPaused.toString().equals(cond.getType())).findAny().isPresent()) {
                                                 currentState = KafkaRebalanceState.ReconciliationPaused;
                                             } else {
                                                 String rebalanceStateType = rebalanceStateConditionType(kafkaRebalanceStatus);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -735,6 +735,18 @@ public class KafkaRebalanceAssemblyOperator
         }
     }
 
+    /**
+     * This method handles the transition from {@code ReconciliationPaused} state.
+     * When the reconciliatiom is unpaused {@link KafkaRebalance} , it calls the Cruise Control API for requesting a rebalance proposal.
+     * If the proposal is immediately ready, the next state is {@code ProposalReady}.
+     * If the proposal is not ready yet and Cruise Control is still processing it, the next state is {@code PendingProposal}.
+     *
+     * @param reconciliation Reconciliation information
+     * @param host Cruise Control service to which sending the rebalance proposal request
+     * @param apiClient Cruise Control REST API client instance
+     * @param rebalanceOptionsBuilder builder for the Cruise Control REST API client options
+     * @return a Future with the next {@code MapAndStatus<ConfigMap, KafkaRebalanceStatus>} including the ConfigMap and state
+     */
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> onReconciliationPaused(Reconciliation reconciliation,
                                                                              String host, CruiseControlApi apiClient,
@@ -1121,8 +1133,6 @@ public class KafkaRebalanceAssemblyOperator
                                             // cluster rebalance is new or it is in one of the others states
                                             if (kafkaRebalanceStatus == null) {
                                                 currentState = KafkaRebalanceState.New;
-                                            } else if (kafkaRebalanceStatus.getConditions().stream().filter(cond -> KafkaRebalanceState.ReconciliationPaused.toString().equals(cond.getType())).findAny().isPresent()) {
-                                                currentState = KafkaRebalanceState.ReconciliationPaused;
                                             } else {
                                                 String rebalanceStateType = rebalanceStateConditionType(kafkaRebalanceStatus);
                                                 if (rebalanceStateType == null) {


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Refactoring

### Description

This PR refactors the implementation of reconciliations paused mechanism and also fixes the bug in its working. Earlier when the resource was `paused`, the state was set to `New` while the correct behaviour should be that state stays as ` ReconciliationPaused` and stays like it until the resource is unpaused.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

