### PR TITLE
replace the deprecated broker-list option with bootstrap-server

### DIFF
--- a/documentation/modules/deploying/proc-deploy-example-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-example-clients.adoc
@@ -17,7 +17,7 @@ This procedure shows how to deploy example producer and consumer clients that us
 . Deploy a Kafka producer.
 +
 [source,shell,subs="+quotes,attributes+"]
-kubectl run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
+kubectl run kafka-producer -ti --image={DockerKafka} --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server _cluster-name_-kafka-bootstrap:9092 --topic _my-topic_
 
 . Type a message into the console where the producer is running.
 

--- a/documentation/modules/oauth/con-oauth-authorization-keycloak-authorization-services.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-keycloak-authorization-services.adoc
@@ -189,7 +189,7 @@ If topic has not yet been created, and autocreation is enabled, the permissions 
 [source,shell]
 ----
 bin/kafka-console-producer.sh  --topic my-topic \
-  --broker-list my-cluster-kafka-bootstrap:9092 --producer.config=/tmp/config.properties
+  --bootstrap-server my-cluster-kafka-bootstrap:9092 --producer.config=/tmp/config.properties
 ----
 
 .Consuming from the topic

--- a/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
@@ -384,7 +384,7 @@ Use the `team-a-client` configuration to check that you can produce messages to 
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic my-topic \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic my-topic \
   --producer.config=/tmp/team-a-client.properties
 First message
 ----
@@ -398,7 +398,7 @@ The topic named `my-topic` matches neither of those rules.
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic a_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic a_messages \
   --producer.config /tmp/team-a-client.properties
 First message
 Second message
@@ -479,7 +479,7 @@ Use the `team-b-client` configuration to produce messages to topics that start w
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic a_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic a_messages \
   --producer.config /tmp/team-b-client.properties
 Message 1
 ----
@@ -490,7 +490,7 @@ This request returns a `Not authorized to access topics: [a_messages]` error.
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic b_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic b_messages \
   --producer.config /tmp/team-b-client.properties
 Message 1
 Message 2
@@ -503,7 +503,7 @@ Messages are produced to Kafka successfully.
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic x_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic x_messages \
   --producer.config /tmp/team-b-client.properties
 Message 1
 ----
@@ -515,7 +515,7 @@ The `team-b-client` can only read from topic `x_messages`.
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic x_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic x_messages \
   --producer.config /tmp/team-a-client.properties
 Message 1
 ----
@@ -556,7 +556,7 @@ The `Dev Team A` and `Dev Team B` roles both have `Describe` permission on topic
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic x_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic x_messages \
   --producer.config /tmp/team-a-client.properties
 Message 1
 Message 2
@@ -569,7 +569,7 @@ As `alice` created the `x_messages` topic, messages are produced to Kafka succes
 +
 [source,shell]
 ----
-bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9093 --topic x_messages \
+bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 --topic x_messages \
   --producer.config /tmp/team-b-client.properties
 Message 4
 Message 5

--- a/documentation/modules/oauth/ref-example-permissions-for-kafka-operations.adoc
+++ b/documentation/modules/oauth/ref-example-permissions-for-kafka-operations.adoc
@@ -44,7 +44,7 @@ If the topic hasn't been created yet, and topic auto-creation is enabled, the pe
 [source,shell]
 ----
 bin/kafka-console-producer.sh  --topic my-topic \
-  --broker-list my-cluster-kafka-bootstrap:9092 --producer.config=/tmp/config.properties
+  --bootstrap-server my-cluster-kafka-bootstrap:9092 --producer.config=/tmp/config.properties
 ----
 
 .Consume messages from a topic
@@ -81,7 +81,7 @@ Cluster:kafka-cluster
 [source,shell]
 ----
 bin/kafka-console-producer.sh  --topic my-topic \
-  --broker-list my-cluster-kafka-bootstrap:9092 --producer.config=/tmp/config.properties --producer-property enable.idempotence=true --request-required-acks -1
+  --bootstrap-server my-cluster-kafka-bootstrap:9092 --producer.config=/tmp/config.properties --producer-property enable.idempotence=true --request-required-acks -1
 ----
 
 .List consumer groups

--- a/documentation/modules/quickstart/proc-sending-messages.adoc
+++ b/documentation/modules/quickstart/proc-sending-messages.adoc
@@ -39,7 +39,7 @@ kubectl get nodes --output=jsonpath='{range .items[*]}{.status.addresses[?(@.typ
 +
 [source,shell,subs=+quotes]
 ----
-bin/kafka-console-producer.sh --broker-list _<node-address>_:_<node-port>_ --topic my-topic
+bin/kafka-console-producer.sh --bootstrap-server _<node-address>_:_<node-port>_ --topic my-topic
 ----
 
 . Type your message into the console where the producer is running.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

The `broker-list` option in `kafka-console-producer.sh` is deprecated in upstream kafka. We should use `bootstrap-server` instead.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests


- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

