### PR TITLE
[systemtest] - LogCollector - fix scraping logs from pods when they are not initialized

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -290,9 +290,14 @@ public class LogCollector {
     }
 
     private void scrapeAndCreateLogs(File path, String podName, ContainerStatus containerStatus, String namespace) {
-        String log = kubeClient.getPodResource(namespace, podName).inContainer(containerStatus.getName()).getLog();
-        // Write logs from containers to files
-        writeFile(path + "/logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
+        try {
+            String log = kubeClient.getPodResource(namespace, podName).inContainer(containerStatus.getName()).getLog();
+            // Write logs from containers to files
+            writeFile(path + "/logs-pod-" + podName + "-container-" + containerStatus.getName() + ".log", log);
+        } catch (Exception e) {
+            LOGGER.warn("Unable to collect log from pod: {} and container: {} - pod container is not initialized", podName, containerStatus.getName());
+        }
+
         // Describe all pods
         String describe = cmdKubeClient(namespace).describe("pod", podName);
         writeFile(path + "/describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Currently, when we are scraping logs from pods after the test fail, we are not checking, if the pod is initialized. So when the pod is in some state as `ImagePullBackOff`, the `kubeClient.getPodResource(namespace, podName).inContainer(containerStatus.getName()).getLog();` simply fails with exception, which cause that other pod logs are not scraped.

This PR fixes this issue.

### Checklist

- [x] Make sure all tests pass

