### PR TITLE
[MO] - [system test] -> proper deletion of KafkaSTs additional namesp…

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1789,5 +1789,7 @@ class KafkaST extends AbstractST {
 
         kubeClient(namespaceName).getClient().resources(KafkaTopic.class, KafkaTopicList.class).inNamespace(namespaceName).delete();
         kubeClient(namespaceName).getClient().persistentVolumeClaims().inNamespace(namespaceName).delete();
+
+        testSuiteNamespaceManager.deleteParallelNamespace(extensionContext);
     }
 }


### PR DESCRIPTION
…aces

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix

### Description

This PR fixes problem with `KafkaST` deletion of auxiliary namespaces. In this test suite we `override` `@AfterEach` annotation and thus deletion of auxiliary namespace is skipped. This results in empty namespaces (but these are deleted after ∀ test cases are executed). This PR deletes namespaces for `KafkaST` in `@AfterEach`.

### Checklist

- [ ] Make sure all tests pass


