### PR TITLE
[systemtest] Add test for podset reconciliation only switch

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -136,6 +136,12 @@ public class Environment {
     public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
 
     /**
+     * CO PodSet-only reconciliation env variable <br>
+     * Only SPS will be reconciled, when this env variable will be true
+     */
+    public static final String STRIMZI_POD_SET_RECONCILIATION_ONLY_ENV = "STRIMZI_POD_SET_RECONCILIATION_ONLY";
+
+    /**
      * Defaults
      */
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -5,11 +5,15 @@
 package io.strimzi.systemtest.resources.kubernetes;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
+
+import java.util.function.Consumer;
 
 
 public class DeploymentResource implements ResourceType<Deployment> {
@@ -34,6 +38,13 @@ public class DeploymentResource implements ResourceType<Deployment> {
     @Override
     public boolean waitForReadiness(Deployment resource) {
         return DeploymentUtils.waitForDeploymentAndPodsReady(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), resource.getSpec().getReplicas());
+    }
+
+    public static void replaceDeployment(String deploymentName, Consumer<Deployment> editor, String namespaceName) {
+        Resource<Deployment> currentDepResource = ResourceManager.kubeClient().getClient().resources(Deployment.class, DeploymentList.class).inNamespace(namespaceName).withName(deploymentName);
+        Deployment currentDep = currentDepResource.get();
+        editor.accept(currentDep);
+        currentDepResource.replace(currentDep);
     }
 
     public static Deployment getDeploymentFromYaml(String yamlPath) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.utils;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
@@ -158,5 +159,29 @@ public class RollingUpdateUtils {
         } else {
             return waitTillComponentHasRolledAndPodsReady(namespaceName, selector, expectedPods, pods);
         }
+    }
+
+    public static void waitForNoKafkaAndZKRollingUpdate(String namespaceName, String clusterName, Map<String, String> kafkaPods, Map<String, String> zkPods) {
+        int[] i = {0};
+
+        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
+        LabelSelector zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
+
+        TestUtils.waitFor("Waiting for stability of rolling update will be not triggered", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> {
+                boolean kafkaRolled = componentHasRolled(namespaceName, kafkaSelector, kafkaPods);
+                boolean zkRolled = componentHasRolled(namespaceName, zkSelector, zkPods);
+
+                if (!kafkaRolled && !zkRolled) {
+                    LOGGER.info("Kafka and ZK pods didn't roll. Remaining seconds for stability: {}", Constants.GLOBAL_RECONCILIATION_COUNT - i[0]);
+                } else {
+                    if (kafkaRolled) {
+                        throw new RuntimeException(kafkaPods.toString() + " pods are rolling!");
+                    }
+                    throw new RuntimeException(zkPods.toString() + " pods are rolling!");
+                }
+                return i[0]++ == Constants.GLOBAL_RECONCILIATION_COUNT;
+            }
+        );
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetIsolatedST.java
@@ -1,25 +1,114 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.systemtest.operators;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.annotations.StrimziPodSetTest;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.IsolatedTest;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.kubernetes.DeploymentResource;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
-@StrimziPodSetTest
+import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
+import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.Constants.STRIMZI_DEPLOYMENT_NAME;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
+
+@Tag(REGRESSION)
+@IsolatedSuite
 public class PodSetIsolatedST extends AbstractST {
 
+    private static final Logger LOGGER = LogManager.getLogger(PodSetIsolatedST.class);
+
+    private static final List<EnvVar> INITIAL_ENV_VARS = Collections.singletonList(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, Constants.USE_STRIMZI_POD_SET, null));
+
+    @IsolatedTest("We are changing CO env variables in this test")
+    void testPodSetOnlyReconciliation(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext);
+        final Map<String, String> coPod = DeploymentUtils.depSnapshot(INFRA_NAMESPACE, STRIMZI_DEPLOYMENT_NAME);
+        final int replicas = 3;
+        final int probeTimeoutSeconds = 6;
+
+        EnvVar reconciliationEnv = new EnvVar(Environment.STRIMZI_POD_SET_RECONCILIATION_ONLY_ENV, "true", null);
+        List<EnvVar> envVars = kubeClient().getDeployment(INFRA_NAMESPACE, Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        envVars.addAll(INITIAL_ENV_VARS);
+        envVars.add(reconciliationEnv);
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), replicas).build());
+
+        LOGGER.info("Changing {} to 'true', so only SPS will be reconciled", Environment.STRIMZI_POD_SET_RECONCILIATION_ONLY_ENV);
+
+        DeploymentResource.replaceDeployment(Constants.STRIMZI_DEPLOYMENT_NAME,
+            coDep -> coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars), INFRA_NAMESPACE);
+
+        DeploymentUtils.waitTillDepHasRolled(INFRA_NAMESPACE, STRIMZI_DEPLOYMENT_NAME, 1, coPod);
+
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
+        Map<String, String> zkPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getZookeeperSelector());
+
+        LOGGER.info("Changing Kafka resource configuration, the pods should not be rolled");
+
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> kafka.getSpec().getZookeeper().setReadinessProbe(new ProbeBuilder().withTimeoutSeconds(probeTimeoutSeconds).build()), testStorage.getNamespaceName());
+        RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), zkPods);
+
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> kafka.getSpec().getKafka().setReadinessProbe(new ProbeBuilder().withTimeoutSeconds(probeTimeoutSeconds).build()), testStorage.getNamespaceName());
+        RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), kafkaPods);
+
+        LOGGER.info("Deleting one Kafka and one ZK pod, the should be recreated");
+        kubeClient().deletePodWithName(testStorage.getNamespaceName(), KafkaResources.kafkaPodName(testStorage.getClusterName(), 0));
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), replicas, true);
+
+        kubeClient().deletePodWithName(testStorage.getNamespaceName(), KafkaResources.zookeeperPodName(testStorage.getClusterName(), 0));
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), replicas, true);
+
+        kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
+        zkPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getZookeeperSelector());
+
+        LOGGER.info("Removing {} env from CO", Environment.STRIMZI_POD_SET_RECONCILIATION_ONLY_ENV);
+
+        envVars.remove(reconciliationEnv);
+        DeploymentResource.replaceDeployment(Constants.STRIMZI_DEPLOYMENT_NAME,
+            coDep -> coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVars), INFRA_NAMESPACE);
+
+        DeploymentUtils.waitTillDepHasRolled(INFRA_NAMESPACE, STRIMZI_DEPLOYMENT_NAME, 1, coPod);
+
+        LOGGER.info("Because the configuration was changed, pods should be rolled");
+
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), replicas, kafkaPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), replicas, zkPods);
+    }
+
     @BeforeAll
-    void setup(ExtensionContext extensionContext) {
+    void setup() {
         clusterOperator.unInstall();
         clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
             .withNamespace(INFRA_NAMESPACE)
-            .withExtraEnvVars()
+            .withExtraEnvVars(INITIAL_ENV_VARS)
             .createInstallation()
             .runInstallation();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetIsolatedST.java
@@ -8,14 +8,12 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.kubernetes.DeploymentResource;
-import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
@@ -36,6 +34,11 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.STRIMZI_DEPLOYMENT_NAME;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
+/**
+ * This suite contains tests related to StrimziPodSet and its features.<br>
+ * The StrimziPodSets can be enabled by `STRIMZI_FEATURE_GATES` environment variable, and
+ * they should be replacement for StatefulSets in the future.
+ */
 @Tag(REGRESSION)
 @IsolatedSuite
 public class PodSetIsolatedST extends AbstractST {
@@ -105,9 +108,8 @@ public class PodSetIsolatedST extends AbstractST {
     @BeforeAll
     void setup() {
         clusterOperator.unInstall();
-        clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
-            .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
-            .withNamespace(INFRA_NAMESPACE)
+        clusterOperator = clusterOperator
+            .defaultInstallation()
             .withExtraEnvVars(INITIAL_ENV_VARS)
             .createInstallation()
             .runInstallation();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetIsolatedST.java
@@ -1,0 +1,26 @@
+package io.strimzi.systemtest.operators;
+
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.BeforeAllOnce;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.annotations.StrimziPodSetTest;
+import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
+
+@StrimziPodSetTest
+public class PodSetIsolatedST extends AbstractST {
+
+    @BeforeAll
+    void setup(ExtensionContext extensionContext) {
+        clusterOperator.unInstall();
+        clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
+            .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
+            .withNamespace(INFRA_NAMESPACE)
+            .withExtraEnvVars()
+            .createInstallation()
+            .runInstallation();
+    }
+}

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -338,6 +338,10 @@ public class KubeClient {
         return client.pods().inNamespace(namespaceName).delete(pod);
     }
 
+    public Boolean deletePodWithName(String namespaceName, String podName) {
+        return client.pods().inNamespace(namespaceName).withName(podName).delete();
+    }
+
     public Boolean deletePod(Pod pod) {
         return deletePod(getNamespace(), pod);
     }


### PR DESCRIPTION
### Type of change

- New test

### Description

This PR adds new test for the "podset reconciliation only" feature, which was added in #6541 .

I created new test suite - `PodSetIsolatedST` - which will contain all tests related to StrimziPodSets. The test itself is checking that when the `STRIMZI_POD_SET_RECONCILIATION_ONLY` env is used (together with SPS FG on), any change to the Kafka CR are not reflected, thus the Kafka and ZK will not be rolled. But, if the Kafka or ZK pods are deleted, they should be properly recreated.

Also, this PR adds new method `replaceDeployment` into the `DeploymentResource`, so we can easily edit deployments the same way how we are editing resources like Kafka, KafkaConnect etc.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass