### PR TITLE
Remove referencing to Cruise Control TLS sidecar from documentation

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.TlsSidecar.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.TlsSidecar.adoc
@@ -4,12 +4,10 @@ In Strimzi, the TLS sidecar uses TLS to encrypt and decrypt communication betwee
 The TLS sidecar is used in:
 
 * Entity Operator
-* Cruise Control
 
 The TLS sidecar is configured using the `tlsSidecar` property in:
 
 * `Kafka.spec.entityOperator`
-* `Kafka.spec.cruiseControl`
 
 The TLS sidecar supports the following additional options:
 
@@ -58,24 +56,5 @@ spec:
         limits:
           cpu: 500m
           memory: 128Mi
-    # ...
-  cruiseControl:
-    # ...
-    tlsSidecar:
-      image: my-org/my-image:latest
-      resources:
-        requests:
-          cpu: 200m
-          memory: 64Mi
-        limits:
-          cpu: 500m
-          memory: 128Mi
-      logLevel: debug
-      readinessProbe:
-        initialDelaySeconds: 15
-        timeoutSeconds: 5
-      livenessProbe:
-        initialDelaySeconds: 15
-        timeoutSeconds: 5
     # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.TlsSidecar.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.TlsSidecar.adoc
@@ -1,13 +1,9 @@
 Configures a TLS sidecar, which is a container that runs in a pod, but serves a supporting purpose.
 In Strimzi, the TLS sidecar uses TLS to encrypt and decrypt communication between components and ZooKeeper.
 
-The TLS sidecar is used in:
+The TLS sidecar is used in the Entity Operator.
 
-* Entity Operator
-
-The TLS sidecar is configured using the `tlsSidecar` property in:
-
-* `Kafka.spec.entityOperator`
+The TLS sidecar is configured using the `tlsSidecar` property in `Kafka.spec.entityOperator`.
 
 The TLS sidecar supports the following additional options:
 

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -187,8 +187,6 @@ spec:
     # ...
   cruiseControl: <34>
     # ...
-    tlsSidecar: <35>
-    # ...
 ----
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes]. If your cluster already has topics defined, you can
 xref:scaling-clusters-{context}[scale clusters].
@@ -227,7 +225,6 @@ Having a stable and highly available ZooKeeper cluster is crucial for Strimzi.
 <32> Specified xref:property-user-operator-logging-reference[User Operator loggers and log levels].
 <33> Kafka Exporter configuration. link:{BookURLDeploying}#assembly-metrics-kafka-exporter-str[Kafka Exporter] is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data.
 <34> Optional configuration for Cruise Control, which is used to xref:cruise-control-concepts-str[rebalance the Kafka cluster].
-<35> Cruise Control xref:type-TlsSidecar-reference[TLS sidecar configuration]. Cruise Control uses the TLS sidecar for secure communication with ZooKeeper.
 
 . Create or update the resource:
 +


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Documentation updates needed after the #6657 got merged about removing the TLS sidecar on Cruise Control.

### Checklist

- [x] Update documentation