### PR TITLE
Make the size of the StrimziPodSetController work queue configurable

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -97,7 +97,7 @@ public class ClusterOperator extends AbstractVerticle {
         getVertx().createSharedWorkerExecutor("kubernetes-ops-pool", config.getOperationsThreadPoolSize(), TimeUnit.SECONDS.toNanos(120));
 
         if (config.featureGates().useStrimziPodSetsEnabled()) {
-            strimziPodSetController = new StrimziPodSetController(namespace, config.getCustomResourceSelector(), resourceOperatorSupplier.kafkaOperator, resourceOperatorSupplier.strimziPodSetOperator, resourceOperatorSupplier.podOperations);
+            strimziPodSetController = new StrimziPodSetController(namespace, config.getCustomResourceSelector(), resourceOperatorSupplier.kafkaOperator, resourceOperatorSupplier.strimziPodSetOperator, resourceOperatorSupplier.podOperations, config.getPodSetControllerWorkQueueSize());
             strimziPodSetController.start();
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -49,6 +49,7 @@ public class ClusterOperatorConfig {
     public static final String STRIMZI_OPERATIONS_THREAD_POOL_SIZE = "STRIMZI_OPERATIONS_THREAD_POOL_SIZE";
     public static final String STRIMZI_DNS_CACHE_TTL = "STRIMZI_DNS_CACHE_TTL";
     public static final String STRIMZI_POD_SET_RECONCILIATION_ONLY = "STRIMZI_POD_SET_RECONCILIATION_ONLY";
+    public static final String STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = "STRIMZI_POD_SET_CONTROLLER_SIZE";
 
     // Feature Flags
     public static final String STRIMZI_RBAC_SCOPE = "STRIMZI_RBAC_SCOPE";
@@ -80,6 +81,7 @@ public class ClusterOperatorConfig {
 
     // Default values
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
+    public static final int DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = 1024;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
     public static final int DEFAULT_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS = 10_000;
     public static final long DEFAULT_CONNECT_BUILD_TIMEOUT_MS = 300_000;
@@ -108,6 +110,7 @@ public class ClusterOperatorConfig {
     private final int operationsThreadPoolSize;
     private final int dnsCacheTtlSec;
     private final boolean podSetReconciliationOnly;
+    private final int podSetControllerWorkQueueSize;
 
     /**
      * Constructor
@@ -131,6 +134,7 @@ public class ClusterOperatorConfig {
      * @param dnsCacheTtlSec Number of seconds to cache a successful DNS name lookup
      * @param podSetReconciliationOnly Indicates whether this Cluster Operator instance should reconcile only the
      *                                 StrimziPodSet resources or not
+     * @param podSetControllerWorkQueueSize Indicates the size of the StrimziPodSetController work queue
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     public ClusterOperatorConfig(
@@ -151,7 +155,8 @@ public class ClusterOperatorConfig {
             int operationsThreadPoolSize,
             int zkAdminSessionTimeoutMs,
             int dnsCacheTtlSec,
-            boolean podSetReconciliationOnly) {
+            boolean podSetReconciliationOnly,
+            int podSetControllerWorkQueueSize) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.operationTimeoutMs = operationTimeoutMs;
@@ -170,6 +175,7 @@ public class ClusterOperatorConfig {
         this.zkAdminSessionTimeoutMs = zkAdminSessionTimeoutMs;
         this.dnsCacheTtlSec = dnsCacheTtlSec;
         this.podSetReconciliationOnly = podSetReconciliationOnly;
+        this.podSetControllerWorkQueueSize = podSetControllerWorkQueueSize;
     }
 
     /**
@@ -222,6 +228,7 @@ public class ClusterOperatorConfig {
         int zkAdminSessionTimeout = parseInt(map.get(STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS), DEFAULT_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS);
         int dnsCacheTtlSec = parseInt(map.get(STRIMZI_DNS_CACHE_TTL), DEFAULT_DNS_CACHE_TTL);
         boolean podSetReconciliationOnly = parseBoolean(map.get(STRIMZI_POD_SET_RECONCILIATION_ONLY), DEFAULT_POD_SET_RECONCILIATION_ONLY);
+        int podSetControllerWorkQueueSize = parseInt(map.get(STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE), DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
 
         return new ClusterOperatorConfig(
                 namespaces,
@@ -241,7 +248,8 @@ public class ClusterOperatorConfig {
                 operationsThreadPoolSize,
                 zkAdminSessionTimeout,
                 dnsCacheTtlSec,
-                podSetReconciliationOnly);
+                podSetReconciliationOnly,
+                podSetControllerWorkQueueSize);
     }
 
     private static Set<String> parseNamespaceList(String namespacesList)   {
@@ -547,6 +555,13 @@ public class ClusterOperatorConfig {
         return podSetReconciliationOnly;
     }
 
+    /**
+     * @return Returns the size of the StrimziPodSetController work queue
+     */
+    public int getPodSetControllerWorkQueueSize() {
+        return podSetControllerWorkQueueSize;
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +
@@ -567,6 +582,7 @@ public class ClusterOperatorConfig {
                 ",zkAdminSessionTimeoutMs=" + zkAdminSessionTimeoutMs +
                 ",dnsCacheTtlSec=" + dnsCacheTtlSec +
                 ",podSetReconciliationOnly=" + podSetReconciliationOnly +
+                ",podSetControllerWorkQueueSize=" + podSetControllerWorkQueueSize +
                 ")";
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -49,7 +49,7 @@ public class ClusterOperatorConfig {
     public static final String STRIMZI_OPERATIONS_THREAD_POOL_SIZE = "STRIMZI_OPERATIONS_THREAD_POOL_SIZE";
     public static final String STRIMZI_DNS_CACHE_TTL = "STRIMZI_DNS_CACHE_TTL";
     public static final String STRIMZI_POD_SET_RECONCILIATION_ONLY = "STRIMZI_POD_SET_RECONCILIATION_ONLY";
-    public static final String STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = "STRIMZI_POD_SET_CONTROLLER_SIZE";
+    public static final String STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = "STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE";
 
     // Feature Flags
     public static final String STRIMZI_RBAC_SCOPE = "STRIMZI_RBAC_SCOPE";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -58,7 +58,7 @@ public class StrimziPodSetController implements Runnable {
     private final Optional<LabelSelector> crSelector;
     private final String watchedNamespace;
 
-    private final BlockingQueue<SimplifiedReconciliation> workQueue = new ArrayBlockingQueue<>(1024);
+    private final BlockingQueue<SimplifiedReconciliation> workQueue;
     private final SharedIndexInformer<Pod> podInformer;
     private final SharedIndexInformer<StrimziPodSet> strimziPodSetInformer;
     private final SharedIndexInformer<Kafka> kafkaInformer;
@@ -78,7 +78,7 @@ public class StrimziPodSetController implements Runnable {
      *                              their status etc.
      * @param podOperator           Pod operator for managing pods
      */
-    public StrimziPodSetController(String watchedNamespace, Labels crSelectorLabels, CrdOperator<KubernetesClient, Kafka, KafkaList> kafkaOperator, CrdOperator<KubernetesClient, StrimziPodSet, StrimziPodSetList> strimziPodSetOperator, PodOperator podOperator) {
+    public StrimziPodSetController(String watchedNamespace, Labels crSelectorLabels, CrdOperator<KubernetesClient, Kafka, KafkaList> kafkaOperator, CrdOperator<KubernetesClient, StrimziPodSet, StrimziPodSetList> strimziPodSetOperator, PodOperator podOperator, int podSetControllerWorkQueueSize) {
         this.podOperator = podOperator;
         this.strimziPodSetOperator = strimziPodSetOperator;
         this.crSelector = (crSelectorLabels == null || crSelectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, crSelectorLabels.toMap()));
@@ -130,6 +130,7 @@ public class StrimziPodSetController implements Runnable {
         }, 10 * 60 * 1000);
 
         controllerThread = new Thread(this, "StrimziPodSetController");
+        this.workQueue = new ArrayBlockingQueue<>(podSetControllerWorkQueueSize);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -83,6 +83,7 @@ public class StrimziPodSetController implements Runnable {
         this.strimziPodSetOperator = strimziPodSetOperator;
         this.crSelector = (crSelectorLabels == null || crSelectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, crSelectorLabels.toMap()));
         this.watchedNamespace = watchedNamespace;
+        this.workQueue = new ArrayBlockingQueue<>(podSetControllerWorkQueueSize);
 
         // Kafka informer and lister is used to get Kafka CRs quickly. This is needed for verification of the CR selector labels
         this.kafkaInformer = kafkaOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap());
@@ -130,7 +131,6 @@ public class StrimziPodSetController implements Runnable {
         }, 10 * 60 * 1000);
 
         controllerThread = new Thread(this, "StrimziPodSetController");
-        this.workQueue = new ArrayBlockingQueue<>(podSetControllerWorkQueueSize);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -89,7 +89,8 @@ public class ClusterOperatorConfigTest {
                 10,
                 20_000,
                 10,
-                false);
+                false,
+                1024);
 
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(60_000L));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -768,7 +768,8 @@ public class ResourceUtils {
                 10,
                 10_000,
                 30,
-                false);
+                false,
+                1024);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfigRolesOnly(KafkaVersion.Lookup versions, long operationTimeoutMs) {
@@ -790,7 +791,8 @@ public class ResourceUtils {
                 10,
                 10_000,
                 30,
-                false);
+                false,
+                1024);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions, long operationTimeoutMs) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -446,7 +446,8 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 10,
                 10_000,
                 30,
-                false);
+                false,
+                1024);
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_19), certManager, passwordGenerator,
                 supplier, config);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -942,7 +942,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 10,
                 10_000,
                 30,
-                false);
+                false,
+                1024);
 
         kcrao = new KafkaRebalanceAssemblyOperator(Vertx.vertx(), pfa, supplier, config);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -62,6 +62,7 @@ public class StrimziPodSetControllerIT {
     private static final Map<String, String> MATCHING_LABELS = Map.of("selector", "matching");
     private static final String OTHER_KAFKA_NAME = "bar";
     private static final Map<String, String> OTHER_LABELS = Map.of("selector", "not-matching");
+    private static final int podSetControllerWorkQueueSize = 1024;
 
     private static KubernetesClient client;
     private static KubeClusterResource cluster;
@@ -223,7 +224,7 @@ public class StrimziPodSetControllerIT {
     }
 
     private static void startController()  {
-        controller = new StrimziPodSetController(NAMESPACE, Labels.fromMap(MATCHING_LABELS), kafkaOperator, podSetOperator, podOperator);
+        controller = new StrimziPodSetController(NAMESPACE, Labels.fromMap(MATCHING_LABELS), kafkaOperator, podSetOperator, podOperator, podSetControllerWorkQueueSize);
         controller.start();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -62,7 +62,7 @@ public class StrimziPodSetControllerIT {
     private static final Map<String, String> MATCHING_LABELS = Map.of("selector", "matching");
     private static final String OTHER_KAFKA_NAME = "bar";
     private static final Map<String, String> OTHER_LABELS = Map.of("selector", "not-matching");
-    private static final int podSetControllerWorkQueueSize = 1024;
+    private static final int POD_SET_CONTROLLER_WORK_QUEUE_SIZE = 1024;
 
     private static KubernetesClient client;
     private static KubeClusterResource cluster;
@@ -224,7 +224,7 @@ public class StrimziPodSetControllerIT {
     }
 
     private static void startController()  {
-        controller = new StrimziPodSetController(NAMESPACE, Labels.fromMap(MATCHING_LABELS), kafkaOperator, podSetOperator, podOperator, podSetControllerWorkQueueSize);
+        controller = new StrimziPodSetController(NAMESPACE, Labels.fromMap(MATCHING_LABELS), kafkaOperator, podSetOperator, podOperator, POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         controller.start();
     }
 


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR makes the StrimziPodSetController work queue size configurable by adding a new env. variable to the `ClusterOperatorConfig` class and fixes the issue mentioned in #6305. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

