### PR TITLE
docs: add quotes around protocol and message versions

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -109,7 +109,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: {DefaultInterBrokerVersion}
+      inter.broker.protocol.version: "{DefaultInterBrokerVersion}"
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <19>
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
@@ -52,8 +52,8 @@ spec:
     #...
     config:
       #...
-      log.message.format.version: {DefaultInterBrokerVersion}
-      inter.broker.protocol.version: {DefaultInterBrokerVersion}
+      log.message.format.version: "{DefaultInterBrokerVersion}"
+      inter.broker.protocol.version: "{DefaultInterBrokerVersion}"
   # ...
 ----
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Puts quotes around example config for `log.message.format.version` and `inter.broker.protocol.version`.
Makes consistent with other examples in the documentation. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

