### PR TITLE
Add atruvia to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -12,6 +12,7 @@
 * [SBB CFF FFS](https://www.sbb.ch/en/home.html)
 * [Swisscom](https://www.swisscom.ch/)
 * [CN Group](https://www.cngroup.dk/)
+* [Atruvia](https://atruvia.de/)
 
 Are you currently using Strimzi in production?
 Please let us know by adding your company name and, if you want, a description of your use case to this document!


### PR DESCRIPTION
Signed-off-by: Philipp Böcker <philipp.boecker@atruvia.de>

### Type of change

Documentation

### Description

Added Atruvia company to adopters list. Atruvia uses Strimzi among others as event backend for the online banking services 