### PR TITLE
Improve the connector example to handle the file connectors being removed form the classpath

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -5,7 +5,7 @@
 [id='using-kafka-connect-with-plug-ins-{context}']
 = Extending Kafka Connect with connector plugins
 
-The Strimzi container images for Kafka Connect include two built-in file connectors for moving file-based data into and out of your Kafka cluster.
+Up until Apache Kafka 3.1.0, the Strimzi container images for Kafka Connect included two built-in file connectors for moving file-based data into and out of your Kafka cluster.
 
 .File connectors
 [cols="2*",options="header",stripes="none",separator=¦]
@@ -22,7 +22,9 @@ m¦FileStreamSinkConnector
 
 |===
 
-The procedures in this section show how to add your own connector classes to connector images by:
+From Apache Kafka 3.1.1 and 3.2.0, these connectors are no longer included.
+
+The procedures in this section describe how you can add the example connectors or your own connectors by doing one of the following:
 
 * xref:creating-new-image-using-kafka-connect-build-{context}[Creating a new container image automatically using Strimzi]
 

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -18,6 +18,11 @@ The file is used to create the following connector instances:
 * A `FileStreamSourceConnector` instance that reads each line from the Kafka license file (the source) and writes the data as messages to a single Kafka topic.
 * A `FileStreamSinkConnector` instance that reads messages from the Kafka topic and writes the messages to a temporary file (the sink).
 
+Up until Apache Kafka 3.1.0, the example connector plugins were included with Apache Kafka.
+Starting from the 3.1.1 and 3.2.0 releases of Apache Kafka, the examples need to be added to the plugin path as any other connector.
+See xref:using-kafka-connect-with-plug-ins-str[Extending Kafka Connect with connector plugins] for more details.
+You can also use the `examples/connect/kafka-connect-build.yaml` example file.
+
 [NOTE]
 ====
 In a production environment, you prepare container images containing your desired Kafka Connect connectors, as described in xref:using-kafka-connect-with-plug-ins-{context}[].

--- a/documentation/modules/overview/con-key-features-kafka-connect.adoc
+++ b/documentation/modules/overview/con-key-features-kafka-connect.adoc
@@ -39,7 +39,7 @@ Specialized connectors for MirrorMaker 2.0 manage data replication between sourc
 
 [NOTE]
 ====
-In addition to the MirrorMaker 2.0 connectors, Kafka provides two built-in connectors as examples:
+In addition to the MirrorMaker 2.0 connectors, Kafka provides two connectors as examples:
 
 * `FileStreamSourceConnector` streams data from a file on the worker's filesystem to Kafka, reading the input file and sending each line to a given Kafka topic.
 * `FileStreamSinkConnector` streams data from Kafka to the worker's filesystem, reading messages from a Kafka topic and writing a line for each in an output file.

--- a/packaging/examples/connect/kafka-connect-build.yaml
+++ b/packaging/examples/connect/kafka-connect-build.yaml
@@ -1,0 +1,43 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+#  annotations:
+#  # use-connector-resources configures this KafkaConnect
+#  # to use KafkaConnector resources to avoid
+#  # needing to call the Connect REST API directly
+#    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 3.1.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  config:
+    group.id: connect-cluster
+    offset.storage.topic: connect-cluster-offsets
+    config.storage.topic: connect-cluster-configs
+    status.storage.topic: connect-cluster-status
+    # -1 means it will use the default replication factor configured in the broker
+    config.storage.replication.factor: -1
+    offset.storage.replication.factor: -1
+    status.storage.replication.factor: -1
+  build:
+    output:
+      type: docker
+      # This image will last only for 24 hours and might be overwritten by other users
+      # Strimzi will use this tag to push the image. But it will use the digest to pull
+      # the container image to make sure it pulls exactly the image we just built. So
+      # it should not happen that you pull someone else's container image. However, we
+      # recommend changing this to your own container registry or using a different
+      # image name for any other than demo purposes.
+      image: ttl.sh/strimzi-connect-example-3.1.0:24h
+    plugins:
+      - name: kafka-connect-file
+        artifacts:
+          - type: maven
+            group: org.apache.kafka
+            artifact: connect-file
+            version: 3.1.0

--- a/packaging/examples/connect/source-connector.yaml
+++ b/packaging/examples/connect/source-connector.yaml
@@ -1,3 +1,7 @@
+# To use the KafkaConnector resource, you have to first enable the connector operator using
+# the strimzi.io/use-connector-resources annotation on the KafkaConnect custom resource.
+# From Apache Kafka 3.1.1 and 3.2.0, you also have to add the FileStreamSourceConnector
+# connector to the container image. You can do that using the kafka-connect-build.yaml example.
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:


### PR DESCRIPTION
### Type of change

- Task

### Description

Up until the Kafka 3.1.0 release, the `FileStreamSourceConnector` is part of the Kafka release and is always in the classpath. However, from Kafka 3.1.1 / 3.2.0, it will not be in the classpath anymore and will need to be added. We currentl use this connector in our `KafkaConnector` example which will stop working out of the box.

This PR tries to improve on this by using Kafka Connect Build feature to pull the connector from Maven, add it to the container image and make sure the `KafkaConnector` examples keeps working. Since the Kafka Connect Build needs a container registry, the example uses the [ttl.sh](https://ttl.sh/) registry which allows unauthenticated storage of temporary images. The image will be by default stored for 24 hours. Since any user trying the example will use out of the box the same image name, it is not on 100% reliable. But it is probably the best we can do. The nice thing about this is that it also adds demo / example for the Connect Build feature.

To keep the things separated, the original `source-connector.yaml` is kept as it was, only with some additional comments. A new file `kafka-connect-build.yaml` is added which has the Kafka Connect Build example. Users can deploy it (with enabled connector operator), have it build the new Connect image with the File connectors and create the connector resource.