### PR TITLE
Clean-up the `KafkaCluster` model class

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaResources.java
@@ -154,6 +154,39 @@ public class KafkaResources {
         return "strimzi-" + namespace + "-" + cluster + "-kafka-init";
     }
 
+    /**
+     * Returns the name of the Kafka Secret with server certificates.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding Kafka Secret.
+     */
+    public static String kafkaSecretName(String clusterName) {
+        return clusterName + "-kafka-brokers";
+    }
+
+    /**
+     * Returns the name of the Kafka Secret with JMX credentials.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding Kafka JMX Secret.
+     */
+    public static String kafkaJmxSecretName(String clusterName) {
+        return clusterName + "-kafka-jmx";
+    }
+
+    /**
+     * Returns the name of the Kafka Network Policy.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
+     *
+     * @return The name of the corresponding Kafka Network Policy.
+     */
+    public static String kafkaNetworkPolicyName(String clusterName) {
+        return clusterName + "-network-policy-kafka";
+    }
+
     ////////
     // ZooKeeper methods
     ////////

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -86,7 +86,7 @@ public class ClusterCa extends Ca {
     public void initCaSecrets(List<Secret> secrets) {
         for (Secret secret: secrets) {
             String name = secret.getMetadata().getName();
-            if (KafkaCluster.brokersSecretName(clusterName).equals(name)) {
+            if (KafkaResources.kafkaSecretName(clusterName).equals(name)) {
                 brokersSecret = secret;
             } else if (KafkaResources.entityTopicOperatorSecretName(clusterName).equals(name)) {
                 entityTopicOperatorSecret = secret;
@@ -203,8 +203,8 @@ public class ClusterCa extends Ca {
             subject.addDnsName(String.format("%s.%s", KafkaResources.brokersServiceName(cluster), namespace));
             subject.addDnsName(kafkaHeadlessDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(kafkaHeadlessDnsGenerator.serviceDnsName());
-            subject.addDnsName(KafkaCluster.podDnsName(namespace, cluster, i));
-            subject.addDnsName(KafkaCluster.podDnsNameWithoutClusterDomain(namespace, cluster, i));
+            subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), KafkaResources.kafkaPodName(cluster, i)));
+            subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(cluster), KafkaResources.kafkaPodName(cluster, i)));
 
             if (externalBootstrapAddresses != null)   {
                 for (String dnsName : externalBootstrapAddresses) {
@@ -234,7 +234,7 @@ public class ClusterCa extends Ca {
             kafka.getSpec().getKafka().getReplicas(),
             subjectFn,
             brokersSecret,
-            podNum -> KafkaCluster.kafkaPodName(cluster, podNum),
+            podNum -> KafkaResources.kafkaPodName(cluster, podNum),
             isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -205,7 +205,7 @@ public class JmxTrans extends AbstractModel {
         String headlessService = KafkaResources.brokersServiceName(cluster);
 
         for (int brokerNumber = 0; brokerNumber < numberOfBrokers; brokerNumber++) {
-            String brokerServiceName = KafkaCluster.externalServiceName(cluster, brokerNumber) + "." + headlessService;
+            String brokerServiceName = KafkaResources.kafkaStatefulSetName(cluster) + "-" + brokerNumber + "." + headlessService;
             servers.add(jmxTransServer(queries, brokerServiceName));
         }
 
@@ -339,8 +339,8 @@ public class JmxTrans extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
 
         if (isJmxAuthenticated) {
-            varList.add(buildEnvVarFromSecret(KafkaCluster.ENV_VAR_KAFKA_JMX_USERNAME, KafkaCluster.jmxSecretName(cluster), KafkaCluster.SECRET_JMX_USERNAME_KEY));
-            varList.add(buildEnvVarFromSecret(KafkaCluster.ENV_VAR_KAFKA_JMX_PASSWORD, KafkaCluster.jmxSecretName(cluster), KafkaCluster.SECRET_JMX_PASSWORD_KEY));
+            varList.add(buildEnvVarFromSecret(KafkaCluster.ENV_VAR_KAFKA_JMX_USERNAME, KafkaResources.kafkaJmxSecretName(cluster), KafkaCluster.SECRET_JMX_USERNAME_KEY));
+            varList.add(buildEnvVarFromSecret(KafkaCluster.ENV_VAR_KAFKA_JMX_PASSWORD, KafkaResources.kafkaJmxSecretName(cluster), KafkaCluster.SECRET_JMX_PASSWORD_KEY));
         }
 
         varList.add(buildEnvVar(ENV_VAR_JMXTRANS_LOGGING_LEVEL, loggingLevel));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -106,7 +106,6 @@ public class KafkaCluster extends AbstractModel {
     protected static final String APPLICATION_NAME = "kafka";
 
     protected static final String ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS = "EXTERNAL_ADDRESS";
-
     private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
 
     // For port names in services, a 'tcp-' prefix is added to support Istio protocol selection
@@ -131,22 +130,16 @@ public class KafkaCluster extends AbstractModel {
     protected static final String OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/certificates";
     protected static final String CUSTOM_AUTHN_SECRETS_VOLUME_MOUNT = "/opt/kafka/custom-authn-secrets";
 
-    private static final String NAME_SUFFIX = "-kafka";
-
     private static final String KAFKA_METRIC_REPORTERS_CONFIG_FIELD = "metric.reporters";
     private static final String KAFKA_NUM_PARTITIONS_CONFIG_FIELD = "num.partitions";
     private static final String KAFKA_REPLICATION_FACTOR_CONFIG_FIELD = "default.replication.factor";
 
-    protected static final String KAFKA_JMX_SECRET_SUFFIX = NAME_SUFFIX + "-jmx";
     protected static final String SECRET_JMX_USERNAME_KEY = "jmx-username";
     protected static final String SECRET_JMX_PASSWORD_KEY = "jmx-password";
     protected static final String ENV_VAR_KAFKA_JMX_USERNAME = "KAFKA_JMX_USERNAME";
     protected static final String ENV_VAR_KAFKA_JMX_PASSWORD = "KAFKA_JMX_PASSWORD";
 
     protected static final String CO_ENV_VAR_CUSTOM_KAFKA_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_LABELS";
-
-    // Suffixes for secrets with certificates
-    private static final String SECRET_BROKERS_SUFFIX = NAME_SUFFIX + "-brokers";
 
     /**
      * Records the Kafka version currently running inside Kafka StatefulSet
@@ -260,80 +253,6 @@ public class KafkaCluster extends AbstractModel {
         this.initImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "quay.io/strimzi/operator:latest");
     }
 
-    public static String podDnsName(String namespace, String cluster, int podId) {
-        return podDnsName(namespace, cluster, KafkaCluster.kafkaPodName(cluster, podId));
-    }
-
-    public static String podDnsName(String namespace, String cluster, String podName) {
-        return DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), podName);
-    }
-
-    public static String podDnsNameWithoutClusterDomain(String namespace, String cluster, int podId) {
-        return podDnsNameWithoutClusterDomain(namespace, cluster, KafkaCluster.kafkaPodName(cluster, podId));
-    }
-
-    public static String podDnsNameWithoutClusterDomain(String namespace, String cluster, String podName) {
-        return DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(cluster), podName);
-    }
-
-    /**
-     * Generates the name of the service for exposing individual pods.
-     *
-     * @param cluster The name of the cluster.
-     * @param pod     Pod sequence number assign by StatefulSet.
-     * @return The name of the external service.
-     */
-    public static String externalServiceName(String cluster, int pod) {
-        return KafkaResources.kafkaStatefulSetName(cluster) + "-" + pod;
-    }
-
-    /**
-     * Gets the name of the given Kafka pod.
-     *
-     * @param cluster The name of the cluster.
-     * @param pod     The id of the pod
-     * @return The name of the pod.
-     */
-    public static String kafkaPodName(String cluster, int pod) {
-        return KafkaResources.kafkaStatefulSetName(cluster) + "-" + pod;
-    }
-
-    /**
-     * @param cluster The name of the cluster.
-     * @return The name of the brokers Secret.
-     */
-    public static String brokersSecretName(String cluster) {
-        return cluster + KafkaCluster.SECRET_BROKERS_SUFFIX;
-    }
-
-    /**
-     * @param cluster The name of the cluster.
-     * @return The name of the jmx Secret.
-     */
-    public static String jmxSecretName(String cluster) {
-        return cluster + KafkaCluster.KAFKA_JMX_SECRET_SUFFIX;
-    }
-
-    public static List<String> generatePodList(String cluster, int replicas) {
-
-        ArrayList<String> podNames = new ArrayList<>(replicas);
-
-        for (int podId = 0; podId < replicas; podId++) {
-
-            podNames.add(kafkaPodName(cluster, podId));
-
-        }
-        return podNames;
-    }
-
-    /**
-     * @param cluster The name of the cluster.
-     * @return The name of the clients CA certificate Secret.
-     */
-    public static String clientsCaCertSecretName(String cluster) {
-        return KafkaResources.clientsCaCertificateSecretName(cluster);
-    }
-
     public static KafkaCluster fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
         return fromCrd(reconciliation, kafkaAssembly, versions, null, 0);
     }
@@ -367,13 +286,13 @@ public class KafkaCluster extends AbstractModel {
             result.setLivenessProbe(kafkaClusterSpec.getLivenessProbe());
         }
 
-        result.setRack(kafkaClusterSpec.getRack());
+        result.rack = kafkaClusterSpec.getRack();
 
         String initImage = kafkaClusterSpec.getBrokerRackInitImage();
         if (initImage == null) {
             initImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "quay.io/strimzi/operator:latest");
         }
-        result.setInitImage(initImage);
+        result.initImage = initImage;
 
         Logging logging = kafkaClusterSpec.getLogging();
         result.setLogging(logging == null ? new InlineLogging() : logging);
@@ -550,6 +469,18 @@ public class KafkaCluster extends AbstractModel {
         result.templatePodLabels = Util.mergeLabelsOrAnnotations(result.templatePodLabels, DEFAULT_POD_LABELS);
 
         return result;
+    }
+
+    public static List<String> generatePodList(String cluster, int replicas) {
+
+        ArrayList<String> podNames = new ArrayList<>(replicas);
+
+        for (int podId = 0; podId < replicas; podId++) {
+
+            podNames.add(KafkaResources.kafkaPodName(cluster, podId));
+
+        }
+        return podNames;
     }
 
     /**
@@ -839,7 +770,7 @@ public class KafkaCluster extends AbstractModel {
                             "TCP")
             );
 
-            Labels selector = getSelectorLabels().withStatefulSetPod(kafkaPodName(cluster, pod));
+            Labels selector = getSelectorLabels().withStatefulSetPod(KafkaResources.kafkaPodName(cluster, pod));
 
             Service service = createService(
                     serviceName,
@@ -1318,17 +1249,17 @@ public class KafkaCluster extends AbstractModel {
 
         Map<String, String> data = new HashMap<>(replicas * 4);
         for (int i = 0; i < replicas; i++) {
-            CertAndKey cert = brokerCerts.get(KafkaCluster.kafkaPodName(cluster, i));
-            data.put(KafkaCluster.kafkaPodName(cluster, i) + ".key", cert.keyAsBase64String());
-            data.put(KafkaCluster.kafkaPodName(cluster, i) + ".crt", cert.certAsBase64String());
-            data.put(KafkaCluster.kafkaPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
-            data.put(KafkaCluster.kafkaPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
+            CertAndKey cert = brokerCerts.get(KafkaResources.kafkaPodName(cluster, i));
+            data.put(KafkaResources.kafkaPodName(cluster, i) + ".key", cert.keyAsBase64String());
+            data.put(KafkaResources.kafkaPodName(cluster, i) + ".crt", cert.certAsBase64String());
+            data.put(KafkaResources.kafkaPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
+            data.put(KafkaResources.kafkaPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
         }
 
         Map<String, String> annotations = Map.of(
                 clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration()),
                 clientsCa.caCertGenerationAnnotation(), String.valueOf(clientsCa.certGeneration()));
-        return createSecret(KafkaCluster.brokersSecretName(cluster), data, annotations);
+        return createSecret(KafkaResources.kafkaSecretName(cluster), data, annotations);
     }
 
     /**
@@ -1344,7 +1275,7 @@ public class KafkaCluster extends AbstractModel {
             data.put(key, Base64.getEncoder().encodeToString(passwordGenerator.generate().getBytes(StandardCharsets.US_ASCII)));
         }
 
-        return createJmxSecret(KafkaCluster.jmxSecretName(cluster), data);
+        return createJmxSecret(KafkaResources.kafkaJmxSecretName(cluster), data);
     }
 
     private List<ContainerPort> getContainerPortList() {
@@ -1398,7 +1329,7 @@ public class KafkaCluster extends AbstractModel {
 
         volumeList.add(createTempDirVolume());
         volumeList.add(VolumeUtils.createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
-        volumeList.add(VolumeUtils.createSecretVolume(BROKER_CERTS_VOLUME, KafkaCluster.brokersSecretName(cluster), isOpenShift));
+        volumeList.add(VolumeUtils.createSecretVolume(BROKER_CERTS_VOLUME, KafkaResources.kafkaSecretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaResources.clientsCaCertificateSecretName(cluster), isOpenShift));
 
         if (perBrokerConfiguration) {
@@ -1662,8 +1593,8 @@ public class KafkaCluster extends AbstractModel {
         if (isJmxEnabled) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_JMX_ENABLED, "true"));
             if (isJmxAuthenticated) {
-                varList.add(buildEnvVarFromSecret(ENV_VAR_KAFKA_JMX_USERNAME, jmxSecretName(cluster), SECRET_JMX_USERNAME_KEY));
-                varList.add(buildEnvVarFromSecret(ENV_VAR_KAFKA_JMX_PASSWORD, jmxSecretName(cluster), SECRET_JMX_PASSWORD_KEY));
+                varList.add(buildEnvVarFromSecret(ENV_VAR_KAFKA_JMX_USERNAME, KafkaResources.kafkaJmxSecretName(cluster), SECRET_JMX_USERNAME_KEY));
+                varList.add(buildEnvVarFromSecret(ENV_VAR_KAFKA_JMX_PASSWORD, KafkaResources.kafkaJmxSecretName(cluster), SECRET_JMX_PASSWORD_KEY));
             }
         }
 
@@ -1674,14 +1605,6 @@ public class KafkaCluster extends AbstractModel {
         addContainerEnvsToExistingEnvs(varList, templateKafkaContainerEnvVars);
 
         return varList;
-    }
-
-    protected void setRack(Rack rack) {
-        this.rack = rack;
-    }
-
-    protected void setInitImage(String initImage) {
-        this.initImage = initImage;
     }
 
     @Override
@@ -1714,14 +1637,6 @@ public class KafkaCluster extends AbstractModel {
         } else {
             return null;
         }
-    }
-
-    /**
-     * @param cluster The name of the cluster.
-     * @return The name of the network policy.
-     */
-    public static String networkPolicyName(String cluster) {
-        return cluster + NETWORK_POLICY_KEY_SUFFIX + NAME_SUFFIX;
     }
 
     /**
@@ -1836,7 +1751,7 @@ public class KafkaCluster extends AbstractModel {
         // Build the final network policy with all rules covering all the ports
         NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
                 .withNewMetadata()
-                    .withName(networkPolicyName(cluster))
+                    .withName(KafkaResources.kafkaNetworkPolicyName(cluster))
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())
                     .withOwnerReferences(createOwnerReference())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -529,7 +529,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                                 clientsCaCertSecret = secret;
                             } else if (secretName.equals(clientsCaKeyName)) {
                                 clientsCaKeySecret = secret;
-                            } else if (secretName.equals(KafkaCluster.brokersSecretName(name))) {
+                            } else if (secretName.equals(KafkaResources.kafkaSecretName(name))) {
                                 brokersSecret = secret;
                             }
                         }
@@ -2317,7 +2317,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         Future<ReconciliationState> kafkaBrokersSecret() {
-            return updateCertificateSecretWithDiff(KafkaCluster.brokersSecretName(name), kafkaCluster.generateBrokersSecret(clusterCa, clientsCa))
+            return updateCertificateSecretWithDiff(KafkaResources.kafkaSecretName(name), kafkaCluster.generateBrokersSecret(clusterCa, clientsCa))
                     .map(changed -> {
                         existingKafkaCertsChanged = changed;
                         return this;
@@ -2326,22 +2326,22 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         Future<ReconciliationState> kafkaJmxSecret() {
             if (kafkaCluster.isJmxAuthenticated()) {
-                Future<Secret> secretFuture = secretOperations.getAsync(namespace, KafkaCluster.jmxSecretName(name));
+                Future<Secret> secretFuture = secretOperations.getAsync(namespace, KafkaResources.kafkaJmxSecretName(name));
                 return secretFuture.compose(res -> {
                     if (res == null) {
-                        return withVoid(secretOperations.reconcile(reconciliation, namespace, KafkaCluster.jmxSecretName(name),
+                        return withVoid(secretOperations.reconcile(reconciliation, namespace, KafkaResources.kafkaJmxSecretName(name),
                                 kafkaCluster.generateJmxSecret()));
                     }
                     return withVoid(Future.succeededFuture(this));
                 });
 
             }
-            return withVoid(secretOperations.reconcile(reconciliation, namespace, KafkaCluster.jmxSecretName(name), null));
+            return withVoid(secretOperations.reconcile(reconciliation, namespace, KafkaResources.kafkaJmxSecretName(name), null));
         }
 
         Future<ReconciliationState> kafkaNetPolicy() {
             if (isNetworkPolicyGeneration) {
-                return withVoid(networkPolicyOperator.reconcile(reconciliation, namespace, KafkaCluster.networkPolicyName(name), kafkaCluster.generateNetworkPolicy(operatorNamespace, operatorNamespaceLabels)));
+                return withVoid(networkPolicyOperator.reconcile(reconciliation, namespace, KafkaResources.kafkaNetworkPolicyName(name), kafkaCluster.generateNetworkPolicy(operatorNamespace, operatorNamespaceLabels)));
             } else {
                 return withVoid(Future.succeededFuture());
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -288,15 +288,15 @@ public class ResourceUtils {
         SecretBuilder builder =
                 new SecretBuilder()
                         .withNewMetadata()
-                        .withName(KafkaCluster.brokersSecretName(name))
+                        .withName(KafkaResources.kafkaSecretName(name))
                         .withNamespace(namespace)
                         .withLabels(Labels.forStrimziCluster(name).toMap())
                         .endMetadata()
                         .addToData("cluster-ca.crt", MockCertManager.clusterCaCert());
 
         for (int i = 0; i < kafkaReplicas; i++) {
-            builder.addToData(KafkaCluster.kafkaPodName(name, i) + ".key", Base64.getEncoder().encodeToString("brokers-internal-base64key".getBytes()))
-                    .addToData(KafkaCluster.kafkaPodName(name, i) + ".crt", Base64.getEncoder().encodeToString("brokers-internal-base64crt".getBytes()));
+            builder.addToData(KafkaResources.kafkaPodName(name, i) + ".key", Base64.getEncoder().encodeToString("brokers-internal-base64key".getBytes()))
+                    .addToData(KafkaResources.kafkaPodName(name, i) + ".crt", Base64.getEncoder().encodeToString("brokers-internal-base64crt".getBytes()));
         }
         secrets.add(builder.build());
 
@@ -309,8 +309,8 @@ public class ResourceUtils {
                         .addToData("ca.crt", Base64.getEncoder().encodeToString("cluster-ca-base64crt".getBytes()));
 
         for (int i = 0; i < kafkaReplicas; i++) {
-            builder.addToData(KafkaCluster.kafkaPodName(name, i) + ".key", Base64.getEncoder().encodeToString("brokers-clients-base64key".getBytes()))
-                    .addToData(KafkaCluster.kafkaPodName(name, i) + ".crt", Base64.getEncoder().encodeToString("brokers-clients-base64crt".getBytes()));
+            builder.addToData(KafkaResources.kafkaPodName(name, i) + ".key", Base64.getEncoder().encodeToString("brokers-clients-base64key".getBytes()))
+                    .addToData(KafkaResources.kafkaPodName(name, i) + ".crt", Base64.getEncoder().encodeToString("brokers-clients-base64crt".getBytes()));
         }
         secrets.add(builder.build());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -169,8 +169,8 @@ public class JmxTransTest {
 
     private List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<>();
-        expected.add(new EnvVarBuilder().withName(KafkaCluster.ENV_VAR_KAFKA_JMX_USERNAME).withNewValueFrom().withNewSecretKeyRef().withName(KafkaCluster.jmxSecretName(cluster)).withKey(KafkaCluster.SECRET_JMX_USERNAME_KEY).endSecretKeyRef().endValueFrom().build());
-        expected.add(new EnvVarBuilder().withName(KafkaCluster.ENV_VAR_KAFKA_JMX_PASSWORD).withNewValueFrom().withNewSecretKeyRef().withName(KafkaCluster.jmxSecretName(cluster)).withKey(KafkaCluster.SECRET_JMX_PASSWORD_KEY).endSecretKeyRef().endValueFrom().build());
+        expected.add(new EnvVarBuilder().withName(KafkaCluster.ENV_VAR_KAFKA_JMX_USERNAME).withNewValueFrom().withNewSecretKeyRef().withName(KafkaResources.kafkaJmxSecretName(cluster)).withKey(KafkaCluster.SECRET_JMX_USERNAME_KEY).endSecretKeyRef().endValueFrom().build());
+        expected.add(new EnvVarBuilder().withName(KafkaCluster.ENV_VAR_KAFKA_JMX_PASSWORD).withNewValueFrom().withNewSecretKeyRef().withName(KafkaResources.kafkaJmxSecretName(cluster)).withKey(KafkaCluster.SECRET_JMX_PASSWORD_KEY).endSecretKeyRef().endValueFrom().build());
         expected.add(new EnvVarBuilder().withName(JmxTrans.ENV_VAR_JMXTRANS_LOGGING_LEVEL).withValue("INFO").build());
         return expected;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -131,7 +131,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings({
     "checkstyle:ClassDataAbstractionCoupling",
@@ -158,10 +157,10 @@ public class KafkaClusterTest {
         kafkaLog.setLoggers(Collections.singletonMap("kafka.root.logger.level", "OFF"));
         zooLog.setLoggers(Collections.singletonMap("zookeeper.root.logger", "OFF"));
     }
-    private final List<SystemProperty> javaSystemProperties = new ArrayList<SystemProperty>() {{
-            add(new SystemPropertyBuilder().withName("javax.net.debug").withValue("verbose").build());
-            add(new SystemPropertyBuilder().withName("something.else").withValue("42").build());
-        }};
+    private final List<SystemProperty> javaSystemProperties = List.of(
+            new SystemPropertyBuilder().withName("javax.net.debug").withValue("verbose").build(),
+            new SystemPropertyBuilder().withName("something.else").withValue("42").build()
+    );
 
     private final Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas, image, healthDelay, healthTimeout, jmxMetricsConfig, configuration, kafkaLog, zooLog))
             .editSpec()
@@ -294,10 +293,10 @@ public class KafkaClusterTest {
         assertThat(headless.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(headless.getSpec().getPorts().size(), is(5));
         assertThat(headless.getSpec().getPorts().get(0).getName(), is(KafkaCluster.CONTROLPLANE_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(KafkaCluster.CONTROLPLANE_PORT)));
+        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(KafkaCluster.CONTROLPLANE_PORT));
         assertThat(headless.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getPorts().get(1).getName(), is(KafkaCluster.REPLICATION_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(Integer.valueOf(KafkaCluster.REPLICATION_PORT)));
+        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(KafkaCluster.REPLICATION_PORT));
         assertThat(headless.getSpec().getPorts().get(1).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getPorts().get(2).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_PLAIN_PORT_NAME));
         assertThat(headless.getSpec().getPorts().get(2).getPort(), is(9092));
@@ -306,7 +305,7 @@ public class KafkaClusterTest {
         assertThat(headless.getSpec().getPorts().get(3).getPort(), is(9093));
         assertThat(headless.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getPorts().get(4).getName(), is(KafkaCluster.JMX_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(4).getPort(), is(Integer.valueOf(KafkaCluster.JMX_PORT)));
+        assertThat(headless.getSpec().getPorts().get(4).getPort(), is(KafkaCluster.JMX_PORT));
         assertThat(headless.getSpec().getPorts().get(4).getProtocol(), is("TCP"));
 
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
@@ -368,10 +367,10 @@ public class KafkaClusterTest {
         assertThat(headless.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(headless.getSpec().getPorts().size(), is(4));
         assertThat(headless.getSpec().getPorts().get(0).getName(), is(KafkaCluster.CONTROLPLANE_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(Integer.valueOf(KafkaCluster.CONTROLPLANE_PORT)));
+        assertThat(headless.getSpec().getPorts().get(0).getPort(), is(KafkaCluster.CONTROLPLANE_PORT));
         assertThat(headless.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getPorts().get(1).getName(), is(KafkaCluster.REPLICATION_PORT_NAME));
-        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(Integer.valueOf(KafkaCluster.REPLICATION_PORT)));
+        assertThat(headless.getSpec().getPorts().get(1).getPort(), is(KafkaCluster.REPLICATION_PORT));
         assertThat(headless.getSpec().getPorts().get(1).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getPorts().get(2).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_PLAIN_PORT_NAME));
         assertThat(headless.getSpec().getPorts().get(2).getPort(), is(9092));
@@ -425,7 +424,7 @@ public class KafkaClusterTest {
     public void testGenerateStatefulSet() {
         // We expect a single statefulSet ...
         StatefulSet sts = kc.generateStatefulSet(true, null, null, null);
-        checkStatefulSet(sts, kafkaAssembly, true);
+        checkStatefulSet(sts, kafkaAssembly);
         checkOwnerReference(kc.createOwnerReference(), sts);
 
         // Check Volumes
@@ -519,7 +518,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, editKafkaAssembly, VERSIONS);
         StatefulSet sts = kc.generateStatefulSet(true, null, null, null);
-        checkStatefulSet(sts, editKafkaAssembly, true);
+        checkStatefulSet(sts, editKafkaAssembly);
     }
 
     @ParallelTest
@@ -534,7 +533,7 @@ public class KafkaClusterTest {
                         .endSpec().build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, editKafkaAssembly, VERSIONS);
         StatefulSet sts = kc.generateStatefulSet(false, null, null, null);
-        checkStatefulSet(sts, editKafkaAssembly, false);
+        checkStatefulSet(sts, editKafkaAssembly);
     }
 
     @ParallelTest
@@ -555,7 +554,7 @@ public class KafkaClusterTest {
         assertThat(sts.getSpec().getPodManagementPolicy(), is(PodManagementPolicy.ORDERED_READY.toValue()));
     }
 
-    private void checkStatefulSet(StatefulSet sts, Kafka cm, boolean isOpenShift) {
+    private void checkStatefulSet(StatefulSet sts, Kafka cm) {
         assertThat(sts.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster)));
         // ... in the same namespace ...
         assertThat(sts.getMetadata().getNamespace(), is(namespace));
@@ -570,19 +569,19 @@ public class KafkaClusterTest {
         assertThat(containers.size(), is(1));
 
         // checks on the main Kafka container
-        assertThat(sts.getSpec().getReplicas(), is(Integer.valueOf(replicas)));
+        assertThat(sts.getSpec().getReplicas(), is(replicas));
         assertThat(sts.getSpec().getPodManagementPolicy(), is(PodManagementPolicy.PARALLEL.toValue()));
         assertThat(containers.get(0).getImage(), is(image));
-        assertThat(containers.get(0).getLivenessProbe().getTimeoutSeconds(), is(Integer.valueOf(healthTimeout)));
-        assertThat(containers.get(0).getLivenessProbe().getInitialDelaySeconds(), is(Integer.valueOf(healthDelay)));
-        assertThat(containers.get(0).getLivenessProbe().getFailureThreshold(), is(Integer.valueOf(10)));
-        assertThat(containers.get(0).getLivenessProbe().getSuccessThreshold(), is(Integer.valueOf(4)));
-        assertThat(containers.get(0).getLivenessProbe().getPeriodSeconds(), is(Integer.valueOf(33)));
-        assertThat(containers.get(0).getReadinessProbe().getTimeoutSeconds(), is(Integer.valueOf(healthTimeout)));
-        assertThat(containers.get(0).getReadinessProbe().getInitialDelaySeconds(), is(Integer.valueOf(healthDelay)));
-        assertThat(containers.get(0).getReadinessProbe().getFailureThreshold(), is(Integer.valueOf(10)));
-        assertThat(containers.get(0).getReadinessProbe().getSuccessThreshold(), is(Integer.valueOf(4)));
-        assertThat(containers.get(0).getReadinessProbe().getPeriodSeconds(), is(Integer.valueOf(33)));
+        assertThat(containers.get(0).getLivenessProbe().getTimeoutSeconds(), is(healthTimeout));
+        assertThat(containers.get(0).getLivenessProbe().getInitialDelaySeconds(), is(healthDelay));
+        assertThat(containers.get(0).getLivenessProbe().getFailureThreshold(), is(10));
+        assertThat(containers.get(0).getLivenessProbe().getSuccessThreshold(), is(4));
+        assertThat(containers.get(0).getLivenessProbe().getPeriodSeconds(), is(33));
+        assertThat(containers.get(0).getReadinessProbe().getTimeoutSeconds(), is(healthTimeout));
+        assertThat(containers.get(0).getReadinessProbe().getInitialDelaySeconds(), is(healthDelay));
+        assertThat(containers.get(0).getReadinessProbe().getFailureThreshold(), is(10));
+        assertThat(containers.get(0).getReadinessProbe().getSuccessThreshold(), is(4));
+        assertThat(containers.get(0).getReadinessProbe().getPeriodSeconds(), is(33));
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)));
         assertThat(containers.get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(containers.get(0).getVolumeMounts().get(1).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
@@ -600,7 +599,7 @@ public class KafkaClusterTest {
         assertThat(containers.get(0).getPorts().get(1).getProtocol(), is("TCP"));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         if (cm.getSpec().getKafka().getRack() != null) {
 
@@ -655,8 +654,8 @@ public class KafkaClusterTest {
         List<PersistentVolumeClaim> pvcs = kc.getPersistentVolumeClaimTemplates();
 
         for (int i = 0; i < replicas; i++) {
-            assertThat(pvcs.get(0).getMetadata().getName() + "-" + KafkaCluster.kafkaPodName(cluster, i),
-                    is(kc.VOLUME_NAME + "-" + KafkaCluster.kafkaPodName(cluster, i)));
+            assertThat(pvcs.get(0).getMetadata().getName() + "-" + KafkaResources.kafkaPodName(cluster, i),
+                    is(KafkaCluster.VOLUME_NAME + "-" + KafkaResources.kafkaPodName(cluster, i)));
         }
 
         assembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
@@ -677,8 +676,8 @@ public class KafkaClusterTest {
         for (int i = 0; i < replicas; i++) {
             int id = 0;
             for (PersistentVolumeClaim pvc : pvcs) {
-                assertThat(pvc.getMetadata().getName() + "-" + KafkaCluster.kafkaPodName(cluster, i),
-                        is(kc.VOLUME_NAME + "-" + id++ + "-" + KafkaCluster.kafkaPodName(cluster, i)));
+                assertThat(pvc.getMetadata().getName() + "-" + KafkaResources.kafkaPodName(cluster, i),
+                        is(KafkaCluster.VOLUME_NAME + "-" + id++ + "-" + KafkaResources.kafkaPodName(cluster, i)));
             }
         }
     }
@@ -755,9 +754,9 @@ public class KafkaClusterTest {
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
-            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaCluster.kafkaPodName(cluster, i)));
+            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(cluster, i)));
             assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
             checkOwnerReference(kc.createOwnerReference(), srv);
         }
@@ -774,10 +773,10 @@ public class KafkaClusterTest {
         // Check per pod router
         for (int i = 0; i < replicas; i++)  {
             Route rt = kc.generateExternalRoutes(i).get(0);
-            assertThat(rt.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(rt.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(rt.getSpec().getTls().getTermination(), is("passthrough"));
             assertThat(rt.getSpec().getTo().getKind(), is("Service"));
-            assertThat(rt.getSpec().getTo().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(rt.getSpec().getTo().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(rt.getSpec().getPort().getTargetPort(), is(new IntOrString(9094)));
             checkOwnerReference(kc.createOwnerReference(), rt);
         }
@@ -829,7 +828,7 @@ public class KafkaClusterTest {
         // Check per pod router
         for (int i = 0; i < replicas; i++)  {
             Route rt = kc.generateExternalRoutes(i).get(0);
-            assertThat(rt.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(rt.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(rt.getSpec().getHost(), is("my-host-" + i + ".cz"));
         }
     }
@@ -885,7 +884,7 @@ public class KafkaClusterTest {
         // Check per pod router
         for (int i = 0; i < replicas; i++)  {
             Route rt = kc.generateExternalRoutes(i).get(0);
-            assertThat(rt.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(rt.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(rt.getMetadata().getAnnotations().get("anno"), is("anno-value-" + i));
             assertThat(rt.getMetadata().getLabels().get("label"), is("label-value-" + i));
         }
@@ -931,10 +930,10 @@ public class KafkaClusterTest {
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(srv.getMetadata().getFinalizers(), is(emptyList()));
             assertThat(srv.getSpec().getType(), is("LoadBalancer"));
-            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaCluster.kafkaPodName(cluster, i)));
+            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(cluster, i)));
             assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
             assertThat(srv.getSpec().getLoadBalancerIP(), is(nullValue()));
             assertThat(srv.getSpec().getExternalTrafficPolicy(), is("Cluster"));
@@ -1066,9 +1065,7 @@ public class KafkaClusterTest {
 
     @ParallelTest
     public void testLoadBalancerSourceRangeFromListener() {
-        List<String> sourceRanges = new ArrayList();
-        sourceRanges.add("10.0.0.0/8");
-        sourceRanges.add("130.211.204.1/32");
+        List<String> sourceRanges = List.of("10.0.0.0/8", "130.211.204.1/32");
 
         Kafka kafkaAssembly = new KafkaBuilder(ResourceUtils.createKafka(namespace, cluster, replicas,
                 image, healthDelay, healthTimeout, jmxMetricsConfig, configuration, emptyMap()))
@@ -1276,9 +1273,9 @@ public class KafkaClusterTest {
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(srv.getSpec().getType(), is("NodePort"));
-            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaCluster.kafkaPodName(cluster, i)));
+            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(cluster, i)));
             assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
             checkOwnerReference(kc.createOwnerReference(), srv);
         }
@@ -1357,9 +1354,9 @@ public class KafkaClusterTest {
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(srv.getSpec().getType(), is("NodePort"));
-            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaCluster.kafkaPodName(cluster, i)));
+            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(cluster, i)));
             if (i == 0) { // pod with index 0 will have overriden port
                 assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, 32101, "TCP"))));
             } else {
@@ -1600,38 +1597,37 @@ public class KafkaClusterTest {
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedStsLabels = new HashMap<>(ssLabels);
         expectedStsLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> ssAnots = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> ssAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
 
         Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
 
         Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
 
         Map<String, String> hSvcLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> hSvcAnots = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> hSvcAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
 
         Map<String, String> exSvcLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> exSvcAnots = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> exSvcAnnotations = TestUtils.map("a9", "v9", "a10", "v10");
 
         Map<String, String> perPodSvcLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> perPodSvcAnots = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> perPodSvcAnnotations = TestUtils.map("a11", "v11", "a12", "v12");
 
         Map<String, String> exRouteLabels = TestUtils.map("l13", "v13", "l14", "v14");
-        Map<String, String> exRouteAnots = TestUtils.map("a13", "v13", "a14", "v14");
+        Map<String, String> exRouteAnnotations = TestUtils.map("a13", "v13", "a14", "v14");
 
         Map<String, String> perPodRouteLabels = TestUtils.map("l15", "v15", "l16", "v16");
-        Map<String, String> perPodRouteAnots = TestUtils.map("a15", "v15", "a16", "v16");
+        Map<String, String> perPodRouteAnnotations = TestUtils.map("a15", "v15", "a16", "v16");
 
         Map<String, String> pdbLabels = TestUtils.map("l17", "v17", "l18", "v18");
-        Map<String, String> pdbAnots = TestUtils.map("a17", "v17", "a18", "v18");
+        Map<String, String> pdbAnnotations = TestUtils.map("a17", "v17", "a18", "v18");
 
         Map<String, String> crbLabels = TestUtils.map("l19", "v19", "l20", "v20");
-        Map<String, String> crbAnots = TestUtils.map("a19", "v19", "a20", "v20");
+        Map<String, String> crbAnnotations = TestUtils.map("a19", "v19", "a20", "v20");
 
         Map<String, String> saLabels = TestUtils.map("l21", "v21", "l22", "v22");
-        Map<String, String> saAnots = TestUtils.map("a21", "v21", "a22", "v22");
+        Map<String, String> saAnnotations = TestUtils.map("a21", "v21", "a22", "v22");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                         .withHostnames("my-host-1", "my-host-2")
@@ -1676,13 +1672,13 @@ public class KafkaClusterTest {
                             .withNewStatefulset()
                                 .withNewMetadata()
                                     .withLabels(ssLabels)
-                                    .withAnnotations(ssAnots)
+                                    .withAnnotations(ssAnnotations)
                                 .endMetadata()
                             .endStatefulset()
                             .withNewPod()
                                 .withNewMetadata()
                                     .withLabels(podLabels)
-                                    .withAnnotations(podAnots)
+                                    .withAnnotations(podAnnotations)
                                 .endMetadata()
                                 .withPriorityClassName("top-priority")
                                 .withSchedulerName("my-scheduler")
@@ -1694,7 +1690,7 @@ public class KafkaClusterTest {
                             .withNewBootstrapService()
                                 .withNewMetadata()
                                     .withLabels(svcLabels)
-                                    .withAnnotations(svcAnots)
+                                    .withAnnotations(svcAnnotations)
                                 .endMetadata()
                                 .withIpFamilyPolicy(IpFamilyPolicy.PREFER_DUAL_STACK)
                                 .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
@@ -1702,7 +1698,7 @@ public class KafkaClusterTest {
                             .withNewBrokersService()
                                 .withNewMetadata()
                                     .withLabels(hSvcLabels)
-                                    .withAnnotations(hSvcAnots)
+                                    .withAnnotations(hSvcAnnotations)
                                 .endMetadata()
                                 .withIpFamilyPolicy(IpFamilyPolicy.SINGLE_STACK)
                                 .withIpFamilies(IpFamily.IPV6)
@@ -1710,43 +1706,43 @@ public class KafkaClusterTest {
                             .withNewExternalBootstrapService()
                                 .withNewMetadata()
                                     .withLabels(exSvcLabels)
-                                    .withAnnotations(exSvcAnots)
+                                    .withAnnotations(exSvcAnnotations)
                                 .endMetadata()
                             .endExternalBootstrapService()
                             .withNewPerPodService()
                                 .withNewMetadata()
                                     .withLabels(perPodSvcLabels)
-                                    .withAnnotations(perPodSvcAnots)
+                                    .withAnnotations(perPodSvcAnnotations)
                                 .endMetadata()
                             .endPerPodService()
                             .withNewExternalBootstrapRoute()
                                 .withNewMetadata()
                                 .withLabels(exRouteLabels)
-                                .withAnnotations(exRouteAnots)
+                                .withAnnotations(exRouteAnnotations)
                                 .endMetadata()
                             .endExternalBootstrapRoute()
                             .withNewPerPodRoute()
                                 .withNewMetadata()
                                 .withLabels(perPodRouteLabels)
-                                .withAnnotations(perPodRouteAnots)
+                                .withAnnotations(perPodRouteAnnotations)
                                 .endMetadata()
                             .endPerPodRoute()
                             .withNewPodDisruptionBudget()
                                 .withNewMetadata()
                                     .withLabels(pdbLabels)
-                                    .withAnnotations(pdbAnots)
+                                    .withAnnotations(pdbAnnotations)
                                 .endMetadata()
                             .endPodDisruptionBudget()
                             .withNewClusterRoleBinding()
                                 .withNewMetadata()
                                     .withLabels(crbLabels)
-                                    .withAnnotations(crbAnots)
+                                    .withAnnotations(crbAnnotations)
                                 .endMetadata()
                             .endClusterRoleBinding()
                             .withNewServiceAccount()
                                 .withNewMetadata()
                                     .withLabels(saLabels)
-                                    .withAnnotations(saAnots)
+                                    .withAnnotations(saAnnotations)
                                 .endMetadata()
                             .endServiceAccount()
                         .endTemplate()
@@ -1758,73 +1754,73 @@ public class KafkaClusterTest {
         // Check StatefulSet
         StatefulSet sts = kc.generateStatefulSet(true, null, null, null);
         assertThat(sts.getMetadata().getLabels().entrySet().containsAll(expectedStsLabels.entrySet()), is(true));
-        assertThat(sts.getMetadata().getAnnotations().entrySet().containsAll(ssAnots.entrySet()), is(true));
+        assertThat(sts.getMetadata().getAnnotations().entrySet().containsAll(ssAnnotations.entrySet()), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
 
         // Check Pods
         assertThat(sts.getSpec().getTemplate().getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
-        assertThat(sts.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnots.entrySet()), is(true));
+        assertThat(sts.getSpec().getTemplate().getMetadata().getAnnotations().entrySet().containsAll(podAnnotations.entrySet()), is(true));
         assertThat(sts.getSpec().getTemplate().getSpec().getSchedulerName(), is("my-scheduler"));
         assertThat(sts.getSpec().getTemplate().getSpec().getHostAliases(), containsInAnyOrder(hostAlias1, hostAlias2));
         assertThat(sts.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
         assertThat(sts.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity("10Mi")));
+            .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity("10Mi")));
 
         // Check Service
         Service svc = kc.generateService();
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(svcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(svcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(svcAnnotations.entrySet()), is(true));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
         assertThat(svc.getSpec().getIpFamilies(), contains("IPv6", "IPv4"));
 
         // Check Headless Service
         svc = kc.generateHeadlessService();
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(hSvcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(hSvcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(hSvcAnnotations.entrySet()), is(true));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is("SingleStack"));
         assertThat(svc.getSpec().getIpFamilies(), contains("IPv6"));
 
         // Check External Bootstrap service
         svc = kc.generateExternalBootstrapServices().get(0);
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(exSvcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(exSvcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(exSvcAnnotations.entrySet()), is(true));
 
         // Check per pod service
         svc = kc.generateExternalServices(0).get(0);
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(perPodSvcLabels.entrySet()), is(true));
-        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(perPodSvcAnots.entrySet()), is(true));
+        assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(perPodSvcAnnotations.entrySet()), is(true));
 
         // Check Bootstrap Route
         Route rt = kc.generateExternalBootstrapRoutes().get(0);
         assertThat(rt.getMetadata().getLabels().entrySet().containsAll(exRouteLabels.entrySet()), is(true));
-        assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(exRouteAnots.entrySet()), is(true));
+        assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(exRouteAnnotations.entrySet()), is(true));
 
         // Check PerPodRoute
         rt = kc.generateExternalRoutes(0).get(0);
         assertThat(rt.getMetadata().getLabels().entrySet().containsAll(perPodRouteLabels.entrySet()), is(true));
-        assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(perPodRouteAnots.entrySet()), is(true));
+        assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(perPodRouteAnnotations.entrySet()), is(true));
 
         // Check PodDisruptionBudget
         PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
-        assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
+        assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
         // Check PodDisruptionBudget V1Beta1
         io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1();
         assertThat(pdbV1Beta1.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
-        assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
+        assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
         // Check ClusterRoleBinding
         ClusterRoleBinding crb = kc.generateClusterRoleBinding("namespace");
         assertThat(crb.getMetadata().getLabels().entrySet().containsAll(crbLabels.entrySet()), is(true));
-        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnots.entrySet()), is(true));
+        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(crbAnnotations.entrySet()), is(true));
 
         // Check Service Account
         ServiceAccount sa = kc.generateServiceAccount();
         assertThat(sa.getMetadata().getLabels().entrySet().containsAll(saLabels.entrySet()), is(true));
-        assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnots.entrySet()), is(true));
+        assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnnotations.entrySet()), is(true));
     }
 
     @ParallelTest
@@ -2069,7 +2065,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         StatefulSet sts = kc.generateStatefulSet(true, null, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(123)));
+        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(123L));
     }
 
     @ParallelTest
@@ -2080,7 +2076,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         StatefulSet sts = kc.generateStatefulSet(true, null, null, null);
-        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(Long.valueOf(30)));
+        assertThat(sts.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(30L));
     }
 
     @ParallelTest
@@ -2181,9 +2177,9 @@ public class KafkaClusterTest {
 
         StatefulSet sts = kc.generateStatefulSet(true, null, null, null);
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(notNullValue()));
-        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(Long.valueOf(123)));
-        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsGroup(), is(Long.valueOf(456)));
-        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(Long.valueOf(789)));
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(123L));
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsGroup(), is(456L));
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsUser(), is(789L));
     }
 
     @ParallelTest
@@ -2483,7 +2479,7 @@ public class KafkaClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -2513,7 +2509,7 @@ public class KafkaClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -2559,7 +2555,7 @@ public class KafkaClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -2610,7 +2606,7 @@ public class KafkaClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -2625,7 +2621,7 @@ public class KafkaClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-st1-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -2705,7 +2701,7 @@ public class KafkaClusterTest {
             PersistentVolumeClaim pvc = pvcs.get(i);
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -2714,7 +2710,7 @@ public class KafkaClusterTest {
             PersistentVolumeClaim pvc = pvcs.get(i);
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("1000Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-st1"));
-            assertThat(pvc.getMetadata().getName().startsWith(kc.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -2727,7 +2723,7 @@ public class KafkaClusterTest {
                     image, healthDelay, healthTimeout, jmxMetricsConfig, configuration, emptyMap()))
                     .editSpec()
                     .editKafka()
-                    .withStorage(new JbodStorageBuilder().withVolumes(Collections.EMPTY_LIST)
+                    .withStorage(new JbodStorageBuilder().withVolumes(List.of())
                             .build())
                     .endKafka()
                     .endSpec()
@@ -2747,7 +2743,7 @@ public class KafkaClusterTest {
                     image, healthDelay, healthTimeout, jmxMetricsConfig, configuration, emptyMap()))
                     .editSpec()
                     .editKafka()
-                    .withStorage(new JbodStorageBuilder().withVolumes(Collections.EMPTY_LIST)
+                    .withStorage(new JbodStorageBuilder().withVolumes(List.of())
                             .build())
                     .endKafka()
                     .endSpec()
@@ -2926,9 +2922,9 @@ public class KafkaClusterTest {
         // Check per pod services
         for (int i = 0; i < replicas; i++)  {
             Service srv = kc.generateExternalServices(i).get(0);
-            assertThat(srv.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
-            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaCluster.kafkaPodName(cluster, i)));
+            assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(cluster, i)));
             assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
             checkOwnerReference(kc.createOwnerReference(), srv);
         }
@@ -2969,7 +2965,7 @@ public class KafkaClusterTest {
         // Check per pod ingress
         for (int i = 0; i < replicas; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
-            assertThat(ing.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ing.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(ing.getSpec().getIngressClassName(), is(nullValue()));
             assertThat(ing.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
             assertThat(ing.getMetadata().getLabels().get("label"), is("label-value"));
@@ -2980,12 +2976,12 @@ public class KafkaClusterTest {
             assertThat(ing.getSpec().getRules().get(0).getHost(), is(String.format("my-broker-kafka-%d.com", i)));
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
-            assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
             checkOwnerReference(kc.createOwnerReference(), ing);
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
-            assertThat(ingV1Beta1.getMetadata().getName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ingV1Beta1.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(ingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
             assertThat(ingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
             assertThat(ingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
@@ -2996,7 +2992,7 @@ public class KafkaClusterTest {
             assertThat(ingV1Beta1.getSpec().getRules().get(0).getHost(), is(String.format("my-broker-kafka-%d.com", i)));
             assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
             assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
-            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaCluster.externalServiceName(cluster, i)));
+            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaResources.kafkaStatefulSetName(cluster) + "-" + i));
             assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
             checkOwnerReference(kc.createOwnerReference(), ingV1Beta1);
         }
@@ -3088,12 +3084,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
 
-        try {
-            KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
-            fail("Expected exception was not thrown");
-        } catch (InvalidResourceException e)    {
-            // pass
-        }
+        assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS));
     }
 
     @ParallelTest
@@ -3892,9 +3883,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
-            KafkaCluster.validateIntConfigProperty(propertyName, kafkaAssembly.getSpec().getKafka());
-        });
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.validateIntConfigProperty(propertyName, kafkaAssembly.getSpec().getKafka()));
         assertThat(ex.getMessage().equals("Kafka configuration option '" + propertyName + "' should be set to " + replicas + " or less because 'spec.kafka.replicas' is " + replicas), is(true));
     }
 
@@ -3930,9 +3919,7 @@ public class KafkaClusterTest {
                     .endCruiseControl()
                 .endSpec()
                 .build();
-        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
-        });
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS));
         assertThat(ex.getMessage(), is("Kafka " + namespace + "/" + cluster + " has invalid configuration. " +
                 "Cruise Control cannot be deployed with a single-node Kafka cluster. It requires at least two Kafka nodes."));
     }
@@ -4033,9 +4020,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
 
-        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        });
+        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS));
 
         assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 6.6.6. Supported versions are:"));
     }
@@ -4050,9 +4035,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
 
-        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        });
+        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS));
 
         assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 2.6.0. Supported versions are:"));
     }
@@ -4068,9 +4051,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
 
-        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        });
+        InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS));
 
         assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 2.6.0. Supported versions are:"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageTest.java
@@ -27,7 +27,6 @@ import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.VolumeUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -157,7 +156,7 @@ public class JbodStorageTest {
                     for (SingleVolumeStorage volume : this.volumes) {
                         if (volume instanceof PersistentClaimStorage) {
 
-                            String expectedPvcName = VolumeUtils.createVolumePrefix(volume.getId(), true) + "-" + KafkaCluster.kafkaPodName(NAME, podId);
+                            String expectedPvcName = VolumeUtils.createVolumePrefix(volume.getId(), true) + "-" + KafkaResources.kafkaPodName(NAME, podId);
                             List<PersistentVolumeClaim> matchingPvcs = pvcs.stream()
                                     .filter(pvc -> pvc.getMetadata().getName().equals(expectedPvcName))
                                     .collect(Collectors.toList());
@@ -306,7 +305,7 @@ public class JbodStorageTest {
             for (SingleVolumeStorage volume : ((JbodStorage) kafka.getSpec().getKafka().getStorage()).getVolumes()) {
                 if (volume instanceof PersistentClaimStorage) {
                     expectedPvcs.add(AbstractModel.VOLUME_NAME + "-" + volume.getId() + "-"
-                            + KafkaCluster.kafkaPodName(NAME, podId));
+                            + KafkaResources.kafkaPodName(NAME, podId));
                 }
             }
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -343,7 +343,7 @@ public class KafkaAssemblyOperatorTest {
         kafka.getSpec().getZookeeper().setJmxOptions(jmxOptions);
         Secret kafkaJmxSecret = new SecretBuilder()
                 .withNewMetadata()
-                .withName(KafkaCluster.jmxSecretName("foo"))
+                .withName(KafkaResources.kafkaJmxSecretName("foo"))
                 .withNamespace("test")
                 .endMetadata()
                 .withData(singletonMap("foo", "bar"))
@@ -383,7 +383,7 @@ public class KafkaAssemblyOperatorTest {
 
         createCluster(context, kafka, Collections.singletonList(new SecretBuilder()
                 .withNewMetadata()
-                .withName(KafkaCluster.jmxSecretName("foo"))
+                .withName(KafkaResources.kafkaJmxSecretName("foo"))
                 .withNamespace("test")
                 .endMetadata()
                 .withData(Collections.singletonMap("foo", "bar"))
@@ -547,7 +547,7 @@ public class KafkaAssemblyOperatorTest {
         Map<String, PersistentVolumeClaim> kafkaPvcs = createPvcs(kafkaNamespace, kafkaCluster.getStorage(), kafkaCluster.getReplicas(),
             (replica, storageId) -> {
                 String name = VolumeUtils.createVolumePrefix(storageId, false);
-                return name + "-" + KafkaCluster.kafkaPodName(kafkaName, replica);
+                return name + "-" + KafkaResources.kafkaPodName(kafkaName, replica);
             });
 
         when(mockPvcOps.get(eq(kafkaNamespace), ArgumentMatchers.startsWith("data-")))
@@ -583,9 +583,9 @@ public class KafkaAssemblyOperatorTest {
         Set<String> expectedSecrets = set(
                 KafkaResources.clientsCaKeySecretName(kafkaName),
                 KafkaResources.clientsCaCertificateSecretName(kafkaName),
-                KafkaCluster.clusterCaCertSecretName(kafkaName),
-                KafkaCluster.clusterCaKeySecretName(kafkaName),
-                KafkaCluster.brokersSecretName(kafkaName),
+                KafkaResources.clusterCaCertificateSecretName(kafkaName),
+                KafkaResources.clusterCaKeySecretName(kafkaName),
+                KafkaResources.kafkaSecretName(kafkaName),
                 KafkaResources.zookeeperSecretName(kafkaName),
                 ClusterOperator.secretName(kafkaName));
 
@@ -736,7 +736,7 @@ public class KafkaAssemblyOperatorTest {
                     Set<String> expectedRoutes = set(KafkaResources.bootstrapServiceName(kafkaName));
 
                     for (int i = 0; i < kafkaCluster.getReplicas(); i++)    {
-                        expectedRoutes.add(KafkaCluster.externalServiceName(kafkaName, i));
+                        expectedRoutes.add(KafkaResources.kafkaStatefulSetName(kafkaName) + "-" + i);
                     }
 
                     assertThat(captured(routeNameCaptor), is(expectedRoutes));
@@ -922,12 +922,12 @@ public class KafkaAssemblyOperatorTest {
                 createPvcs(clusterNamespace, originalKafkaCluster.getStorage(), originalKafkaCluster.getReplicas(),
                     (replica, storageId) -> {
                         String name = VolumeUtils.createVolumePrefix(storageId, false);
-                        return name + "-" + KafkaCluster.kafkaPodName(clusterName, replica);
+                        return name + "-" + KafkaResources.kafkaPodName(clusterName, replica);
                     });
         kafkaPvcs.putAll(createPvcs(clusterNamespace, updatedKafkaCluster.getStorage(), updatedKafkaCluster.getReplicas(),
             (replica, storageId) -> {
                 String name = VolumeUtils.createVolumePrefix(storageId, false);
-                return name + "-" + KafkaCluster.kafkaPodName(clusterName, replica);
+                return name + "-" + KafkaResources.kafkaPodName(clusterName, replica);
             }));
 
         when(mockPvcOps.get(eq(clusterNamespace), ArgumentMatchers.startsWith("data-")))
@@ -1095,7 +1095,7 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.list(anyString(), any())).thenReturn(
                 emptyList()
         );
-        when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.jmxSecretName(clusterName))).thenReturn(
+        when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.kafkaJmxSecretName(clusterName))).thenReturn(
                 Future.succeededFuture(originalKafkaCluster.generateJmxSecret())
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.zookeeperJmxSecretName(clusterName))).thenReturn(
@@ -1104,7 +1104,7 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.zookeeperSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );
-        when(mockSecretOps.getAsync(clusterNamespace, KafkaCluster.brokersSecretName(clusterName))).thenReturn(
+        when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.kafkaSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );
         when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.entityTopicOperatorSecretName(clusterName))).thenReturn(
@@ -1124,7 +1124,7 @@ public class KafkaAssemblyOperatorTest {
         );
 
         // Mock NetworkPolicy get
-        when(mockPolicyOps.get(clusterNamespace, KafkaCluster.networkPolicyName(clusterName))).thenReturn(originalKafkaCluster.generateNetworkPolicy(null, null));
+        when(mockPolicyOps.get(clusterNamespace, KafkaResources.kafkaNetworkPolicyName(clusterName))).thenReturn(originalKafkaCluster.generateNetworkPolicy(null, null));
         when(mockPolicyOps.get(clusterNamespace, KafkaResources.zookeeperNetworkPolicyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy(null, null));
 
         // Mock PodDisruptionBudget get

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateTest.java
@@ -25,7 +25,6 @@ import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
@@ -162,11 +161,11 @@ public class PartialRollingUpdateTest {
         this.zkPod0 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0)).get();
         this.zkPod1 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, 1)).get();
         this.zkPod2 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, 2)).get();
-        this.kafkaPod0 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 0)).get();
-        this.kafkaPod1 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 1)).get();
-        this.kafkaPod2 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 2)).get();
-        this.kafkaPod3 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 3)).get();
-        this.kafkaPod4 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, 4)).get();
+        this.kafkaPod0 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, 0)).get();
+        this.kafkaPod1 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, 1)).get();
+        this.kafkaPod2 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, 2)).get();
+        this.kafkaPod3 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, 3)).get();
+        this.kafkaPod4 = bootstrapClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, 4)).get();
         this.clusterCaCert = bootstrapClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)).get();
         this.clusterCaKey = bootstrapClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clusterCaKeySecretName(CLUSTER_NAME)).get();
         this.clientsCaCert = bootstrapClient.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME)).get();
@@ -220,7 +219,7 @@ public class PartialRollingUpdateTest {
         kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 4; i++) {
-                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, i)).get();
+                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, i)).get();
                 String generation = pod.getMetadata().getAnnotations().get(StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION);
                 int finalI = i;
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected generation " + generation, generation, is("3")));
@@ -281,7 +280,7 @@ public class PartialRollingUpdateTest {
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected cert generation " + certGeneration, certGeneration, is("3")));
             }
             for (int i = 0; i <= 4; i++) {
-                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, i)).get();
+                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, i)).get();
                 String certGeneration = pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION);
                 int finalI = i;
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected cert generation " + certGeneration, certGeneration, is("3")));
@@ -308,7 +307,7 @@ public class PartialRollingUpdateTest {
             if (ar.failed()) ar.cause().printStackTrace();
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
             for (int i = 0; i <= 4; i++) {
-                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaPodName(CLUSTER_NAME, i)).get();
+                Pod pod = mockClient.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, i)).get();
                 String certGeneration = pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION);
                 int finalI = i;
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected cert generation " + certGeneration, certGeneration, is("3")));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -9,8 +9,8 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
@@ -60,7 +60,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 
 @ExtendWith(VertxExtension.class)
 public class KafkaRollerTest {
@@ -212,7 +211,7 @@ public class KafkaRollerTest {
         ArrayList<String> podNames = new ArrayList<>(replicas);
 
         for (int podId = 0; podId < replicas; podId++) {
-            podNames.add(KafkaCluster.kafkaPodName(clusterName(), podId));
+            podNames.add(KafkaResources.kafkaPodName(clusterName(), podId));
         }
 
         return podNames;
@@ -221,11 +220,11 @@ public class KafkaRollerTest {
     public List<String> addDisconnectedPodNames(int replicas) {
         ArrayList<String> podNames = new ArrayList<>(replicas);
 
-        podNames.add(KafkaCluster.kafkaPodName(clusterName(), 10));
-        podNames.add(KafkaCluster.kafkaPodName(clusterName(), 200));
-        podNames.add(KafkaCluster.kafkaPodName(clusterName(), 30));
-        podNames.add(KafkaCluster.kafkaPodName(clusterName(), 400));
-        podNames.add(KafkaCluster.kafkaPodName(clusterName(), 500));
+        podNames.add(KafkaResources.kafkaPodName(clusterName(), 10));
+        podNames.add(KafkaResources.kafkaPodName(clusterName(), 200));
+        podNames.add(KafkaResources.kafkaPodName(clusterName(), 30));
+        podNames.add(KafkaResources.kafkaPodName(clusterName(), 400));
+        podNames.add(KafkaResources.kafkaPodName(clusterName(), 500));
         return podNames;
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR cleans-up the `KafkaCluster` model class:
* Removes the static methods redirecting to another static methods
* Removes unnecessary getters / setters used only internally. Getters / setters used also from outside are kept.
* Moved some of the name definitions to `KafkaResources` class

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally