### PR TITLE
Improve the default memory configuration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -138,10 +138,10 @@ public abstract class AbstractModel {
 
     public static final String NETWORK_POLICY_KEY_SUFFIX = "-network-policy";
 
-    public static final String ENV_VAR_DYNAMIC_HEAP_FRACTION = "DYNAMIC_HEAP_FRACTION";
+    public static final String ENV_VAR_DYNAMIC_HEAP_PERCENTAGE = "STRIMZI_DYNAMIC_HEAP_PERCENTAGE";
     public static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
     public static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
-    public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
+    public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "STRIMZI_DYNAMIC_HEAP_MAX";
     public static final String ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED = "STRIMZI_KAFKA_GC_LOG_ENABLED";
     public static final String ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES = "STRIMZI_JAVA_SYSTEM_PROPERTIES";
     public static final String ENV_VAR_STRIMZI_JAVA_OPTS = "STRIMZI_JAVA_OPTS";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -464,7 +464,7 @@ public class CruiseControl extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_API_PORT,  String.valueOf(REST_API_PORT)));
         varList.add(buildEnvVar(ENV_VAR_API_HEALTHCHECK_PATH, API_HEALTHCHECK_PATH));
 
-        ModelUtils.heapOptions(varList, 1.0, 0L, getJvmOptions(), getResources());
+        ModelUtils.heapOptions(varList, 75, 0L, getJvmOptions(), getResources());
         ModelUtils.jvmPerformanceOptions(varList, getJvmOptions());
         ModelUtils.jvmSystemProperties(varList, getJvmOptions());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1645,7 +1645,7 @@ public class KafkaCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
-        ModelUtils.heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L, getJvmOptions(), getResources());
+        ModelUtils.heapOptions(varList, 50, 5L * 1024L * 1024L * 1024L, getJvmOptions(), getResources());
         ModelUtils.jvmPerformanceOptions(varList, getJvmOptions());
         ModelUtils.jvmSystemProperties(varList, getJvmOptions());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -539,7 +539,7 @@ public class KafkaConnectCluster extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_BOOTSTRAP_SERVERS, bootstrapServers));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
 
-        ModelUtils.heapOptions(varList, 1.0, 0L, getJvmOptions(), getResources());
+        ModelUtils.heapOptions(varList, 75, 0L, getJvmOptions(), getResources());
         ModelUtils.jvmPerformanceOptions(varList, getJvmOptions());
         ModelUtils.jvmSystemProperties(varList, getJvmOptions());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -351,7 +351,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
             varList.add(buildEnvVar(ENV_VAR_STRIMZI_TRACING, tracing.getType()));
         }
 
-        ModelUtils.heapOptions(varList, 1.0, 0L, getJvmOptions(), getResources());
+        ModelUtils.heapOptions(varList, 75, 0L, getJvmOptions(), getResources());
         ModelUtils.jvmPerformanceOptions(varList, getJvmOptions());
         ModelUtils.jvmSystemProperties(varList, getJvmOptions());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -547,15 +547,15 @@ public class ModelUtils {
 
     /**
      * Adds KAFKA_HEAP_OPTS variable to the EnvVar list if any heap related options were specified through the provided JVM options
-     * If Xmx Java Options are not set DYNAMIC_HEAP_FRACTION and DYNAMIC_HEAP_MAX may also be set by using the ResourceRequirements
+     * If Xmx Java Options are not set STRIMZI_DYNAMIC_HEAP_PERCENTAGE and STRIMZI_DYNAMIC_HEAP_MAX may also be set by using the ResourceRequirements
      *
      * @param envVars list of the Environment Variables to add to
-     * @param dynamicHeapFraction value to set for the DYNAMIC_HEAP_FRACTION
-     * @param dynamicHeapMaxBytes value to set for the DYNAMIC_HEAP_MAX
+     * @param dynamicHeapPercentage value to set for the STRIMZI_DYNAMIC_HEAP_PERCENTAGE
+     * @param dynamicHeapMaxBytes value to set for the STRIMZI_DYNAMIC_HEAP_MAX
      * @param jvmOptions JVM options
      * @param resources the resource requirements
      */
-    public static void heapOptions(List<EnvVar> envVars, double dynamicHeapFraction, long dynamicHeapMaxBytes, JvmOptions jvmOptions, ResourceRequirements resources) {
+    public static void heapOptions(List<EnvVar> envVars, int dynamicHeapPercentage, long dynamicHeapMaxBytes, JvmOptions jvmOptions, ResourceRequirements resources) {
         StringBuilder kafkaHeapOpts = new StringBuilder();
 
         String xms = jvmOptions != null ? jvmOptions.getXms() : null;
@@ -573,7 +573,7 @@ public class ModelUtils {
             // Delegate to the container to figure out only when CGroup memory limits are defined to prevent allocating
             // too much memory on the kubelet.
             if (cpuMemory != null && cpuMemory.get("memory") != null) {
-                envVars.add(AbstractModel.buildEnvVar(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION, Double.toString(dynamicHeapFraction)));
+                envVars.add(AbstractModel.buildEnvVar(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE, Integer.toString(dynamicHeapPercentage)));
                 if (dynamicHeapMaxBytes > 0) {
                     envVars.add(AbstractModel.buildEnvVar(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX, Long.toString(dynamicHeapMaxBytes)));
                 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -556,6 +556,10 @@ public class ModelUtils {
      * @param resources the resource requirements
      */
     public static void heapOptions(List<EnvVar> envVars, int dynamicHeapPercentage, long dynamicHeapMaxBytes, JvmOptions jvmOptions, ResourceRequirements resources) {
+        if (dynamicHeapPercentage <= 0 || dynamicHeapPercentage > 100)  {
+            throw new RuntimeException("The Heap percentage " + dynamicHeapPercentage + " is invalid. It has to be >0 and <= 100.");
+        }
+
         StringBuilder kafkaHeapOpts = new StringBuilder();
 
         String xms = jvmOptions != null ? jvmOptions.getXms() : null;
@@ -569,17 +573,28 @@ public class ModelUtils {
             // Honour user provided explicit max heap
             kafkaHeapOpts.append(' ').append("-Xmx").append(xmx);
         } else {
-            Map<String, Quantity> cpuMemory = resources != null ? resources.getRequests() : null;
-            // Delegate to the container to figure out only when CGroup memory limits are defined to prevent allocating
-            // too much memory on the kubelet.
-            if (cpuMemory != null && cpuMemory.get("memory") != null) {
+            // Get the resources => if requests are set, take request. If requests are not set, try limits
+            Quantity configuredMemory = null;
+            if (resources != null)  {
+                if (resources.getRequests() != null && resources.getRequests().get("memory") != null)    {
+                    configuredMemory = resources.getRequests().get("memory");
+                } else if (resources.getLimits() != null && resources.getLimits().get("memory") != null)   {
+                    configuredMemory = resources.getLimits().get("memory");
+                }
+            }
+
+            if (configuredMemory != null) {
+                // Delegate to the container to figure out only when CGroup memory limits are defined to prevent allocating
+                // too much memory on the kubelet.
+
                 envVars.add(AbstractModel.buildEnvVar(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE, Integer.toString(dynamicHeapPercentage)));
+
                 if (dynamicHeapMaxBytes > 0) {
                     envVars.add(AbstractModel.buildEnvVar(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX, Long.toString(dynamicHeapMaxBytes)));
                 }
+            } else if (xms == null) {
                 // When no memory limit, `Xms`, and `Xmx` are defined then set a default `Xms` and
                 // leave `Xmx` undefined.
-            } else if (xms == null) {
                 kafkaHeapOpts.append("-Xms").append(AbstractModel.DEFAULT_JVM_XMS);
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -551,7 +551,7 @@ public class ZookeeperCluster extends AbstractModel {
             }
         }
 
-        ModelUtils.heapOptions(varList, 0.75, 2L * 1024L * 1024L * 1024L, getJvmOptions(), getResources());
+        ModelUtils.heapOptions(varList, 75, 2L * 1024L * 1024L * 1024L, getJvmOptions(), getResources());
         ModelUtils.jvmPerformanceOptions(varList, getJvmOptions());
         ModelUtils.jvmSystemProperties(varList, getJvmOptions());
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONFIGURATION, configuration.getConfiguration()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -69,13 +69,13 @@ public class AbstractModelTest {
     @ParallelTest
     public void testJvmMemoryOptionsExplicit() {
         Map<String, String> env = getStringStringMap("4", "4",
-                0.5, 4_000_000_000L, null);
+                50, 4_000_000_000L, null);
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4 -Xmx4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is(nullValue()));
+        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }
 
-    private Map<String, String> getStringStringMap(String xmx, String xms, double dynamicFraction, long dynamicMax, ResourceRequirements resources) {
+    private Map<String, String> getStringStringMap(String xmx, String xms, int dynamicPercentage, long dynamicMax, ResourceRequirements resources) {
         Kafka resource = new KafkaBuilder()
                 .withNewMetadata()
                 .endMetadata()
@@ -86,25 +86,25 @@ public class AbstractModelTest {
         am.setJvmOptions(jvmOptions(xmx, xms));
         am.setResources(resources);
         List<EnvVar> envVars = new ArrayList<>(1);
-        ModelUtils.heapOptions(envVars, dynamicFraction, dynamicMax, am.getJvmOptions(), am.getResources());
+        ModelUtils.heapOptions(envVars, dynamicPercentage, dynamicMax, am.getJvmOptions(), am.getResources());
         return envVars.stream().collect(Collectors.toMap(e -> e.getName(), e -> e.getValue()));
     }
 
     @ParallelTest
     public void testJvmMemoryOptionsXmsOnly() {
         Map<String, String> env = getStringStringMap(null, "4",
-                0.5, 5_000_000_000L, null);
+                50, 5_000_000_000L, null);
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is(nullValue()));
+        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }
 
     @ParallelTest
     public void testJvmMemoryOptionsXmxOnly() {
         Map<String, String> env = getStringStringMap("4", null,
-                0.5, 5_000_000_000L, null);
+                50, 5_000_000_000L, null);
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xmx4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is(nullValue()));
+        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }
 
@@ -112,9 +112,9 @@ public class AbstractModelTest {
     @ParallelTest
     public void testJvmMemoryOptionsDefaultWithNoMemoryLimitOrJvmOptions() {
         Map<String, String> env = getStringStringMap(null, null,
-                0.5, 5_000_000_000L, null);
+                50, 5_000_000_000L, null);
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms" + AbstractModel.DEFAULT_JVM_XMS));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is(nullValue()));
+        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }
 
@@ -126,18 +126,18 @@ public class AbstractModelTest {
     @ParallelTest
     public void testJvmMemoryOptionsDefaultWithMemoryLimit() {
         Map<String, String> env = getStringStringMap(null, "4",
-                0.5, 5_000_000_000L, getResourceRequest());
+                50, 5_000_000_000L, getResourceRequest());
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is("0.5"));
+        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is("50"));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("5000000000"));
     }
 
     @ParallelTest
     public void testJvmMemoryOptionsMemoryRequest() {
         Map<String, String> env = getStringStringMap(null, null,
-                0.7, 10_000_000_000L, getResourceRequest());
+                70, 10_000_000_000L, getResourceRequest());
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is(nullValue()));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION), is("0.7"));
+        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is("70"));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("10000000000"));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -7,10 +7,8 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -24,16 +22,12 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
-
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -57,88 +51,6 @@ public class AbstractModelTest {
         protected List<Container> getContainers(ImagePullPolicy imagePullPolicy) {
             return null;
         }
-    }
-
-    private static JvmOptions jvmOptions(String xmx, String xms) {
-        JvmOptions result = new JvmOptions();
-        result.setXms(xms);
-        result.setXmx(xmx);
-        return result;
-    }
-
-    @ParallelTest
-    public void testJvmMemoryOptionsExplicit() {
-        Map<String, String> env = getStringStringMap("4", "4",
-                50, 4_000_000_000L, null);
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4 -Xmx4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
-    }
-
-    private Map<String, String> getStringStringMap(String xmx, String xms, int dynamicPercentage, long dynamicMax, ResourceRequirements resources) {
-        Kafka resource = new KafkaBuilder()
-                .withNewMetadata()
-                .endMetadata()
-                .build();
-        AbstractModel am = new Model(resource);
-
-        am.setLabels(Labels.forStrimziCluster("foo"));
-        am.setJvmOptions(jvmOptions(xmx, xms));
-        am.setResources(resources);
-        List<EnvVar> envVars = new ArrayList<>(1);
-        ModelUtils.heapOptions(envVars, dynamicPercentage, dynamicMax, am.getJvmOptions(), am.getResources());
-        return envVars.stream().collect(Collectors.toMap(e -> e.getName(), e -> e.getValue()));
-    }
-
-    @ParallelTest
-    public void testJvmMemoryOptionsXmsOnly() {
-        Map<String, String> env = getStringStringMap(null, "4",
-                50, 5_000_000_000L, null);
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
-    }
-
-    @ParallelTest
-    public void testJvmMemoryOptionsXmxOnly() {
-        Map<String, String> env = getStringStringMap("4", null,
-                50, 5_000_000_000L, null);
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xmx4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
-    }
-
-
-    @ParallelTest
-    public void testJvmMemoryOptionsDefaultWithNoMemoryLimitOrJvmOptions() {
-        Map<String, String> env = getStringStringMap(null, null,
-                50, 5_000_000_000L, null);
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms" + AbstractModel.DEFAULT_JVM_XMS));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
-    }
-
-    private ResourceRequirements getResourceRequest() {
-        return new ResourceRequirementsBuilder()
-                .addToRequests("memory", new Quantity("16000000000")).build();
-    }
-
-    @ParallelTest
-    public void testJvmMemoryOptionsDefaultWithMemoryLimit() {
-        Map<String, String> env = getStringStringMap(null, "4",
-                50, 5_000_000_000L, getResourceRequest());
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms4"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is("50"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("5000000000"));
-    }
-
-    @ParallelTest
-    public void testJvmMemoryOptionsMemoryRequest() {
-        Map<String, String> env = getStringStringMap(null, null,
-                70, 10_000_000_000L, getResourceRequest());
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is(nullValue()));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is("70"));
-        assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("10000000000"));
     }
 
     @ParallelTest

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -40,17 +40,8 @@ if [ "$CRUISE_CONTROL_METRICS_ENABLED" = "true" ]; then
   export KAFKA_OPTS
 fi
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
-    . ./dynamic_resources.sh
-    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
-    # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
-    if [ -n "$CALC_MAX_HEAP" ]; then
-      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
-      echo "Configuring Cruise Control heap: $KAFKA_HEAP_OPTS"
-    fi
-fi
+# Configure heap based on the available resources if needed
+. ./dynamic_resources.sh
 
 # Generate and print the config file
 echo "Starting Cruise Control with configuration:"

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -40,14 +40,15 @@ if [ "$CRUISE_CONTROL_METRICS_ENABLED" = "true" ]; then
   export KAFKA_OPTS
 fi
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
     . ./dynamic_resources.sh
-    # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
     # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${DYNAMIC_HEAP_FRACTION}" "${DYNAMIC_HEAP_MAX}")
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
     if [ -n "$CALC_MAX_HEAP" ]; then
       export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring Cruise Control heap: $KAFKA_HEAP_OPTS"
     fi
 fi
 

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/dynamic_resources.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/dynamic_resources.sh
@@ -2,20 +2,19 @@
 set -e
 
 function get_heap_size {
-  FRACTION=$1
+  PERCENTAGE=$1
   MAX=$2
   # Get the max heap used by a jvm which used all the ram available to the container
-  MAX_POSSIBLE_HEAP=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
+  POSSIBLE_HEAP=$(java -XX:MaxRAMPercentage="$PERCENTAGE" -XshowSettings:vm -version \
     |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
     | gawk -f to_bytes.gawk)
 
-  ACTUAL_MAX_HEAP=$(echo "${MAX_POSSIBLE_HEAP} ${FRACTION}" | awk '{ printf "%d", $1 * $2 }')
-
   if [ "${MAX}" ]; then
     MAX=$(echo "${MAX}" | gawk -f to_bytes.gawk)
-    if [ "${MAX}" -lt "${ACTUAL_MAX_HEAP}" ]; then
-      ACTUAL_MAX_HEAP=$MAX
+    if [ "${MAX}" -lt "${POSSIBLE_HEAP}" ]; then
+      POSSIBLE_HEAP=$MAX
     fi
   fi
-  echo "$ACTUAL_MAX_HEAP"
+
+  echo "$POSSIBLE_HEAP"
 }

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/dynamic_resources.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/dynamic_resources.sh
@@ -18,3 +18,14 @@ function get_heap_size {
 
   echo "$POSSIBLE_HEAP"
 }
+
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
+    # available to a jvm using 100% of the CGroup-aware memory
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
+    if [ -n "$CALC_MAX_HEAP" ]; then
+      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring Java heap: $KAFKA_HEAP_OPTS"
+    fi
+fi

--- a/docker-images/kafka-based/kafka/scripts/dynamic_resources.sh
+++ b/docker-images/kafka-based/kafka/scripts/dynamic_resources.sh
@@ -2,20 +2,19 @@
 set -e
 
 function get_heap_size {
-  FRACTION=$1
+  PERCENTAGE=$1
   MAX=$2
   # Get the max heap used by a jvm which used all the ram available to the container
-  MAX_POSSIBLE_HEAP=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
+  POSSIBLE_HEAP=$(java -XX:MaxRAMPercentage="$PERCENTAGE" -XshowSettings:vm -version \
     |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
     | gawk -f to_bytes.gawk)
 
-  ACTUAL_MAX_HEAP=$(echo "${MAX_POSSIBLE_HEAP} ${FRACTION}" | awk '{ printf "%d", $1 * $2 }')
-
   if [ "${MAX}" ]; then
     MAX=$(echo "${MAX}" | gawk -f to_bytes.gawk)
-    if [ "${MAX}" -lt "${ACTUAL_MAX_HEAP}" ]; then
-      ACTUAL_MAX_HEAP=$MAX
+    if [ "${MAX}" -lt "${POSSIBLE_HEAP}" ]; then
+      POSSIBLE_HEAP=$MAX
     fi
   fi
-  echo "$ACTUAL_MAX_HEAP"
+
+  echo "$POSSIBLE_HEAP"
 }

--- a/docker-images/kafka-based/kafka/scripts/dynamic_resources.sh
+++ b/docker-images/kafka-based/kafka/scripts/dynamic_resources.sh
@@ -18,3 +18,14 @@ function get_heap_size {
 
   echo "$POSSIBLE_HEAP"
 }
+
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
+    # available to a jvm using 100% of the CGroup-aware memory
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
+    if [ -n "$CALC_MAX_HEAP" ]; then
+      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring Java heap: $KAFKA_HEAP_OPTS"
+    fi
+fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -53,18 +53,6 @@ if [ "$STRIMZI_TRACING" = "jaeger" ]; then
     export KAFKA_OPTS
 fi
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
-    . ./dynamic_resources.sh
-    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
-    # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
-    if [ -n "$CALC_MAX_HEAP" ]; then
-      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
-      echo "Configuring Connect heap: $KAFKA_HEAP_OPTS"
-    fi
-fi
-
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi
@@ -74,6 +62,10 @@ if [ "$FIPS_MODE" = "disabled" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} -Dcom.redhat.fips=false"
 fi
 
+# Configure heap based on the available resources if needed
+. ./dynamic_resources.sh
+
+# Configure Garbage Collection logging
 . ./set_kafka_gc_options.sh
 
 set -x

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -53,14 +53,15 @@ if [ "$STRIMZI_TRACING" = "jaeger" ]; then
     export KAFKA_OPTS
 fi
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
     . ./dynamic_resources.sh
-    # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
     # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${DYNAMIC_HEAP_FRACTION}" "${DYNAMIC_HEAP_MAX}")
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
     if [ -n "$CALC_MAX_HEAP" ]; then
       export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring Connect heap: $KAFKA_HEAP_OPTS"
     fi
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
@@ -74,18 +74,6 @@ if [ "$STRIMZI_TRACING" = "jaeger" ]; then
   export KAFKA_OPTS
 fi
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
-    . ./dynamic_resources.sh
-    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
-    # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
-    if [ -n "$CALC_MAX_HEAP" ]; then
-      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
-      echo "Configuring Mirror Maker heap: $KAFKA_HEAP_OPTS"
-    fi
-fi
-
 if [ -n "$KAFKA_MIRRORMAKER_INCLUDE" ]; then
     # shellcheck disable=SC2089
     include="--whitelist \"${KAFKA_MIRRORMAKER_INCLUDE}\""
@@ -116,6 +104,10 @@ if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi
 
+# Configure heap based on the available resources if needed
+. ./dynamic_resources.sh
+
+# Configure Garbage Collection logging
 . ./set_kafka_gc_options.sh
 
 set -x

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
@@ -74,14 +74,15 @@ if [ "$STRIMZI_TRACING" = "jaeger" ]; then
   export KAFKA_OPTS
 fi
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
     . ./dynamic_resources.sh
