### PR TITLE
Moved to use Clock to check certificate expiration

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -36,6 +36,7 @@ import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
@@ -848,10 +849,10 @@ public abstract class Ca {
     }
 
     public boolean certNeedsRenewal(X509Certificate cert)  {
-        Date notAfter = cert.getNotAfter();
-        LOGGER.traceCr(reconciliation, "Certificate {} expires on {}", cert.getSubjectDN(), notAfter);
-        long msTillExpired = notAfter.getTime() - System.currentTimeMillis();
-        return msTillExpired < renewalDays * 24L * 60L * 60L * 1000L;
+        Instant notAfter = cert.getNotAfter().toInstant();
+        Instant renewalPeriodBegin = notAfter.minus(renewalDays, ChronoUnit.DAYS);
+        LOGGER.traceCr(reconciliation, "Certificate {} expires on {} renewal period begins on {}", cert.getSubjectDN(), notAfter, renewalPeriodBegin);
+        return this.clock.instant().isAfter(renewalPeriodBegin);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -40,7 +40,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR fixes #6595 by using the `Clock` instead of the `System.currentTimeMillis()` to check certificate expiration by changing the code to do that as well.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass