### PR TITLE
Removed the use of RestartPlan class in the Kafka Roller Class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -219,16 +219,17 @@ public class KafkaRoller {
         final Promise<Void> promise;
         final BackOff backOff;
         private long connectionErrorStart = 0L;
+
         boolean needsRestart;
         boolean needsReconfig;
         boolean forceRestart;
         KafkaBrokerConfigurationDiff diff;
         KafkaBrokerLoggingConfigurationDiff logDiff;
 
-       RestartContext(Supplier<BackOff> backOffSupplier) {
-           promise = Promise.promise();
-           backOff = backOffSupplier.get();
-           backOff.delayMs();
+        RestartContext(Supplier<BackOff> backOffSupplier) {
+            promise = Promise.promise();
+            backOff = backOffSupplier.get();
+            backOff.delayMs();
         }
 
         public void clearConnectionError() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -219,7 +219,6 @@ public class KafkaRoller {
         final Promise<Void> promise;
         final BackOff backOff;
         private long connectionErrorStart = 0L;
-
         boolean needsRestart;
         boolean needsReconfig;
         boolean forceRestart;
@@ -227,11 +226,10 @@ public class KafkaRoller {
         KafkaBrokerLoggingConfigurationDiff logDiff;
 
        RestartContext(Supplier<BackOff> backOffSupplier) {
-            promise = Promise.promise();
-            backOff = backOffSupplier.get();
-            backOff.delayMs();
+           promise = Promise.promise();
+           backOff = backOffSupplier.get();
+           backOff.delayMs();
         }
-
 
         public void clearConnectionError() {
             connectionErrorStart = 0L;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -323,7 +323,7 @@ public class KafkaRoller {
         }
 
         try {
-            restartPlan(podRef, pod, restartContext);
+            checkReconfigurability(podRef, pod, restartContext);
             if (restartContext.forceRestart || restartContext.needsRestart || restartContext.needsReconfig) {
                 if (!restartContext.forceRestart && deferController(podRef, restartContext)) {
                     LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to roll", podRef);
@@ -424,7 +424,7 @@ public class KafkaRoller {
      * Determine whether the pod should be restarted, or the broker reconfigured.
      */
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
-    private void restartPlan(PodRef podRef, Pod pod, RestartContext restartContext) throws ForceableProblem, InterruptedException, FatalProblem {
+    private void checkReconfigurability(PodRef podRef, Pod pod, RestartContext restartContext) throws ForceableProblem, InterruptedException, FatalProblem {
 
         List<String> reasonToRestartPod = Objects.requireNonNull(podNeedsRestart.apply(pod));
         boolean podStuck = pod != null

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -456,6 +456,7 @@ public class KafkaRoller {
             restartContext.forceRestart = true;
             restartContext.diff = null;
             restartContext.logDiff = null;
+            return;
         }
         Config brokerConfig;
         try {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description
This is the starting step for making the process of KafkaRoller class more clean and effective. This PR removes the use `RestartPlan` class. The `restartPlan` method was earlier making use of the `RestartPlan` instance for the on describing how the restart needs to be performed. Instead of creating seperate objects for them we now shifted the parameters of `RestartPlan` to `RestartContext itself to more or less use a single object ie `RestartContext` instance for determining the restart plan. 

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