-    # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
     # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${DYNAMIC_HEAP_FRACTION}" "${DYNAMIC_HEAP_MAX}")
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
     if [ -n "$CALC_MAX_HEAP" ]; then
       export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring Mirror Maker heap: $KAFKA_HEAP_OPTS"
     fi
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -52,14 +52,15 @@ echo "Starting Kafka with configuration:"
 ./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
     . ./dynamic_resources.sh
-    # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
     # available to a jvm using 100% of the CGroup-aware memory
-    # up to some optional DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${DYNAMIC_HEAP_FRACTION}" "${DYNAMIC_HEAP_MAX}")
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
     if [ -n "$CALC_MAX_HEAP" ]; then
       export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring Kafka heap: $KAFKA_HEAP_OPTS"
     fi
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -52,18 +52,10 @@ echo "Starting Kafka with configuration:"
 ./kafka_config_generator.sh | tee /tmp/strimzi.properties | sed -e 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' -e 's/password=.*/password=[hidden]/g'
 echo ""
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
-    . ./dynamic_resources.sh
-    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
-    # available to a jvm using 100% of the CGroup-aware memory
-    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
-    if [ -n "$CALC_MAX_HEAP" ]; then
-      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
-      echo "Configuring Kafka heap: $KAFKA_HEAP_OPTS"
-    fi
-fi
+# Configure heap based on the available resources if needed
+. ./dynamic_resources.sh
 
+# Configure Garbage Collection logging
 . ./set_kafka_gc_options.sh
 
 set -x

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -57,14 +57,15 @@ fi
 
 . ./set_kafka_jmx_options.sh "${ZOOKEEPER_JMX_ENABLED}" "${ZOOKEEPER_JMX_USERNAME}" "${ZOOKEEPER_JMX_PASSWORD}"
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${DYNAMIC_HEAP_FRACTION}" ]; then
+if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
     . ./dynamic_resources.sh
-    # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
+    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
     # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${DYNAMIC_HEAP_FRACTION}" "${DYNAMIC_HEAP_MAX}")
+    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
     if [ -n "$CALC_MAX_HEAP" ]; then
       export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+      echo "Configuring ZooKeeper heap: $KAFKA_HEAP_OPTS"
     fi
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -57,18 +57,10 @@ fi
 
 . ./set_kafka_jmx_options.sh "${ZOOKEEPER_JMX_ENABLED}" "${ZOOKEEPER_JMX_USERNAME}" "${ZOOKEEPER_JMX_PASSWORD}"
 
-if [ -z "$KAFKA_HEAP_OPTS" ] && [ -n "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" ]; then
-    . ./dynamic_resources.sh
-    # Calculate a max heap size based some STRIMZI_DYNAMIC_HEAP_PERCENTAGE of the heap
-    # available to a jvm using 100% of the GCroup-aware memory
-    # up to some optional STRIMZI_DYNAMIC_HEAP_MAX
-    CALC_MAX_HEAP=$(get_heap_size "${STRIMZI_DYNAMIC_HEAP_PERCENTAGE}" "${STRIMZI_DYNAMIC_HEAP_MAX}")
-    if [ -n "$CALC_MAX_HEAP" ]; then
-      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
-      echo "Configuring ZooKeeper heap: $KAFKA_HEAP_OPTS"
-    fi
-fi
+# Configure heap based on the available resources if needed
+. ./dynamic_resources.sh
 
+# Configure Garbage Collection logging
 . ./set_kafka_gc_options.sh
 
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Strimzi tries to by default configure the Java heap for most of our operands. However, for some components, we seem to configure it to 100% of the available memory which does not make sense (since in addition to the heap it uses also some of-heap memory). This PR changes it to 75% based on previous discussion with @tombentley. Thsi includes Connect, Cruise Control, MM1 and MM2 (which uses Connect).

This PR does also some additional cleanup to the `dynamic_resources.sh` script:
* It removes the Java options which are not needed anymore in Java 11
* Moves from deprecated `MaxRAMFraction` to `MaxRAMPercentage`
* Changes the way Strimzi configures this to use the percentage directly. This includes renaming of the environment variables and fields in the Cluster Operator Java code.
* Since the configuration to Kafka and its compoenents is passed through its internal environment variables, I added also an echo statement to show what is it being set to since that was not visible from the logs.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally