### PR TITLE
Provide better logging when renewing and replacing certificates

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
@@ -41,6 +42,8 @@ import java.util.function.Supplier;
  * reconciliation pipeline and is also used to store the state between them.
  */
 public class CruiseControlReconciler {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(CruiseControlReconciler.class.getName());
+
     private final Reconciliation reconciliation;
     private final CruiseControl cruiseControl;
     private final ClusterCa clusterCa;
@@ -269,6 +272,7 @@ public class CruiseControlReconciler {
                         if (patchResult instanceof ReconcileResult.Noop)   {
                             // Deployment needs ot be rolled because the certificate secret changed or older/expired cluster CA removed
                             if (existingCertsChanged || clusterCa.certsRemoved()) {
+                                LOGGER.infoCr(reconciliation, "Rolling Cruise Control to update or remove certificates");
                                 return cruiseControlRollingUpdate();
                             }
                         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
@@ -39,6 +40,8 @@ import java.util.function.Supplier;
  * reconciliation pipeline and is also used to store the state between them.
  */
 public class EntityOperatorReconciler {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(EntityOperatorReconciler.class.getName());
+
     private final Reconciliation reconciliation;
     private final long operationTimeoutMs;
     private final EntityOperator entityOperator;
@@ -398,6 +401,7 @@ public class EntityOperatorReconciler {
                         if (patchResult instanceof ReconcileResult.Noop)   {
                             // Deployment needs ot be rolled because the certificate secret changed or older/expired cluster CA removed
                             if (existingEntityTopicOperatorCertsChanged || existingEntityUserOperatorCertsChanged || clusterCa.certsRemoved()) {
+                                LOGGER.infoCr(reconciliation, "Rolling Entity Operator to update or remove certificates");
                                 return rollDeployment();
                             }
                         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -603,7 +603,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return deploymentOperations.getAsync(namespace, deploymentName)
                     .compose(dep -> {
                         if (dep != null) {
-                            LOGGER.debugCr(reconciliation, "Rolling Deployment {} to {}", deploymentName, reasons);
+                            LOGGER.infoCr(reconciliation, "Rolling Deployment {} to {}", deploymentName, reasons);
                             return deploymentOperations.rollingUpdate(reconciliation, namespace, deploymentName, operationTimeoutMs);
                         } else {
                             return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
@@ -34,6 +35,8 @@ import java.util.function.Supplier;
  * reconciliation pipeline and is also used to store the state between them.
  */
 public class KafkaExporterReconciler {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaExporterReconciler.class.getName());
+
     private final Reconciliation reconciliation;
     private final long operationTimeoutMs;
     private final KafkaExporter kafkaExporter;
@@ -162,6 +165,7 @@ public class KafkaExporterReconciler {
                         if (patchResult instanceof ReconcileResult.Noop)   {
                             // Deployment needs ot be rolled because the certificate secret changed or older/expired cluster CA removed
                             if (existingKafkaExporterCertsChanged || clusterCa.certsRemoved()) {
+                                LOGGER.infoCr(reconciliation, "Rolling Kafka Exporter to update or remove certificates");
                                 return kafkaExporterRollingUpdate();
                             }
                         }


### PR DESCRIPTION
### Type of change

- Improvement

### Description

While renewing or replacing certificates, all compoenents are rolled by the operator. But currently, the only information about  the rolling updates logged on the INFO level is about the Kafka and ZooKeeper rolling. This PR adds additional log messages also for rolling od the Deployments. The messages for the CA replacement were already there, but they are moved to the INFO level. New messages are added to the CC, KE and EO reconcilers when the deployment is rolled for the certificate replacement or removal of the old CA.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally