### PR TITLE
docs: updates heap size information

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -455,55 +455,54 @@ This is different from the units used for xref:con-common-configuration-resource
 
 Specify heap configuration for your components using the `-Xms` option to set an initial heap size and the `-Xmx` option to set a maximum heap size.
 
-If you don't specify heap configuration, the Cluster Operator imposes default heap sizes automatically.
+If you don't specify heap configuration, but configure memory request or limit, the Cluster Operator imposes default heap sizes automatically.
 
-The Cluster Operator sets a minimum heap value based on a percentage allocation of available memory in the node.
-It also sets a maximum heap size for the Strimzi components where appropriate.
+The Cluster Operator sets maximum and minimum heap values based on a percentage allocation of available memory in the node.
 
-The following table shows the default heap value.
+The following table shows the default heap values.
 
 .Default heap settings for components
 [cols="4,2,2",options="header"]
 |===
 
 |Component
-|Available memory (%)
+|Percent of available memory allocated to the heap
 |Maximum limit
 
 |Kafka
-|50
+|50%
 |5 GB
 
 |ZooKeeper
-|75
+|75%
 |2 GB
 
 |Kafka Connect
-|75
+|75%
 |None
 
 |MirrorMaker 2.0
-|75
+|75%
 |None
 
 |MirrorMaker
-|75
+|75%
 |None
 
 |Cruise Control
-|75
+|75%
 |None
 
 |Kafka Bridge
-|50
+|50%
 |31 Gi
 
 |===
 
 Heap configuration values should make the best use of a container's xref:con-common-configuration-resources-reference[memory request] without exceeding it.
 
-* If a memory request limit is specified, a JVM's minimum and maximum memory is set to a value corresponding to the limit.
-* If a memory request limit is not specified, a JVM's minimum memory is set to `128M`.
+* If a memory request or limit is specified, a JVM's minimum and maximum memory is set to a value corresponding to the limit.
+* If a memory request or limit is not specified, a JVM's minimum memory is set to `128M`.
 The JVM's maximum memory is not defined to allow the memory to increase as needed. This is ideal for single node environments in test and development.
 
 Total JVM memory usage can be a lot more than the maximum heap size.

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -96,7 +96,7 @@ tls:
   trustedCertificates: []
 ----
 
-For information on configuring TLS client authentication, see xref:type-KafkaClientAuthenticationTls-reference[`KafkaClientAuthenticationTls` schema reference].
+For information on configuring TLS client authentication, see the xref:type-KafkaClientAuthenticationTls-reference[`KafkaClientAuthenticationTls` schema reference].
 
 [id='con-common-configuration-resources-{context}']
 === `resources`
@@ -354,7 +354,7 @@ livenessProbe:
 # ...
 ----
 
-For more information about the `livenessProbe` and `readinessProbe` options, see xref:type-Probe-reference[Probe schema reference].
+For more information about the `livenessProbe` and `readinessProbe` options, see the xref:type-Probe-reference[Probe schema reference].
 
 [id='con-common-configuration-prometheus-{context}']
 === `metricsConfig`
@@ -441,38 +441,78 @@ To optimize their performance on different platforms and architectures, you conf
 
 You can specify the following options in your configuration:
 
-`-Xms`:: Minimum initial allocation heap size when the JVM starts.
-`-Xmx`:: Maximum heap size.
-`-XX`:: Advanced runtime options for the JVM.
-`javaSystemProperties`:: Additional system properties.
-`gcLoggingEnabled`:: xref:con-common-configuration-garbage-collection-{context}[Enables garbage collector logging].
-
-The full schema of `jvmOptions` is described in xref:type-JvmOptions-reference[`JvmOptions` schema reference].
+`-Xms`:: Minimum initial allocation heap size when the JVM starts
+`-Xmx`:: Maximum heap size
+`-XX`:: Advanced runtime options for the JVM
+`javaSystemProperties`:: Additional system properties
+`gcLoggingEnabled`:: xref:con-common-configuration-garbage-collection-{context}[Enables garbage collector logging]
 
 NOTE: The units accepted by JVM settings, such as `-Xmx` and `-Xms`, are the same units accepted by the JDK `java` binary in the corresponding image.
 Therefore, `1g` or `1G` means 1,073,741,824 bytes, and `Gi` is not a valid unit suffix.
-This is different from the units used for xref:con-common-configuration-resources-reference[memory requests and limits], which follow the Kubernetes convention where `1G` means 1,000,000,000 bytes, and `1Gi` means 1,073,741,824 bytes
+This is different from the units used for xref:con-common-configuration-resources-reference[memory requests and limits], which follow the Kubernetes convention where `1G` means 1,000,000,000 bytes, and `1Gi` means 1,073,741,824 bytes.
 
 .`-Xms` and `-Xmx` options
 
-The default values used for `-Xms` and `-Xmx` depend on whether there is a xref:con-common-configuration-resources-reference[memory request] limit configured for the container.
+Specify heap configuration for your components using the `-Xms` option to set an initial heap size and the `-Xmx` option to set a maximum heap size.
 
-* If there is a memory limit, the JVM's minimum and maximum memory is set to a value corresponding to the limit.
-* If there is no memory limit, the JVM's minimum memory is set to `128M`. The JVM's maximum memory is not defined to allow the memory to increase as needed. This is ideal for single node environments in test and development.
+If you don't specify heap configuration, the Cluster Operator imposes default heap sizes automatically.
 
-Before setting `-Xmx` explicitly, consider the following:
+The Cluster Operator sets a minimum heap value based on a percentage allocation of available memory in the node.
+It also sets a maximum heap size for the Strimzi components where appropriate.
 
-* Total JVM memory usage can be a lot more than the maximum heap size. Try experimenting to find a value for `-Xmx` that makes the best use of the container's memory request without exceeding it.
-* Setting an appropriate Kubernetes memory request.
-** Kubernetes might kill the container if there is pressure on memory from other pods running on the node.
-** Kubernetes might schedule the container to a node with insufficient memory.
+The following table shows the default heap value.
+
+.Default heap settings for components
+[cols="4,2,2",options="header"]
+|===
+
+|Component
+|Available memory (%)
+|Maximum limit
+
+|Kafka
+|50
+|5 GB
+
+|ZooKeeper
+|75
+|2 GB
+
+|Kafka Connect
+|75
+|None
+
+|MirrorMaker 2.0
+|75
+|None
+
+|MirrorMaker
+|75
+|None
+
+|Cruise Control
+|75
+|None
+
+|Kafka Bridge
+|50
+|31 Gi
+
+|===
+
+Heap configuration values should make the best use of a container's xref:con-common-configuration-resources-reference[memory request] without exceeding it.
+
+* If a memory request limit is specified, a JVM's minimum and maximum memory is set to a value corresponding to the limit.
+* If a memory request limit is not specified, a JVM's minimum memory is set to `128M`.
+The JVM's maximum memory is not defined to allow the memory to increase as needed. This is ideal for single node environments in test and development.
+
+Total JVM memory usage can be a lot more than the maximum heap size.
+
+Setting an appropriate memory request can prevent the following:
+
+* Kubernetes killing a container if there is pressure on memory from other pods running on the node.
+* Kubernetes scheduling a container to a node with insufficient memory.
 If `-Xms` is set to `-Xmx`, the container will crash immediately; if not, the container will crash at a later time.
-
-It is _recommended_ to:
-
-* Set the memory request and the memory limit to the same value
-* Use a memory request that is at least 4.5 × the `-Xmx`
-* Consider setting `-Xms` to the same value as `-Xmx`
 
 In this example, the JVM uses 2 GiB (=2,147,483,648 bytes) for its heap.
 Its total memory usage is approximately 8GiB.
@@ -490,7 +530,7 @@ jvmOptions:
 Setting the same value for initial (`-Xms`) and maximum (`-Xmx`) heap sizes avoids the JVM having to allocate memory after startup, at the cost of possibly allocating more heap than is really needed.
 
 IMPORTANT: Containers performing lots of disk I/O, such as Kafka broker containers, require available memory for use as an operating system page cache.
-On such containers, the requested memory should be significantly higher than the memory used by the JVM.
+For such containers, the requested memory should be significantly higher than the memory used by the JVM.
 
 .-XX option
 
@@ -528,6 +568,7 @@ jvmOptions:
       value: ssl
 ----
 
+For more information about the `jvmOptions`, see the xref:type-JvmOptions-reference[`JvmOptions` schema reference].
 
 [id='con-common-configuration-garbage-collection-{context}']
 === Garbage collector logging


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

### Documentation update

Updates [jvmOptions](https://strimzi.io/docs/operators/in-development/configuring.html#con-common-configuration-jvm-reference) in the _Configuring_ guide. 

Introduces a table describing the default heap size allocation. Removes the recommendations on setting the heap size.  

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

