### PR TITLE
Add paused KafkaConnector resources metric (#6569)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -84,7 +84,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -123,7 +122,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     private Map<String, Counter> connectorsReconciliationsCounterMap = new ConcurrentHashMap<>(1);
     private Map<String, Counter> connectorsFailedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
     private Map<String, Counter> connectorsSuccessfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
-    private Map<String, AtomicInteger> connectorsResourceCounterMap = new ConcurrentHashMap<>(1);
     private Map<String, Timer> connectorsReconciliationsTimerMap = new ConcurrentHashMap<>(1);
 
     public AbstractConnectOperator(Vertx vertx, PlatformFeaturesAvailability pfa, String kind,
@@ -192,12 +190,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                     String connectorKind = kafkaConnector.getKind();
                     String connectName = kafkaConnector.getMetadata().getLabels() == null ? null : kafkaConnector.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
                     String connectNamespace = connectorNamespace;
-
-                    if (action == Action.ADDED) {
-                        connectOperator.connectorsResourceCounter(connectorNamespace).incrementAndGet();
-                    } else if (action == Action.DELETED) {
-                        connectOperator.connectorsResourceCounter(connectorNamespace).decrementAndGet();
-                    }
 
                     switch (action) {
                         case ADDED:
@@ -882,12 +874,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     public Counter connectorsSuccessfulReconciliationsCounter(String namespace) {
         return Operator.getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.successful", metrics, null, connectorsSuccessfulReconciliationsCounterMap,
                 "Number of reconciliations done by the operator for individual resources which were successful");
-    }
-
-    public AtomicInteger connectorsResourceCounter(String namespace) {
-        return Operator.getGauge(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "resources",
-                metrics, null, connectorsResourceCounterMap,
-                "Number of custom resources the operator sees");
     }
 
     public Timer connectorsReconciliationsTimer(String namespace) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -13,8 +15,10 @@ import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnectSpec;
+import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -23,10 +27,13 @@ import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Operator;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -40,8 +47,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * <p>Assembly operator for a "Kafka Connect" assembly, which manages:</p>
@@ -55,6 +67,8 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     private final ConnectBuildOperator connectBuildOperator;
     private final KafkaVersion.Lookup versions;
     protected final long connectBuildTimeoutMs;
+
+    private final Map<String, AtomicInteger> pausedConnectorsResourceCounterMap = new ConcurrentHashMap<>(1);
 
     /**
      * @param vertx The Vertx instance
@@ -171,21 +185,30 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     }
 
     @Override
-    public void reconcileAll(String trigger, String namespace, Handler<AsyncResult<Void>> handler) {
-        super.reconcileAll(trigger, namespace, ignore -> connectorOperator.listAsync(namespace, selector())
-                .onComplete(ar -> {
-                    if (ar.succeeded()) {
-                        pausedConnectorsResourceCounterMap.forEach((key, counter) -> counter.set(0));
-                        ar.result().forEach(connector -> {
-                            if (isPaused(connector.getStatus())) {
-                                pausedConnectorsResourceCounter(connector.getMetadata().getNamespace()).incrementAndGet();
+    public void reconcileThese(String trigger, Set<NamespaceAndName> desiredNames, String namespace, Handler<AsyncResult<Void>> handler) {
+        super.reconcileThese(trigger, desiredNames, namespace, ignore -> {
+            List<String> connects = desiredNames.stream().map(NamespaceAndName::getName).collect(Collectors.toList());
+            LabelSelectorRequirement requirement = new LabelSelectorRequirement(Labels.STRIMZI_CLUSTER_LABEL, "In", connects);
+            Optional<LabelSelector> connectorsSelector = Optional.of(new LabelSelector(List.of(requirement), null));
+            connectorOperator.listAsync(namespace, connectorsSelector)
+                    .onComplete(ar -> {
+                        if (ar.succeeded()) {
+                            if (namespace.equals("*")) {
+                                pausedConnectorsResourceCounterMap.forEach((key, counter) -> counter.set(0));
+                            } else {
+                                pausedConnectorsResourceCounter(namespace).set(0);
                             }
-                        });
-                        handler.handle(Future.succeededFuture());
-                    } else {
-                        handler.handle(ar.map((Void) null));
-                    }
-                }));
+                            ar.result().forEach(connector -> {
+                                if (isPaused(connector.getStatus())) {
+                                    pausedConnectorsResourceCounter(connector.getMetadata().getNamespace()).incrementAndGet();
+                                }
+                            });
+                            handler.handle(Future.succeededFuture());
+                        } else {
+                            handler.handle(ar.map((Void) null));
+                        }
+                    });
+        });
     }
 
     /**
@@ -250,5 +273,15 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage(image);
         }
         return dep;
+    }
+
+    private boolean isPaused(KafkaConnectorStatus status) {
+        return status != null && status.getConditions().stream().anyMatch(condition -> "ReconciliationPaused".equals(condition.getType()));
+    }
+
+    public AtomicInteger pausedConnectorsResourceCounter(String namespace) {
+        return Operator.getGauge(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "resources.paused",
+                metrics, null, pausedConnectorsResourceCounterMap,
+                "Number of connectors the connect operator sees but does not reconcile due to paused reconciliations");
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -14,11 +14,7 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.RouteBuilder;
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBridge;
@@ -63,6 +59,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -114,7 +111,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
@@ -644,33 +640,7 @@ public class ResourceUtils {
     }
 
     public static MetricsProvider metricsProvider() {
-        return new MetricsProvider() {
-            @Override
-            public MeterRegistry meterRegistry() {
-                MeterRegistry mockRegistry = mock(MeterRegistry.class);
-                MeterRegistry.Config mockConfig = mock(MeterRegistry.Config.class);
-                Clock mockClock = mock(Clock.class);
-                when(mockConfig.clock()).thenReturn(mockClock);
-                when(mockRegistry.config()).thenReturn(mockConfig);
-
-                return mockRegistry;
-            }
-
-            @Override
-            public Counter counter(String name, String description, Tags tags) {
-                return mock(Counter.class);
-            }
-
-            @Override
-            public Timer timer(String name, String description, Tags tags) {
-                return mock(Timer.class);
-            }
-
-            @Override
-            public AtomicInteger gauge(String name, String description, Tags tags) {
-                return new AtomicInteger(0);
-            }
-        };
+        return new MicrometerMetricsProvider(new SimpleMeterRegistry());
     }
 
     public static ResourceOperatorSupplier supplierWithMocks(boolean openShift) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -694,11 +694,13 @@ public class KafkaConnectAssemblyOperatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         var mockConnectOps = supplier.connectOperator;
+        var mockConnectorOps = supplier.kafkaConnectorOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
 
+        when(mockConnectorOps.listAsync(any(), any(Optional.class))).thenReturn(Future.succeededFuture(List.of()));
         String kcNamespace = "test";
 
         KafkaConnect foo = ResourceUtils.createEmptyKafkaConnect(kcNamespace, "foo");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -571,12 +571,10 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
     public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
-        var mockConnectorOps = supplier.kafkaConnectorOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
 
-        when(mockConnectorOps.listAsync(any(), any(Optional.class))).thenReturn(Future.succeededFuture(List.of()));
         String kmm2Namespace = "test";
 
         KafkaMirrorMaker2 foo = ResourceUtils.createEmptyKafkaMirrorMaker2(kmm2Namespace, "foo");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -571,10 +571,12 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
     public void testReconcile(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
+        var mockConnectorOps = supplier.kafkaConnectorOperator;
         DeploymentOperator mockDcOps = supplier.deploymentOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
 
+        when(mockConnectorOps.listAsync(any(), any(Optional.class))).thenReturn(Future.succeededFuture(List.of()));
         String kmm2Namespace = "test";
 
         KafkaMirrorMaker2 foo = ResourceUtils.createEmptyKafkaMirrorMaker2(kmm2Namespace, "foo");

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -28,6 +28,14 @@ public class MicrometerMetricsProvider implements MetricsProvider {
     }
 
     /**
+     * Constructor of the Micrometer metrics provider
+     * @param metrics   Meter registry
+     */
+    public MicrometerMetricsProvider(MeterRegistry metrics) {
+        this.metrics = metrics;
+    }
+
+    /**
      * Returns the Micrometer MeterRegistry with all metrics
      *
      * @return  MeterRegistry

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -28,7 +28,7 @@ public class MicrometerMetricsProvider implements MetricsProvider {
     }
 
     /**
-     * Constructor of the Micrometer metrics provider
+     * Constructor of the Micrometer metrics provider. Mainly for test purposes
      * @param metrics   Meter registry
      */
     public MicrometerMetricsProvider(MeterRegistry metrics) {


### PR DESCRIPTION
Signed-off-by: abushmin <diskbu@yandex.ru>

### Type of change

- Bugfix

### Description

Add metric for KafkaConnect resources with paused reconciliation. #6569
I've tested it manually and I'm not sure if I need to write a test for such changes.

### Checklist


- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

