### PR TITLE
[ST] Add KafkaUser cert renewal within maintenanceTimeWindow

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -741,7 +741,7 @@ class SecurityST extends AbstractST {
         assertThat("Cluster CA certificate has not been regenerated yet", secretCa.getMetadata().getAnnotations().get("strimzi.io/ca-cert-generation"), is("0"));
         kubeClient(namespaceName).patchSecret(namespaceName, clusterSecretName, secretCa);
 
-        LOGGER.info("Annotate secret {} with secret force-renew annotation", clusterSecretName);
+        LOGGER.info("Annotate secret {} with secret force-renew annotation", clientsSecretName);
         Secret secretCli = new SecretBuilder(kubeClient(namespaceName).getSecret(namespaceName, clientsSecretName))
             .editMetadata()
                 .addToAnnotations(Ca.ANNO_STRIMZI_IO_FORCE_RENEW, "true")


### PR DESCRIPTION
- Test enhancement

This PR updates existing SystemTest `testCertRenewalInMaintenanceTimeWindow` for PR #6573 , which introduces KafkaUser cert renewal within maintenaceTimeWindow. 

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

