### PR TITLE
Update the Fabric8 dependency to 5.12.2

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -359,7 +359,7 @@ public class StrimziPodSetControllerIT {
 
             // Scale-up the pod-set
             Pod pod2 = pod(pod2Name, KAFKA_NAME, podSetName);
-            podSetOp().inNamespace(NAMESPACE).patch(podSet(podSetName, KAFKA_NAME, pod1, pod2));
+            podSetOp().inNamespace(NAMESPACE).withName(podSetName).patch(podSet(podSetName, KAFKA_NAME, pod1, pod2));
 
             // Wait until the new pod is ready
             TestUtils.waitFor(
@@ -383,7 +383,7 @@ public class StrimziPodSetControllerIT {
                     () -> context.failNow("Pod stats do not match"));
 
             // Scale-down the pod-set
-            podSetOp().inNamespace(NAMESPACE).patch(podSet(podSetName, KAFKA_NAME, pod1));
+            podSetOp().inNamespace(NAMESPACE).withName(podSetName).patch(podSet(podSetName, KAFKA_NAME, pod1));
 
             // Wait until the pod is ready
             TestUtils.waitFor(
@@ -457,7 +457,7 @@ public class StrimziPodSetControllerIT {
             Pod updatedPod = pod(podName, KAFKA_NAME, podSetName);
             updatedPod.getMetadata().getAnnotations().put(PodRevision.STRIMZI_REVISION_ANNOTATION, "new-revision");
             updatedPod.getSpec().setTerminationGracePeriodSeconds(1L);
-            podSetOp().inNamespace(NAMESPACE).patch(podSet(podSetName, KAFKA_NAME, updatedPod));
+            podSetOp().inNamespace(NAMESPACE).withName(podSetName).patch(podSet(podSetName, KAFKA_NAME, updatedPod));
 
             // Check status of the PodSet
             TestUtils.waitFor(

--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,12 @@
         <jacoco.version>0.7.9</jacoco.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <sundrio.version>0.40.1</sundrio.version>
-        <fabric8.kubernetes-client.version>5.12.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>5.12.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>5.12.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>5.12.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>5.12.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>5.12.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <vertx.version>4.2.4</vertx.version>
         <vertx-junit5.version>4.2.4</vertx-junit5.version>
-        <vertx.kafka.client>4.2.4</vertx.kafka.client>
         <log4j.version>2.17.2</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR bumps the Fabric8 dependency to 5.12.2. It also removes the unused `vertx-kafka-client` variable from the `pom.xml`

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally