### PR TITLE
Add KafkaConnect build feature test to acceptance

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -60,6 +60,7 @@ import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -473,6 +474,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         assertEquals(fileName, Util.hashStub(ECHO_SINK_JAR_URL));
     }
 
+    @Tag(SANITY)
     @Tag(ACCEPTANCE)
     @ParallelTest
     void testBuildPluginUsingMavenCoordinatesArtifacts(ExtensionContext extensionContext) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
@@ -472,6 +473,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         assertEquals(fileName, Util.hashStub(ECHO_SINK_JAR_URL));
     }
 
+    @Tag(ACCEPTANCE)
     @ParallelTest
     void testBuildPluginUsingMavenCoordinatesArtifacts(ExtensionContext extensionContext) {
         TestStorage storage = new TestStorage(extensionContext, INFRA_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerIsolatedST.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
@@ -46,6 +47,7 @@ public class DrainCleanerIsolatedST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(DrainCleanerIsolatedST.class);
     private static SetupDrainCleaner drainCleaner = new SetupDrainCleaner();
 
+    @Tag(ACCEPTANCE)
     @IsolatedTest
     @RequiredMinKubeApiVersion(version = 1.17)
     void testDrainCleanerWithComponents(ExtensionContext extensionContext) {


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds `ConnectBuilderIsolatedST#testBuildPluginUsingMavenCoordinatesArtifacts` to acceptance profile to verify, that image specified by `STRIMZI_DEFAULT_MAVEN_BUILDER` is pullble.

### Checklist

- [x] Make sure all tests pass


