### PR TITLE
Logging custom resource paused at INFO level

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -197,7 +197,7 @@ public abstract class AbstractOperator<
                         }
                     });
                     pausedResourceCounter(namespace).getAndIncrement();
-                    LOGGER.debugCr(reconciliation, "Reconciliation of {} {} is paused", kind, name);
+                    LOGGER.infoCr(reconciliation, "Reconciliation of {} {} is paused", kind, name);
                     return createOrUpdate.future();
                 } else if (cr.getSpec() == null) {
                     InvalidResourceException exception = new InvalidResourceException("Spec cannot be null");


### PR DESCRIPTION
The usual log of a `Kafka` resource to be reconciled is something like this.

```shell
2022-04-11 08:07:56 INFO  AbstractOperator:226 - Reconciliation #94834(timer) Kafka(my-kafka-ns/dev-cluster-a): Kafka dev-cluster-a will be checked for creation or modification
...
...
2022-04-11 08:08:06 INFO  AbstractOperator:517 - Reconciliation #94834(timer) Kafka(my-kafka-ns/dev-cluster-a): reconciled
```

So there is the messages couple about checking for creation/modification and the reconciling end. It makes totally sense.
When a `Kafka` resource is paused, the first line is missing because the operator will skip it but then we have just the last one.

```shell
...
...
2022-04-11 08:07:56 INFO  AbstractOperator:517 - Reconciliation #94841(timer) Kafka(second-kafka-ns/test-cluster): reconciled
```

Currently the fact that a `Kafka` custom resource is paused is logged at DEBUG level only while I think it would make clear when a resource is paused by logging it at INFO level so that user can see something like.

```shell
2022-04-11 08:07:56 INFO  AbstractOperator:200 - Reconciliation #94841(timer) Reconciliation of Kafka test-cluster is paused
...
...
2022-04-11 08:08:00 INFO  AbstractOperator:517 - Reconciliation #94841(timer) Kafka(second-kafka-ns/test-cluster): reconciled
```