### PR TITLE
[systemtest] Enable Kafka scale up & down tests to be runnable with STS

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -148,5 +149,14 @@ public class RollingUpdateUtils {
                 }
             }
         );
+    }
+
+    public static Map<String, String> waitForComponentScaleUpOrDown(String namespaceName, LabelSelector selector, int expectedPods, Map<String, String> pods) {
+        if (Environment.isStrimziPodSetEnabled()) {
+            waitForComponentAndPodsReady(namespaceName, selector, expectedPods);
+            return PodUtils.podSnapshot(namespaceName, selector);
+        } else {
+            return waitTillComponentHasRolledAndPodsReady(namespaceName, selector, expectedPods, pods);
+        }
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerIsolatedST.java
@@ -28,7 +28,6 @@ import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
-import io.strimzi.systemtest.annotations.StatefulSetTest;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -75,10 +74,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class KafkaRollerIsolatedST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaRollerIsolatedST.class);
 
-    // When using StrimziPodSets, Kafka pods are not all rolled when scaling up or down.
-    // This test needs to be updated to support StrimziPodSets as well
-    //             => https://github.com/strimzi/strimzi-kafka-operator/issues/6493
-    @StatefulSetTest
     @ParallelNamespaceTest
     void testKafkaRollsWhenTopicIsUnderReplicated(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
@@ -110,7 +105,7 @@ public class KafkaRollerIsolatedST extends AbstractST {
         int scaledUpReplicas = 4;
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getKafka().setReplicas(scaledUpReplicas), namespaceName);
 
-        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, scaledUpReplicas, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(namespaceName, kafkaSelector, scaledUpReplicas, kafkaPods);
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName, 4, 4, 4).build());
 
@@ -125,7 +120,7 @@ public class KafkaRollerIsolatedST extends AbstractST {
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getKafka().setReplicas(scaledDownReplicas), namespaceName);
 
-        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, scaledDownReplicas, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(namespaceName, kafkaSelector, scaledDownReplicas, kafkaPods);
 
         PodUtils.verifyThatRunningPodsAreStable(namespaceName, clusterName);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -346,7 +346,7 @@ class RollingUpdateST extends AbstractST {
         LOGGER.info("Scale down Kafka to {}", initialReplicas);
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getKafka().setReplicas(initialReplicas), namespaceName);
 
-        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, initialReplicas, kafkaPods);
+        RollingUpdateUtils.waitForComponentScaleUpOrDown(namespaceName, kafkaSelector, initialReplicas, kafkaPods);
 
         LOGGER.info("Kafka scale down to {} finished", initialReplicas);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -24,7 +24,6 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
-import io.strimzi.systemtest.annotations.StatefulSetTest;
 import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
 import io.strimzi.systemtest.metrics.MetricsCollector;
 import io.strimzi.systemtest.resources.ComponentType;
@@ -256,10 +255,6 @@ class RollingUpdateST extends AbstractST {
         internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
     }
 
-    // When using StrimziPodSets, Kafka pods are not all rolled when scaling up or down.
-    // This test needs to be updated to support StrimziPodSets as well
-    //             => https://github.com/strimzi/strimzi-kafka-operator/issues/6493
-    @StatefulSetTest
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
     @Tag(SCALABILITY)
@@ -322,7 +317,7 @@ class RollingUpdateST extends AbstractST {
             kafka.getSpec().getKafka().setReplicas(scaleTo);
         }, namespaceName);
 
-        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, scaleTo, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(namespaceName, kafkaSelector, scaleTo, kafkaPods);
 
         LOGGER.info("Kafka scale up to {} finished", scaleTo);
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR adds `waitForComponentScaleUpOrDown` method, which handles the usage of STS or SPS when we are waiting for scaling the Kafka replicas up or down - by this, I'm enabling back the `testKafkaRollsWhenTopicIsUnderReplicated` and `testKafkaAndZookeeperScaleUpScaleDown` tests to be run even with STS.

Closes #6493 

### Checklist

- [x] Make sure all tests pass

