### PR TITLE
Clean-up of the `ZookeeperCluster` model class

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -204,6 +204,39 @@ public class KafkaResources {
         return clusterName + "-zookeeper-nodes";
     }
 
+    /**
+     * Returns the name of the ZooKeeper Secret with server certificates.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding ZooKeeper Secret.
+     */
+    public static String zookeeperSecretName(String clusterName) {
+        return clusterName + "-zookeeper-nodes";
+    }
+
+    /**
+     * Returns the name of the ZooKeeper Secret with JMX credentials.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding ZooKeeper JMX Secret.
+     */
+    public static String zookeeperJmxSecretName(String clusterName) {
+        return clusterName + "-zookeeper-jmx";
+    }
+
+    /**
+     * Returns the name of the ZooKeeper Network Policy.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding ZooKeeper Network Policy.
+     */
+    public static String zookeeperNetworkPolicyName(String clusterName) {
+        return clusterName + "-network-policy-zookeeper";
+    }
+
     ////////
     // Entity Operator methods
     ////////

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -439,20 +439,4 @@ public class AuthenticationUtils {
             kafkaConnectCluster.setJmxAuthenticated(false);
         }
     }
-
-    /**
-     * Generates the necessary resources that the Zookeeper Cluster needs to secure the Jmx Port
-     *
-     * @param authentication the Authentication Configuration for the Jmx Port
-     * @param zookeeperCluster the current state of the zookeeper Cluster within the Kafka CR
-     */
-    public static void configureZookeeperJmxOptions(KafkaJmxAuthentication authentication, ZookeeperCluster zookeeperCluster)   {
-        if (authentication != null) {
-            if (authentication instanceof KafkaJmxAuthenticationPassword) {
-                zookeeperCluster.setJmxAuthenticated(true);
-            }
-        } else {
-            zookeeperCluster.setJmxAuthenticated(false);
-        }
-    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -92,7 +92,7 @@ public class ClusterCa extends Ca {
                 entityTopicOperatorSecret = secret;
             } else if (KafkaResources.entityUserOperatorSecretName(clusterName).equals(name)) {
                 entityUserOperatorSecret = secret;
-            } else if (ZookeeperCluster.nodesSecretName(clusterName).equals(name)) {
+            } else if (KafkaResources.zookeeperSecretName(clusterName).equals(name)) {
                 zkNodesSecret = secret;
             } else if (ClusterOperator.secretName(clusterName).equals(name)) {
                 clusterOperatorSecret = secret;
@@ -155,19 +155,19 @@ public class ClusterCa extends Ca {
         String cluster = kafka.getMetadata().getName();
         String namespace = kafka.getMetadata().getNamespace();
 
-        DnsNameGenerator zkDnsGenerator = DnsNameGenerator.of(namespace, ZookeeperCluster.serviceName(cluster));
-        DnsNameGenerator zkHeadlessDnsGenerator = DnsNameGenerator.of(namespace, ZookeeperCluster.headlessServiceName(cluster));
+        DnsNameGenerator zkDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperServiceName(cluster));
+        DnsNameGenerator zkHeadlessDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperHeadlessServiceName(cluster));
 
         Function<Integer, Subject> subjectFn = i -> {
             Subject.Builder subject = new Subject.Builder()
                     .withOrganizationName("io.strimzi")
-                    .withCommonName(ZookeeperCluster.zookeeperClusterName(cluster));
-            subject.addDnsName(ZookeeperCluster.serviceName(cluster));
-            subject.addDnsName(String.format("%s.%s", ZookeeperCluster.serviceName(cluster), namespace));
+                    .withCommonName(KafkaResources.zookeeperStatefulSetName(cluster));
+            subject.addDnsName(KafkaResources.zookeeperServiceName(cluster));
+            subject.addDnsName(String.format("%s.%s", KafkaResources.zookeeperServiceName(cluster), namespace));
             subject.addDnsName(zkDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkDnsGenerator.serviceDnsName());
-            subject.addDnsName(ZookeeperCluster.podDnsName(namespace, cluster, i));
-            subject.addDnsName(ZookeeperCluster.podDnsNameWithoutSuffix(namespace, cluster, i));
+            subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.zookeeperHeadlessServiceName(cluster), KafkaResources.zookeeperPodName(cluster, i)));
+            subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.zookeeperHeadlessServiceName(cluster), KafkaResources.zookeeperPodName(cluster, i)));
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsName());
             subject.addDnsName(zkHeadlessDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
@@ -181,7 +181,7 @@ public class ClusterCa extends Ca {
             kafka.getSpec().getZookeeper().getReplicas(),
             subjectFn,
             zkNodesSecret,
-            podNum -> ZookeeperCluster.zookeeperPodName(cluster, podNum),
+            podNum -> KafkaResources.zookeeperPodName(cluster, podNum),
             isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -178,7 +178,7 @@ public class CruiseControl extends AbstractModel {
         this.logAndMetricsConfigMountPath = LOG_AND_METRICS_CONFIG_VOLUME_MOUNT;
         this.isMetricsEnabled = DEFAULT_CRUISE_CONTROL_METRICS_ENABLED;
 
-        this.zookeeperConnect = ZookeeperCluster.serviceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
+        this.zookeeperConnect = KafkaResources.zookeeperServiceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -100,7 +100,7 @@ public class EntityOperator extends AbstractModel {
         super(reconciliation, resource, APPLICATION_NAME);
         this.name = KafkaResources.entityOperatorDeploymentName(cluster);
         this.replicas = EntityOperatorSpec.DEFAULT_REPLICAS;
-        this.zookeeperConnect = ZookeeperCluster.serviceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
+        this.zookeeperConnect = KafkaResources.zookeeperServiceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -182,7 +182,7 @@ public class KafkaBrokerConfigurationBuilder {
      */
     public KafkaBrokerConfigurationBuilder withZookeeper(String clusterName)  {
         printSectionHeader("Zookeeper");
-        writer.println(String.format("zookeeper.connect=%s:%d", ZookeeperCluster.serviceName(clusterName), ZookeeperCluster.CLIENT_TLS_PORT));
+        writer.println(String.format("zookeeper.connect=%s:%d", KafkaResources.zookeeperServiceName(clusterName), ZookeeperCluster.CLIENT_TLS_PORT));
         writer.println("zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty");
         writer.println("zookeeper.ssl.client.enable=true");
         writer.println("zookeeper.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -33,6 +33,7 @@ import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
+import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPassword;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
@@ -75,14 +76,9 @@ public class ZookeeperCluster extends AbstractModel {
     protected static final String ZOOKEEPER_NODE_CERTIFICATES_VOLUME_MOUNT = "/opt/kafka/zookeeper-node-certs/";
     protected static final String ZOOKEEPER_CLUSTER_CA_VOLUME_NAME = "cluster-ca-certs";
     protected static final String ZOOKEEPER_CLUSTER_CA_VOLUME_MOUNT = "/opt/kafka/cluster-ca-certs/";
-    private static final String NAME_SUFFIX = "-zookeeper";
-    private static final String SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-client";
-    private static final String HEADLESS_SERVICE_NAME_SUFFIX = NAME_SUFFIX + "-nodes";
-    private static final String NODES_CERTS_SUFFIX = NAME_SUFFIX + "-nodes";
 
     // Env vars for JMX service
     protected static final String ENV_VAR_ZOOKEEPER_JMX_ENABLED = "ZOOKEEPER_JMX_ENABLED";
-    private static final String ZOOKEEPER_JMX_SECRET_SUFFIX = NAME_SUFFIX + "-jmx";
     private static final String SECRET_JMX_USERNAME_KEY = "jmx-username";
     private static final String SECRET_JMX_PASSWORD_KEY = "jmx-password";
     private static final String ENV_VAR_ZOOKEEPER_JMX_USERNAME = "ZOOKEEPER_JMX_USERNAME";
@@ -90,9 +86,8 @@ public class ZookeeperCluster extends AbstractModel {
 
     // Zookeeper configuration
     private final boolean isSnapshotCheckEnabled;
-    private String version;
-    private boolean isJmxEnabled;
-    private boolean isJmxAuthenticated;
+    private boolean isJmxEnabled = false;
+    private boolean isJmxAuthenticated = false;
 
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withTimeoutSeconds(5)
@@ -121,90 +116,12 @@ public class ZookeeperCluster extends AbstractModel {
      */
     private Map<String, CertAndKey> nodeCerts;
 
-    public static String zookeeperClusterName(String cluster) {
-        return KafkaResources.zookeeperStatefulSetName(cluster);
-    }
-
-    public static String zookeeperMetricAndLogConfigsName(String cluster) {
-        return KafkaResources.zookeeperMetricsAndLogConfigMapName(cluster);
-    }
-
-    public static String serviceName(String cluster) {
-        return cluster + ZookeeperCluster.SERVICE_NAME_SUFFIX;
-    }
-
-    public static String headlessServiceName(String cluster) {
-        return cluster + ZookeeperCluster.HEADLESS_SERVICE_NAME_SUFFIX;
-    }
-
     private static final Map<String, String> DEFAULT_POD_LABELS = new HashMap<>();
     static {
         String value = System.getenv(CO_ENV_VAR_CUSTOM_ZOOKEEPER_POD_LABELS);
         if (value != null) {
             DEFAULT_POD_LABELS.putAll(Util.parseMap(value));
         }
-    }
-
-    /**
-     * Generates the DNS name of the pod including the cluster suffix
-     * (i.e. usually with the cluster.local - but can be different on different clusters)
-     * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc.cluster.local
-     *
-     * @param namespace     Namespace of the pod
-     * @param cluster       Name of the cluster
-     * @param podId         Id of the pod within the STS
-     *
-     * @return              DNS name of the pod
-     */
-    public static String podDnsName(String namespace, String cluster, int podId) {
-        return DnsNameGenerator.podDnsName(
-                namespace,
-                ZookeeperCluster.headlessServiceName(cluster),
-                ZookeeperCluster.zookeeperPodName(cluster, podId));
-    }
-
-    /**
-     * Generates the DNS name of the pod including the cluster suffix
-     * (i.e. usually with the cluster.local - but can be different on different clusters)
-     * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc.cluster.local
-     *
-     * @param namespace     Namespace of the pod
-     * @param cluster       Name of the cluster
-     * @param podName       Name of the pod
-     *
-     * @return              DNS name of the pod
-     */
-    public static String podDnsName(String namespace, String cluster, String podName) {
-        return DnsNameGenerator.podDnsName(
-                namespace,
-                ZookeeperCluster.headlessServiceName(cluster),
-                podName);
-    }
-
-    /**
-     * Generates the full DNS name of the pod without the cluster suffix
-     * (i.e. usually without the cluster.local - but can be different on different clusters)
-     * Example: my-cluster-zookeeper-1.my-cluster-zookeeper-nodes.svc
-     *
-     * @param namespace     Namespace of the pod
-     * @param cluster       Name of the cluster
-     * @param podId         Id of the pod within the STS
-     *
-     * @return              DNS name of the pod without the cluster domain suffix
-     */
-    public static String podDnsNameWithoutSuffix(String namespace, String cluster, int podId) {
-        return DnsNameGenerator.podDnsNameWithoutClusterDomain(
-                namespace,
-                ZookeeperCluster.headlessServiceName(cluster),
-                ZookeeperCluster.zookeeperPodName(cluster, podId));
-    }
-
-    public static String zookeeperPodName(String cluster, int pod) {
-        return KafkaResources.zookeeperPodName(cluster, pod);
-    }
-
-    public static String nodesSecretName(String cluster) {
-        return cluster + ZookeeperCluster.NODES_CERTS_SUFFIX;
     }
 
     /**
@@ -215,10 +132,10 @@ public class ZookeeperCluster extends AbstractModel {
      */
     private ZookeeperCluster(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, APPLICATION_NAME);
-        this.name = zookeeperClusterName(cluster);
-        this.serviceName = serviceName(cluster);
-        this.headlessServiceName = headlessServiceName(cluster);
-        this.ancillaryConfigMapName = zookeeperMetricAndLogConfigsName(cluster);
+        this.name = KafkaResources.zookeeperStatefulSetName(cluster);
+        this.serviceName = KafkaResources.zookeeperServiceName(cluster);
+        this.headlessServiceName = KafkaResources.zookeeperHeadlessServiceName(cluster);
+        this.ancillaryConfigMapName = KafkaResources.zookeeperMetricsAndLogConfigMapName(cluster);
         this.image = null;
         this.replicas = ZookeeperClusterSpec.DEFAULT_REPLICAS;
         this.readinessPath = "/opt/kafka/zookeeper_healthcheck.sh";
@@ -254,12 +171,11 @@ public class ZookeeperCluster extends AbstractModel {
         zk.setReplicas(replicas);
 
         // Get the ZK version information from either the CRD or from the default setting
-        KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
-        String version = versions.supportedVersion(kafkaClusterSpec != null ? kafkaClusterSpec.getVersion() : null).zookeeperVersion();
-        zk.setVersion(version);
+
 
         String image = zookeeperClusterSpec.getImage();
         if (image == null) {
+            KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
             image = versions.kafkaImage(kafkaClusterSpec != null ? kafkaClusterSpec.getImage() : null,
                     kafkaClusterSpec != null ? kafkaClusterSpec.getVersion() : null);
         }
@@ -315,8 +231,11 @@ public class ZookeeperCluster extends AbstractModel {
         zk.setJvmOptions(zookeeperClusterSpec.getJvmOptions());
 
         if (zookeeperClusterSpec.getJmxOptions() != null) {
-            zk.setJmxEnabled(Boolean.TRUE);
-            AuthenticationUtils.configureZookeeperJmxOptions(zookeeperClusterSpec.getJmxOptions().getAuthentication(), zk);
+            zk.isJmxEnabled = true;
+
+            if (zookeeperClusterSpec.getJmxOptions().getAuthentication() != null)   {
+                zk.isJmxAuthenticated = zookeeperClusterSpec.getJmxOptions().getAuthentication() instanceof KafkaJmxAuthenticationPassword;
+            }
         }
 
         if (zookeeperClusterSpec.getTemplate() != null) {
@@ -381,10 +300,6 @@ public class ZookeeperCluster extends AbstractModel {
         return createService("ClusterIP", ports, templateServiceAnnotations);
     }
 
-    public static String policyName(String cluster) {
-        return cluster + NETWORK_POLICY_KEY_SUFFIX + NAME_SUFFIX;
-    }
-
     /**
      * Generates the NetworkPolicies relevant for ZooKeeper nodes
      *
@@ -411,7 +326,7 @@ public class ZookeeperCluster extends AbstractModel {
         NetworkPolicyPeer zookeeperClusterPeer = new NetworkPolicyPeer();
         LabelSelector labelSelector2 = new LabelSelector();
         Map<String, String> expressions2 = new HashMap<>(1);
-        expressions2.put(Labels.STRIMZI_NAME_LABEL, zookeeperClusterName(cluster));
+        expressions2.put(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(cluster));
         labelSelector2.setMatchLabels(expressions2);
         zookeeperClusterPeer.setPodSelector(labelSelector2);
 
@@ -495,7 +410,7 @@ public class ZookeeperCluster extends AbstractModel {
 
         NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
                 .withNewMetadata()
-                    .withName(policyName(cluster))
+                    .withName(KafkaResources.zookeeperNetworkPolicyName(cluster))
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())
                     .withOwnerReferences(createOwnerReference())
@@ -586,14 +501,14 @@ public class ZookeeperCluster extends AbstractModel {
 
         Map<String, String> data = new HashMap<>(replicas * 4);
         for (int i = 0; i < replicas; i++) {
-            CertAndKey cert = nodeCerts.get(ZookeeperCluster.zookeeperPodName(cluster, i));
-            data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".key", cert.keyAsBase64String());
-            data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".crt", cert.certAsBase64String());
-            data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
-            data.put(ZookeeperCluster.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
+            CertAndKey cert = nodeCerts.get(KafkaResources.zookeeperPodName(cluster, i));
+            data.put(KafkaResources.zookeeperPodName(cluster, i) + ".key", cert.keyAsBase64String());
+            data.put(KafkaResources.zookeeperPodName(cluster, i) + ".crt", cert.certAsBase64String());
+            data.put(KafkaResources.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
+            data.put(KafkaResources.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
 
-        return createSecret(ZookeeperCluster.nodesSecretName(cluster), data,
+        return createSecret(KafkaResources.zookeeperSecretName(cluster), data,
                 Collections.singletonMap(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())));
     }
 
@@ -631,8 +546,8 @@ public class ZookeeperCluster extends AbstractModel {
         if (isJmxEnabled) {
             varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_JMX_ENABLED, "true"));
             if (isJmxAuthenticated) {
-                varList.add(buildEnvVarFromSecret(ENV_VAR_ZOOKEEPER_JMX_USERNAME, jmxSecretName(cluster), SECRET_JMX_USERNAME_KEY));
-                varList.add(buildEnvVarFromSecret(ENV_VAR_ZOOKEEPER_JMX_PASSWORD, jmxSecretName(cluster), SECRET_JMX_PASSWORD_KEY));
+                varList.add(buildEnvVarFromSecret(ENV_VAR_ZOOKEEPER_JMX_USERNAME, KafkaResources.zookeeperJmxSecretName(cluster), SECRET_JMX_USERNAME_KEY));
+                varList.add(buildEnvVarFromSecret(ENV_VAR_ZOOKEEPER_JMX_PASSWORD, KafkaResources.zookeeperJmxSecretName(cluster), SECRET_JMX_PASSWORD_KEY));
             }
         }
 
@@ -689,7 +604,7 @@ public class ZookeeperCluster extends AbstractModel {
 
         volumeList.add(createTempDirVolume());
         volumeList.add(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigMapName));
-        volumeList.add(VolumeUtils.createSecretVolume(ZOOKEEPER_NODE_CERTIFICATES_VOLUME_NAME, ZookeeperCluster.nodesSecretName(cluster), isOpenShift));
+        volumeList.add(VolumeUtils.createSecretVolume(ZOOKEEPER_NODE_CERTIFICATES_VOLUME_NAME, KafkaResources.zookeeperSecretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(ZOOKEEPER_CLUSTER_CA_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
 
         return volumeList;
@@ -799,30 +714,19 @@ public class ZookeeperCluster extends AbstractModel {
     }
 
     /**
-     * Get the name of the zookeeper service account given the name of the {@code zookeeperResourceName}.
-     * @param zookeeperResourceName The resource name.
-     * @return The service account name.
+     * Sets the image used for ZooKeeper. This method is called from outside the ZooKeeper model. It overrides the
+     * method from the super class to make it public.
+     *
+     * @param image Image which should be used by ZooKeeper cluster
      */
-    public static String containerServiceAccountName(String zookeeperResourceName) {
-        return zookeeperClusterName(zookeeperResourceName);
-    }
-
-    @Override
-    protected String getServiceAccountName() {
-        return containerServiceAccountName(cluster);
-    }
-
     @Override
     public void setImage(String image) {
         super.setImage(image);
     }
 
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public String getVersion() {
-        return this.version;
+    @Override
+    public String getServiceAccountName() {
+        return KafkaResources.zookeeperStatefulSetName(cluster);
     }
 
     /**
@@ -838,24 +742,8 @@ public class ZookeeperCluster extends AbstractModel {
         return zkConfigMap;
     }
 
-    public void setJmxEnabled(boolean jmxEnabled) {
-        isJmxEnabled = jmxEnabled;
-    }
-
     public boolean isJmxAuthenticated() {
         return isJmxAuthenticated;
-    }
-
-    public void setJmxAuthenticated(boolean jmxAuthenticated) {
-        isJmxAuthenticated = jmxAuthenticated;
-    }
-
-    /**
-     * @param cluster The name of the cluster.
-     * @return The name of the jmx Secret.
-     */
-    public static String jmxSecretName(String cluster) {
-        return cluster + ZookeeperCluster.ZOOKEEPER_JMX_SECRET_SUFFIX;
     }
 
     /**
@@ -871,6 +759,6 @@ public class ZookeeperCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createJmxSecret(ZookeeperCluster.jmxSecretName(cluster), data);
+        return createJmxSecret(KafkaResources.zookeeperJmxSecretName(cluster), data);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -5,8 +5,10 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.cluster.model.DnsNameGenerator;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
@@ -289,7 +291,7 @@ public class ZookeeperLeaderFinder {
      * @return                  Hostname of the ZooKeeper node
      */
     protected String host(Reconciliation reconciliation, String podName) {
-        return ZookeeperCluster.podDnsName(reconciliation.namespace(), reconciliation.name(), podName);
+        return DnsNameGenerator.podDnsName(reconciliation.namespace(), KafkaResources.zookeeperHeadlessServiceName(reconciliation.name()), podName);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -55,7 +55,6 @@ import io.strimzi.operator.cluster.model.ClientsCa;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperScaler;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperScalerProvider;
@@ -317,15 +316,15 @@ public class ResourceUtils {
 
         builder = new SecretBuilder()
                         .withNewMetadata()
-                            .withName(ZookeeperCluster.nodesSecretName(name))
+                            .withName(KafkaResources.zookeeperSecretName(name))
                             .withNamespace(namespace)
                             .withLabels(Labels.forStrimziCluster(name).toMap())
                         .endMetadata()
                         .addToData("cluster-ca.crt", Base64.getEncoder().encodeToString("cluster-ca-base64crt".getBytes()));
 
         for (int i = 0; i < zkReplicas; i++) {
-            builder.addToData(ZookeeperCluster.zookeeperPodName(name, i) + ".key", Base64.getEncoder().encodeToString("nodes-base64key".getBytes()))
-                    .addToData(ZookeeperCluster.zookeeperPodName(name, i) + ".crt", Base64.getEncoder().encodeToString("nodes-base64crt".getBytes()));
+            builder.addToData(KafkaResources.zookeeperPodName(name, i) + ".key", Base64.getEncoder().encodeToString("nodes-base64key".getBytes()))
+                    .addToData(KafkaResources.zookeeperPodName(name, i) + ".crt", Base64.getEncoder().encodeToString("nodes-base64crt".getBytes()));
         }
         secrets.add(builder.build());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -134,7 +134,7 @@ public class EntityOperatorTest {
         // checks on the TLS sidecar container
         Container tlsSidecarContainer = containers.get(2);
         assertThat(tlsSidecarContainer.getImage(), is(image));
-        assertThat(AbstractModel.containerEnvVars(tlsSidecarContainer).get(EntityOperator.ENV_VAR_ZOOKEEPER_CONNECT), is(ZookeeperCluster.serviceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT));
+        assertThat(AbstractModel.containerEnvVars(tlsSidecarContainer).get(EntityOperator.ENV_VAR_ZOOKEEPER_CONNECT), is(KafkaResources.zookeeperServiceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT));
         assertThat(AbstractModel.containerEnvVars(tlsSidecarContainer).get(ModelUtils.TLS_SIDECAR_LOG_LEVEL), is(TlsSidecarLogLevel.NOTICE.toValue()));
         assertThat(EntityOperatorTest.volumeMounts(tlsSidecarContainer.getVolumeMounts()), is(map(
                         EntityOperator.TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
@@ -155,7 +155,7 @@ public class EntityOperatorTest {
     public void testFromCrd() {
         assertThat(entityOperator.namespace, is(namespace));
         assertThat(entityOperator.cluster, is(cluster));
-        assertThat(entityOperator.zookeeperConnect, is(ZookeeperCluster.serviceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT));
+        assertThat(entityOperator.zookeeperConnect, is(KafkaResources.zookeeperServiceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.KafkaAuthorization;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.KafkaAuthorizationOpaBuilder;
 import io.strimzi.api.kafka.model.KafkaAuthorizationSimpleBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuthBuilder;
@@ -157,7 +158,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withZookeeper("my-cluster")
                 .build();
 
-        assertThat(configuration, isEquivalent(String.format("zookeeper.connect=%s:%d\n", ZookeeperCluster.serviceName("my-cluster"), ZookeeperCluster.CLIENT_TLS_PORT) +
+        assertThat(configuration, isEquivalent(String.format("zookeeper.connect=%s:%d\n", KafkaResources.zookeeperServiceName("my-cluster"), ZookeeperCluster.CLIENT_TLS_PORT) +
                 "zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty\n" +
                 "zookeeper.ssl.client.enable=true\n" +
                 "zookeeper.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -105,8 +105,6 @@ public class ZookeeperClusterTest {
     private final String image = "image";
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
-    private final int tlsHealthDelay = 120;
-    private final int tlsHealthTimeout = 30;
     private final Map<String, Object> metricsCm = singletonMap("animal", "wombat");
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String metricsCMName = "metrics-cm";
@@ -144,7 +142,7 @@ public class ZookeeperClusterTest {
     private Map<String, String> expectedLabels()    {
         return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, cluster,
             "my-user-label", "cromulent",
-            Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster),
+            Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(cluster),
             Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
             Labels.KUBERNETES_NAME_LABEL, ZookeeperCluster.APPLICATION_NAME,
             Labels.KUBERNETES_INSTANCE_LABEL, this.cluster,
@@ -154,19 +152,19 @@ public class ZookeeperClusterTest {
 
     @ParallelTest
     public void testGenerateService() {
-        Service headful = zc.generateService();
+        Service svc = zc.generateService();
 
-        assertThat(headful.getSpec().getType(), is("ClusterIP"));
-        assertThat(headful.getSpec().getSelector(), is(expectedSelectorLabels()));
-        assertThat(headful.getSpec().getPorts().size(), is(1));
-        assertThat(headful.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
-        assertThat(headful.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(ZookeeperCluster.CLIENT_TLS_PORT)));
-        assertThat(headful.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(headful.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(headful.getSpec().getIpFamilies(), is(emptyList()));
-        assertThat(headful.getMetadata().getAnnotations(), is(nullValue()));
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector(), is(expectedSelectorLabels()));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
+        assertThat(svc.getSpec().getPorts().get(0).getPort(), is(ZookeeperCluster.CLIENT_TLS_PORT));
+        assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
 
-        checkOwnerReference(zc.createOwnerReference(), headful);
+        checkOwnerReference(zc.createOwnerReference(), svc);
     }
 
     @ParallelTest
@@ -179,18 +177,18 @@ public class ZookeeperClusterTest {
                 .endSpec()
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        Service headful = zc.generateService();
+        Service svc = zc.generateService();
 
-        assertThat(headful.getSpec().getType(), is("ClusterIP"));
-        assertThat(headful.getSpec().getSelector(), is(expectedSelectorLabels()));
-        assertThat(headful.getSpec().getPorts().size(), is(1));
-        assertThat(headful.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
-        assertThat(headful.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(ZookeeperCluster.CLIENT_TLS_PORT)));
-        assertThat(headful.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector(), is(expectedSelectorLabels()));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
+        assertThat(svc.getSpec().getPorts().get(0).getPort(), is(ZookeeperCluster.CLIENT_TLS_PORT));
+        assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        assertThat(headful.getMetadata().getAnnotations(), is(nullValue()));
+        assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
 
-        checkOwnerReference(zc.createOwnerReference(), headful);
+        checkOwnerReference(zc.createOwnerReference(), svc);
     }
 
     @ParallelTest
@@ -201,17 +199,17 @@ public class ZookeeperClusterTest {
     }
 
     private void checkHeadlessService(Service headless) {
-        assertThat(headless.getMetadata().getName(), is(ZookeeperCluster.headlessServiceName(cluster)));
+        assertThat(headless.getMetadata().getName(), is(KafkaResources.zookeeperHeadlessServiceName(cluster)));
         assertThat(headless.getSpec().getType(), is("ClusterIP"));
         assertThat(headless.getSpec().getClusterIP(), is("None"));
         assertThat(headless.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(headless.getSpec().getPorts().size(), is(3));
         assertThat(headless.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(ZookeeperCluster.CLIENT_TLS_PORT)));
+        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(ZookeeperCluster.CLIENT_TLS_PORT));
         assertThat(headless.getSpec().getPorts().get(1).getName(), is(ZookeeperCluster.CLUSTERING_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(Integer.valueOf(ZookeeperCluster.CLUSTERING_PORT)));
+        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(ZookeeperCluster.CLUSTERING_PORT));
         assertThat(headless.getSpec().getPorts().get(2).getName(), is(ZookeeperCluster.LEADER_ELECTION_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(2).getPort(), is(Integer.valueOf(ZookeeperCluster.LEADER_ELECTION_PORT)));
+        assertThat(headless.getSpec().getPorts().get(2).getPort(), is(ZookeeperCluster.LEADER_ELECTION_PORT));
         assertThat(headless.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
@@ -229,20 +227,20 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
         Service headless = zc.generateHeadlessService();
 
-        assertThat(headless.getMetadata().getName(), is(ZookeeperCluster.headlessServiceName(cluster)));
+        assertThat(headless.getMetadata().getName(), is(KafkaResources.zookeeperHeadlessServiceName(cluster)));
         assertThat(headless.getSpec().getType(), is("ClusterIP"));
         assertThat(headless.getSpec().getClusterIP(), is("None"));
         assertThat(headless.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(headless.getSpec().getPorts().size(), is(4));
         assertThat(headless.getSpec().getPorts().get(0).getName(), is(ZookeeperCluster.CLIENT_TLS_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(ZookeeperCluster.CLIENT_TLS_PORT)));
+        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(ZookeeperCluster.CLIENT_TLS_PORT));
         assertThat(headless.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getPorts().get(1).getName(), is(ZookeeperCluster.CLUSTERING_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(Integer.valueOf(ZookeeperCluster.CLUSTERING_PORT)));
+        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(ZookeeperCluster.CLUSTERING_PORT));
         assertThat(headless.getSpec().getPorts().get(2).getName(), is(ZookeeperCluster.LEADER_ELECTION_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(2).getPort(), is(Integer.valueOf(ZookeeperCluster.LEADER_ELECTION_PORT)));
+        assertThat(headless.getSpec().getPorts().get(2).getPort(), is(ZookeeperCluster.LEADER_ELECTION_PORT));
         assertThat(headless.getSpec().getPorts().get(3).getName(), is(ZookeeperCluster.JMX_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(3).getPort(), is(Integer.valueOf(ZookeeperCluster.JMX_PORT)));
+        assertThat(headless.getSpec().getPorts().get(3).getPort(), is(ZookeeperCluster.JMX_PORT));
         assertThat(headless.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
@@ -367,7 +365,7 @@ public class ZookeeperClusterTest {
     }
 
     private void checkStatefulSet(StatefulSet sts) {
-        assertThat(sts.getMetadata().getName(), is(ZookeeperCluster.zookeeperClusterName(cluster)));
+        assertThat(sts.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(cluster)));
         // ... in the same namespace ...
         assertThat(sts.getMetadata().getNamespace(), is(namespace));
         // ... with these labels
@@ -381,19 +379,19 @@ public class ZookeeperClusterTest {
         assertThat(containers.size(), is(1));
 
         // checks on the main Zookeeper container
-        assertThat(sts.getSpec().getReplicas(), is(Integer.valueOf(replicas)));
+        assertThat(sts.getSpec().getReplicas(), is(replicas));
         assertThat(sts.getSpec().getPodManagementPolicy(), is(PodManagementPolicy.PARALLEL.toValue()));
         assertThat(containers.get(0).getImage(), is(image + "-zk"));
-        assertThat(containers.get(0).getLivenessProbe().getTimeoutSeconds(), is(Integer.valueOf(healthTimeout)));
-        assertThat(containers.get(0).getLivenessProbe().getInitialDelaySeconds(), is(Integer.valueOf(healthDelay)));
-        assertThat(containers.get(0).getLivenessProbe().getFailureThreshold(), is(Integer.valueOf(10)));
-        assertThat(containers.get(0).getLivenessProbe().getSuccessThreshold(), is(Integer.valueOf(4)));
-        assertThat(containers.get(0).getLivenessProbe().getPeriodSeconds(), is(Integer.valueOf(33)));
-        assertThat(containers.get(0).getReadinessProbe().getTimeoutSeconds(), is(Integer.valueOf(healthTimeout)));
-        assertThat(containers.get(0).getReadinessProbe().getInitialDelaySeconds(), is(Integer.valueOf(healthDelay)));
-        assertThat(containers.get(0).getReadinessProbe().getFailureThreshold(), is(Integer.valueOf(10)));
-        assertThat(containers.get(0).getReadinessProbe().getSuccessThreshold(), is(Integer.valueOf(4)));
-        assertThat(containers.get(0).getReadinessProbe().getPeriodSeconds(), is(Integer.valueOf(33)));
+        assertThat(containers.get(0).getLivenessProbe().getTimeoutSeconds(), is(healthTimeout));
+        assertThat(containers.get(0).getLivenessProbe().getInitialDelaySeconds(), is(healthDelay));
+        assertThat(containers.get(0).getLivenessProbe().getFailureThreshold(), is(10));
+        assertThat(containers.get(0).getLivenessProbe().getSuccessThreshold(), is(4));
+        assertThat(containers.get(0).getLivenessProbe().getPeriodSeconds(), is(33));
+        assertThat(containers.get(0).getReadinessProbe().getTimeoutSeconds(), is(healthTimeout));
+        assertThat(containers.get(0).getReadinessProbe().getInitialDelaySeconds(), is(healthDelay));
+        assertThat(containers.get(0).getReadinessProbe().getFailureThreshold(), is(10));
+        assertThat(containers.get(0).getReadinessProbe().getSuccessThreshold(), is(4));
+        assertThat(containers.get(0).getReadinessProbe().getPeriodSeconds(), is(33));
         OrderedProperties expectedConfig = new OrderedProperties().addMapPairs(ZookeeperConfiguration.DEFAULTS).addPair("foo", "bar");
         OrderedProperties actual = new OrderedProperties()
                 .addStringPairs(AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
@@ -409,7 +407,7 @@ public class ZookeeperClusterTest {
         assertThat(containers.get(0).getVolumeMounts().get(4).getMountPath(), is(ZookeeperCluster.ZOOKEEPER_CLUSTER_CA_VOLUME_MOUNT));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
     }
 
     // TODO test volume claim templates
@@ -418,7 +416,7 @@ public class ZookeeperClusterTest {
     public void testPodNames() {
 
         for (int i = 0; i < replicas; i++) {
-            assertThat(zc.getPodName(i), is(ZookeeperCluster.zookeeperPodName(cluster, i)));
+            assertThat(zc.getPodName(i), is(KafkaResources.zookeeperPodName(cluster, i)));
         }
     }
 
@@ -436,8 +434,8 @@ public class ZookeeperClusterTest {
         PersistentVolumeClaim pvc = zc.getPersistentVolumeClaimTemplates().get(0);
 
         for (int i = 0; i < replicas; i++) {
-            assertThat(pvc.getMetadata().getName() + "-" + ZookeeperCluster.zookeeperPodName(cluster, i),
-                    is(zc.VOLUME_NAME + "-" + ZookeeperCluster.zookeeperPodName(cluster, i)));
+            assertThat(pvc.getMetadata().getName() + "-" + KafkaResources.zookeeperPodName(cluster, i),
+                    is(ZookeeperCluster.VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(cluster, i)));
         }
     }
 
@@ -496,22 +494,22 @@ public class ZookeeperClusterTest {
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedStsLabels = new HashMap<>(ssLabels);
         expectedStsLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> ssAnots = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> ssAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
 
         Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
 
         Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
 
         Map<String, String> hSvcLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> hSvcAnots = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> hSvcAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
 
         Map<String, String> pdbLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> pdbAnots = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> pdbAnnotations = TestUtils.map("a9", "v9", "a10", "v10");
 
         Map<String, String> saLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> saAnots = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> saAnnotations = TestUtils.map("a11", "v11", "a12", "v12");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")
@@ -544,13 +542,13 @@ public class ZookeeperClusterTest {
                             .withNewStatefulset()
                                 .withNewMetadata()
                                     .withLabels(ssLabels)
-                                    .withAnnotations(ssAnots)
+                                    .withAnnotations(ssAnnotations)
                                 .endMetadata()
                             .endStatefulset()
                             .withNewPod()
                                 .withNewMetadata()
                                     .withLabels(podLabels)
-                                    .withAnnotations(podAnots)
+                                    .withAnnotations(podAnnotations)
                                 .endMetadata()
                                 .withPriorityClassName("top-priority")
                                 .withSchedulerName("my-scheduler")
@@ -562,7 +560,7 @@ public class ZookeeperClusterTest {
                             .withNewClientService()
                                 .withNewMetadata()
                                     .withLabels(svcLabels)
-                                    .withAnnotations(svcAnots)
+                                    .withAnnotations(svcAnnotations)
                                 .endMetadata()
                                 .withIpFamilyPolicy(IpFamilyPolicy.PREFER_DUAL_STACK)
                                 .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
@@ -570,7 +568,7 @@ public class ZookeeperClusterTest {
                             .withNewNodesService()
                                 .withNewMetadata()
                                     .withLabels(hSvcLabels)
-                                    .withAnnotations(hSvcAnots)
+                                    .withAnnotations(hSvcAnnotations)
                                 .endMetadata()
                                 .withIpFamilyPolicy(IpFamilyPolicy.SINGLE_STACK)
                                 .withIpFamilies(IpFamily.IPV6)
@@ -578,13 +576,13 @@ public class ZookeeperClusterTest {
                             .withNewPodDisruptionBudget()
                                 .withNewMetadata()
                                     .withLabels(pdbLabels)
-                                    .withAnnotations(pdbAnots)
+                                    .withAnnotations(pdbAnnotations)
                                 .endMetadata()
                             .endPodDisruptionBudget()
                             .withNewServiceAccount()
                                 .withNewMetadata()
                                     .withLabels(saLabels)
-                                    .withAnnotations(saAnots)
+                                    .withAnnotations(saAnnotations)
                                 .endMetadata()
                             .endServiceAccount()
                         .endTemplate()
@@ -596,48 +594,48 @@ public class ZookeeperClusterTest {
         // Check StatefulSet
         StatefulSet sts = zc.generateStatefulSet(true, null, null);
         assertThat(sts.getMetadata().getLabels().entrySet().containsAll(expectedStsLabels.entrySet()), is(true));
-        assertThat(sts.getMetadata().getAnnotations().entrySet().containsAll(ssAnots.entrySet()), is(true));
+        assertThat(sts.getMetadata().getAnnotations().entrySet().containsAll(ssAnnotations.entrySet()), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
 
         // Check Pods
         assertThat(sts.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
-        assertThat(sts.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
+        assertThat(sts.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnnotations.entrySet()), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(sts.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
         assertThat(sts.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
         assertThat(sts.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("10Mi")));
+            .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity("10Mi")));
 
         // Check Service
         Service svc = zc.generateService();
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(svcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(svcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(svcAnnotations.entrySet()), is(true));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
         assertThat(svc.getSpec().getIpFamilies(), contains("IPv6", "IPv4"));
 
         // Check Headless Service
         svc = zc.generateHeadlessService();
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(hSvcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(hSvcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(hSvcAnnotations.entrySet()), is(true));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is("SingleStack"));
         assertThat(svc.getSpec().getIpFamilies(), contains("IPv6"));
 
         // Check PodDisruptionBudget
         PodDisruptionBudget pdb = zc.generatePodDisruptionBudget();
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
-        assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
+        assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
         // Check PodDisruptionBudgetV1Beta1
         io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generatePodDisruptionBudgetV1Beta1();
         assertThat(pdbV1Beta1.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
-        assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
+        assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
         // Check Service Account
         ServiceAccount sa = zc.generateServiceAccount();
         assertThat(sa.getMetadata().getLabels().entrySet().containsAll(saLabels.entrySet()), is(true));
-        assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnots.entrySet()), is(true));
+        assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnnotations.entrySet()), is(true));
     }
 
     @ParallelTest
@@ -657,7 +655,7 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         StatefulSet sts = zc.generateStatefulSet(true, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
+        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(123L));
     }
 
     @ParallelTest
@@ -668,7 +666,7 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         StatefulSet sts = zc.generateStatefulSet(true, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
+        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(30L));
     }
 
     @ParallelTest
@@ -769,9 +767,9 @@ public class ZookeeperClusterTest {
 
         StatefulSet sts = zc.generateStatefulSet(true, null, null);
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(notNullValue()));
-        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(Long.valueOf(123)));
-        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsGroup(), is(Long.valueOf(456)));
-        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(123L));
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsGroup(), is(456L));
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(789L));
     }
 
     @ParallelTest
@@ -824,7 +822,7 @@ public class ZookeeperClusterTest {
         Kafka kafkaAssembly = ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, jmxMetricsConfig, configurationJson, emptyMap());
         kafkaAssembly.getSpec().getKafka().setRack(new RackBuilder().withTopologyKey("topology-key").build());
-        ZookeeperCluster kc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
+        ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         StatefulSet sts = zc.generateStatefulSet(true, ImagePullPolicy.ALWAYS, null);
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
@@ -844,7 +842,7 @@ public class ZookeeperClusterTest {
         NetworkPolicy np = zc.generateNetworkPolicy("operator-namespace", null);
 
         LabelSelector podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(zc.getCluster())));
         assertThat(np.getSpec().getPodSelector(), is(podSelector));
 
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress();
@@ -858,7 +856,7 @@ public class ZookeeperClusterTest {
 
         assertThat(zooRule.getFrom().size(), is(1));
         podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(zc.getCluster())));
         assertThat(zooRule.getFrom().get(0), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         // Port 2181
@@ -873,7 +871,7 @@ public class ZookeeperClusterTest {
         assertThat(clientsRule.getFrom().get(0), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(zc.getCluster())));
+        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(zc.getCluster())));
         assertThat(clientsRule.getFrom().get(1), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         podSelector = new LabelSelector();
@@ -938,7 +936,7 @@ public class ZookeeperClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(zc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -967,7 +965,7 @@ public class ZookeeperClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(zc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -1012,7 +1010,7 @@ public class ZookeeperClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(zc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperPodSetTest.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
@@ -86,12 +87,12 @@ public class ZookeeperPodSetTest {
         PodDisruptionBudget pdb = zc.generateCustomControllerPodDisruptionBudget();
         io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generateCustomControllerPodDisruptionBudgetV1Beta1();
 
-        assertThat(pdb.getMetadata().getName(), is(ZookeeperCluster.zookeeperClusterName(CLUSTER)));
+        assertThat(pdb.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
         assertThat(pdb.getSpec().getMinAvailable().getIntVal(), is(2));
         assertThat(pdb.getSpec().getSelector().getMatchLabels(), is(zc.getSelectorLabels().toMap()));
 
-        assertThat(pdbV1Beta1.getMetadata().getName(), is(ZookeeperCluster.zookeeperClusterName(CLUSTER)));
+        assertThat(pdbV1Beta1.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(nullValue()));
         assertThat(pdbV1Beta1.getSpec().getMinAvailable().getIntVal(), is(2));
         assertThat(pdbV1Beta1.getSpec().getSelector().getMatchLabels(), is(zc.getSelectorLabels().toMap()));
@@ -140,7 +141,7 @@ public class ZookeeperPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
         StrimziPodSet ps = zc.generatePodSet(3, true, null, null, Map.of());
 
-        assertThat(ps.getMetadata().getName(), is(ZookeeperCluster.zookeeperClusterName(CLUSTER)));
+        assertThat(ps.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(zc.getLabelsWithStrimziName(zc.getName(), null).toMap().entrySet()), is(true));
         assertThat(ps.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new PersistentClaimStorageBuilder().withSize("100Gi").withDeleteClaim(false).build())));
         assertThat(ps.getMetadata().getOwnerReferences().size(), is(1));
@@ -330,7 +331,7 @@ public class ZookeeperPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
         StrimziPodSet ps = zc.generatePodSet(3, true, null, null, Map.of("special", "annotation"));
 
-        assertThat(ps.getMetadata().getName(), is(ZookeeperCluster.zookeeperClusterName(CLUSTER)));
+        assertThat(ps.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(spsLabels.entrySet()), is(true));
         assertThat(ps.getMetadata().getAnnotations().entrySet().containsAll(spsAnnos.entrySet()), is(true));
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(zc.getSelectorLabels().toMap()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -45,7 +45,6 @@ import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
@@ -323,19 +322,19 @@ public class KafkaAssemblyOperatorMockTest {
                 assertThat(kafkaSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
                 assertThat(kafkaSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
 
-                StatefulSet zkSts = client.apps().statefulSets().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME)).get();
+                StatefulSet zkSts = client.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).get();
                 assertThat(zkSts, is(notNullValue()));
                 assertThat(zkSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "0"));
                 assertThat(zkSts.getSpec().getTemplate().getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
 
                 assertThat(client.configMaps().inNamespace(NAMESPACE).withName(KafkaResources.kafkaMetricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.configMaps().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperMetricAndLogConfigsName(CLUSTER_NAME)).get(), is(notNullValue()));
+                assertThat(client.configMaps().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertResourceRequirements(context, KafkaResources.kafkaStatefulSetName(CLUSTER_NAME));
                 assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaKeySecretName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaCluster.brokersSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
-                assertThat(client.secrets().inNamespace(NAMESPACE).withName(ZookeeperCluster.nodesSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
+                assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperSecretName(CLUSTER_NAME)).get(), is(notNullValue()));
             })));
     }
 
@@ -362,7 +361,7 @@ public class KafkaAssemblyOperatorMockTest {
                 KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME),
                 KafkaCluster.clusterCaCertSecretName(CLUSTER_NAME),
                 KafkaCluster.brokersSecretName(CLUSTER_NAME),
-                ZookeeperCluster.nodesSecretName(CLUSTER_NAME),
+                KafkaResources.zookeeperSecretName(CLUSTER_NAME),
                 ClusterOperator.secretName(CLUSTER_NAME));
     }
 
@@ -422,8 +421,8 @@ public class KafkaAssemblyOperatorMockTest {
         init(params);
 
         initialReconcileThenDeleteServicesThenReconcile(context,
-                ZookeeperCluster.serviceName(CLUSTER_NAME),
-                ZookeeperCluster.headlessServiceName(CLUSTER_NAME));
+                KafkaResources.zookeeperServiceName(CLUSTER_NAME),
+                KafkaResources.zookeeperHeadlessServiceName(CLUSTER_NAME));
     }
 
     @ParameterizedTest
@@ -441,7 +440,7 @@ public class KafkaAssemblyOperatorMockTest {
     public void testReconcileReplacesDeletedZookeeperStatefulSet(Params params, VertxTestContext context) {
         init(params);
 
-        String statefulSet = ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME);
+        String statefulSet = KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME);
         initialReconcileThenDeleteStatefulSetsThenReconcile(context, statefulSet);
     }
 
@@ -644,7 +643,7 @@ public class KafkaAssemblyOperatorMockTest {
         Map<String, String> zkLabels = new HashMap<>();
         zkLabels.put(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
         zkLabels.put(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME);
-        zkLabels.put(Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME));
+        zkLabels.put(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME));
 
         AtomicReference<Set<String>> kafkaPvcs = new AtomicReference<>();
         AtomicReference<Set<String>> zkPvcs = new AtomicReference<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -27,7 +27,6 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.common.PasswordGenerator;
@@ -159,10 +158,10 @@ public class PartialRollingUpdateTest {
         LOGGER.info("bootstrap reconciliation complete");
 
         this.kafkaSts = bootstrapClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).get();
-        this.zkSts = bootstrapClient.apps().statefulSets().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperClusterName(CLUSTER_NAME)).get();
-        this.zkPod0 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperPodName(CLUSTER_NAME, 0)).get();
-        this.zkPod1 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperPodName(CLUSTER_NAME, 1)).get();
-        this.zkPod2 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperPodName(CLUSTER_NAME, 2)).get();
+        this.zkSts = bootstrapClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).get();
+        this.zkPod0 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0)).get();
+        this.zkPod1 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, 1)).get();
+        this.zkPod2 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, 2)).get();
         this.kafkaPod0 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 0)).get();
         this.kafkaPod1 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 1)).get();
         this.kafkaPod2 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 2)).get();
@@ -246,7 +245,7 @@ public class PartialRollingUpdateTest {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 2; i++) {
-                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperPodName(CLUSTER_NAME, i)).get();
+                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, i)).get();
                 String generation = pod.getMetadata().getAnnotations().get(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION);
                 int finalI = i;
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected generation " + generation, generation, is("3")));
@@ -276,7 +275,7 @@ public class PartialRollingUpdateTest {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 2; i++) {
-                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperPodName(CLUSTER_NAME, i)).get();
+                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, i)).get();
                 String certGeneration = pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION);
                 int finalI = i;
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected cert generation " + certGeneration, certGeneration, is("3")));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinderTest.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.model.Ca;
-import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -399,13 +398,13 @@ public class ZookeeperLeaderFinderTest {
     public void testGetHostReturnsCorrectHostForGivenPod() {
         Pod pod = new PodBuilder()
                 .withNewMetadata()
-                    .withName(ZookeeperCluster.zookeeperPodName("my-cluster", 3))
+                    .withName(KafkaResources.zookeeperPodName("my-cluster", 3))
                     .withNamespace("myproject")
                     .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, "my-cluster")
                 .endMetadata()
             .build();
 
-        assertThat(new ZookeeperLeaderFinder(vertx, this::backoff).host(new Reconciliation("test", "Kafka", "myproject", "my-cluster"), ZookeeperCluster.zookeeperPodName("my-cluster", 3)),
+        assertThat(new ZookeeperLeaderFinder(vertx, this::backoff).host(new Reconciliation("test", "Kafka", "myproject", "my-cluster"), KafkaResources.zookeeperPodName("my-cluster", 3)),
                 is("my-cluster-zookeeper-3.my-cluster-zookeeper-nodes.myproject.svc.cluster.local"));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR cleans-up the `ZookeeperCluster` model class:
* Removes the static methods redirecting to another static methods
* Removes unnecessary getters / setters used only internally. Getters / setters used also from outside are kept.
* Moved some of the name definitions to `KafkaResources` class

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally