### PR TITLE
[systemtest] SecurityST - fix flakiness of `testAutoReplaceAllCaKeysTriggeredByAnno`

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -501,13 +501,20 @@ class SecurityST extends AbstractST {
 
             if (eoShouldRoll) {
                 LOGGER.info("Wait for EO to rolling restart ({})...", i);
-                eoPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPod);
+                eoPod = i < expectedRolls ?
+                    DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), eoPod) :
+                    DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPod);
             }
 
             if (keAndCCShouldRoll) {
                 LOGGER.info("Wait for KafkaExporter and CruiseControl to rolling restart ({})...", i);
-                kePod = DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
-                ccPod = DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
+                kePod = i < expectedRolls ?
+                    DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), kePod) :
+                    DeploymentUtils.waitTillDepHasRolled(namespaceName, KafkaExporterResources.deploymentName(clusterName), 1, kePod);
+
+                ccPod = i < expectedRolls ?
+                    DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), ccPod) :
+                    DeploymentUtils.waitTillDepHasRolled(namespaceName, CruiseControlResources.deploymentName(clusterName), 1, ccPod);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes mainly `testAutoReplaceAllCaKeysTriggeredByAnno`, which is flaky - we are waiting for rolling update with pods readiness, but sometimes we hit moment, when the components like KE, CC and EO starts rolling again, so the test fails with exception waiting for rolling update and pods to be ready.

In this PR, I'm changing the behavior to wait for pods readiness for KE, CC and EO pods as the last time, which should fix this race condition.

### Checklist

- [ ] Make sure all tests pass

