### PR TITLE
[MO] - [system test] -> ReconciliationST namespace handling fix

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -175,8 +175,8 @@ public class KafkaTopicUtils {
         LOGGER.info("{} KafkaTopics were created", topicCount);
     }
 
-    public static String describeTopicViaKafkaPod(String topicName, String kafkaPodName, String bootstrapServer) {
-        return cmdKubeClient().execInPod(kafkaPodName, "/opt/kafka/bin/kafka-topics.sh",
+    public static String describeTopicViaKafkaPod(final String namespaceName, String topicName, String kafkaPodName, String bootstrapServer) {
+        return cmdKubeClient().namespace(namespaceName).execInPod(kafkaPodName, "/opt/kafka/bin/kafka-topics.sh",
             "--topic",
             topicName,
             "--describe",
@@ -185,13 +185,13 @@ public class KafkaTopicUtils {
             .out();
     }
 
-    public static void waitForKafkaTopicSpecStability(String topicName, String podName, String bootstrapServer) {
+    public static void waitForKafkaTopicSpecStability(final String namespaceName, String topicName, String podName, String bootstrapServer) {
         int[] stableCounter = {0};
 
-        String oldSpec = describeTopicViaKafkaPod(topicName, podName, bootstrapServer);
+        String oldSpec = describeTopicViaKafkaPod(namespaceName, topicName, podName, bootstrapServer);
 
         TestUtils.waitFor("KafkaTopic's spec will be stable", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-            if (oldSpec.equals(describeTopicViaKafkaPod(topicName, podName, bootstrapServer))) {
+            if (oldSpec.equals(describeTopicViaKafkaPod(namespaceName, topicName, podName, bootstrapServer))) {
                 stableCounter[0]++;
                 if (stableCounter[0] == Constants.GLOBAL_STABILITY_OFFSET_COUNT) {
                     LOGGER.info("KafkaTopic's spec is stable for {} polls intervals", stableCounter[0]);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -151,12 +151,13 @@ public class ReconciliationST extends AbstractST {
         }, namespaceName);
 
         KafkaTopicUtils.waitForKafkaTopicStatus(namespaceName, topicName, CustomResourceStatus.ReconciliationPaused);
-        KafkaTopicUtils.waitForKafkaTopicSpecStability(topicName, KafkaResources.kafkaPodName(clusterName, 0), KafkaResources.plainBootstrapAddress(clusterName));
+        KafkaTopicUtils.waitForKafkaTopicSpecStability(namespaceName, topicName, KafkaResources.kafkaPodName(clusterName, 0), KafkaResources.plainBootstrapAddress(clusterName));
 
         LOGGER.info("Setting annotation to \"false\", partitions should be scaled to {}", SCALE_TO);
-        KafkaTopicResource.replaceTopicResource(topicName,
-            topic -> topic.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"));
-        KafkaTopicUtils.waitForKafkaTopicPartitionChange(topicName, SCALE_TO);
+        KafkaTopicResource.replaceTopicResourceInSpecificNamespace(topicName,
+            topic -> topic.getMetadata().getAnnotations().replace(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true", "false"),
+            namespaceName);
+        KafkaTopicUtils.waitForKafkaTopicPartitionChange(namespaceName, topicName, SCALE_TO);
 
         resourceManager.createResource(extensionContext, KafkaRebalanceTemplates.kafkaRebalance(clusterName).build());
 


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

In #5023 and #4771 PRs, we did not specify the namespace and thus when we execute cluster-wide parallelization it can happen that the client is in another namespace, which results in an error. This PR eliminates such problem.

### Checklist

- [x] Make sure all tests pass