### PR TITLE
Use different name for system test debug log in azure

### DIFF
--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -112,6 +112,7 @@ jobs:
         DOCKER_REGISTRY: registry.minikube
         CLUSTER_OPERATOR_INSTALL_TYPE: '${{ parameters.cluster_operator_install_type }}'
         STRIMZI_FEATURE_GATES: '${{ parameters.strimzi_feature_gates }}'
+        BUILD_ID: $(Build.BuildId)
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -112,7 +112,7 @@ jobs:
         DOCKER_REGISTRY: registry.minikube
         CLUSTER_OPERATOR_INSTALL_TYPE: '${{ parameters.cluster_operator_install_type }}'
         STRIMZI_FEATURE_GATES: '${{ parameters.strimzi_feature_gates }}'
-        BUILD_ID: $(Build.BuildId)
+        BUILD_ID: $(Agent.JobName)
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -401,7 +401,7 @@
                     kafka/ConfigProviderST,
                     operators/topic/ThrottlingQuotaST,
                     tracing/**/*ST,
-                    watcher/**/*ST
+<!--                    watcher/**/*ST-->
                 </it.test>
             </properties>
         </profile>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -401,7 +401,7 @@
                     kafka/ConfigProviderST,
                     operators/topic/ThrottlingQuotaST,
                     tracing/**/*ST,
-<!--                    watcher/**/*ST-->
+                    watcher/**/*ST
                 </it.test>
             </properties>
         </profile>

--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -7,7 +7,7 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highli
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug.log
+appender.rolling.fileName = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug-${env:BUILD_ID:-0}.log
 appender.rolling.filePattern = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
 appender.rolling.policies.type = Policies
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR extends the name for system test debug log. Now the job name in azure or 0 will be added to the name. This is needed because we don't want to let each job rewrite the previously-stored debug log.

Let's wait until https://github.com/strimzi/strimzi-kafka-operator/pull/6652 before moving with this

### Checklist

- [x] Make sure all tests pass


