### PR TITLE
[systemtest] OauthScopeIsolatedST - fix namespace handling in ClientUtils methods

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -60,8 +60,8 @@ public class ClientUtils {
     public static void waitForClientsSuccess(String producerName, String consumerName, String namespace, int messageCount, boolean deleteAfterSuccess) {
         LOGGER.info("Waiting till producer {} and consumer {} finish", producerName, consumerName);
         TestUtils.waitFor("clients finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-            () -> kubeClient().namespace(namespace).checkSucceededJobStatus(namespace, producerName, 1)
-                && kubeClient().namespace(namespace).checkSucceededJobStatus(namespace, consumerName, 1),
+            () -> kubeClient().checkSucceededJobStatus(namespace, producerName, 1)
+                && kubeClient().checkSucceededJobStatus(namespace, consumerName, 1),
             () -> {
                 JobUtils.logCurrentJobStatus(producerName, namespace);
                 JobUtils.logCurrentJobStatus(consumerName, namespace);
@@ -81,7 +81,7 @@ public class ClientUtils {
         TestUtils.waitFor("job finished", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
             () -> {
                 LOGGER.debug("Job {} in namespace {}, has status {}", jobName, namespace, kubeClient().namespace(namespace).getJobStatus(jobName));
-                return kubeClient().namespace(namespace).checkSucceededJobStatus(namespace, jobName, 1);
+                return kubeClient().checkSucceededJobStatus(namespace, jobName, 1);
             },
             () -> JobUtils.logCurrentJobStatus(jobName, namespace));
 
@@ -94,8 +94,8 @@ public class ClientUtils {
         LOGGER.info("Waiting for producer/consumer:{} to finish with failure.", jobName);
         try {
             TestUtils.waitFor("Job did not finish within time limit (as expected).", Constants.GLOBAL_POLL_INTERVAL, timeoutForClientFinishJob(messageCount),
-                () -> kubeClient().namespace(namespace).checkSucceededJobStatus(jobName));
-            if (kubeClient().namespace(namespace).getJobStatus(jobName).getFailed().equals(1)) {
+                () -> kubeClient().checkSucceededJobStatus(namespace, jobName));
+            if (kubeClient().getJobStatus(namespace, jobName).getFailed().equals(1)) {
                 LOGGER.debug("Job finished with 1 failed pod (expected - timeout).");
             } else {
                 JobUtils.logCurrentJobStatus(jobName, namespace);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
@@ -62,12 +62,9 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
 
     @ParallelTest
     @Tag(CONNECT)
-    void testScopeKafkaConnectSetIncorrectly(ExtensionContext extensionContext) throws UnexpectedException {
+    void testScopeKafkaConnectSetIncorrectly(ExtensionContext extensionContext) {
         final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
-        final String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
         // SCOPE TESTING
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
@@ -105,12 +102,9 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
 
     @ParallelTest
     @Tag(CONNECT)
-    void testScopeKafkaConnectSetCorrectly(ExtensionContext extensionContext) throws UnexpectedException {
+    void testScopeKafkaConnectSetCorrectly(ExtensionContext extensionContext) {
         final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
-        final String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
         // SCOPE TESTING
         resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(INFRA_NAMESPACE, false, kafkaClientsName).build());
@@ -153,8 +147,7 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
     }
 
     @ParallelTest
-    void testClientScopeKafkaSetCorrectly(ExtensionContext extensionContext) throws UnexpectedException {
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+    void testClientScopeKafkaSetCorrectly(ExtensionContext extensionContext) {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         final String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
         final String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
@@ -183,7 +176,6 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
 
     @IsolatedTest("Modification of shared Kafka cluster")
     void testClientScopeKafkaSetIncorrectly(ExtensionContext extensionContext) throws UnexpectedException {
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         final String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
         final String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -635,6 +635,10 @@ public class KubeClient {
         return checkSucceededJobStatus(getNamespace(), jobName, 1);
     }
 
+    public boolean checkSucceededJobStatus(String namespace, String jobName) {
+        return checkSucceededJobStatus(namespace, jobName, 1);
+    }
+
     public boolean checkSucceededJobStatus(String namespaceName, String jobName, int expectedSucceededPods) {
         return getJobStatus(namespaceName, jobName).getSucceeded().equals(expectedSucceededPods);
     }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes handling of namespaces inside the `ClientUtils` methods, as the `kubeClient().namespace(namespace)` is not ensuring, that the resources are taken from the `namespace` - so it needs to be specified in `inNamespace(namespace)` method.

Also, I'm removing some of the variables, which are not used inside the `OauthScopeIsolatedST`

### Checklist

- [ ] Make sure all tests pass

