### PR TITLE
Add support for millibyte unit in `StorageUtils`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -116,8 +116,8 @@ public class StorageDiff extends AbstractJsonDiff {
                     PersistentClaimStorage persistentCurrent = (PersistentClaimStorage) current;
                     PersistentClaimStorage persistentDesired = (PersistentClaimStorage) desired;
 
-                    long currentSize = StorageUtils.parseMemory(persistentCurrent.getSize());
-                    long desiredSize = StorageUtils.parseMemory(persistentDesired.getSize());
+                    long currentSize = StorageUtils.convertToMillibytes(persistentCurrent.getSize());
+                    long desiredSize = StorageUtils.convertToMillibytes(persistentDesired.getSize());
 
                     if (currentSize > desiredSize) {
                         shrinkSize = true;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -12,13 +12,12 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.VolumeUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
-
-import static io.strimzi.operator.cluster.model.StorageUtils.parseMemory;
 
 public class Capacity {
     // CC allows specifying a generic "default" broker entry in the capacity configuration to apply to all brokers without a specific broker entry.
@@ -169,7 +168,7 @@ public class Capacity {
         if (size == null) {
             return DEFAULT_BROKER_DISK_CAPACITY_IN_MIB;
         }
-        return parseMemory(size, "Mi");
+        return StorageUtils.convertTo(size, "Mi");
     }
 
     /*
@@ -181,6 +180,6 @@ public class Capacity {
      */
     public static Double getThroughputInKiB(String throughput) {
         String size = throughput.substring(0, throughput.indexOf("B"));
-        return parseMemory(size, "Ki");
+        return StorageUtils.convertTo(size, "Ki");
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
@@ -91,8 +91,8 @@ public class PvcReconciler {
                         resultPromise.complete();
                     } else {
                         // The PVC is Bound and resizing is not in progress => We should check if the SC supports resizing and check if size changed
-                        Long currentSize = StorageUtils.parseMemory(currentPvc.getSpec().getResources().getRequests().get("storage"));
-                        Long desiredSize = StorageUtils.parseMemory(desiredPvc.getSpec().getResources().getRequests().get("storage"));
+                        Long currentSize = StorageUtils.convertToMillibytes(currentPvc.getSpec().getResources().getRequests().get("storage"));
+                        Long desiredSize = StorageUtils.convertToMillibytes(desiredPvc.getSpec().getResources().getRequests().get("storage"));
 
                         if (!currentSize.equals(desiredSize))   {
                             // The sizes are different => we should resize (shrinking will be handled in StorageDiff, so we do not need to check that)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -128,7 +128,7 @@ public class StatefulSetDiff extends AbstractJsonDiff {
         if (VOLUME_SIZE.matcher(pathValue).matches()) {
             JsonNode current = lookupPath(source, pathValue);
             JsonNode desired = lookupPath(target, pathValue);
-            return StorageUtils.parseMemory(current.asText()) != StorageUtils.parseMemory(desired.asText());
+            return StorageUtils.convertToMillibytes(current.asText()) != StorageUtils.convertToMillibytes(desired.asText());
         }
         return false;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -104,10 +104,15 @@ public class StorageDiffTest {
         Storage persistent = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("100Gi").build();
         Storage persistent2 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("1000Gi").build();
         Storage persistent3 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("10Gi").build();
+        Storage persistent4 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("3.2Ti").build(); // Used to test millibytes
+        Storage persistent5 = new PersistentClaimStorageBuilder().withStorageClass("gp2-ssd").withDeleteClaim(false).withId(0).withSize("3518437208883200m").build(); // Used to test millibytes
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, 3, 3).shrinkSize(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, 3, 3).shrinkSize(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent3, 3, 3).shrinkSize(), is(true));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent4, persistent5, 3, 3).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent4, persistent, 3, 3).shrinkSize(), is(true));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent5, persistent, 3, 3).shrinkSize(), is(true));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageUtilsTest.java
@@ -19,31 +19,44 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class StorageUtilsTest {
     @ParallelTest
     public void testSizeConversion() {
-        assertThat(StorageUtils.parseMemory("100Gi"), is(100L * 1_024L * 1_024L * 1_024L));
-        assertThat(StorageUtils.parseMemory("100G"), is(100L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageUtils.parseMemory("100000Mi"), is(100_000L * 1_024L * 1_024L));
-        assertThat(StorageUtils.parseMemory("100000M"), is(100L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageUtils.parseMemory("100Ti"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L));
-        assertThat(StorageUtils.parseMemory("100T"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageUtils.parseMemory("100Pi"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L * 1_024L));
-        assertThat(StorageUtils.parseMemory("100P"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageUtils.parseMemory("100.5P"), is((long) (100.5 * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L)));
-        assertThat(StorageUtils.parseMemory("2.1e6"), is((long) (2.1 * 1_000L * 1_000L)));
+        assertThat(StorageUtils.convertToMillibytes("100Gi"), is(100L * 1_024L * 1_024L * 1_024L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("100G"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("100000Mi"), is(100_000L * 1_024L * 1_024L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("100000M"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("100Ti"), is(100L * 1_024L * 1_024L * 1_024L * 1_024L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("100T"), is(100L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("1Pi"), is(1L * 1_024L * 1_024L * 1_024L * 1_024L * 1_024L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("1P"), is(1L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes("1.5P"), is((long) (1.5 * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L * 1_000L)));
+        assertThat(StorageUtils.convertToMillibytes("2.1e6"), is((long) (2.1 * 1_000L * 1_000L * 1_000L)));
+        assertThat(StorageUtils.convertToMillibytes("3.2Ti"), is(3_518_437_208_883_200L));
+        assertThat(StorageUtils.convertToMillibytes("3518437208883200m"), is(3_518_437_208_883_200L));
 
-        assertThat(StorageUtils.parseMemory("100Gi") == StorageUtils.parseMemory("100Gi"), is(true));
-        assertThat(StorageUtils.parseMemory("1000Gi") > StorageUtils.parseMemory("100Gi"), is(true));
-        assertThat(StorageUtils.parseMemory("1000000Mi") > StorageUtils.parseMemory("100Gi"), is(true));
-        assertThat(StorageUtils.parseMemory("100Pi") > StorageUtils.parseMemory("100Gi"), is(true));
-        assertThat(StorageUtils.parseMemory("1000G") == StorageUtils.parseMemory("1T"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("100Gi") == StorageUtils.convertToMillibytes("100Gi"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("1000Gi") > StorageUtils.convertToMillibytes("100Gi"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("1000000Mi") > StorageUtils.convertToMillibytes("100Gi"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("3.2Ti") > StorageUtils.convertToMillibytes("3Ti"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("10Pi") > StorageUtils.convertToMillibytes("100Gi"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("1000G") == StorageUtils.convertToMillibytes("1T"), is(true));
+        assertThat(StorageUtils.convertToMillibytes("3.2Ti") == StorageUtils.convertToMillibytes("3518437208883200m"), is(true));
     }
 
     @ParallelTest
     public void testQuantityConversion()    {
-        assertThat(StorageUtils.parseMemory(new Quantity("1000G")), is(1_000L * 1_000L * 1_000L * 1_000L));
-        assertThat(StorageUtils.parseMemory(new Quantity("100Gi")), is(100L * 1_024L * 1_024L * 1_024L));
+        assertThat(StorageUtils.convertToMillibytes(new Quantity("1000G")), is(1_000L * 1_000L * 1_000L * 1_000L * 1_000L));
+        assertThat(StorageUtils.convertToMillibytes(new Quantity("100Gi")), is(100L * 1_024L * 1_024L * 1_024L * 1_000L));
 
         Quantity size = new Quantity("100", "Gi");
-        assertThat(StorageUtils.parseMemory(size), is(100L * 1_024L * 1_024L * 1_024L));
+        assertThat(StorageUtils.convertToMillibytes(size), is(100L * 1_024L * 1_024L * 1_024L * 1_000L));
+    }
+
+    @ParallelTest
+    public void testUnitConversions()    {
+        assertThat(StorageUtils.convertTo("1000G", "M"), is(1_000_000.0));
+        assertThat(StorageUtils.convertTo("1000Gi", "Mi"), is(1_024_000.0));
+        assertThat(StorageUtils.convertTo("1000G", "Gi"), is(931.3225746154785));
+        assertThat(StorageUtils.convertTo("3518437208883200m", "Ti"), is(3.2));
+        assertThat(StorageUtils.convertTo("3.2Ti", "m"), is(3_518_437_208_883_200.0));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiffTest.java
@@ -186,8 +186,32 @@ public class StatefulSetDiffTest {
                             .build())
                 .endSpec()
                 .build();
+        StatefulSet ss3 = new StatefulSetBuilder() // Used for millibytes test
+                .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewTemplate()
+                        .withNewSpec()
+                            .addToVolumes(0, new VolumeBuilder()
+                                    .withConfigMap(new ConfigMapVolumeSourceBuilder().withDefaultMode(2).build())
+                                    .build())
+                        .endSpec()
+                    .endTemplate()
+                    .withVolumeClaimTemplates(new PersistentVolumeClaimBuilder()
+                            .withNewSpec()
+                            .withNewResources()
+                            .withRequests(singletonMap("storage", new Quantity("3518437208883200m")))
+                            .endResources()
+                            .endSpec()
+                            .build())
+                .endSpec()
+                .build();
         assertThat(new StatefulSetDiff(Reconciliation.DUMMY_RECONCILIATION, ss1, ss2).changesVolumeClaimTemplates(), is(false));
         assertThat(new StatefulSetDiff(Reconciliation.DUMMY_RECONCILIATION, ss1, ss2).changesVolumeSize(), is(true));
+        assertThat(new StatefulSetDiff(Reconciliation.DUMMY_RECONCILIATION, ss1, ss3).changesVolumeClaimTemplates(), is(false));
+        assertThat(new StatefulSetDiff(Reconciliation.DUMMY_RECONCILIATION, ss1, ss3).changesVolumeSize(), is(true));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Wen the user uses some specific values for storage capacity, such as `0.2Ti` or `3.2Ti`, the resulting capacity is converted by Kubernetes to millibytes. Strimzi currently does not handle millibytes in storage, so as a result, the Cluster Operator starts failing with errors like this:

```
java.lang.IllegalArgumentException: Invalid memory suffix: m
	at io.strimzi.operator.cluster.model.StorageUtils.memoryFactor(StorageUtils.java:124) ~[io.strimzi.cluster-operator-0.29.0-SNAPSHOT.jar:0.29.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.StorageUtils.parseMemory(StorageUtils.java:65) ~[io.strimzi.cluster-operator-0.29.0-SNAPSHOT.jar:0.29.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.StorageUtils.parseMemory(StorageUtils.java:42) ~[io.strimzi.cluster-operator-0.29.0-SNAPSHOT.jar:0.29.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.PvcReconciler.lambda$resizeAndReconcilePvcs$4(PvcReconciler.java:94) ~[io.strimzi.cluster-operator-0.29.0-SNAPSHOT.jar:0.29.0-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) ~[io.netty.netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) ~[io.netty.netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) ~[io.netty.netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[io.netty.netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.74.Final.jar:4.1.74.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

This PR adds support to millibytes to the `StorageUtils` class which handles our internal conversions. To achieve that, it starts converting the storage capacity always to millibytes instead of bytes. We uses these conversions mainly for comparing different storage values. We do not start using the millibytes values in some Kubernetes resources due to this change, we will keep using the same as before.

As part of this change I also renamed some of the methods to make it more intuitive to understand what it does. `parseMemory` does not make it completely clear that the method converts the Kubernetes storage capacity to bytes or millibytes.

Because of using `long` and moving to millibytes, we can now handle the storage capacity only up to 8Pi before the `long` overflows. But since the is a capacity of a single block storage disk, I do not think this is a significant limitation and it is acceptable.

This should resolve #6700.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
