### PR TITLE
Removed duplicated Cruise Control constants

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -283,20 +283,20 @@ public class CruiseControl extends AbstractModel {
     public void checkGoals(CruiseControlConfiguration configuration) {
         // If self healing goals are defined then these take precedence.
         // Right now, self.healing.goals must either be null or an empty list
-        if (configuration.getConfigOption(CruiseControlConfigurationParameters.CRUISE_CONTROL_SELF_HEALING_CONFIG_KEY.toString()) != null) {
-            String selfHealingGoalsString = configuration.getConfigOption(CruiseControlConfigurationParameters.CRUISE_CONTROL_SELF_HEALING_CONFIG_KEY.toString());
+        if (configuration.getConfigOption(CruiseControlConfigurationParameters.SELF_HEALING_CONFIG_KEY.toString()) != null) {
+            String selfHealingGoalsString = configuration.getConfigOption(CruiseControlConfigurationParameters.SELF_HEALING_CONFIG_KEY.toString());
             List<String> selfHealingGoals = Arrays.asList(selfHealingGoalsString.split("\\s*,\\s*"));
             if (!selfHealingGoals.isEmpty()) {
                 throw new UnsupportedOperationException("Cruise Control's self healing functionality is not currently supported. Please remove " +
-                        CruiseControlConfigurationParameters.CRUISE_CONTROL_SELF_HEALING_CONFIG_KEY + " config");
+                        CruiseControlConfigurationParameters.SELF_HEALING_CONFIG_KEY + " config");
             }
         }
 
         // If no anomaly detection goals have been defined by the user, the defaults defined in Cruise Control will be used.
-        String anomalyGoalsString = configuration.getConfigOption(CruiseControlConfigurationParameters.CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY.toString(), CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS);
+        String anomalyGoalsString = configuration.getConfigOption(CruiseControlConfigurationParameters.ANOMALY_DETECTION_CONFIG_KEY.toString(), CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS);
         Set<String> anomalyDetectionGoals = new HashSet<>(Arrays.asList(anomalyGoalsString.split("\\s*,\\s*")));
 
-        String defaultGoalsString = configuration.getConfigOption(CruiseControlConfigurationParameters.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY.toString(), CRUISE_CONTROL_GOALS);
+        String defaultGoalsString = configuration.getConfigOption(CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY.toString(), CRUISE_CONTROL_GOALS);
         Set<String> defaultGoals = new HashSet<>(Arrays.asList(defaultGoalsString.split("\\s*,\\s*")));
 
         // Remove all the goals which are present in the default goals set from the anomaly detection goals
@@ -305,7 +305,7 @@ public class CruiseControl extends AbstractModel {
         if (!anomalyDetectionGoals.isEmpty()) {
             // If the anomaly detection goals contain goals which are not in the default goals then the CC startup
             // checks will fail, so we make the anomaly goals match the default goals
-            configuration.setConfigOption(CruiseControlConfigurationParameters.CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY.toString(), defaultGoalsString);
+            configuration.setConfigOption(CruiseControlConfigurationParameters.ANOMALY_DETECTION_CONFIG_KEY.toString(), defaultGoalsString);
             LOGGER.warnCr(reconciliation, "Anomaly goals contained goals which are not in the configured default goals. Anomaly goals have " +
                     "been changed to match the specified default goals.");
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -77,20 +77,20 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     * of Cruise Control deployment.
     */
     private static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP = Collections.unmodifiableSortedMap(new TreeMap<>(Map.ofEntries(
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1"),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "20"),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(), Long.toString(TimeUnit.DAYS.toMillis(1))),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_HARD_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_HARD_GOALS),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED)),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_AUTH_CREDENTIALS_FILE.getValue(), CruiseControl.API_AUTH_CREDENTIALS_FILE),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED)),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME),
-            Map.entry(CruiseControlConfigurationParameters.CRUISE_CONTROL_METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)
+            Map.entry(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
+            Map.entry(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1"),
+            Map.entry(CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
+            Map.entry(CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "20"),
+            Map.entry(CruiseControlConfigurationParameters.COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(), Long.toString(TimeUnit.DAYS.toMillis(1))),
+            Map.entry(CruiseControlConfigurationParameters.GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
+            Map.entry(CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_GOALS),
+            Map.entry(CruiseControlConfigurationParameters.HARD_GOALS_CONFIG_KEY.getValue(), CRUISE_CONTROL_HARD_GOALS),
+            Map.entry(CruiseControlConfigurationParameters.WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED)),
+            Map.entry(CruiseControlConfigurationParameters.WEBSERVER_AUTH_CREDENTIALS_FILE.getValue(), CruiseControl.API_AUTH_CREDENTIALS_FILE),
+            Map.entry(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED)),
+            Map.entry(CruiseControlConfigurationParameters.PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME),
+            Map.entry(CruiseControlConfigurationParameters.BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME),
+            Map.entry(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)
     )));
 
     private static final List<String> FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
@@ -117,10 +117,10 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
     }
 
     public boolean isApiAuthEnabled() {
-        return isEnabledInConfiguration(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED));
+        return isEnabledInConfiguration(CruiseControlConfigurationParameters.WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED));
     }
 
     public boolean isApiSslEnabled() {
-        return isEnabledInConfiguration(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED));
+        return isEnabledInConfiguration(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -130,7 +130,7 @@ public class KafkaBrokerConfigurationBuilder {
         if (cruiseControl != null) {
             printSectionHeader("Cruise Control configuration");
             String metricsTopicName = Optional.ofNullable(cruiseControl.getConfig())
-                    .map(config -> config.get(CruiseControlConfigurationParameters.CRUISE_CONTROL_METRIC_REPORTER_TOPIC_NAME.getValue()))
+                    .map(config -> config.get(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue()))
                     .map(Object::toString)
                     .orElse(CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME);
             writer.println(CruiseControlConfigurationParameters.METRICS_TOPIC_NAME + "=" + metricsTopicName);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -71,8 +71,8 @@ import java.util.Optional;
 import static io.strimzi.operator.cluster.model.CruiseControl.API_HEALTHCHECK_PATH;
 import static io.strimzi.operator.cluster.model.CruiseControl.API_USER_NAME;
 import static io.strimzi.operator.cluster.model.CruiseControl.ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION;
-import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY;
-import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY;
+import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.ANOMALY_DETECTION_CONFIG_KEY;
+import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -615,8 +615,8 @@ public class CruiseControlTest {
         EnvVar e2 = new EnvVar(e2Key, e2Value, null);
 
         Map<String, Object> config = ccConfig;
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE.getValue(), apiAuthEnabled);
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_WEBSERVER_SSL_ENABLE.getValue(), apiSslEnabled);
+        config.put(CruiseControlConfigurationParameters.WEBSERVER_SECURITY_ENABLE.getValue(), apiAuthEnabled);
+        config.put(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), apiSslEnabled);
 
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
                 .withImage(ccImage)
@@ -826,7 +826,7 @@ public class CruiseControlTest {
                 "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal";
 
         Map<String, Object> customGoalConfig = ccConfig;
-        customGoalConfig.put(CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY.getValue(), customGoals);
+        customGoalConfig.put(DEFAULT_GOALS_CONFIG_KEY.getValue(), customGoals);
 
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
                 .withImage(ccImage)
@@ -839,7 +839,7 @@ public class CruiseControlTest {
 
         String anomalyDetectionGoals =  cruiseControlWithCustomGoals
                 .getConfiguration().asOrderedProperties().asMap()
-                .get(CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY.getValue());
+                .get(ANOMALY_DETECTION_CONFIG_KEY.getValue());
 
         assertThat(anomalyDetectionGoals, is(customGoals));
     }
@@ -894,17 +894,17 @@ public class CruiseControlTest {
                 .findFirst();
         assertThat(configEnvVar.isPresent(), is(true));
         String config = configEnvVar.get().getValue();
-        assertThat(config, containsString(String.format("%s=%s", CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME)));
-        assertThat(config, containsString(String.format("%s=%s", CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME)));
-        assertThat(config, containsString(String.format("%s=%s", CruiseControlConfigurationParameters.CRUISE_CONTROL_METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)));
+        assertThat(config, containsString(String.format("%s=%s", CruiseControlConfigurationParameters.PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME)));
+        assertThat(config, containsString(String.format("%s=%s", CruiseControlConfigurationParameters.BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME)));
+        assertThat(config, containsString(String.format("%s=%s", CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)));
     }
 
     @ParallelTest
     public void testCustomTopicNames() {
         Map<String, String> topicConfigs = new HashMap<>();
-        topicConfigs.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRIC_TOPIC_NAME.getValue(), "partition-topic");
-        topicConfigs.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRIC_TOPIC_NAME.getValue(), "broker-topic");
-        topicConfigs.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_METRIC_REPORTER_TOPIC_NAME.getValue(), "metric-reporter-topic");
+        topicConfigs.put(CruiseControlConfigurationParameters.PARTITION_METRIC_TOPIC_NAME.getValue(), "partition-topic");
+        topicConfigs.put(CruiseControlConfigurationParameters.BROKER_METRIC_TOPIC_NAME.getValue(), "broker-topic");
+        topicConfigs.put(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), "metric-reporter-topic");
         Map<String, Object> customConfig = ccConfig;
         customConfig.putAll(topicConfigs);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -114,7 +114,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     public void testCruiseControlCustomMetricReporterTopic()  {
         String metricReporterTopicName = "metric-reporter-topic";
         Map<String, Object> config = new HashMap<>();
-        config.put(CruiseControlConfigurationParameters.CRUISE_CONTROL_METRIC_REPORTER_TOPIC_NAME.getValue(), metricReporterTopicName);
+        config.put(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), metricReporterTopicName);
         CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder().withConfig(config).build();
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlConfigurationParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlConfigurationParameters.java
@@ -5,15 +5,10 @@
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 public enum CruiseControlConfigurationParameters {
-    CONCURRENT_PARTITION_MOVEMENTS("num.concurrent.partition.movements.per.broker"),
-    CONCURRENT_INTRA_PARTITION_MOVEMENTS("num.concurrent.intra.broker.partition.movements"),
-    CONCURRENT_LEADER_MOVEMENTS("num.concurrent.leader.movements"),
-    REPLICATION_THROTTLE("default.replication.throttle"),
-    BROKER_METRICS_WINDOWS("num.broker.metrics.windows"),
-    BROKER_METRICS_WINDOW_MS("broker.metrics.window.ms"),
-    PARTITION_METRICS_WINDOWS("num.partition.metrics.windows"),
-    PARTITION_METRICS_WINDOW_MS("partition.metrics.window.ms"),
-    COMPLETED_USER_TASK_RETENTION_MS("completed.user.task.retention.time.ms"),
+    CRUISE_CONTROL_CONCURRENT_PARTITION_MOVEMENTS("num.concurrent.partition.movements.per.broker"),
+    CRUISE_CONTROL_CONCURRENT_INTRA_PARTITION_MOVEMENTS("num.concurrent.intra.broker.partition.movements"),
+    CRUISE_CONTROL_CONCURRENT_LEADER_MOVEMENTS("num.concurrent.leader.movements"),
+    CRUISE_CONTROL_REPLICATION_THROTTLE("default.replication.throttle"),
     CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY("partition.metrics.window.ms"),
     CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY("num.partition.metrics.windows"),
     CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY("broker.metrics.window.ms"),

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlConfigurationParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlConfigurationParameters.java
@@ -5,21 +5,21 @@
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 public enum CruiseControlConfigurationParameters {
-    CRUISE_CONTROL_CONCURRENT_PARTITION_MOVEMENTS("num.concurrent.partition.movements.per.broker"),
-    CRUISE_CONTROL_CONCURRENT_INTRA_PARTITION_MOVEMENTS("num.concurrent.intra.broker.partition.movements"),
-    CRUISE_CONTROL_CONCURRENT_LEADER_MOVEMENTS("num.concurrent.leader.movements"),
-    CRUISE_CONTROL_REPLICATION_THROTTLE("default.replication.throttle"),
-    CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY("partition.metrics.window.ms"),
-    CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY("num.partition.metrics.windows"),
-    CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY("broker.metrics.window.ms"),
-    CRUISE_CONTROL_BROKER_METRICS_WINDOW_NUM_CONFIG_KEY("num.broker.metrics.windows"),
-    CRUISE_CONTROL_COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY("completed.user.task.retention.time.ms"),
-    CRUISE_CONTROL_WEBSERVER_SECURITY_ENABLE("webserver.security.enable"),
-    CRUISE_CONTROL_WEBSERVER_AUTH_CREDENTIALS_FILE("webserver.auth.credentials.file"),
-    CRUISE_CONTROL_WEBSERVER_SSL_ENABLE("webserver.ssl.enable"),
-    CRUISE_CONTROL_PARTITION_METRIC_TOPIC_NAME("partition.metric.sample.store.topic"),
-    CRUISE_CONTROL_BROKER_METRIC_TOPIC_NAME("broker.metric.sample.store.topic"),
-    CRUISE_CONTROL_METRIC_REPORTER_TOPIC_NAME("metric.reporter.topic"),
+    CONCURRENT_PARTITION_MOVEMENTS("num.concurrent.partition.movements.per.broker"),
+    CONCURRENT_INTRA_PARTITION_MOVEMENTS("num.concurrent.intra.broker.partition.movements"),
+    CONCURRENT_LEADER_MOVEMENTS("num.concurrent.leader.movements"),
+    REPLICATION_THROTTLE("default.replication.throttle"),
+    PARTITION_METRICS_WINDOW_MS_CONFIG_KEY("partition.metrics.window.ms"),
+    PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY("num.partition.metrics.windows"),
+    BROKER_METRICS_WINDOW_MS_CONFIG_KEY("broker.metrics.window.ms"),
+    BROKER_METRICS_WINDOW_NUM_CONFIG_KEY("num.broker.metrics.windows"),
+    COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY("completed.user.task.retention.time.ms"),
+    WEBSERVER_SECURITY_ENABLE("webserver.security.enable"),
+    WEBSERVER_AUTH_CREDENTIALS_FILE("webserver.auth.credentials.file"),
+    WEBSERVER_SSL_ENABLE("webserver.ssl.enable"),
+    PARTITION_METRIC_TOPIC_NAME("partition.metric.sample.store.topic"),
+    BROKER_METRIC_TOPIC_NAME("broker.metric.sample.store.topic"),
+    METRIC_REPORTER_TOPIC_NAME("metric.reporter.topic"),
 
     // Metrics reporter configurations
     METRICS_REPORTER_BOOTSTRAP_SERVERS("cruise.control.metrics.reporter.bootstrap.servers"),
@@ -41,11 +41,11 @@ public enum CruiseControlConfigurationParameters {
     METRICS_TOPIC_MIN_ISR("cruise.control.metrics.topic.min.insync.replicas"),
 
     // Goals String lists
-    CRUISE_CONTROL_GOALS_CONFIG_KEY("goals"),
-    CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY("default.goals"),
-    CRUISE_CONTROL_HARD_GOALS_CONFIG_KEY("hard.goals"),
-    CRUISE_CONTROL_SELF_HEALING_CONFIG_KEY("self.healing.goals"),
-    CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY("anomaly.detection.goals");
+    GOALS_CONFIG_KEY("goals"),
+    DEFAULT_GOALS_CONFIG_KEY("default.goals"),
+    HARD_GOALS_CONFIG_KEY("hard.goals"),
+    SELF_HEALING_CONFIG_KEY("self.healing.goals"),
+    ANOMALY_DETECTION_CONFIG_KEY("anomaly.detection.goals");
 
     // Defaults
     public static final boolean DEFAULT_WEBSERVER_SECURITY_ENABLED = true;

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -220,11 +220,11 @@ public class CruiseControlConfigurationST extends AbstractST {
 
         LOGGER.info("Verifying that all configuration in the cruise control container matching the cruise control file {} properties", Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH);
         List<String> checkCCProperties = Arrays.asList(
-                CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOWS.getValue(),
-                CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS.getValue(),
-                CruiseControlConfigurationParameters.BROKER_METRICS_WINDOWS.getValue(),
-                CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_MS.getValue(),
-                CruiseControlConfigurationParameters.COMPLETED_USER_TASK_RETENTION_MS.getValue(),
+                CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.CRUISE_CONTROL_COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(),
                 "goals", "default.goals");
 
         for (String propertyName : checkCCProperties) {
@@ -261,10 +261,10 @@ public class CruiseControlConfigurationST extends AbstractST {
         Map<String, String> kafkaSnapShot = PodUtils.podSnapshot(namespaceName, kafkaSelector);
         Map<String, String> cruiseControlSnapShot = DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName));
         Map<String, Object> performanceTuningOpts = new HashMap<String, Object>() {{
-                put(CruiseControlConfigurationParameters.CONCURRENT_INTRA_PARTITION_MOVEMENTS.getValue(), 2);
-                put(CruiseControlConfigurationParameters.CONCURRENT_PARTITION_MOVEMENTS.getValue(), 5);
-                put(CruiseControlConfigurationParameters.CONCURRENT_LEADER_MOVEMENTS.getValue(), 1000);
-                put(CruiseControlConfigurationParameters.REPLICATION_THROTTLE.getValue(), -1);
+                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_CONCURRENT_INTRA_PARTITION_MOVEMENTS.getValue(), 2);
+                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_CONCURRENT_PARTITION_MOVEMENTS.getValue(), 5);
+                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_CONCURRENT_LEADER_MOVEMENTS.getValue(), 1000);
+                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_REPLICATION_THROTTLE.getValue(), -1);
             }};
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -220,11 +220,11 @@ public class CruiseControlConfigurationST extends AbstractST {
 
         LOGGER.info("Verifying that all configuration in the cruise control container matching the cruise control file {} properties", Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH);
         List<String> checkCCProperties = Arrays.asList(
-                CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(),
-                CruiseControlConfigurationParameters.CRUISE_CONTROL_PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(),
-                CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(),
-                CruiseControlConfigurationParameters.CRUISE_CONTROL_BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(),
-                CruiseControlConfigurationParameters.CRUISE_CONTROL_COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.BROKER_METRICS_WINDOW_MS_CONFIG_KEY.getValue(),
+                CruiseControlConfigurationParameters.COMPLETED_USER_TASK_RETENTION_MS_CONFIG_KEY.getValue(),
                 "goals", "default.goals");
 
         for (String propertyName : checkCCProperties) {
@@ -261,10 +261,10 @@ public class CruiseControlConfigurationST extends AbstractST {
         Map<String, String> kafkaSnapShot = PodUtils.podSnapshot(namespaceName, kafkaSelector);
         Map<String, String> cruiseControlSnapShot = DeploymentUtils.depSnapshot(namespaceName, CruiseControlResources.deploymentName(clusterName));
         Map<String, Object> performanceTuningOpts = new HashMap<String, Object>() {{
-                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_CONCURRENT_INTRA_PARTITION_MOVEMENTS.getValue(), 2);
-                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_CONCURRENT_PARTITION_MOVEMENTS.getValue(), 5);
-                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_CONCURRENT_LEADER_MOVEMENTS.getValue(), 1000);
-                put(CruiseControlConfigurationParameters.CRUISE_CONTROL_REPLICATION_THROTTLE.getValue(), -1);
+                put(CruiseControlConfigurationParameters.CONCURRENT_INTRA_PARTITION_MOVEMENTS.getValue(), 2);
+                put(CruiseControlConfigurationParameters.CONCURRENT_PARTITION_MOVEMENTS.getValue(), 5);
+                put(CruiseControlConfigurationParameters.CONCURRENT_LEADER_MOVEMENTS.getValue(), 1000);
+                put(CruiseControlConfigurationParameters.REPLICATION_THROTTLE.getValue(), -1);
             }};
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {


### PR DESCRIPTION
Trivial PR about removing some duplicated Cruise Control constants and renaming others following the pattern with the `CRUISE_CONTROL_` suffix.