### PR TITLE
[MO] - [system test] -> SecurityST race condition fixes and correct R…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -385,6 +385,7 @@ public interface Constants {
     String KAFKA_TRACING_CLIENT_KEY = "KAFKA_TRACING_CLIENT";
     String KAFKA_SELECTOR = "KAFKA_SELECTOR";
     String ZOOKEEPER_SELECTOR = "ZOOKEEPER_SELECTOR";
+    String ENTITY_OPERATOR_NAME = "ENTITY_OPERATOR_NAME";
 
     /**
      * Resource constants for Cluster Operator. In case we execute more than 5 test cases in parallel we at least these configuration

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -41,6 +41,7 @@ final public class TestStorage {
     private String userName;
     private LabelSelector kafkaSelector;
     private LabelSelector zkSelector;
+    private String eoDeploymentName;
 
     public TestStorage(ExtensionContext extensionContext) {
         this(extensionContext, INFRA_NAMESPACE);
@@ -59,6 +60,7 @@ final public class TestStorage {
         this.userName = clusterName + "-" + USER;
         this.kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
         this.zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
+        this.eoDeploymentName = KafkaResources.entityOperatorDeploymentName(clusterName);
 
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.NAMESPACE_KEY, this.namespaceName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.CLUSTER_KEY, this.clusterName);
@@ -71,6 +73,7 @@ final public class TestStorage {
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.USER_NAME_KEY, this.userName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.KAFKA_SELECTOR, this.kafkaSelector);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.ZOOKEEPER_SELECTOR, this.zkSelector);
+        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.ENTITY_OPERATOR_NAME, this.eoDeploymentName);
     }
 
     public void addToTestStorage(String key, Object value) {
@@ -119,5 +122,9 @@ final public class TestStorage {
 
     public LabelSelector getZookeeperSelector() {
         return (LabelSelector) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.ZOOKEEPER_SELECTOR);
+    }
+
+    public String getEoDeploymentName() {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.ENTITY_OPERATOR_NAME).toString();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1490,7 +1490,7 @@ class SecurityST extends AbstractST {
 
         final Map<String, String> zkPods = PodUtils.podSnapshot(ts.getNamespaceName(), ts.getZookeeperSelector());
         final Map<String, String> kafkaPods = PodUtils.podSnapshot(ts.getNamespaceName(), ts.getKafkaSelector());
-        final Map<String, String> eoPod = DeploymentUtils.depSnapshot(ts.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(ts.getClusterName()));
+        final Map<String, String> eoPod = DeploymentUtils.depSnapshot(ts.getNamespaceName(), ts.getEoDeploymentName());
 
         Secret clusterCASecret = kubeClient(ts.getNamespaceName()).getSecret(ts.getNamespaceName(), KafkaResources.clusterCaCertificateSecretName(ts.getClusterName()));
         X509Certificate cacert = SecretUtils.getCertificateFromSecret(clusterCASecret, "ca.crt");
@@ -1522,7 +1522,7 @@ class SecurityST extends AbstractST {
         //   c) and other components to trust the new Cluster CA certificate. (i.e., EntityOperator)
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(ts.getNamespaceName(), ts.getZookeeperSelector(), 3, zkPods);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(ts.getNamespaceName(), ts.getKafkaSelector(), 3, kafkaPods);
-        DeploymentUtils.waitTillDepHasRolled(ts.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(ts.getClusterName()), 1, eoPod);
+        DeploymentUtils.waitTillDepHasRolled(ts.getNamespaceName(), ts.getEoDeploymentName(), 1, eoPod);
 
         // Read renewed secret/certs again
         clusterCASecret = kubeClient(ts.getNamespaceName()).getSecret(ts.getNamespaceName(), KafkaResources.clusterCaCertificateSecretName(ts.getClusterName()));


### PR DESCRIPTION
…ollingUpdates

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes the functionality of some security system tests (introduced in #4369). Specifically:

1. testClusterCACertRenew = this test case is checked after Cluster CA renews the Kafka Pods rolls. This doesn't seem right because Cluster Operator must perform a Rolling Update of ZooKeeper, Kafka and Entity Operators pods. 
2. testClientsCACertRenew = in this test case, we checked only Entity Operator, which is again wrong! The correct way is that Cluster Operator must perform a Rolling Update of Kafka and then Entity Operator pods

This also applies to the testCustomClusterCACertificateRenew test case in CustomCaST.

Many of you also face the issue with the regression pipeline (f.e., these tests cases are flaky). Because we only checked the Kafka or Entity Pods (before ZooKeeper or Kafka pods), which results in TimeoutException. This PR eliminates such flakiness.

### Checklist

- [x] Make sure all tests pass