### PR TITLE
[MO] - [system test] -> OauthPlainIsolatedST removing unnecessary kafka clients

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -258,7 +258,6 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
     void testProducerConsumerConnect(ExtensionContext extensionContext) {
-        String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
         String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
@@ -283,7 +282,6 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(extensionContext, clusterName, oauthClusterName, 1)
             .editMetadata()
                 .withNamespace(INFRA_NAMESPACE)
@@ -732,7 +730,7 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
 
         keycloakInstance.setRealm("internal", false);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(oauthClusterName, 1, 1)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(oauthClusterName, 3)
             .editMetadata()
                 .withNamespace(INFRA_NAMESPACE)
             .endMetadata()


### PR DESCRIPTION
…case

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement
- Refactoring

### Description

This PR changes the number of replicas that are used in the Kafka cluster during Oauth verification. Moreover, I have removed the unnecessary deployment of Kafka clients. 

This also removed the flakiness of `testProducerConsumerConnect` test case because when I run it locally before this change it fails with a 50% chance (but you had to run the whole test suite, not a single test case). With such a change I was unable to reproduce the error...

### Checklist

- [x] Make sure all tests pass