### PR TITLE
Refactor Cruise Control reconciliation out of the `KafkaAssemblyOperator` class

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlResources.java
@@ -80,4 +80,17 @@ public class CruiseControlResources {
     public static String logAndMetricsConfigMapName(String clusterName) {
         return clusterName + "-cruise-control-config";
     }
+
+    /**
+     * Returns the name of the Cruise Control {@code NetworkPolicy} for a {@code Kafka} cluster of the given name.
+     * This {@code NetworkPolicy} will only exist if {@code Kafka.spec.cruiseControl} is configured in the
+     * {@code Kafka} resource with the given name.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding Cruise Control {@code NetworkPolicy}.
+     */
+    public static String networkPolicyName(String clusterName) {
+        return clusterName + "-network-policy-cruise-control";
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -10,9 +10,6 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.operator.common.Reconciliation;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -21,32 +18,29 @@ import java.util.concurrent.TimeUnit;
  * Class for handling Cruise Control configuration passed by the user
  */
 public class CruiseControlConfiguration extends AbstractConfiguration {
-
     /**
      * A list of case insensitive goals that Cruise Control supports in the order of priority.
      * The high priority goals will be executed first.
      */
-    protected static final List<String> CRUISE_CONTROL_GOALS_LIST = Collections.unmodifiableList(
-        Arrays.asList(
-                CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
-                CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
-                CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
-                CruiseControlGoals.DISK_CAPACITY_GOAL.toString(),
-                CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL.toString(),
-                CruiseControlGoals.NETWORK_OUTBOUND_CAPACITY_GOAL.toString(),
-                CruiseControlGoals.CPU_CAPACITY_GOAL.toString(),
-                CruiseControlGoals.REPLICA_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.POTENTIAL_NETWORK_OUTAGE_GOAL.toString(),
-                CruiseControlGoals.DISK_USAGE_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.CPU_USAGE_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.TOPIC_REPLICA_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.LEADER_REPLICA_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.LEADER_BYTES_IN_DISTRIBUTION_GOAL.toString(),
-                CruiseControlGoals.PREFERRED_LEADER_ELECTION_GOAL.toString()
-        )
-     );
+    protected static final List<String> CRUISE_CONTROL_GOALS_LIST = List.of(
+            CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
+            CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
+            CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.DISK_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.NETWORK_OUTBOUND_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.CPU_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.REPLICA_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.POTENTIAL_NETWORK_OUTAGE_GOAL.toString(),
+            CruiseControlGoals.DISK_USAGE_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.NETWORK_INBOUND_USAGE_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.NETWORK_OUTBOUND_USAGE_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.CPU_USAGE_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.TOPIC_REPLICA_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.LEADER_REPLICA_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.LEADER_BYTES_IN_DISTRIBUTION_GOAL.toString(),
+            CruiseControlGoals.PREFERRED_LEADER_ELECTION_GOAL.toString()
+    );
 
     public static final String CRUISE_CONTROL_GOALS = String.join(",", CRUISE_CONTROL_GOALS_LIST);
 
@@ -54,26 +48,22 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
      * A list of case insensitive goals that Cruise Control will use as hard goals that must all be met for an optimization
      * proposal to be valid.
      */
-    protected static final List<String> CRUISE_CONTROL_HARD_GOALS_LIST = Collections.unmodifiableList(
-            Arrays.asList(
-                    CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
-                    CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
-                    CruiseControlGoals.DISK_CAPACITY_GOAL.toString(),
-                    CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL.toString(),
-                    CruiseControlGoals.NETWORK_OUTBOUND_CAPACITY_GOAL.toString(),
-                    CruiseControlGoals.CPU_CAPACITY_GOAL.toString()
-            )
+    protected static final List<String> CRUISE_CONTROL_HARD_GOALS_LIST = List.of(
+            CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
+            CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.DISK_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.NETWORK_INBOUND_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.NETWORK_OUTBOUND_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.CPU_CAPACITY_GOAL.toString()
     );
 
     public static final String CRUISE_CONTROL_HARD_GOALS = String.join(",", CRUISE_CONTROL_HARD_GOALS_LIST);
 
-    protected static final List<String> CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST = Collections.unmodifiableList(
-        Arrays.asList(
-                CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
-                CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
-                CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
-                CruiseControlGoals.DISK_CAPACITY_GOAL.toString()
-        )
+    protected static final List<String> CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST = List.of(
+            CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
+            CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
+            CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
+            CruiseControlGoals.DISK_CAPACITY_GOAL.toString()
     );
 
     public static final String CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS =
@@ -82,30 +72,24 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     /*
     * Map containing default values for required configuration properties
     */
-    private static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
+    private static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP = Map.ofEntries(
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1"),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "20"),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(), Long.toString(TimeUnit.DAYS.toMillis(1))),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_HARD_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_HARD_GOALS),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED)),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_AUTH_CREDENTIALS_FILE.getValue(), CruiseControl.API_AUTH_CREDENTIALS_FILE),
+            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED))
+    );
 
-    private static final List<String> FORBIDDEN_PREFIXES;
-    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
+    private static final List<String> FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
-    static {
-        Map<String, String> config = new HashMap<>(11);
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000));
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1");
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000));
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "20");
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(), Long.toString(TimeUnit.DAYS.toMillis(1)));
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS);
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS);
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_HARD_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_HARD_GOALS);
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControl.DEFAULT_WEBSERVER_SECURITY_ENABLED));
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_AUTH_CREDENTIALS_FILE.getValue(), CruiseControl.API_AUTH_CREDENTIALS_FILE);
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControl.DEFAULT_WEBSERVER_SSL_ENABLED));
 
-        CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP = Collections.unmodifiableMap(config);
-
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
-    }
 
     /**
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
@@ -118,11 +102,20 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
         super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
-    private CruiseControlConfiguration(Reconciliation reconciliation, String configuration, List<String> forbiddenPrefixes) {
-        super(reconciliation, configuration, forbiddenPrefixes);
-    }
-
     public static Map<String, String> getCruiseControlDefaultPropertiesMap() {
         return CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
+    }
+
+    private boolean isEnabledInConfiguration(String s1, String s2) {
+        String s = getConfigOption(s1, s2);
+        return Boolean.parseBoolean(s);
+    }
+
+    public boolean isApiAuthEnabled() {
+        return isEnabledInConfiguration(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED));
+    }
+
+    public boolean isApiSslEnabled() {
+        return isEnabledInConfiguration(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -45,6 +45,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.strimzi.api.kafka.model.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
@@ -1760,7 +1761,7 @@ public class KafkaCluster extends AbstractModel {
 
         NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector() // Cruise Control
-                     .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(cluster))
+                     .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(cluster))
                 .endPodSelector()
                 .build();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -29,6 +29,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPort;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
@@ -453,7 +454,7 @@ public class ZookeeperCluster extends AbstractModel {
         NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeer();
         LabelSelector labelSelector5 = new LabelSelector();
         Map<String, String> expressions5 = new HashMap<>(1);
-        expressions5.put(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(cluster));
+        expressions5.put(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(cluster));
         labelSelector5.setMatchLabels(expressions5);
         cruiseControlPeer.setPodSelector(labelSelector5);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.strimzi.api.kafka.model.CruiseControlResources;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.cluster.model.ClusterCa;
+import io.strimzi.operator.cluster.model.CruiseControl;
+import io.strimzi.operator.cluster.model.ImagePullPolicy;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
+import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.vertx.core.Future;
+
+import java.util.Date;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Class used for reconciliation of Cruise Control. This class contains both the steps of the Cruise Control
+ * reconciliation pipeline and is also used to store the state between them.
+ */
+public class CruiseControlReconciler {
+    private final Reconciliation reconciliation;
+    private final CruiseControl cruiseControl;
+    private final ClusterCa clusterCa;
+    private final List<String> maintenanceWindows;
+    private final long operationTimeoutMs;
+    private final String operatorNamespace;
+    private final Labels operatorNamespaceLabels;
+    private final boolean isNetworkPolicyGeneration;
+
+    private final DeploymentOperator deploymentOperator;
+    private final SecretOperator secretOperator;
+    private final ServiceAccountOperator serviceAccountOperator;
+    private final ServiceOperator serviceOperator;
+    private final NetworkPolicyOperator networkPolicyOperator;
+    private final ConfigMapOperator configMapOperator;
+
+    private boolean existingCertsChanged = false;
+
+    /**
+     * Constructs the Cruise Control reconciler
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param kafkaAssembly             The Kafka custom resource
+     * @param versions                  The supported Kafka versions
+     * @param storage                   The actual storage configuration used by the cluster. This might differ from the
+     *                                  storage configuration configured by the user in the Kafka CR due to un-allowed changes.
+     * @param clusterCa                 The Cluster CA instance
+     * @param operationTimeoutMs        Timeout for Kubernetes operations
+     * @param operatorNamespace         Namespace where the Cluster Operator is running (used to generate network policies)
+     * @param operatorNamespaceLabels   Labels of the namespace where the Cluster Operator is running (used to generate network policies)
+     * @param isNetworkPolicyGeneration Flag indicating whether network policies should be generated or not
+     * @param deploymentOperator        The Deployment operator for working with Kubernetes Deployments
+     * @param secretOperator            The Secret operator for working with Kubernetes Secrets
+     * @param serviceAccountOperator    The Service Account operator for working with Kubernetes Service Accounts
+     * @param serviceOperator           The Service operator for working with Kubernetes Service Accounts
+     * @param networkPolicyOperator     The Network Policy operator for working with Kubernetes Service Accounts
+     * @param configMapOperator         The Config Map operator for working with Kubernetes Config Maps
+     */
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    public CruiseControlReconciler(
+            Reconciliation reconciliation,
+            Kafka kafkaAssembly,
+            KafkaVersion.Lookup versions,
+            Storage storage,
+            ClusterCa clusterCa,
+            long operationTimeoutMs,
+            String operatorNamespace,
+            Labels operatorNamespaceLabels,
+            boolean isNetworkPolicyGeneration,
+            DeploymentOperator deploymentOperator,
+            SecretOperator secretOperator,
+            ServiceAccountOperator serviceAccountOperator,
+            ServiceOperator serviceOperator,
+            NetworkPolicyOperator networkPolicyOperator,
+            ConfigMapOperator configMapOperator
+    ) {
+        this.reconciliation = reconciliation;
+        this.cruiseControl = CruiseControl.fromCrd(reconciliation, kafkaAssembly, versions, storage);
+        this.clusterCa = clusterCa;
+        this.maintenanceWindows = kafkaAssembly.getSpec().getMaintenanceTimeWindows();
+        this.operationTimeoutMs = operationTimeoutMs;
+        this.operatorNamespace = operatorNamespace;
+        this.operatorNamespaceLabels = operatorNamespaceLabels;
+        this.isNetworkPolicyGeneration = isNetworkPolicyGeneration;
+
+        this.deploymentOperator = deploymentOperator;
+        this.secretOperator = secretOperator;
+        this.serviceAccountOperator = serviceAccountOperator;
+        this.serviceOperator = serviceOperator;
+        this.networkPolicyOperator = networkPolicyOperator;
+        this.configMapOperator = configMapOperator;
+    }
+
+    /**
+     * The main reconciliation method which triggers the whole reconciliation pipeline. This is the method which is
+     * expected to be called from the outside to trigger the reconciliation.
+     *
+     * @param isOpenShift       Flag indicating whether we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  List of Image pull secrets
+     * @param dateSupplier      Date supplier for checking maintenance windows
+     *
+     * @return                  Future which completes when the reconciliation completes
+     */
+    public Future<Void> reconcile(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets, Supplier<Date> dateSupplier)    {
+        return cruiseControlNetworkPolicy()
+                .compose(i -> cruiseControlServiceAccount())
+                .compose(i -> cruiseControlLoggingAndMetricsConfigMap())
+                .compose(i -> cruiseControlCertificatesSecret(dateSupplier))
+                .compose(i -> cruiseControlApiSecret())
+                .compose(i -> cruiseControlService())
+                .compose(i -> cruiseControlDeployment(isOpenShift, imagePullPolicy, imagePullSecrets))
+                .compose(i -> cruiseControlReady());
+    }
+
+    /**
+     * Manages the Cruise Control Network Policies.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlNetworkPolicy() {
+        if (isNetworkPolicyGeneration) {
+            return networkPolicyOperator
+                    .reconcile(
+                            reconciliation,
+                            reconciliation.namespace(),
+                            CruiseControlResources.networkPolicyName(reconciliation.name()),
+                            cruiseControl != null ? cruiseControl.generateNetworkPolicy(operatorNamespace, operatorNamespaceLabels) : null
+                    ).map((Void) null);
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
+    /**
+     * Manages the Cruise Control Service Account.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlServiceAccount() {
+        return serviceAccountOperator
+                .reconcile(
+                        reconciliation,
+                        reconciliation.namespace(),
+                        CruiseControlResources.serviceAccountName(reconciliation.name()),
+                        cruiseControl != null ? cruiseControl.generateServiceAccount() : null
+                ).map((Void) null);
+    }
+
+    /**
+     * Manages the Cruise Control Config Map with logging and metrics configuration.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlLoggingAndMetricsConfigMap() {
+        if (cruiseControl != null)  {
+            return Util.metricsAndLogging(reconciliation, configMapOperator, reconciliation.namespace(), cruiseControl.getLogging(), cruiseControl.getMetricsConfigInCm())
+                    .compose(metricsAndLogging -> {
+                        ConfigMap logAndMetricsConfigMap = cruiseControl.generateMetricsAndLogConfigMap(metricsAndLogging);
+
+                        return configMapOperator
+                                .reconcile(
+                                        reconciliation,
+                                        reconciliation.namespace(),
+                                        CruiseControlResources.logAndMetricsConfigMapName(reconciliation.name()),
+                                        logAndMetricsConfigMap
+                                ).map((Void) null);
+                    });
+        } else {
+            return configMapOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.logAndMetricsConfigMapName(reconciliation.name()), null)
+                    .map((Void) null);
+        }
+    }
+
+    /**
+     * Manages the Cruise Control certificates Secret.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlCertificatesSecret(Supplier<Date> dateSupplier) {
+        if (cruiseControl != null) {
+            return secretOperator.getAsync(reconciliation.namespace(), CruiseControlResources.secretName(reconciliation.name()))
+                    .compose(oldSecret -> {
+                        return secretOperator
+                                .reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.secretName(reconciliation.name()),
+                                        cruiseControl.generateCertificatesSecret(reconciliation.namespace(), reconciliation.name(), clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, dateSupplier)))
+                                .compose(patchResult -> {
+                                    if (patchResult instanceof ReconcileResult.Patched) {
+                                        // The secret is patched and some changes to the existing certificates actually occurred
+                                        existingCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
+                                    } else {
+                                        existingCertsChanged = false;
+                                    }
+
+                                    return Future.succeededFuture();
+                                });
+                    });
+        } else {
+            return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.secretName(reconciliation.name()), null)
+                    .map((Void) null);
+        }
+    }
+
+    /**
+     * Manages the Cruise Control API keys secret.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlApiSecret() {
+        if (cruiseControl != null) {
+            return secretOperator.getAsync(reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()))
+                    .compose(oldSecret -> {
+                        Secret newSecret = cruiseControl.generateApiSecret();
+
+                        if (oldSecret != null)  {
+                            // The credentials should not change with every release
+                            // So if the secret with credentials already exists, we re-use the values
+                            // But we use the new secret to update labels etc. if needed
+                            newSecret.setData(oldSecret.getData());
+                        }
+
+                        return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()), newSecret)
+                                .map((Void) null);
+                    });
+        } else {
+            return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()), null)
+                    .map((Void) null);
+        }
+    }
+
+    /**
+     * Manages the Cruise Control Service.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlService() {
+        return serviceOperator
+                .reconcile(
+                        reconciliation,
+                        reconciliation.namespace(),
+                        CruiseControlResources.serviceName(reconciliation.name()),
+                        cruiseControl != null ? cruiseControl.generateService() : null
+                ).map((Void) null);
+    }
+
+    /**
+     * Manages the Cruise Control Deployment.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlDeployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
+        if (cruiseControl != null) {
+            Deployment deployment = cruiseControl.generateDeployment(isOpenShift, imagePullPolicy, imagePullSecrets);
+
+            int caCertGeneration = ModelUtils.caCertGeneration(clusterCa);
+            Annotations.annotations(deployment.getSpec().getTemplate()).put(
+                    Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
+
+            return deploymentOperator
+                    .reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), deployment)
+                    .compose(patchResult -> {
+                        if (patchResult instanceof ReconcileResult.Noop)   {
+                            // Deployment needs ot be rolled because the certificate secret changed
+                            if (existingCertsChanged) {
+                                return cruiseControlRollingUpdate();
+                            }
+                        }
+
+                        // No need to roll, we patched the deployment (and it will roll itself) or we created a new one
+                        return Future.succeededFuture();
+                    });
+        } else {
+            return deploymentOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), null)
+                    .map((Void) null);
+        }
+    }
+
+    /**
+     * Triggers the rolling update of the Cruise Control. This is used to trigger the roll when the certificates change.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlRollingUpdate() {
+        return deploymentOperator.rollingUpdate(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), operationTimeoutMs);
+    }
+
+    /**
+     * Waits for the Cruise Control deployment to finish any rolling and get ready.
+     *
+     * @return  Future which completes when the reconciliation is done
+     */
+    Future<Void> cruiseControlReady() {
+        if (cruiseControl != null) {
+            return deploymentOperator.waitForObserved(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), 1_000, operationTimeoutMs)
+                    .compose(i -> deploymentOperator.readiness(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), 1_000, operationTimeoutMs));
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1098,8 +1098,8 @@ public class KafkaRebalanceAssemblyOperator
                                 }
 
                                 CruiseControlConfiguration c = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet());
-                                boolean apiAuthEnabled = CruiseControl.isApiAuthEnabled(c);
-                                boolean apiSslEnabled = CruiseControl.isApiSslEnabled(c);
+                                boolean apiAuthEnabled = c.isApiAuthEnabled();
+                                boolean apiSslEnabled = c.isApiSslEnabled();
                                 CruiseControlApi apiClient = cruiseControlClientProvider(ccSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
 
                                 // get latest KafkaRebalance state as it may have changed

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1097,9 +1097,9 @@ public class KafkaRebalanceAssemblyOperator
                                     return Future.failedFuture(Util.missingSecretException(clusterNamespace, ccApiSecretName));
                                 }
 
-                                CruiseControlConfiguration c = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet());
-                                boolean apiAuthEnabled = c.isApiAuthEnabled();
-                                boolean apiSslEnabled = c.isApiSslEnabled();
+                                CruiseControlConfiguration ccConfig = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet());
+                                boolean apiAuthEnabled = ccConfig.isApiAuthEnabled();
+                                boolean apiSslEnabled = ccConfig.isApiSslEnabled();
                                 CruiseControlApi apiClient = cruiseControlClientProvider(ccSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
 
                                 // get latest KafkaRebalance state as it may have changed

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -23,8 +23,6 @@ import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeoutException;
 
-import static io.strimzi.operator.cluster.model.CruiseControl.encodeToBase64;
-
 public class CruiseControlApiImpl implements CruiseControlApi {
     private static final boolean HTTP_CLIENT_ACTIVITY_LOGGING = false;
     public static final int HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS = -1; // use default internal HTTP client timeout
@@ -66,7 +64,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
     private static HTTPHeader generateAuthHttpHeader(String user, String password) {
         String headerName = "Authorization";
-        String headerValue = "Basic " + encodeToBase64(String.join(":", user, password));
+        String headerValue = "Basic " + Util.encodeToBase64(String.join(":", user, password));
 
         return new HTTPHeader(headerName, headerValue);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -46,6 +46,7 @@ import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.GenericSecretSourceBuilder;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
@@ -1804,7 +1805,7 @@ public class KafkaClusterTest {
 
         NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
-                    .withMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(cluster)))
+                    .withMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(cluster)))
                 .endPodSelector()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -884,7 +885,7 @@ public class ZookeeperClusterTest {
         assertThat(clientsRule.getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(new LabelSelector()).build()));
 
         podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, CruiseControl.cruiseControlName(zc.getCluster())));
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(zc.getCluster())));
         assertThat(clientsRule.getFrom().get(4), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         // Port 9404

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.strimzi.api.kafka.model.CruiseControlResources;
+import io.strimzi.api.kafka.model.CruiseControlSpec;
+import io.strimzi.api.kafka.model.CruiseControlSpecBuilder;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.balancing.BrokerCapacityBuilder;
+import io.strimzi.certs.OpenSslCertManager;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.ClusterCa;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.PasswordGenerator;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
+import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.vertx.core.Future;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Date;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class CruiseControlReconcilerTest {
+    private static final String NAMESPACE = "namespace";
+    private static final String NAME = "name";
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+
+    private final CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
+            .withBrokerCapacity(new BrokerCapacityBuilder().withInboundNetwork("10000KB/s").withOutboundNetwork("10000KB/s").build())
+            .withConfig(Map.of("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal"))
+            .build();
+
+    @Test
+    public void reconcileEnabledCruiseControl(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        ServiceAccountOperator mockSaOps = supplier.serviceAccountOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolicyOps = supplier.networkPolicyOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+
+        ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
+        when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceAccountName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Secret> secretCaptor = ArgumentCaptor.forClass(Secret.class);
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.secretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.apiSecretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceName(NAME)), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<NetworkPolicy> netPolicyCaptor = ArgumentCaptor.forClass(NetworkPolicy.class);
+        when(mockNetPolicyOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.networkPolicyName(NAME)), netPolicyCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<ConfigMap> cmCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.logAndMetricsConfigMapName(NAME)), cmCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.deploymentName(NAME)), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(any(), eq(NAMESPACE), eq(CruiseControlResources.deploymentName(NAME)), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.readiness(any(), eq(NAMESPACE), eq(CruiseControlResources.deploymentName(NAME)), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        Kafka kafka = new KafkaBuilder(ResourceUtils.createKafka(NAMESPACE, NAME, 3, "foo", 120, 30))
+                .editSpec()
+                    .withCruiseControl(cruiseControlSpec)
+                .endSpec()
+                .build();
+
+        ClusterCa clusterCa = new ClusterCa(
+                Reconciliation.DUMMY_RECONCILIATION,
+                new OpenSslCertManager(),
+                new PasswordGenerator(10, "a", "a"),
+                NAME,
+                ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME, AbstractModel.clusterCaCertSecretName(NAME), MockCertManager.clusterCaCert(), MockCertManager.clusterCaCertStore(), "123456"),
+                ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME, AbstractModel.clusterCaKeySecretName(NAME), MockCertManager.clusterCaKey())
+        );
+
+        CruiseControlReconciler rcnclr = new CruiseControlReconciler(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafka,
+                VERSIONS,
+                kafka.getSpec().getKafka().getStorage(),
+                clusterCa,
+                300_000,
+                null,
+                null,
+                true,
+                mockDepOps,
+                mockSecretOps,
+                mockSaOps,
+                mockServiceOps,
+                mockNetPolicyOps,
+                mockCmOps
+        );
+
+        Checkpoint async = context.checkpoint();
+        rcnclr.reconcile(false, null, null, Date::new)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(saCaptor.getAllValues().size(), is(1));
+                    assertThat(saCaptor.getValue(), is(notNullValue()));
+
+                    assertThat(secretCaptor.getAllValues().size(), is(2));
+                    assertThat(secretCaptor.getAllValues().get(0), is(notNullValue()));
+                    assertThat(secretCaptor.getAllValues().get(1), is(notNullValue()));
+
+                    assertThat(serviceCaptor.getAllValues().size(), is(1));
+                    assertThat(serviceCaptor.getValue(), is(notNullValue()));
+
+                    assertThat(netPolicyCaptor.getAllValues().size(), is(1));
+                    assertThat(netPolicyCaptor.getValue(), is(notNullValue()));
+
+                    assertThat(cmCaptor.getAllValues().size(), is(1));
+                    assertThat(cmCaptor.getValue(), is(notNullValue()));
+
+                    assertThat(depCaptor.getAllValues().size(), is(1));
+                    assertThat(depCaptor.getValue(), is(notNullValue()));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void reconcileDisabledCruiseControl(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        ServiceAccountOperator mockSaOps = supplier.serviceAccountOperations;
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        NetworkPolicyOperator mockNetPolicyOps = supplier.networkPolicyOperator;
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+
+        ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
+        when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceAccountName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Secret> secretCaptor = ArgumentCaptor.forClass(Secret.class);
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.secretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.apiSecretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceName(NAME)), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<NetworkPolicy> netPolicyCaptor = ArgumentCaptor.forClass(NetworkPolicy.class);
+        when(mockNetPolicyOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.networkPolicyName(NAME)), netPolicyCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<ConfigMap> cmCaptor = ArgumentCaptor.forClass(ConfigMap.class);
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.logAndMetricsConfigMapName(NAME)), cmCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDepOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.deploymentName(NAME)), depCaptor.capture())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(any(), eq(NAMESPACE), eq(CruiseControlResources.deploymentName(NAME)), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.readiness(any(), eq(NAMESPACE), eq(CruiseControlResources.deploymentName(NAME)), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, "foo", 120, 30);
+
+        ClusterCa clusterCa = new ClusterCa(
+                Reconciliation.DUMMY_RECONCILIATION,
+                new OpenSslCertManager(),
+                new PasswordGenerator(10, "a", "a"),
+                NAME,
+                ResourceUtils.createInitialCaCertSecret(NAMESPACE, NAME, AbstractModel.clusterCaCertSecretName(NAME), MockCertManager.clusterCaCert(), MockCertManager.clusterCaCertStore(), "123456"),
+                ResourceUtils.createInitialCaKeySecret(NAMESPACE, NAME, AbstractModel.clusterCaKeySecretName(NAME), MockCertManager.clusterCaKey())
+        );
+
+        CruiseControlReconciler rcnclr = new CruiseControlReconciler(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafka,
+                VERSIONS,
+                kafka.getSpec().getKafka().getStorage(),
+                clusterCa,
+                300_000,
+                null,
+                null,
+                true,
+                mockDepOps,
+                mockSecretOps,
+                mockSaOps,
+                mockServiceOps,
+                mockNetPolicyOps,
+                mockCmOps
+        );
+
+        Checkpoint async = context.checkpoint();
+        rcnclr.reconcile(false, null, null, Date::new)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(saCaptor.getAllValues().size(), is(1));
+                    assertThat(saCaptor.getValue(), is(nullValue()));
+
+                    assertThat(secretCaptor.getAllValues().size(), is(2));
+                    assertThat(secretCaptor.getAllValues().get(0), is(nullValue()));
+                    assertThat(secretCaptor.getAllValues().get(1), is(nullValue()));
+
+                    assertThat(serviceCaptor.getAllValues().size(), is(1));
+                    assertThat(serviceCaptor.getValue(), is(nullValue()));
+
+                    assertThat(netPolicyCaptor.getAllValues().size(), is(1));
+                    assertThat(netPolicyCaptor.getValue(), is(nullValue()));
+
+                    assertThat(cmCaptor.getAllValues().size(), is(1));
+                    assertThat(cmCaptor.getValue(), is(nullValue()));
+
+                    assertThat(depCaptor.getAllValues().size(), is(1));
+                    assertThat(depCaptor.getValue(), is(nullValue()));
+
+                    async.flag();
+                })));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -20,13 +19,11 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
-import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
@@ -42,7 +39,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,7 +52,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -313,65 +308,6 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
 
                     assertThat(clusterCaCertSecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
                     assertThat(clusterCaKeySecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
-
-                    async.flag();
-                })));
-    }
-
-    /*
-     * This test covers the issue described in PR #5128 / issue #5126 where the getCruiseControlDescription returns
-     * without really waiting for the actual description. the way it is tested here is that we trigger an error when
-     * querying the metrics CM needed for the description and check that the reconciliation fails because of it which
-     * means the right outcome is returned.
-     */
-    @Test
-    public void testCruiseControlDescription(VertxTestContext context) throws NoSuchFieldException, IllegalAccessException {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                    .withName(NAME)
-                    .withNamespace(NAMESPACE)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewKafka()
-                        .withReplicas(3)
-                        .withNewEphemeralStorage()
-                        .endEphemeralStorage()
-                    .endKafka()
-                    .withNewZookeeper()
-                        .withReplicas(3)
-                        .withNewEphemeralStorage()
-                        .endEphemeralStorage()
-                    .endZookeeper()
-                    .withNewCruiseControl()
-                        .withNewJmxPrometheusExporterMetricsConfig()
-                            .withNewValueFrom()
-                                .withConfigMapKeyRef(new ConfigMapKeySelectorBuilder().withName("my-metrics-cm").withKey("my-metrics.yaml").build())
-                            .endValueFrom()
-                        .endJmxPrometheusExporterMetricsConfig()
-                    .endCruiseControl()
-                .endSpec()
-                .build();
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-        ConfigMapOperator cmOps = supplier.configMapOperations;
-        when(cmOps.getAsync(eq(NAMESPACE), eq("my-metrics-cm"))).thenReturn(Future.failedFuture("Failed ConfigMap getAsync call"));
-
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
-                supplier, ResourceUtils.dummyClusterOperatorConfig(KafkaVersionTestUtils.getKafkaVersionLookup(), 1L));
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-
-        Checkpoint async = context.checkpoint();
-        KafkaAssemblyOperator.ReconciliationState reconciliationState =  op.new ReconciliationState(reconciliation, kafka);
-
-        KafkaCluster mockKafkaCluster = mock(KafkaCluster.class);
-        when(mockKafkaCluster.getStorage()).thenReturn(kafka.getSpec().getKafka().getStorage());
-        Field field = reconciliationState.getClass().getDeclaredField("kafkaCluster");
-        field.setAccessible(true);
-        field.set(reconciliationState, mockKafkaCluster);
-
-        reconciliationState.getCruiseControlDescription()
-                .onComplete(context.failing(c -> context.verify(() -> {
-                    assertThat(c.getMessage(), is("Failed ConfigMap getAsync call"));
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -22,6 +22,7 @@ import io.fabric8.openshift.api.model.RouteIngressBuilder;
 import io.fabric8.openshift.api.model.RouteStatus;
 import io.fabric8.openshift.api.model.RouteStatusBuilder;
 import io.strimzi.api.kafka.StrimziPodSetList;
+import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.EntityOperatorSpecBuilder;
 import io.strimzi.api.kafka.model.EntityTopicOperatorSpecBuilder;
@@ -1120,7 +1121,7 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.getAsync(clusterNamespace, ClusterOperator.secretName(clusterName))).thenReturn(
                 Future.succeededFuture(new Secret())
         );
-        when(mockSecretOps.getAsync(clusterNamespace, CruiseControl.secretName(clusterName))).thenReturn(
+        when(mockSecretOps.getAsync(clusterNamespace, CruiseControlResources.secretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );
 
@@ -1156,11 +1157,11 @@ public class KafkaAssemblyOperatorTest {
         }
 
         if (originalCruiseControl != null) {
-            when(mockDepOps.get(clusterNamespace, CruiseControl.cruiseControlName(clusterName))).thenReturn(
-                    originalCruiseControl.generateDeployment(true, Map.of(), null, null)
+            when(mockDepOps.get(clusterNamespace, CruiseControlResources.deploymentName(clusterName))).thenReturn(
+                    originalCruiseControl.generateDeployment(true, null, null)
             );
             when(mockDepOps.getAsync(clusterNamespace, EntityOperator.entityOperatorName(clusterName))).thenReturn(
-                    Future.succeededFuture(originalCruiseControl.generateDeployment(true, Map.of(), null, null))
+                    Future.succeededFuture(originalCruiseControl.generateDeployment(true, null, null))
             );
             when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(
                     Future.succeededFuture()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -162,7 +162,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     }
 
     private void mockSecretResources() {
-        when(mockSecretOps.getAsync(CLUSTER_NAMESPACE, CruiseControl.secretName(CLUSTER_NAME)))
+        when(mockSecretOps.getAsync(CLUSTER_NAMESPACE, CruiseControlResources.secretName(CLUSTER_NAME)))
                 .thenReturn(Future.succeededFuture(MockCruiseControl.CC_SECRET));
         when(mockSecretOps.getAsync(CLUSTER_NAMESPACE, CruiseControlResources.apiSecretName(CLUSTER_NAME)))
                 .thenReturn(Future.succeededFuture(MockCruiseControl.CC_API_SECRET));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -69,7 +69,7 @@ public class MockCruiseControl {
 
     public static final Secret CC_SECRET = new SecretBuilder()
             .withNewMetadata()
-              .withName(CruiseControl.secretName(CLUSTER))
+              .withName(CruiseControlResources.secretName(CLUSTER))
               .withNamespace(NAMESPACE)
             .endMetadata()
             .addToData("cruise-control.crt", MockCertManager.clusterCaCert())

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlConfigurationParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlConfigurationParameters.java
@@ -49,6 +49,10 @@ public enum CruiseControlConfigurationParameters {
     CRUISE_CONTROL_SELF_HEALING_CONFIG_KEY("self.healing.goals"),
     CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY("anomaly.detection.goals");
 
+    // Defaults
+    public static final boolean DEFAULT_WEBSERVER_SECURITY_ENABLED = true;
+    public static final boolean DEFAULT_WEBSERVER_SSL_ENABLED = true;
+
     private final String value;
 
     CruiseControlConfigurationParameters(String value) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -746,4 +746,15 @@ public class Util {
             return false;
         }
     }
+
+    /**
+     * Encodes a String into Base64
+     *
+     * @param encode    String which should be encoded
+     *
+     * @return          Base64 data
+     */
+    public static String encodeToBase64(String encode)  {
+        return Base64.getEncoder().encodeToString(encode.getBytes(StandardCharsets.US_ASCII));
+    }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This is another step in the `KafkaAssemblyOperator` refactoring. This PR handles the Cruise Control. It moves the reconciliation and all its state out from `KafkaAssemblyOperator` into a new class `CruiseControlReconciler`. It also does the usual clean-up of the `CruiseControl` model class (removing unnecessary setters / getters, static methods calling another static methods etc.). It also tries to create more clear separation between the classes related to the KafkaRebalance recocniliatin and the `CruiseControl` model => the model should be mainly about the actual Cruise Control deployment and its details should not be needed for KafkaRebalance reconciliation => as a result some fields and methods were moved.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally