### PR TITLE
Added removal of older cluster CA certificates after renewal by new CA private key

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -281,8 +281,8 @@ public class CruiseControlReconciler {
                     .reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), deployment)
                     .compose(patchResult -> {
                         if (patchResult instanceof ReconcileResult.Noop)   {
-                            // Deployment needs ot be rolled because the certificate secret changed
-                            if (existingCertsChanged) {
+                            // Deployment needs ot be rolled because the certificate secret changed or older/expired cluster CA removed
+                            if (existingCertsChanged || clusterCa.certsRemoved()) {
                                 return cruiseControlRollingUpdate();
                             }
                         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -404,8 +404,8 @@ public class EntityOperatorReconciler {
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), deployment)
                     .compose(patchResult -> {
                         if (patchResult instanceof ReconcileResult.Noop)   {
-                            // Deployment needs ot be rolled because the certificate secret changed
-                            if (existingEntityTopicOperatorCertsChanged || existingEntityUserOperatorCertsChanged) {
+                            // Deployment needs ot be rolled because the certificate secret changed or older/expired cluster CA removed
+                            if (existingEntityTopicOperatorCertsChanged || existingEntityUserOperatorCertsChanged || clusterCa.certsRemoved()) {
                                 return rollDeployment();
                             }
                         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -346,6 +346,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.prepareVersionChange())
                 // Roll everything if a new CA is added to the trust store.
                 .compose(state -> state.rollingUpdateForNewCaKey())
+                // Remove older Cluster CA certificates if renewal happened with a new CA private key
+                .compose(state -> state.maybeRemoveOldClusterCaCertificates())
 
                 // Run reconciliations of the different components
                 .compose(state -> reconcileZooKeeper(state))
@@ -689,6 +691,44 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             if (ca != null && !ca.isGenerateCertificateAuthority() && (certSecret == null || keySecret == null))   {
                 throw new InvalidConfigurationException(caDescription + " should not be generated, but the secrets were not found.");
             }
+        }
+
+        /**
+         * Remove older cluster CA certificates if present in the corresponding Secret
+         * after a renewal by replacing the corresponding CA private key
+         */
+        Future<ReconciliationState> maybeRemoveOldClusterCaCertificates() {
+            // building the selector for Kafka related components
+            Labels labels =  Labels.forStrimziCluster(name).withStrimziKind(Kafka.RESOURCE_KIND);
+            return podOperations.listAsync(namespace, labels)
+                    .compose(pods -> {
+                        // still no Pods, a new Kafka cluster is under creation
+                        if (pods.isEmpty()) {
+                            return Future.succeededFuture();
+                        }
+                        int clusterCaCertGeneration = clusterCa.certGeneration();
+                        LOGGER.debugCr(reconciliation, "Current cluster CA cert generation {}", clusterCaCertGeneration);
+                        // only if all Kafka related components pods are updated to the new cluster CA cert generation,
+                        // there is the possibility that we should remove the older cluster CA from the Secret and stores
+                        for (Pod pod : pods) {
+                            int podClusterCaCertGeneration = Integer.parseInt(pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION));
+                            LOGGER.debugCr(reconciliation, "Pod {} cluster CA cert generation {}", pod.getMetadata().getName(), podClusterCaCertGeneration);
+                            if (clusterCaCertGeneration != podClusterCaCertGeneration) {
+                                return Future.succeededFuture();
+                            }
+                        }
+                        LOGGER.debugCr(reconciliation, "Maybe there are old cluster CA certificates to remove");
+                        this.clusterCa.maybeDeleteOldCerts();
+                        return Future.succeededFuture(this.clusterCa);
+                    })
+                    .compose(ca -> {
+                        if (ca != null && ca.certsRemoved()) {
+                            return secretOperations.reconcile(reconciliation, namespace, AbstractModel.clusterCaCertSecretName(name), ca.caCertSecret());
+                        } else {
+                            return Future.succeededFuture();
+                        }
+                    })
+                    .map(this);
         }
 
         /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -162,8 +162,8 @@ public class KafkaExporterReconciler {
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.deploymentName(reconciliation.name()), deployment)
                     .compose(patchResult -> {
                         if (patchResult instanceof ReconcileResult.Noop)   {
-                            // Deployment needs ot be rolled because the certificate secret changed
-                            if (existingKafkaExporterCertsChanged) {
+                            // Deployment needs ot be rolled because the certificate secret changed or older/expired cluster CA removed
+                            if (existingKafkaExporterCertsChanged || clusterCa.certsRemoved()) {
                                 return kafkaExporterRollingUpdate();
                             }
                         }

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -808,11 +808,6 @@ public abstract class Ca {
         this.caCertsRemoved = removeCerts(this.caCertSecret.getData(), entry -> OLD_CA_CERT_PATTERN.matcher(entry.getKey()).matches()) > 0;
         if (this.caCertsRemoved) {
             LOGGER.infoCr(reconciliation, "{}: Old CA certificates removed", this);
-            /*
-            this.caCertSecret = new SecretBuilder(this.caCertSecret)
-                    .withData(this.caCertSecret.getData())
-                    .build();
-             */
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #1979.
As usual, when a new private cluster CA key is generated, the cluster CA renewal happens and the older one is stored in the corresponding Secret as `ca-<expiration_date_time>.crt`.
The operator runs two rollings: the first one to trust the new cluster CA cert, the second one to generate the new server certs signed by the new cluster CA cert.
With this PR a third rolling is added after checking that a removal of the older CA cert happened.
This check is based on the fact that the first two rolling happened and all Kafka components related pods have the cluster CA cert generation equals to the one of the new cluster CA cert. After that, the older cluster CA cert can be removed.
The effect of such a removal is a new rolling of the pods that anyway happens on the next reconcile loop.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging