### PR TITLE
[MO] - [system test] -> concurrent exception deletion mulitple namesp…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -173,9 +174,9 @@ public class TestSuiteNamespaceManager {
 
     public void deleteAdditionalNamespaces(ExtensionContext extensionContext) {
         CollectorElement collectorElement = CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName());
-        Set<String> namespacesToDelete = KubeClusterResource.getMapWithSuiteNamespaces().get(collectorElement);
 
-        if (namespacesToDelete != null) {
+        if (KubeClusterResource.getMapWithSuiteNamespaces().get(collectorElement) != null) {
+            Set<String> namespacesToDelete = new HashSet<>(KubeClusterResource.getMapWithSuiteNamespaces().get(collectorElement));
             // delete namespaces for specific test suite (we can not delete in parallel because of ConcurrentModificationException)
             namespacesToDelete.forEach(ns -> {
                 if (!ns.equals(Constants.INFRA_NAMESPACE)) {

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -391,8 +391,7 @@ public class KubeClusterResource {
 
     private synchronized void deleteNamespaceFromSet(CollectorElement collectorElement, String namespaceName) {
         // dynamically removing from the map
-        // TODO: May caused ConcurrentHashMap modification
-        Set<String> testSuiteNamespaces = MAP_WITH_SUITE_NAMESPACES.get(collectorElement);
+        Set<String> testSuiteNamespaces = new HashSet<>(MAP_WITH_SUITE_NAMESPACES.get(collectorElement));
         testSuiteNamespaces.remove(namespaceName);
         MAP_WITH_SUITE_NAMESPACES.put(collectorElement, testSuiteNamespaces);
         LOGGER.trace("SUITE_NAMESPACE_MAP after deletion: {}", MAP_WITH_SUITE_NAMESPACES);


### PR DESCRIPTION
…aces at once

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes problem using `ConcurrentModificationException`, where we delete multiple namespaces created by Cluster Operator. We resolve such a problem by instantiating a new map which will eliminate this exception.

### Checklist

- [x] Make sure all tests pass