### PR TITLE
[MO] - [system test] -> use scraper pod instead of kafka clients to c…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -147,22 +147,24 @@ public class KafkaConnectUtils {
      * @param connectPodName kafkaConnect pod name
      * @param topicName topic to be used
      * @param kafkaClientsPodName kafkaClients pod name
+     * @param scraperPodName Scraper Pod used for call KafkaConnect API
      * @param namespace namespace name
      * @param clusterName cluster name
      */
-    public static void sendReceiveMessagesThroughConnect(String connectPodName, String topicName, String kafkaClientsPodName, String namespace, String clusterName) {
+    public static void sendReceiveMessagesThroughConnect(String connectPodName, String topicName, final String kafkaClientsPodName,
+                                                         final String scraperPodName, String namespace, String clusterName) {
         LOGGER.info("Send and receive messages through KafkaConnect");
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(namespace, connectPodName);
-        KafkaConnectorUtils.createFileSinkConnector(namespace, kafkaClientsPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(clusterName, namespace, 8083));
+        KafkaConnectorUtils.createFileSinkConnector(namespace, scraperPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(clusterName, namespace, 8083));
 
         InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-                .withUsingPodName(kafkaClientsPodName)
-                .withTopicName(topicName)
-                .withNamespaceName(namespace)
-                .withClusterName(clusterName)
-                .withMessageCount(100)
-                .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
-                .build();
+            .withUsingPodName(kafkaClientsPodName)
+            .withTopicName(topicName)
+            .withNamespaceName(namespace)
+            .withClusterName(clusterName)
+            .withMessageCount(100)
+            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+            .build();
 
         internalKafkaClient.checkProducedAndConsumedMessages(
                 internalKafkaClient.sendMessagesPlain(),

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ScraperUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ScraperUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.specific;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.strimzi.systemtest.Constants;
+
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
+/**
+ *  Provides auxiliary methods for Scraper Pod, which reaches KafkaConnect API in the Kubernetes cluster.
+ */
+public class ScraperUtils {
+
+    private ScraperUtils() { }
+
+    public static Pod getScraperPod(final String namespaceName) {
+        return kubeClient(namespaceName).listPods(namespaceName, getDefaultLabelSelector()).stream().findFirst().orElseThrow();
+    }
+
+    private static LabelSelector getDefaultLabelSelector() {
+        return new LabelSelectorBuilder()
+            .addToMatchLabels(Constants.SCRAPER_LABEL_KEY, Constants.SCRAPER_LABEL_VALUE)
+            .build();
+    }
+}


### PR DESCRIPTION
…all KC api

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes problem with the following test cases:
1. testRackAwareConnectWrongDeployment
2. testRackAwareConnectCorrectDeployment

The problem is that currently`kafkaClientsPodName` **can't** call KafkaConnect API and only our `Scraper Pod` is allowed to do so. In other words, these test cases always fail because KafkaClients pods are not allowed to call KafkaConnect API.

### Checklist

- [x] Make sure all tests pass