### PR TITLE
[systemtest] Rewrite throttling quotas tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -60,6 +60,8 @@ public interface Constants {
     // it is replacement instead of checking logs for reconciliation using dynamic waiting on some change for some period of time
     int GLOBAL_RECONCILIATION_COUNT = (int) ((RECONCILIATION_INTERVAL / GLOBAL_POLL_INTERVAL) + GLOBAL_STABILITY_OFFSET_COUNT);
 
+    long THROTTLING_EXCEPTION_TIMEOUT = Duration.ofMinutes(10).toMillis();
+
     /**
      * Scraper pod labels
      */
@@ -380,6 +382,7 @@ public interface Constants {
     String SCRAPER_KEY = "SCRAPER_NAME";
     String PRODUCER_KEY = "PRODUCER_NAME";
     String CONSUMER_KEY = "CONSUMER_NAME";
+    String ADMIN_KEY = "ADMIN_NAME";
     String USER_NAME_KEY = "USER_NAME";
     String KAFKA_CLIENTS_POD_KEY = "KAFKA_CLIENTS_POD_NAME";
     String KAFKA_TRACING_CLIENT_KEY = "KAFKA_TRACING_CLIENT";

--- a/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.cli;
 
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import org.apache.logging.log4j.Level;
 
 import java.util.Arrays;
 import java.util.List;
@@ -67,5 +68,20 @@ public class KafkaCmdClient {
 
     public static String updateTopicPartitionsCountUsingPodCli(String clusterName, int kafkaPodId, String topic, int partitions) {
         return updateTopicPartitionsCountUsingPodCli(kubeClient().getNamespace(), clusterName, kafkaPodId, topic, partitions);
+    }
+
+    public static String listTopicsUsingPodCliWithConfigProperties(String namespaceName, String bootstrapName, String kafkaPodName, String properties) {
+        cmdKubeClient().namespace(namespaceName).execInPod(Level.TRACE,
+            kafkaPodName,
+            "/bin/bash", "-c", "echo \"" + properties + "\" | tee /tmp/config.properties"
+        );
+
+        return cmdKubeClient().namespace(namespaceName).execInPod(Level.DEBUG, kafkaPodName, "/opt/kafka/bin/kafka-topics.sh",
+                "--list",
+                "--bootstrap-server",
+                bootstrapName,
+                "--command-config",
+                "/tmp/config.properties")
+            .out();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/AdminClientOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/AdminClientOperation.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.kafkaclients.internalClients;
 
-public enum AdminClientOperations {
+public enum AdminClientOperation {
     CREATE_TOPICS("create"),
     DELETE_TOPICS("delete"),
     LIST_TOPICS("list"),
@@ -13,7 +13,7 @@ public enum AdminClientOperations {
 
     private final String operation;
 
-    AdminClientOperations(String operation) {
+    AdminClientOperation(String operation) {
         this.operation = operation;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaAdminClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaAdminClients.java
@@ -27,7 +27,7 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 public class KafkaAdminClients extends BaseClients {
     private int partitions;
     private int replicationFactor;
-    private String topicOperation;
+    private AdminClientOperations topicOperation;
     private String adminName;
     private int topicCount;
     private int topicOffset;
@@ -73,15 +73,15 @@ public class KafkaAdminClients extends BaseClients {
         this.replicationFactor = replicationFactor <= 0 ? 1 : replicationFactor;
     }
 
-    public String getTopicOperation() {
+    public AdminClientOperations getTopicOperation() {
         return topicOperation;
     }
 
-    public void setTopicOperation(String topicOperation) {
-        if (topicOperation == null || topicOperation.isEmpty()) {
+    public void setTopicOperation(AdminClientOperations topicOperation) {
+        if (topicOperation == null) {
             throw new InvalidParameterException("TopicOperation must be set.");
         } else if ((this.getTopicName() == null || this.getTopicName().isEmpty())
-            && !(topicOperation.equals("help") || topicOperation.equals("list"))) {
+            && !(topicOperation.equals(AdminClientOperations.HELP) || topicOperation.equals(AdminClientOperations.LIST_TOPICS))) {
             throw new InvalidParameterException("Topic name (or 'prefix' if topic count > 1) is not set.");
         }
         this.topicOperation = topicOperation;
@@ -122,13 +122,13 @@ public class KafkaAdminClients extends BaseClients {
             .withNewMetadata()
                 .withNamespace(this.getNamespaceName())
                 .withLabels(adminLabels)
-                .withName(adminName)
+                .withName(this.getAdminName())
             .endMetadata()
             .withNewSpec()
                 .withBackoffLimit(0)
                 .withNewTemplate()
                     .withNewMetadata()
-                        .withName(adminName)
+                        .withName(this.getAdminName())
                         .withNamespace(this.getNamespaceName())
                         .withLabels(adminLabels)
                     .endMetadata()
@@ -136,7 +136,7 @@ public class KafkaAdminClients extends BaseClients {
                         .withRestartPolicy("Never")
                             .withContainers()
                                 .addNewContainer()
-                                .withName(adminName)
+                                .withName(this.getAdminName())
                                 .withImagePullPolicy(Constants.IF_NOT_PRESENT_IMAGE_PULL_POLICY)
                                 .withImage(Environment.TEST_ADMIN_IMAGE)
                                 .addNewEnv()
@@ -149,23 +149,23 @@ public class KafkaAdminClients extends BaseClients {
                                 .endEnv()
                                 .addNewEnv()
                                     .withName("TOPIC_OPERATION")
-                                    .withValue(topicOperation)
+                                    .withValue(this.getTopicOperation().toString())
                                 .endEnv()
                                 .addNewEnv()
                                     .withName("REPLICATION_FACTOR")
-                                    .withValue(String.valueOf(replicationFactor))
+                                    .withValue(String.valueOf(this.getReplicationFactor()))
                                 .endEnv()
                                 .addNewEnv()
                                     .withName("PARTITIONS")
-                                    .withValue(String.valueOf(partitions))
+                                    .withValue(String.valueOf(this.getPartitions()))
                                 .endEnv()
                                 .addNewEnv()
                                     .withName("TOPICS_COUNT")
-                                    .withValue(String.valueOf(topicCount))
+                                    .withValue(String.valueOf(this.getTopicCount()))
                                 .endEnv()
                                 .addNewEnv()
                                     .withName("TOPIC_OFFSET")
-                                    .withValue(String.valueOf(topicOffset))
+                                    .withValue(String.valueOf(this.getTopicOffset()))
                                 .endEnv()
                                 .addNewEnv()
                                     .withName("LOG_LEVEL")

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -25,6 +25,7 @@ final public class TestStorage {
 
     private static final String PRODUCER = "hello-world-producer";
     private static final String CONSUMER = "hello-world-consumer";
+    private static final String ADMIN = "admin-client";
     private static final String USER = "user";
     private static final String CLUSTER_NAME_PREFIX = "my-cluster-";
     private static final Random RANDOM = new Random();
@@ -38,6 +39,7 @@ final public class TestStorage {
     private String scraperName;
     private String producerName;
     private String consumerName;
+    private String adminName;
     private String userName;
     private LabelSelector kafkaSelector;
     private LabelSelector zkSelector;
@@ -57,6 +59,7 @@ final public class TestStorage {
         this.scraperName = clusterName + "-" + Constants.SCRAPER_NAME;
         this.producerName = clusterName + "-" + PRODUCER;
         this.consumerName = clusterName  + "-" + CONSUMER;
+        this.adminName = clusterName + "-" + ADMIN;
         this.userName = clusterName + "-" + USER;
         this.kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
         this.zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
@@ -70,6 +73,7 @@ final public class TestStorage {
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.SCRAPER_KEY, this.scraperName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PRODUCER_KEY, this.producerName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.CONSUMER_KEY, this.consumerName);
+        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.ADMIN_KEY, this.adminName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.USER_NAME_KEY, this.userName);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.KAFKA_SELECTOR, this.kafkaSelector);
         extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.ZOOKEEPER_SELECTOR, this.zkSelector);
@@ -110,6 +114,10 @@ final public class TestStorage {
 
     public String getConsumerName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.CONSUMER_KEY).toString();
+    }
+
+    public String getAdminName() {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.ADMIN_KEY).toString();
     }
 
     public String getUserName() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -217,12 +217,11 @@ public class KafkaTopicUtils {
         KafkaTopicUtils.getAllKafkaTopicsWithPrefix(namespace, prefix).forEach(topic ->
             cmdKubeClient().namespace(namespace).deleteByName(KafkaTopic.RESOURCE_SINGULAR, topic.getMetadata().getName())
         );
-        waitForTopicsByPrefixDeletion(namespace, prefix);
     }
 
-    public static void waitForTopicsByPrefixDeletion(String namespace, String prefix) {
-        LOGGER.info("Waiting for all topics with prefix {} will be deleted", prefix);
+    public static void waitForTopicsByPrefixDeletionUsingPodCli(String namespace, String prefix, String bootstrapName, String kafkaPodName, String properties) {
+        LOGGER.info("Waiting for all topics with prefix {} will be deleted from Kafka", prefix);
         TestUtils.waitFor(String.format("all topics with prefix %s deletion", prefix), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
-            () -> getAllKafkaTopicsWithPrefix(namespace, prefix).size() == 0);
+            () -> !KafkaCmdClient.listTopicsUsingPodCliWithConfigProperties(namespace, bootstrapName, kafkaPodName, properties).contains(prefix));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -213,9 +213,16 @@ public class KafkaTopicUtils {
             .collect(Collectors.toList());
     }
 
-    public static void deleteAllKafkaTopicsWithPrefix(String namespace, String prefix) {
+    public static void deleteAllKafkaTopicsByPrefixWithWait(String namespace, String prefix) {
         KafkaTopicUtils.getAllKafkaTopicsWithPrefix(namespace, prefix).forEach(topic ->
             cmdKubeClient().namespace(namespace).deleteByName(KafkaTopic.RESOURCE_SINGULAR, topic.getMetadata().getName())
         );
+        waitForTopicsByPrefixDeletion(namespace, prefix);
+    }
+
+    public static void waitForTopicsByPrefixDeletion(String namespace, String prefix) {
+        LOGGER.info("Waiting for all topics with prefix {} will be deleted", prefix);
+        TestUtils.waitFor(String.format("all topics with prefix %s deletion", prefix), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
+            () -> getAllKafkaTopicsWithPrefix(namespace, prefix).size() == 0);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.operators.topic;
 
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.KafkaUserScramSha512ClientAuthentication;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
@@ -16,6 +15,7 @@ import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.AdminClientOperations;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaAdminClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaAdminClientsBuilder;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
@@ -24,287 +24,163 @@ import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import static io.strimzi.systemtest.Constants.GLOBAL_TIMEOUT;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+/**
+ * Test checks for throttling quotas set for user
+ * on creation & deletion of topics and create partition operations.
+ */
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
 @ParallelSuite
 public class ThrottlingQuotaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(ThrottlingQuotaST.class);
-    private static final String CLUSTER_NAME = "quota-cluster";
+
+    private static final String THROTTLING_ERROR_MSG =
+        "org.apache.kafka.common.errors.ThrottlingQuotaExceededException: The throttling quota has been exceeded.";
 
     private final String namespace = testSuiteNamespaceManager.getMapOfAdditionalNamespaces().get(ThrottlingQuotaST.class.getSimpleName()).stream().findFirst().get();
-    private final String classTopicPrefix = "quota-topic-test";
 
-    /**
-     * Test checks for throttling quotas set for user
-     * on creation & deletion of topics and create partition operations.
-     */
-    @ParallelTest
-    void testThrottlingQuotasCreateTopic(ExtensionContext extensionContext) {
-        final String kafkaUsername = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String createAdminName = "create-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String topicNamePrefix = classTopicPrefix + "-create";
-        int topicsCountOverQuota = 500;
-        setupKafkaUserInNamespace(extensionContext, kafkaUsername);
-
-        KafkaAdminClients adminClientJob = new KafkaAdminClientsBuilder()
-                .withAdminName(createAdminName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withTopicName(topicNamePrefix)
-                .withTopicCount(topicsCountOverQuota)
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.CREATE_TOPICS.toString())
-                .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(namespace, kafkaUsername, 240000))
-                .build();
-
-        resourceManager.createResource(extensionContext, adminClientJob.defaultAdmin());
-        String createPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", createAdminName).get(0);
-
-        PodUtils.waitUntilMessageIsInPodLogs(
-                namespace,
-                createPodName,
-                "org.apache.kafka.common.errors.ThrottlingQuotaExceededException: The throttling quota has been exceeded.",
-                GLOBAL_TIMEOUT
-        );
-        JobUtils.deleteJobWithWait(namespace, createAdminName);
-
-        // Teardown delete created topics
-        KafkaTopicUtils.deleteAllKafkaTopicsWithPrefix(namespace, topicNamePrefix);
-    }
+    private KafkaAdminClientsBuilder adminClientsBuilder;
 
     @ParallelTest
-    void testThrottlingQuotasDeleteTopic(ExtensionContext extensionContext) {
-        final String kafkaUsername = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String createAdminName = "create-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String deleteAdminName = "delete-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String topicNamePrefix = classTopicPrefix + "-delete";
-        int topicsCountOverQuota = 500;
-        setupKafkaUserInNamespace(extensionContext, kafkaUsername);
+    void testThrottlingQuotasDuringAllTopicOperations(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        // Create many topics in multiple rounds using starting offset
-        KafkaAdminClients createAdminClientJob = new KafkaAdminClientsBuilder()
-                .withAdminName(createAdminName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withTopicName(topicNamePrefix)
-                .withTopicCount(100)
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.CREATE_TOPICS.toString())
-                .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(namespace, kafkaUsername, 240000))
-                .build();
-        String createPodName;
-        int offset = 100;
-        int iterations = topicsCountOverQuota / 100;
-        for (int i = 0; i < iterations; i++) {
-            LOGGER.info("Executing {}/{} iteration.", i + 1, iterations);
-            createAdminClientJob = new KafkaAdminClientsBuilder(createAdminClientJob).withTopicOffset(i * offset).build();
+        final String createAdminName = "create-" + testStorage.getAdminName();
+        final String alterAdminName = "alter-" + testStorage.getAdminName();
+        final String deleteAdminName = "delete-" + testStorage.getAdminName();
+        final String listAdminName = "list-" + testStorage.getAdminName();
 
-            resourceManager.createResource(extensionContext, createAdminClientJob.defaultAdmin());
-            ClientUtils.waitForClientSuccess(createAdminName, namespace, 100, false);
-            createPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", createAdminName).get(0);
-            PodUtils.waitUntilMessageIsInPodLogs(namespace, createPodName, "All topics created", Constants.GLOBAL_TIMEOUT);
-            JobUtils.deleteJobWithWait(namespace, createAdminName);
-        }
+        int numOfTopics = 25;
+        int numOfPartitions = 100;
 
-        // Test delete all topics at once - should fail on Throttling Quota limit
-        KafkaAdminClients deleteAdminClientJob = new KafkaAdminClientsBuilder()
-                .withAdminName(deleteAdminName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withTopicName(topicNamePrefix)
-                .withTopicCount(topicsCountOverQuota)
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.DELETE_TOPICS.toString())
-                .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(namespace, kafkaUsername, 240000))
-                .build();
-        resourceManager.createResource(extensionContext, deleteAdminClientJob.defaultAdmin());
-        String deletePodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", deleteAdminName).get(0);
-        PodUtils.waitUntilMessageIsInPodLogs(
-                namespace,
-                deletePodName,
-                "org.apache.kafka.common.errors.ThrottlingQuotaExceededException: The throttling quota has been exceeded.",
-                Constants.GLOBAL_TIMEOUT
-        );
-        JobUtils.deleteJobWithWait(namespace, deleteAdminName);
+        int iterations = numOfTopics / 5;
 
-        // Teardown - delete all (remaining) topics (within Quota limits) in multiple rounds using starting offsets
-        for (int i = 0; i < iterations; i++) {
-            LOGGER.info("Executing {}/{} iteration for {}.", i + 1, iterations, deleteAdminName);
-            deleteAdminClientJob = new KafkaAdminClientsBuilder(deleteAdminClientJob)
-                    .withTopicOffset(i * offset)
-                    .withTopicCount(100)
-                    .withAdditionalConfig("")
-                    .build();
-            resourceManager.createResource(extensionContext, deleteAdminClientJob.defaultAdmin());
-            ClientUtils.waitForClientSuccess(deleteAdminName, namespace, 10);
-        }
-    }
-
-    @ParallelTest
-    void testThrottlingQuotasCreateAlterPartitions(ExtensionContext extensionContext) {
-        final String kafkaUsername = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String createAdminName = "create-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String alterAdminName = "alter-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String topicNamePrefix = classTopicPrefix + "-partitions";
-        int topicsCount = 50;
-        int topicPartitions = 100;
-
-        setupKafkaUserInNamespace(extensionContext, kafkaUsername);
-
-        KafkaAdminClients adminClientJob = new KafkaAdminClientsBuilder()
-                .withAdminName(createAdminName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withTopicName(topicNamePrefix)
-                .withTopicCount(topicsCount)
-                .withPartitions(topicPartitions)
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.CREATE_TOPICS.toString())
-                .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(namespace, kafkaUsername, 240000))
-                .build();
-
-        resourceManager.createResource(extensionContext, adminClientJob.defaultAdmin());
-        String createPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", createAdminName).get(0);
-        PodUtils.waitUntilMessageIsInPodLogs(
-                namespace,
-                createPodName,
-                "org.apache.kafka.common.errors.ThrottlingQuotaExceededException: The throttling quota has been exceeded.",
-                Constants.GLOBAL_TIMEOUT
-        );
-        JobUtils.deleteJobWithWait(namespace, createAdminName);
-
-        // Delete created topics (as they were created in random order, we have to use KafkaTopic instead of this client)
-        KafkaTopicUtils.deleteAllKafkaTopicsWithPrefix(namespace, topicNamePrefix);
-
-        // Throttling quota after performed 'alter' partitions on existing topic
-        int topicAlter = 20;
-        adminClientJob = new KafkaAdminClientsBuilder(adminClientJob)
-                .withTopicCount(topicAlter)
-                .withPartitions(1)
-                .build();
-
-        resourceManager.createResource(extensionContext, adminClientJob.defaultAdmin());
-        createPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", createAdminName).get(0);
-
-        PodUtils.waitUntilMessageIsInPodLogs(namespace, createPodName, "All topics created", GLOBAL_TIMEOUT);
-        JobUtils.deleteJobWithWait(namespace, createAdminName);
-
-        // All topics altered
-        adminClientJob = new KafkaAdminClientsBuilder(adminClientJob)
-            .withAdminName(alterAdminName)
-            .withTopicCount(topicAlter)
-            .withPartitions(500)
-            .withTopicOperation(AdminClientOperations.UPDATE_TOPICS.toString())
+        KafkaAdminClients createTopicJob = adminClientsBuilder
+            .withAdminName(createAdminName)
+            .withTopicName(testStorage.getTopicName())
+            .withTopicCount(numOfTopics)
+            .withPartitions(numOfPartitions)
+            .withTopicOperation(AdminClientOperations.CREATE_TOPICS)
             .build();
 
-        resourceManager.createResource(extensionContext, adminClientJob.defaultAdmin());
-        String alterPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", alterAdminName).get(0);
+        LOGGER.info("Creating {} topics with {} partitions, we should hit the quota", numOfTopics, numOfPartitions);
 
-        PodUtils.waitUntilMessageIsInPodLogs(
-                namespace,
-                alterPodName,
-                "org.apache.kafka.common.errors.ThrottlingQuotaExceededException: The throttling quota has been exceeded.",
-                GLOBAL_TIMEOUT
-        );
-        JobUtils.deleteJobWithWait(namespace, alterAdminName);
+        resourceManager.createResource(extensionContext, createTopicJob.defaultAdmin());
+        ClientUtils.waitForClientContainsMessage(createAdminName, testStorage.getNamespaceName(), THROTTLING_ERROR_MSG);
 
-        // Teardown - delete all (remaining) topics (within Quota limits)
-        String teardownClientName = "teardown-delete";
-        KafkaAdminClients deleteAdminClientJob = new KafkaAdminClientsBuilder()
-                .withAdminName(teardownClientName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withTopicName(topicNamePrefix)
-                .withTopicCount(topicAlter)
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.DELETE_TOPICS.toString())
+        KafkaTopicUtils.deleteAllKafkaTopicsByPrefixWithWait(testStorage.getNamespaceName(), testStorage.getTopicName());
+
+        numOfPartitions = 5;
+
+        createTopicJob = new KafkaAdminClientsBuilder(createTopicJob)
+            .withPartitions(numOfPartitions)
+            .build();
+
+        LOGGER.info("Creating {} topics with {} partitions, the quota should not be exceeded", numOfTopics, numOfPartitions);
+
+        resourceManager.createResource(extensionContext, createTopicJob.defaultAdmin());
+        ClientUtils.waitForClientContainsMessage(createAdminName, testStorage.getNamespaceName(), "All topics created");
+
+        KafkaAdminClients listTopicJob = new KafkaAdminClientsBuilder(createTopicJob)
+            .withAdminName(listAdminName)
+            .withTopicName("")
+            .withTopicOperation(AdminClientOperations.LIST_TOPICS)
+            .build();
+
+        LOGGER.info("Listing topics after creation");
+        resourceManager.createResource(extensionContext, listTopicJob.defaultAdmin());
+        ClientUtils.waitForClientContainsMessage(listAdminName, testStorage.getNamespaceName(), testStorage.getTopicName() + "-" + (numOfTopics - 1));
+
+        int partitionAlter = 25;
+
+        KafkaAdminClients alterTopicsJob = new KafkaAdminClientsBuilder(createTopicJob)
+            .withAdminName(alterAdminName)
+            .withPartitions(partitionAlter)
+            .withTopicOperation(AdminClientOperations.UPDATE_TOPICS)
+            .build();
+
+        LOGGER.info("Altering {} topics - setting partitions to {} - we should hit the quota", numOfTopics, partitionAlter);
+
+        // because we are not hitting the quota, this should pass without a problem
+        resourceManager.createResource(extensionContext, alterTopicsJob.defaultAdmin());
+        ClientUtils.waitForClientContainsMessage(alterAdminName, testStorage.getNamespaceName(), THROTTLING_ERROR_MSG);
+
+        // we need to set higher partitions - for case when we altered some topics before hitting the quota to 25 partitions
+        partitionAlter = 30;
+        int numOfTopicsIter = 5;
+
+        alterTopicsJob = new KafkaAdminClientsBuilder(alterTopicsJob)
+            .withPartitions(partitionAlter)
+            .withTopicCount(numOfTopicsIter)
+            .build();
+
+        for (int i = 0; i < iterations; i++) {
+            alterTopicsJob = new KafkaAdminClientsBuilder(alterTopicsJob)
+                .withTopicCount(numOfTopicsIter)
+                .withTopicOffset(numOfTopicsIter * i)
                 .build();
 
-        resourceManager.createResource(extensionContext, deleteAdminClientJob.defaultAdmin());
-        ClientUtils.waitForClientSuccess(teardownClientName, namespace, 10);
-    }
+            LOGGER.info("Altering {} topics with offset {} - setting partitions to {} - we should not hit the quota", numOfTopicsIter, numOfTopicsIter * i, partitionAlter);
+            resourceManager.createResource(extensionContext, alterTopicsJob.defaultAdmin());
+            ClientUtils.waitForClientContainsMessage(alterAdminName, testStorage.getNamespaceName(), "All topics altered");
+        }
 
-    @ParallelTest
-    void testKafkaAdminTopicOperations(ExtensionContext extensionContext) {
-        final String kafkaUsername = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String createAdminName = "create-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String deleteAdminName = "delete-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String listAdminName = "list-admin-" + mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final String topicNamePrefix = classTopicPrefix + "-simple";
-        int topicsCountBelowQuota = 100;
+        // delete few topics
+        KafkaAdminClients deleteTopicsJob = adminClientsBuilder
+            .withTopicName(testStorage.getTopicName())
+            .withAdminName(deleteAdminName)
+            .withTopicOperation(AdminClientOperations.DELETE_TOPICS)
+            .withTopicCount(numOfTopicsIter)
+            .build();
 
-        setupKafkaUserInNamespace(extensionContext, kafkaUsername);
-        // Create 'topicsCountBelowQuota' topics
-        KafkaAdminClients adminClientJob = new KafkaAdminClientsBuilder()
-                .withAdminName(createAdminName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withTopicName(topicNamePrefix)
-                .withTopicCount(topicsCountBelowQuota)
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.CREATE_TOPICS.toString())
-                .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(namespace, kafkaUsername, 240000))
-                .build();
+        LOGGER.info("Deleting first {} topics, we will not hit the quota", numOfTopicsIter);
+        resourceManager.createResource(extensionContext, deleteTopicsJob.defaultAdmin());
+        ClientUtils.waitForClientContainsMessage(deleteAdminName, testStorage.getNamespaceName(), "Successfully removed all " + numOfTopicsIter);
 
-        resourceManager.createResource(extensionContext, adminClientJob.defaultAdmin());
+        int remainingTopics = numOfTopics - numOfTopicsIter;
 
-        String createPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", createAdminName).get(0);
-        PodUtils.waitUntilMessageIsInPodLogs(namespace, createPodName, "All topics created");
-        JobUtils.deleteJobWithWait(namespace, createAdminName);
+        deleteTopicsJob = new KafkaAdminClientsBuilder(deleteTopicsJob)
+            .withTopicCount(remainingTopics)
+            .withTopicOffset(numOfTopicsIter)
+            .build();
 
-        // List 'topicsCountBelowQuota' topics
-        KafkaAdminClients adminClientListJob = new KafkaAdminClientsBuilder()
-                .withAdminName(listAdminName)
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(CLUSTER_NAME))
-                .withNamespaceName(namespace)
-                .withTopicOperation(AdminClientOperations.LIST_TOPICS.toString())
-                .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(namespace, kafkaUsername, 600000))
-                .build();
+        LOGGER.info("Trying to remove all remaining {} topics with offset of {} - we should hit the quota", remainingTopics, numOfTopicsIter);
+        resourceManager.createResource(extensionContext, deleteTopicsJob.defaultAdmin());
+        ClientUtils.waitForClientContainsMessage(deleteAdminName, testStorage.getNamespaceName(), THROTTLING_ERROR_MSG);
 
-        resourceManager.createResource(extensionContext, adminClientListJob.defaultAdmin());
-
-        String listPodName = kubeClient().listPodNamesInSpecificNamespace(namespace, "job-name", listAdminName).get(0);
-        PodUtils.waitUntilMessageIsInPodLogs(namespace, listPodName, topicNamePrefix + "-" + (topicsCountBelowQuota - 1));
-        JobUtils.deleteJobWithWait(namespace, listAdminName);
-
-        // Delete 'topicsCountBelowQuota' topics
-        adminClientJob = new KafkaAdminClientsBuilder(adminClientJob)
-                .withAdminName(deleteAdminName)
-                .withTopicOperation(AdminClientOperations.DELETE_TOPICS.toString())
-                .build();
-
-        resourceManager.createResource(extensionContext, adminClientJob.defaultAdmin());
-
-        String deletePodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", deleteAdminName).get(0);
-        PodUtils.waitUntilMessageIsInPodLogs(namespace, deletePodName, "Successfully removed all " + topicsCountBelowQuota);
-        JobUtils.deleteJobWithWait(namespace, deleteAdminName);
+        LOGGER.info("Because we hit quota, removing the remaining topics through console");
+        KafkaTopicUtils.deleteAllKafkaTopicsByPrefixWithWait(testStorage.getNamespaceName(), testStorage.getTopicName());
 
         // List topics after deletion
-        resourceManager.createResource(extensionContext, adminClientListJob.defaultAdmin());
-        ClientUtils.waitForClientSuccess(listAdminName, namespace, 0, false);
+        resourceManager.createResource(extensionContext, listTopicJob.defaultAdmin());
+        ClientUtils.waitForClientSuccess(listAdminName, testStorage.getNamespaceName(), 0, false);
 
-        listPodName = kubeClient(namespace).listPodNamesInSpecificNamespace(namespace, "job-name", listAdminName).get(0);
-        String afterDeletePodLogs = kubeClient(namespace).logsInSpecificNamespace(namespace, listPodName);
+        String listPodName = PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), listAdminName);
+        String afterDeletePodLogs = kubeClient().logsInSpecificNamespace(testStorage.getNamespaceName(), listPodName);
 
-        assertThat(afterDeletePodLogs.contains(topicNamePrefix), is(false));
-        assertThat(afterDeletePodLogs, not(containsString(topicNamePrefix)));
+        assertFalse(afterDeletePodLogs.contains(testStorage.getTopicName()));
+        JobUtils.deleteJobWithWait(testStorage.getNamespaceName(), listAdminName);
     }
 
-    void setupKafkaInNamespace(ExtensionContext extensionContext) {
+    @BeforeAll
+    void setup(ExtensionContext extensionContext) {
+        TestStorage testStorage = new TestStorage(extensionContext, namespace);
+
         // Deploy kafka with ScramSHA512
-        LOGGER.info("Deploying shared Kafka across all test cases in {} namespace", namespace);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(CLUSTER_NAME, 1)
+        LOGGER.info("Deploying shared Kafka across all test cases in {} namespace", testStorage.getNamespaceName());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3)
             .editMetadata()
-                .withNamespace(namespace)
+                .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .editSpec()
                 .editKafka()
@@ -323,35 +199,24 @@ public class ThrottlingQuotaST extends AbstractST {
                             .withType(KafkaListenerType.INTERNAL)
                             .withTls(true)
                             .withNewKafkaListenerAuthenticationTlsAuth()
-                        .endKafkaListenerAuthenticationTlsAuth()
-                        .build())
+                            .endKafkaListenerAuthenticationTlsAuth()
+                            .build())
                 .endKafka()
             .endSpec()
             .build());
-    }
 
-    void setupKafkaUserInNamespace(ExtensionContext extensionContext, String kafkaUsername) {
-        // Deploy KafkaUser with defined Quotas
-        KafkaUser kafkaUserWQuota = KafkaUserTemplates.defaultUser(namespace, CLUSTER_NAME, kafkaUsername)
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.defaultUser(testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getUserName())
             .editOrNewSpec()
                 .withNewQuotas()
                     .withControllerMutationRate(1.0)
                 .endQuotas()
                 .withAuthentication(new KafkaUserScramSha512ClientAuthentication())
             .endSpec()
-            .build();
-        resourceManager.createResource(extensionContext, kafkaUserWQuota);
-    }
+            .build());
 
-    @BeforeAll
-    void setup(ExtensionContext extensionContext) {
-        setupKafkaInNamespace(extensionContext);
-    }
-
-    @AfterAll
-    void clearTestResources() {
-        LOGGER.info("Tearing down resources after all test");
-        JobUtils.removeAllJobs(namespace);
-        KafkaTopicUtils.deleteAllKafkaTopicsWithPrefix(namespace, classTopicPrefix);
+        adminClientsBuilder = new KafkaAdminClientsBuilder()
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withAdditionalConfig(KafkaAdminClients.getAdminClientScramConfig(testStorage.getNamespaceName(), testStorage.getUserName(), 240000));
     }
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Refactoring

### Description

The tests inside `ThrottlingQuotaST` were pretty flaky, which caused longer execution time inside AZP, or complete failure of the pipeline.

Issues which I found:
- 3 tests checking 3 different topic operations, 4th was mix of 3 tests before
- we were not waited long enough for throttling quota exception
- 1 Kafka and 1 ZK is not enough for these operations
- duplicates of code
- stuff which should have method were separated there
- creating too many topics - it's not scalability test and the quota can be hit differently
- passing Admin operation strangely - we have Enum for operations and we are passing it via String to the builder - why?
- when tests were running in parallel, there were like 1500 topics created
- steps which can be done one time (like creating same user) appeared in each tests

The quotas can be hit differently than creating big amount of topics - how is it written in [KIP-599](https://cwiki.apache.org/confluence/display/KAFKA/KIP-599%3A+Throttle+Create+Topic%2C+Create+Partition+and+Delete+Topic+Operations) it matters how many mutations will be done during the operation (f.e. we want to create 20 topics with 20 partitions and 1 replication factor -> 20 * 20 * 1 = 400 mutations) and the time spent on the operations.

This PR rewrites the whole suite:
- one test case for all operations
- 3 Kafka brokers and 3 ZKs
- proper waits for messages
- less topics (25 topics)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
