### PR TITLE
[systemtest] Test clients exchange - mirrormaker, olm, operators and rollingupdate packages

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -40,6 +40,7 @@ public class KafkaClients extends BaseClients {
     private long delayMs;
     private String userName;
     private String caCertSecretName;
+    private String headers;
 
     public String getProducerName() {
         return producerName;
@@ -115,6 +116,14 @@ public class KafkaClients extends BaseClients {
         this.caCertSecretName = caCertSecretName;
     }
 
+    public String getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(String headers) {
+        this.headers = headers;
+    }
+
     public Job producerStrimzi() {
         return defaultProducerStrimzi().build();
     }
@@ -173,7 +182,7 @@ public class KafkaClients extends BaseClients {
             podSpecBuilder.withImagePullSecrets(imagePullSecrets);
         }
 
-        return new JobBuilder()
+        JobBuilder builder = new JobBuilder()
             .withNewMetadata()
                 .withNamespace(this.getNamespaceName())
                 .withLabels(producerLabels)
@@ -234,6 +243,24 @@ public class KafkaClients extends BaseClients {
                     .endSpec()
                 .endTemplate()
             .endSpec();
+
+        if (this.getHeaders() != null) {
+            builder = builder
+                .editSpec()
+                    .editTemplate()
+                        .editSpec()
+                            .editFirstContainer()
+                                .addNewEnv()
+                                    .withName("HEADERS")
+                                    .withValue(this.getHeaders())
+                                .endEnv()
+                            .endContainer()
+                        .endSpec()
+                    .endTemplate()
+                .endSpec();
+        }
+
+        return builder;
     }
 
     public Job consumerScramShaPlainStrimzi() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -7,15 +7,11 @@ package io.strimzi.systemtest.mirrormaker;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationTls;
@@ -35,12 +31,10 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.storage.TestStorage;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaMirrorMaker2Templates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
@@ -62,9 +56,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -84,10 +78,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
 @Tag(REGRESSION)
@@ -99,19 +93,14 @@ class MirrorMaker2IsolatedST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(MirrorMaker2IsolatedST.class);
 
-    private static final String MIRRORMAKER2_TOPIC_NAME = "mirrormaker2-topic-example";
-    private final int messagesCount = 200;
-
-    @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelNamespaceTest
     void testMirrorMaker2(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String sourceTopicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
-        String targetTopicName = "availability-topic-target-" + mapWithTestTopics.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
 
         Map<String, Object> expectedConfig = StUtils.loadProperties("group.id=mirrormaker2-cluster\n" +
                 "key.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n" +
@@ -126,122 +115,76 @@ class MirrorMaker2IsolatedST extends AbstractST {
                 "config.providers=file\n" + 
                 "config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider\n");
 
-        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
-        String topicSourceNameMirrored = kafkaClusterSourceName + "." + sourceTopicName;
+        // Deploy source and target kafka
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1).build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1).build()
+        );
 
-        // Deploy source kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        // Deploy target kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
-        // Deploy Topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
+        // Deploy source topic
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build());
 
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, false, kafkaClientsName).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(sourceTopicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
             .build();
 
         // Check brokers availability
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            sourceTopicName, kafkaClusterSourceName, MESSAGE_COUNT);
+        LOGGER.info("Messages exchange - topic {}, cluster {} and message count of {}",
+            testStorage.getTopicName(), kafkaClusterSourceName, MESSAGE_COUNT);
 
-        internalKafkaClient.produceAndConsumesPlainMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        LOGGER.info("Setting topic to {}, cluster to {} and changing consumer group",
-            targetTopicName, kafkaClusterTargetName);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(targetTopicName)
-            .withClusterName(kafkaClusterTargetName)
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            targetTopicName, kafkaClusterTargetName, MESSAGE_COUNT);
-
-        internalKafkaClient.produceAndConsumesPlainMessagesUntilBothOperationsAreSuccessful();
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .editFirstMirror()
                     .editSourceConnector()
-                        .addToConfig("refresh.topics.interval.seconds", "60")
+                        .addToConfig("refresh.topics.interval.seconds", "1")
                     .endSourceConnector()
                 .endMirror()
             .endSpec()
             .build());
 
-        LOGGER.info("Looks like the mirrormaker2 cluster my-cluster deployed OK");
-
-        String podName = PodUtils.getPodNameByPrefix(namespaceName, KafkaMirrorMaker2Resources.deploymentName(clusterName));
-        String kafkaPodJson = TestUtils.toJsonString(kubeClient(namespaceName).getPod(namespaceName, podName));
+        String podName = PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), KafkaMirrorMaker2Resources.deploymentName(testStorage.getClusterName()));
+        String kafkaPodJson = TestUtils.toJsonString(kubeClient().getPod(testStorage.getNamespaceName(), podName));
 
         assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder(0, "KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
                 hasItem(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))));
         assertThat(StUtils.getPropertiesFromJson(0, kafkaPodJson, "KAFKA_CONNECT_CONFIGURATION"), is(expectedConfig));
-        testDockerImagesForKafkaMirrorMaker2(clusterName, INFRA_NAMESPACE, namespaceName);
+        testDockerImagesForKafkaMirrorMaker2(testStorage.getClusterName(), INFRA_NAMESPACE, testStorage.getNamespaceName());
 
-        verifyLabelsOnPods(namespaceName, clusterName, "mirrormaker2", "KafkaMirrorMaker2");
-        verifyLabelsForService(namespaceName, clusterName, "mirrormaker2-api", "KafkaMirrorMaker2");
-        verifyLabelsForConfigMaps(namespaceName, kafkaClusterSourceName, null, kafkaClusterTargetName);
-        verifyLabelsForServiceAccounts(namespaceName, kafkaClusterSourceName, null);
-
-        LOGGER.info("Setting topic to {}, cluster to {} and changing consumer group",
-            topicSourceName, kafkaClusterSourceName);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceName)
-            .withClusterName(kafkaClusterSourceName)
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            topicSourceName, kafkaClusterSourceName, MESSAGE_COUNT);
-        int sent = internalKafkaClient.sendMessagesPlain();
-
-        LOGGER.info("Consumer in source cluster and topic should receive {} messages", MESSAGE_COUNT);
-
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
+        verifyLabelsOnPods(testStorage.getNamespaceName(), testStorage.getClusterName(), "mirrormaker2", KafkaMirrorMaker2.RESOURCE_KIND);
+        verifyLabelsForService(testStorage.getNamespaceName(), testStorage.getClusterName(), "mirrormaker2-api", KafkaMirrorMaker2.RESOURCE_KIND);
+        verifyLabelsForConfigMaps(testStorage.getNamespaceName(), kafkaClusterSourceName, null, kafkaClusterTargetName);
+        verifyLabelsForServiceAccounts(testStorage.getNamespaceName(), kafkaClusterSourceName, null);
 
         LOGGER.info("Now setting topic to {} and cluster to {} - the messages should be mirrored",
-            topicTargetName, kafkaClusterTargetName);
+            sourceMirroredTopicName, kafkaClusterTargetName);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetName)
-            .withClusterName(kafkaClusterTargetName)
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
         LOGGER.info("Consumer in target cluster and topic should receive {} messages", MESSAGE_COUNT);
 
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
-
-
-        LOGGER.info("Changing topic to {}", topicSourceNameMirrored);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceNameMirrored)
-            .build();
-
-        LOGGER.info("Check if mm2 mirror automatically created topic");
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Mirrored successful");
 
-        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
+        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).withName(sourceMirroredTopicName).get();
         assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
         assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
 
         // Replace source topic resource with new data and check that mm2 update target topi
-        KafkaTopicResource.replaceTopicResourceInSpecificNamespace(topicSourceName, kt -> kt.getSpec().setPartitions(8), namespaceName);
-        KafkaTopicUtils.waitForKafkaTopicPartitionChange(namespaceName, topicTargetName, 8);
+        KafkaTopicResource.replaceTopicResourceInSpecificNamespace(testStorage.getTopicName(), kt -> kt.getSpec().setPartitions(8), testStorage.getNamespaceName());
+        KafkaTopicUtils.waitForKafkaTopicPartitionChange(testStorage.getNamespaceName(), sourceMirroredTopicName, 8);
     }
 
     /**
@@ -250,30 +193,28 @@ class MirrorMaker2IsolatedST extends AbstractST {
     @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
-    void testMirrorMaker2TlsAndTlsClientAuth(ExtensionContext extensionContext) throws Exception {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String topicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicSourceNameMirrored = kafkaClusterSourceName + "." + topicName;
-        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
-        String kafkaUserSourceName = clusterName + "-my-user-source";
-        String kafkaUserTargetName = clusterName + "-my-user-target";
+    void testMirrorMaker2TlsAndTlsClientAuth(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
+
+        String kafkaUserSourceName = testStorage.getUserName() + "-source";
+        String kafkaUserTargetName = testStorage.getUserName() + "-target";
 
         // Deploy source kafka with tls listener and mutual tls auth
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withListeners(new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationTls())
-                            .build())
+                        .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                        .withPort(9093)
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withTls(true)
+                        .withAuth(new KafkaListenerAuthenticationTls())
+                        .build())
                 .endKafka()
             .endSpec()
             .build());
@@ -283,60 +224,22 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .editSpec()
                 .editKafka()
                     .withListeners(new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationTls())
-                            .build())
+                        .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                        .withPort(9093)
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withTls(true)
+                        .withAuth(new KafkaListenerAuthenticationTls())
+                        .build())
                 .endKafka()
             .endSpec()
             .build());
 
         // Deploy topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
-        // Create Kafka user
-        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build();
-        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build();
-
-        resourceManager.createResource(extensionContext, userSource);
-        resourceManager.createResource(extensionContext, userTarget);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, userSource, userTarget).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicTestName1 = baseTopic + "-test-1";
-        String topicTestName2 = baseTopic + "-test-2";
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterTargetName, topicTestName2).build());
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicTestName1)
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .build();
-
-        // Check brokers availability
-        ClientUtils.waitUntilProducerAndConsumerSuccessfullySendAndReceiveMessages(extensionContext, internalKafkaClient);
-
-        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-            topicTestName2, kafkaClusterTargetName, userTarget.getMetadata().getName());
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .withTopicName(topicTestName2)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            topicTestName2, kafkaClusterTargetName, messagesCount);
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build(),
+            KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build(),
+            KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build()
+        );
 
         // Initialize CertSecretSource with certificate and secret names for source
         CertSecretSource certSecretSource = new CertSecretSource();
@@ -348,115 +251,90 @@ class MirrorMaker2IsolatedST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
-        // Deploy Mirror Maker 2.0 with tls listener and mutual tls auth
-        KafkaMirrorMaker2ClusterSpec sourceClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-                .withAlias(kafkaClusterSourceName)
-                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
-                .withNewKafkaClientAuthenticationTls()
-                    .withNewCertificateAndKey()
-                        .withSecretName(kafkaUserSourceName)
-                        .withCertificate("user.crt")
-                        .withKey("user.key")
-                    .endCertificateAndKey()
-                .endKafkaClientAuthenticationTls()
-                .withNewTls()
-                    .withTrustedCertificates(certSecretSource)
-                .endTls()
-                .build();
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
+            .build();
 
-        KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-                .withAlias(kafkaClusterTargetName)
-                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
-                .withNewKafkaClientAuthenticationTls()
-                    .withNewCertificateAndKey()
-                        .withSecretName(kafkaUserTargetName)
-                        .withCertificate("user.crt")
-                        .withKey("user.key")
-                    .endCertificateAndKey()
-                .endKafkaClientAuthenticationTls()
-                .withNewTls()
-                    .withTrustedCertificates(certSecretTarget)
-                .endTls()
-                .addToConfig("config.storage.replication.factor", -1)
-                .addToConfig("offset.storage.replication.factor", -1)
-                .addToConfig("status.storage.replication.factor", -1)
-                .build();
+        // Check brokers availability
+        LOGGER.info("Messages exchange - topic {}, cluster {} and message count of {}",
+            testStorage.getTopicName(), kafkaClusterSourceName, MESSAGE_COUNT);
 
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(kafkaClusterSourceName), clients.consumerTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
-                .withClusters(sourceClusterWithTlsAuth, targetClusterWithTlsAuth)
-                .editFirstMirror()
-                    .withTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
-                .endMirror()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterSourceName))
+                    .withNewKafkaClientAuthenticationTls()
+                        .withNewCertificateAndKey()
+                            .withSecretName(kafkaUserSourceName)
+                            .withCertificate("user.crt")
+                            .withKey("user.key")
+                        .endCertificateAndKey()
+                    .endKafkaClientAuthenticationTls()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretSource)
+                    .endTls()
+                .endCluster()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterTargetName))
+                    .withNewKafkaClientAuthenticationTls()
+                        .withNewCertificateAndKey()
+                            .withSecretName(kafkaUserTargetName)
+                            .withCertificate("user.crt")
+                            .withKey("user.key")
+                        .endCertificateAndKey()
+                    .endKafkaClientAuthenticationTls()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretTarget)
+                    .endTls()
+                .endCluster()
             .endSpec()
             .build());
 
-        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+        LOGGER.info("Changing to mirrored topic - topic {}, cluster {}, user {}", sourceMirroredTopicName, kafkaClusterTargetName, kafkaClusterTargetName);
+
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            topicSourceName, kafkaClusterSourceName, messagesCount);
-        int sent = internalKafkaClient.sendMessagesTls();
-
-        LOGGER.info("Receiving messages from - topic {}, cluster {} and message count of {}",
-            topicSourceName, kafkaClusterSourceName, messagesCount);
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            sent,
-            internalKafkaClient.receiveMessagesTls()
-        );
-
-        LOGGER.info("Now setting topic to {}, cluster to {} and user to {} - the messages should be mirrored",
-            topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetName)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            sent,
-            internalKafkaClient.receiveMessagesTls()
-        );
+        LOGGER.info("Now messages should be mirrored to target topic and cluster");
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
         LOGGER.info("Messages successfully mirrored");
 
-        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
+        KafkaTopicUtils.waitForKafkaTopicCreation(testStorage.getNamespaceName(), sourceMirroredTopicName);
+        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).withName(sourceMirroredTopicName).get();
+
         assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
         assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
-
-        mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicSourceNameMirrored).get();
-        assertThat(mirroredTopic, nullValue());
     }
 
     /**
      * Test mirroring messages by MirrorMaker 2.0 over tls transport using scram-sha-512 auth
      */
-    @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelNamespaceTest
     void testMirrorMaker2TlsAndScramSha512Auth(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String sourceTopicName = "availability-topic-source-" + mapWithTestTopics.get(extensionContext.getDisplayName());
-        String targetTopicName = "availability-topic-target-" + mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicSourceNameMirrored = kafkaClusterSourceName + "." + sourceTopicName;
-        String topicSourceName = MIRRORMAKER2_TOPIC_NAME + "-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicTargetName = kafkaClusterSourceName + "." + topicSourceName;
-        String kafkaUserSource = clusterName + "-my-user-source";
-        String kafkaUserTarget = clusterName + "-my-user-target";
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
-        // Deploy source kafka with tls listener and SCRAM-SHA authentication
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
+
+        String kafkaUserSourceName = testStorage.getUserName() + "-source";
+        String kafkaUserTargetName = testStorage.getUserName() + "-target";
+
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
             .editSpec()
                 .editKafka()
                     .withListeners(new GenericKafkaListenerBuilder()
@@ -468,42 +346,36 @@ class MirrorMaker2IsolatedST extends AbstractST {
                             .build())
                 .endKafka()
             .endSpec()
-            .build());
-
-        // Deploy target kafka with tls listener and SCRAM-SHA authentication
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
-            .editSpec()
-                .editKafka()
-                    .withListeners(new GenericKafkaListenerBuilder()
+            .build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder()
                             .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
                             .withPort(9093)
                             .withType(KafkaListenerType.INTERNAL)
                             .withTls(true)
                             .withAuth(new KafkaListenerAuthenticationScramSha512())
                             .build())
-                .endKafka()
-            .endSpec()
-            .build());
+                    .endKafka()
+                .endSpec()
+                .build()
+        );
 
-        // Deploy topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName, 3).build());
-
-        // Create Kafka user for source cluster
-        KafkaUser userSource = KafkaUserTemplates.scramShaUser(kafkaClusterSourceName, kafkaUserSource).build();
-        resourceManager.createResource(extensionContext, userSource);
-
-        // Create Kafka user for target cluster
-        KafkaUser userTarget = KafkaUserTemplates.scramShaUser(kafkaClusterTargetName, kafkaUserTarget).build();
-        resourceManager.createResource(extensionContext, userTarget);
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build(),
+            KafkaUserTemplates.scramShaUser(kafkaClusterSourceName, kafkaUserSourceName).build(),
+            KafkaUserTemplates.scramShaUser(kafkaClusterTargetName, kafkaUserTargetName).build()
+        );
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in MirrorMaker2 spec
         PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
-        passwordSecretSource.setSecretName(kafkaUserSource);
+        passwordSecretSource.setSecretName(kafkaUserSourceName);
         passwordSecretSource.setPassword("password");
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in MirrorMaker2 spec
         PasswordSecretSource passwordSecretTarget = new PasswordSecretSource();
-        passwordSecretTarget.setSecretName(kafkaUserTarget);
+        passwordSecretTarget.setSecretName(kafkaUserTargetName);
         passwordSecretTarget.setPassword("password");
 
         // Initialize CertSecretSource with certificate and secret names for source
@@ -515,201 +387,159 @@ class MirrorMaker2IsolatedST extends AbstractST {
         CertSecretSource certSecretTarget = new CertSecretSource();
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
-        // Deploy client
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, true, kafkaClientsName, userSource, userTarget).build());
 
-        final String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(sourceTopicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            sourceTopicName, kafkaClusterSourceName, messagesCount);
         // Check brokers availability
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        LOGGER.info("Messages exchange - topic {}, cluster {} and message count of {}",
+            testStorage.getTopicName(), kafkaClusterSourceName, MESSAGE_COUNT);
 
-        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-            targetTopicName, kafkaClusterTargetName, userTarget.getMetadata().getName());
+        resourceManager.createResource(extensionContext, clients.producerScramShaTlsStrimzi(kafkaClusterSourceName), clients.consumerScramShaTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(targetTopicName)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            targetTopicName, kafkaClusterTargetName, messagesCount);
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
-
-        // Deploy Mirror Maker with TLS and ScramSha512
-        KafkaMirrorMaker2ClusterSpec sourceClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder()
-                .withAlias(kafkaClusterSourceName)
-                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
-                .withNewKafkaClientAuthenticationScramSha512()
-                    .withUsername(kafkaUserSource)
-                    .withPasswordSecret(passwordSecretSource)
-                .endKafkaClientAuthenticationScramSha512()
-                .withNewTls()
-                    .withTrustedCertificates(certSecretSource)
-                .endTls()
-                .build();
-
-        KafkaMirrorMaker2ClusterSpec targetClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder()
-                .withAlias(kafkaClusterTargetName)
-                .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
-                .withNewKafkaClientAuthenticationScramSha512()
-                    .withUsername(kafkaUserTarget)
-                    .withPasswordSecret(passwordSecretTarget)
-                .endKafkaClientAuthenticationScramSha512()
-                .withNewTls()
-                    .withTrustedCertificates(certSecretTarget)
-                .endTls()
-                .addToConfig("config.storage.replication.factor", -1)
-                .addToConfig("offset.storage.replication.factor", -1)
-                .addToConfig("status.storage.replication.factor", -1)
-                .build();
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
-                .withClusters(targetClusterWithScramSha512Auth, sourceClusterWithScramSha512Auth)
-                .editFirstMirror()
-                    .withTopicsExcludePattern("availability.*")
-                .endMirror()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterSourceName))
+                    .withNewKafkaClientAuthenticationScramSha512()
+                        .withUsername(kafkaUserSourceName)
+                        .withPasswordSecret(passwordSecretSource)
+                    .endKafkaClientAuthenticationScramSha512()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretSource)
+                    .endTls()
+                .endCluster()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterTargetName))
+                    .withNewKafkaClientAuthenticationScramSha512()
+                        .withUsername(kafkaUserTargetName)
+                        .withPasswordSecret(passwordSecretTarget)
+                    .endKafkaClientAuthenticationScramSha512()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretTarget)
+                    .endTls()
+                .endCluster()
             .endSpec()
             .build());
 
-        LOGGER.info("Setting topic to {}, cluster to {} and changing user to {}",
-            topicSourceName, kafkaClusterSourceName, userSource.getMetadata().getName());
+        LOGGER.info("Changing to mirrored topic - topic {}, cluster {}, user {}", sourceMirroredTopicName, kafkaClusterTargetName, kafkaClusterTargetName);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .build();
-
-        LOGGER.info("Sending messages to - topic {}, cluster {} and message count of {}",
-            topicSourceName, kafkaClusterSourceName, messagesCount);
-        int sent = internalKafkaClient.sendMessagesTls();
-
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            sent,
-            internalKafkaClient.receiveMessagesTls()
-        );
-
-        LOGGER.info("Changing to target - topic {}, cluster {}, user {}", topicTargetName, kafkaClusterTargetName, userTarget.getMetadata().getName());
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetName)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(userTarget.getMetadata().getName())
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
         LOGGER.info("Now messages should be mirrored to target topic and cluster");
-        internalKafkaClient.checkProducedAndConsumedMessages(
-            sent,
-            internalKafkaClient.receiveMessagesTls()
-        );
+        resourceManager.createResource(extensionContext, clients.consumerScramShaTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
         LOGGER.info("Messages successfully mirrored");
 
-        KafkaTopicUtils.waitForKafkaTopicCreation(namespaceName, topicTargetName);
-        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicTargetName).get();
+        KafkaTopicUtils.waitForKafkaTopicCreation(testStorage.getNamespaceName(), sourceMirroredTopicName);
+        KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).withName(sourceMirroredTopicName).get();
+
         assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
         assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
-
-        mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicSourceNameMirrored).get();
-        assertThat(mirroredTopic, nullValue());
-    }
-
-    private void testDockerImagesForKafkaMirrorMaker2(String clusterName, String clusterOperatorNamespace, String mirrorMakerNamespace) {
-        LOGGER.info("Verifying docker image names");
-        // we must use INFRA_NAMESPACE because there is CO deployed
-        Map<String, String> imgFromDeplConf = getImagesFromConfig(clusterOperatorNamespace);
-        //Verifying docker image for kafka mirrormaker2
-        String mirrormaker2ImageName = PodUtils.getFirstContainerImageNameFromPod(mirrorMakerNamespace, kubeClient(mirrorMakerNamespace).listPods(mirrorMakerNamespace, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND)
-               .get(0).getMetadata().getName());
-
-        String mirrormaker2Version = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(mirrorMakerNamespace).withName(clusterName).get().getSpec().getVersion();
-        if (mirrormaker2Version == null) {
-            mirrormaker2Version = Environment.ST_KAFKA_VERSION;
-        }
-
-        assertThat(TestUtils.parseImageMap(imgFromDeplConf.get(KAFKA_MIRROR_MAKER_2_IMAGE_MAP)).get(mirrormaker2Version), is(mirrormaker2ImageName));
-        LOGGER.info("Docker images verified");
     }
 
     @ParallelNamespaceTest
     @Tag(SCALABILITY)
-    void testScaleMirrorMaker2Subresource(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+    void testScaleMirrorMaker2UpAndDownToZero(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(testStorage.getClusterName());
 
         // Deploy source kafka
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).build());
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false).build());
 
         int scaleTo = 2;
-        long mm2ObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration();
-        String mm2GenName = kubeClient(namespaceName).listPods(namespaceName, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getGenerateName();
+        long mm2ObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getObservedGeneration();
+        String mm2GenName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getGenerateName();
 
-        LOGGER.info("-------> Scaling KafkaMirrorMaker2 subresource <-------");
+        LOGGER.info("-------> Scaling KafkaMirrorMaker2 up <-------");
+
         LOGGER.info("Scaling subresource replicas to {}", scaleTo);
-        cmdKubeClient(namespaceName).scaleByName(KafkaMirrorMaker2.RESOURCE_KIND, clusterName, scaleTo);
-        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, KafkaMirrorMaker2Resources.deploymentName(clusterName), scaleTo);
+
+        cmdKubeClient(testStorage.getNamespaceName()).scaleByName(KafkaMirrorMaker2.RESOURCE_KIND, testStorage.getClusterName(), scaleTo);
+        DeploymentUtils.waitForDeploymentAndPodsReady(testStorage.getNamespaceName(), KafkaMirrorMaker2Resources.deploymentName(testStorage.getClusterName()), scaleTo);
 
         LOGGER.info("Check if replicas is set to {}, naming prefix should be same and observed generation higher", scaleTo);
-        List<String> mm2Pods = kubeClient(namespaceName).listPodNames(namespaceName, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND);
+        List<String> mm2Pods = kubeClient(testStorage.getNamespaceName()).listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND);
 
-        assertThat(mm2Pods.size(), is(2));
-        assertThat(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getSpec().getReplicas(), is(2));
-        assertThat(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus().getReplicas(), is(2));
+        assertThat(mm2Pods.size(), is(scaleTo));
+        assertThat(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getSpec().getReplicas(), is(scaleTo));
+        assertThat(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getReplicas(), is(scaleTo));
         /*
         observed generation should be higher than before scaling -> after change of spec and successful reconciliation,
         the observed generation is increased
         */
-        assertThat(mm2ObsGen < KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration(), is(true));
+        long actualObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getMetadata().getGeneration();
+
+        assertTrue(mm2ObsGen < actualObsGen);
         for (String pod : mm2Pods) {
-            assertThat(pod.contains(mm2GenName), is(true));
+            assertTrue(pod.contains(mm2GenName));
         }
+
+        mm2ObsGen = actualObsGen;
+
+        LOGGER.info("-------> Scaling KafkaMirrorMaker2 down <-------");
+
+        LOGGER.info("Scaling MirrorMaker2 to zero");
+        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(testStorage.getClusterName(), mm2 -> mm2.getSpec().setReplicas(0), testStorage.getNamespaceName());
+
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), kubeClient(testStorage.getNamespaceName()).getDeploymentSelectors(mm2DepName), 0, true, () -> { });
+
+        mm2Pods = kubeClient().listPodNames(testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND);
+        KafkaMirrorMaker2Status mm2Status = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus();
+        actualObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getMetadata().getGeneration();
+
+        assertThat(mm2Pods.size(), is(0));
+        assertThat(mm2Status.getConditions().get(0).getType(), is(Ready.toString()));
+        assertThat(actualObsGen, is(not(mm2ObsGen)));
+
+        TestUtils.waitFor("Until mirror maker 2 status url is null", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT, () -> {
+            KafkaMirrorMaker2Status mm2StatusUrl = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus();
+            return mm2StatusUrl.getUrl() == null;
+        });
     }
 
     @ParallelNamespaceTest
     void testMirrorMaker2CorrectlyMirrorsHeaders(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String sourceProducerName = clusterName + "-source-producer";
-        String targetConsumerName = clusterName + "-target-consumer";
-        String sourceExampleTopic = clusterName + "-source-example-topic";
-        String targetExampleTopic = kafkaClusterSourceName + "." + sourceExampleTopic;
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
 
         // Deploy source kafka
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
         // Deploy Topic for example clients
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, sourceExampleTopic).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName()).build());
 
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false).build());
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false).build());
 
-        //deploying example clients for checking if mm2 will mirror messages with headers
+        // Deploying example clients for checking if mm2 will mirror messages with headers
 
         KafkaClients targetKafkaClientsJob = new KafkaClientsBuilder()
-            .withConsumerName(targetConsumerName)
+            .withConsumerName(testStorage.getConsumerName())
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
-            .withTopicName(targetExampleTopic)
+            .withTopicName(sourceMirroredTopicName)
             .withMessageCount(MESSAGE_COUNT)
             .withDelayMs(1000)
             .build();
@@ -717,75 +547,24 @@ class MirrorMaker2IsolatedST extends AbstractST {
         resourceManager.createResource(extensionContext, targetKafkaClientsJob.consumerStrimzi());
 
         KafkaClients sourceKafkaClientsJob = new KafkaClientsBuilder()
-            .withProducerName(sourceProducerName)
+            .withProducerName(testStorage.getProducerName())
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
-            .withTopicName(sourceExampleTopic)
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
+            .withHeaders("header_key_one=header_value_one, header_key_two=header_value_two")
             .withDelayMs(1000)
             .build();
 
-        resourceManager.createResource(extensionContext, new JobBuilder(sourceKafkaClientsJob.producerStrimzi())
-            .editSpec()
-                .editTemplate()
-                    .editSpec()
-                        .editContainer(0)
-                            .addNewEnv()
-                                .withName("HEADERS")
-                                .withValue("header_key_one=header_value_one, header_key_two=header_value_two")
-                            .endEnv()
-                        .endContainer()
-                    .endSpec()
-                .endTemplate()
-            .endSpec()
-            .build());
+        resourceManager.createResource(extensionContext, sourceKafkaClientsJob.producerStrimzi());
 
-        ClientUtils.waitForClientsSuccess(sourceProducerName, targetConsumerName, namespaceName, MESSAGE_COUNT, false);
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT, false);
 
-        LOGGER.info("Checking log of {} job if the headers are correct", targetConsumerName);
+        LOGGER.info("Checking log of {} job if the headers are correct", testStorage.getConsumerName());
         String header1 = "key: header_key_one, value: header_value_one";
         String header2 = "key: header_key_two, value: header_value_two";
-        String log = StUtils.getLogFromPodByTime(namespaceName, kubeClient(namespaceName).listPodsByPrefixInName(targetConsumerName).get(0).getMetadata().getName(), "", MESSAGE_COUNT + "s");
+        String log = StUtils.getLogFromPodByTime(testStorage.getNamespaceName(), kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(testStorage.getConsumerName()).get(0).getMetadata().getName(), "", MESSAGE_COUNT + "s");
         assertThat(log, containsString(header1));
         assertThat(log, containsString(header2));
-    }
-
-    @ParallelNamespaceTest
-    @Tag(SCALABILITY)
-    void testScaleMirrorMaker2ToZero(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-
-        // Deploy source kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        // Deploy target kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 3, false).build());
-
-        long oldObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration();
-        String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(clusterName);
-        List<String> mm2Pods = kubeClient(namespaceName).listPodNames(clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND);
-        assertThat(mm2Pods.size(), is(3));
-
-        LOGGER.info("Scaling MirrorMaker2 to zero");
-        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(clusterName, mm2 -> mm2.getSpec().setReplicas(0), namespaceName);
-
-        PodUtils.waitForPodsReady(namespaceName, kubeClient(namespaceName).getDeploymentSelectors(mm2DepName), 0, true, () -> { });
-
-        mm2Pods = kubeClient().listPodNames(clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND);
-        KafkaMirrorMaker2Status mm2Status = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus();
-        long actualObsGen = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getMetadata().getGeneration();
-
-        assertThat(mm2Pods.size(), is(0));
-        assertThat(mm2Status.getConditions().get(0).getType(), is(Ready.toString()));
-        assertThat(actualObsGen, is(not(oldObsGen)));
-
-        TestUtils.waitFor("Until mirror maker 2 status url is null", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT, () -> {
-            KafkaMirrorMaker2Status mm2StatusUrl = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus();
-            return mm2StatusUrl.getUrl() == null;
-        });
     }
 
     /*
@@ -793,25 +572,20 @@ class MirrorMaker2IsolatedST extends AbstractST {
      */
     @ParallelNamespaceTest
     void testIdentityReplicationPolicy(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String originalTopicName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
-        // Deploy source kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        // Deploy target kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build()
+        );
+
         // Create topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, originalTopicName, 3).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build());
 
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, false, kafkaClientsName).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .editMirror(0)
                     .editSourceConnector()
@@ -822,35 +596,35 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .build());
 
         LOGGER.info("Sending and receiving messages via {}", kafkaClusterSourceName);
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withNamespaceName(namespaceName)
-            .withTopicName(originalTopicName)
-            .withClusterName(kafkaClusterSourceName)
+
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withUsingPodName(kafkaClientsPodName)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
             .build();
 
-        internalKafkaClient.assertSentAndReceivedMessages(
-            internalKafkaClient.sendMessagesPlain(),
-            internalKafkaClient.receiveMessagesPlain()
-        );
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Changing to {} and will try to receive messages", kafkaClusterTargetName);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
+        clients = new KafkaClientsBuilder(clients)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
-        assertThat(internalKafkaClient.receiveMessagesPlain(), equalTo(MESSAGE_COUNT));
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Checking if the mirrored topic name is same as the original one");
 
-        List<String> kafkaTopics = KafkaCmdClient.listTopicsUsingPodCli(namespaceName, kafkaClusterTargetName, 0);
-        assertNotNull(kafkaTopics.stream().filter(kafkaTopic -> kafkaTopic.equals(originalTopicName)).findAny());
+        List<String> kafkaTopics = KafkaCmdClient.listTopicsUsingPodCli(testStorage.getNamespaceName(), kafkaClusterTargetName, 0);
+        assertNotNull(kafkaTopics.stream().filter(kafkaTopic -> kafkaTopic.equals(testStorage.getTopicName())).findAny());
 
-        List<String> kafkaTopicSpec = KafkaCmdClient.describeTopicUsingPodCli(namespaceName, kafkaClusterTargetName, 0, originalTopicName);
-        assertThat(kafkaTopicSpec.stream().filter(token -> token.startsWith("Topic:")).findFirst().orElse(null), equalTo("Topic:" + originalTopicName));
+        List<String> kafkaTopicSpec = KafkaCmdClient.describeTopicUsingPodCli(testStorage.getNamespaceName(), kafkaClusterTargetName, 0, testStorage.getTopicName());
+        assertThat(kafkaTopicSpec.stream().filter(token -> token.startsWith("Topic:")).findFirst().orElse(null), equalTo("Topic:" + testStorage.getTopicName()));
         assertThat(kafkaTopicSpec.stream().filter(token -> token.startsWith("PartitionCount:")).findFirst().orElse(null), equalTo("PartitionCount:3"));
     }
 
@@ -862,25 +636,20 @@ class MirrorMaker2IsolatedST extends AbstractST {
      */
     @ParallelNamespaceTest
     void testStrimziIdentityReplicationPolicy(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String originalTopicName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
-        // Deploy source kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        // Deploy target kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build()
+        );
+
         // Create topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, originalTopicName, 3).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build());
 
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(namespaceName, false, kafkaClientsName).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .editMirror(0)
                     .editSourceConnector()
@@ -891,51 +660,51 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .build());
 
         LOGGER.info("Sending and receiving messages via {}", kafkaClusterSourceName);
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withNamespaceName(namespaceName)
-            .withTopicName(originalTopicName)
-            .withClusterName(kafkaClusterSourceName)
+
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withUsingPodName(kafkaClientsPodName)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
             .build();
 
-        internalKafkaClient.assertSentAndReceivedMessages(
-            internalKafkaClient.sendMessagesPlain(),
-            internalKafkaClient.receiveMessagesPlain()
-        );
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Changing to {} and will try to receive messages", kafkaClusterTargetName);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
+        clients = new KafkaClientsBuilder(clients)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
-        assertThat(internalKafkaClient.receiveMessagesPlain(), equalTo(MESSAGE_COUNT));
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Checking if the mirrored topic name is same as the original one");
 
-        List<String> kafkaTopics = KafkaCmdClient.listTopicsUsingPodCli(namespaceName, kafkaClusterTargetName, 0);
-        assertNotNull(kafkaTopics.stream().filter(kafkaTopic -> kafkaTopic.equals(originalTopicName)).findAny());
+        List<String> kafkaTopics = KafkaCmdClient.listTopicsUsingPodCli(testStorage.getNamespaceName(), kafkaClusterTargetName, 0);
+        assertNotNull(kafkaTopics.stream().filter(kafkaTopic -> kafkaTopic.equals(testStorage.getTopicName())).findAny());
 
-        List<String> kafkaTopicSpec = KafkaCmdClient.describeTopicUsingPodCli(namespaceName, kafkaClusterTargetName, 0, originalTopicName);
-        assertThat(kafkaTopicSpec.stream().filter(token -> token.startsWith("Topic:")).findFirst().orElse(null), equalTo("Topic:" + originalTopicName));
+        List<String> kafkaTopicSpec = KafkaCmdClient.describeTopicUsingPodCli(testStorage.getNamespaceName(), kafkaClusterTargetName, 0, testStorage.getTopicName());
+        assertThat(kafkaTopicSpec.stream().filter(token -> token.startsWith("Topic:")).findFirst().orElse(null), equalTo("Topic:" + testStorage.getTopicName()));
         assertThat(kafkaTopicSpec.stream().filter(token -> token.startsWith("PartitionCount:")).findFirst().orElse(null), equalTo("PartitionCount:3"));
     }
 
     @ParallelNamespaceTest
     void testConfigureDeploymentStrategy(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
 
         // Deploy source kafka
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
         // Deploy target kafka
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
-        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
             .editSpec()
                 .editOrNewTemplate()
                     .editOrNewDeployment()
@@ -945,14 +714,14 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .endSpec()
             .build());
 
-        String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(clusterName);
+        String mm2DepName = KafkaMirrorMaker2Resources.deploymentName(testStorage.getClusterName());
 
         LOGGER.info("Adding label to MirrorMaker2 resource, the CR should be recreated");
-        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(clusterName,
-            mm2 -> mm2.getMetadata().setLabels(Collections.singletonMap("some", "label")), namespaceName);
-        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, mm2DepName, 1);
+        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(testStorage.getClusterName(),
+            mm2 -> mm2.getMetadata().setLabels(Collections.singletonMap("some", "label")), testStorage.getNamespaceName());
+        DeploymentUtils.waitForDeploymentAndPodsReady(testStorage.getNamespaceName(), mm2DepName, 1);
 
-        KafkaMirrorMaker2 kmm2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get();
+        KafkaMirrorMaker2 kmm2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
 
         LOGGER.info("Checking that observed gen. is still on 1 (recreation) and new label is present");
         assertThat(kmm2.getStatus().getObservedGeneration(), is(1L));
@@ -960,122 +729,115 @@ class MirrorMaker2IsolatedST extends AbstractST {
         assertThat(kmm2.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(DeploymentStrategy.RECREATE));
 
         LOGGER.info("Changing deployment strategy to {}", DeploymentStrategy.ROLLING_UPDATE);
-        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(clusterName,
-            mm2 -> mm2.getSpec().getTemplate().getDeployment().setDeploymentStrategy(DeploymentStrategy.ROLLING_UPDATE), namespaceName);
-        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(namespaceName, clusterName);
+        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(testStorage.getClusterName(),
+            mm2 -> mm2.getSpec().getTemplate().getDeployment().setDeploymentStrategy(DeploymentStrategy.ROLLING_UPDATE), testStorage.getNamespaceName());
+        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         LOGGER.info("Adding another label to MirrorMaker2 resource, pods should be rolled");
-        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(clusterName, mm2 -> mm2.getMetadata().getLabels().put("another", "label"), namespaceName);
-        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, mm2DepName, 1);
+        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(testStorage.getClusterName(), mm2 -> mm2.getMetadata().getLabels().put("another", "label"), testStorage.getNamespaceName());
+        DeploymentUtils.waitForDeploymentAndPodsReady(testStorage.getNamespaceName(), mm2DepName, 1);
 
         LOGGER.info("Checking that observed gen. higher (rolling update) and label is changed");
-        kmm2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get();
+        kmm2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
         assertThat(kmm2.getStatus().getObservedGeneration(), is(2L));
         assertThat(kmm2.getMetadata().getLabels().toString(), containsString("another=label"));
         assertThat(kmm2.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(DeploymentStrategy.ROLLING_UPDATE));
     }
 
     @ParallelNamespaceTest
-    @SuppressWarnings({"checkstyle:MethodLength"})
     void testRestoreOffsetsInConsumerGroup(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String kafkaClusterSourceName = clusterName + "-source";
-        final String kafkaClusterTargetName = clusterName + "-target";
-        final String syncGroupOffsetsIntervalSeconds = "1";
-        final String topicSourceNameMirrored = "test-sync-offset-" + new Random().nextInt(Integer.MAX_VALUE);
-        final String topicTargetNameMirrored = kafkaClusterSourceName + "." + topicSourceNameMirrored;
-        final String consumerGroup = "mm2-test-consumer-group";
-        final String sourceProducerName = "mm2-producer-source-" + ClientUtils.generateRandomConsumerGroup();
-        final String sourceConsumerName = "mm2-consumer-source-" + ClientUtils.generateRandomConsumerGroup();
-        final String targetProducerName = "mm2-producer-target-" + ClientUtils.generateRandomConsumerGroup();
-        final String targetConsumerName = "mm2-consumer-target-" + ClientUtils.generateRandomConsumerGroup();
-        final String mm2SrcTrgName = clusterName + "-src-trg";
-        final String mm2TrgSrcName = clusterName + "-trg-src";
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
-        resourceManager.createResource(extensionContext, false,
-            // Deploy source kafka
-            KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1, 1).build(),
-            // Deploy target kafka
-            KafkaTemplates.kafkaPersistent(kafkaClusterTargetName, 1, 1).build()
-        );
+        final String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        final String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
 
-        // Wait for Kafka clusters readiness
-        KafkaUtils.waitForKafkaReady(namespaceName, kafkaClusterSourceName);
-        KafkaUtils.waitForKafkaReady(namespaceName, kafkaClusterTargetName);
+        final String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
+        final String consumerGroup = ClientUtils.generateRandomConsumerGroup();
+
+        final String sourceProducerName = testStorage.getProducerName() + "-source";
+        final String sourceConsumerName = testStorage.getConsumerName() + "-source";
+
+        final String targetProducerName = testStorage.getProducerName() + "-target";
+        final String targetConsumerName = testStorage.getProducerName() + "-target";
 
         resourceManager.createResource(extensionContext,
-            // MM2 Active (S) <-> Active (T) // direction S -> T mirroring
-            // *.replication.factor(s) to 1 are added just to speed up test by using only 1 ZK and 1 Kafka
-            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(mm2TrgSrcName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+            KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1).build(),
+            KafkaTemplates.kafkaPersistent(kafkaClusterTargetName, 1).build()
+        );
+
+        Map<String, Object> sourceConnectorConfig = new HashMap<>();
+        sourceConnectorConfig.put("refresh.topics.interval.seconds", "1");
+        sourceConnectorConfig.put("replication.factor", "1");
+        sourceConnectorConfig.put("offset-syncs.topic.replication.factor", "1");
+
+        Map<String, Object> checkpointConnectorConfig = new HashMap<>();
+        checkpointConnectorConfig.put("refresh.groups.interval.seconds", "1");
+        checkpointConnectorConfig.put("sync.group.offsets.enabled", "true");
+        checkpointConnectorConfig.put("sync.group.offsets.interval.seconds", "1");
+        checkpointConnectorConfig.put("emit.checkpoints.enabled", "true");
+        checkpointConnectorConfig.put("emit.checkpoints.interval.seconds", "1");
+        checkpointConnectorConfig.put("checkpoints.topic.replication.factor", "1");
+
+        Map<String, Object> heartbeatConnectorConfig = new HashMap<>();
+        heartbeatConnectorConfig.put("heartbeats.topic.replication.factor", "1");
+
+        resourceManager.createResource(extensionContext,
+            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(kafkaClusterSourceName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
                 .editSpec()
-                .editFirstMirror()
-                    .editSourceConnector()
-                        .addToConfig("refresh.topics.interval.seconds", "1")
-                        .addToConfig("replication.factor", "1")
-                        .addToConfig("offset-syncs.topic.replication.factor", "1")
-                    .endSourceConnector()
-                    .editCheckpointConnector()
-                        .addToConfig("refresh.groups.interval.seconds", "1")
-                        .addToConfig("sync.group.offsets.enabled", "true")
-                        .addToConfig("sync.group.offsets.interval.seconds", syncGroupOffsetsIntervalSeconds)
-                        .addToConfig("emit.checkpoints.enabled", "true")
-                        .addToConfig("emit.checkpoints.interval.seconds", "1")
-                        .addToConfig("checkpoints.topic.replication.factor", "1")
-                    .endCheckpointConnector()
-                    .editHeartbeatConnector()
-                        .addToConfig("heartbeats.topic.replication.factor", "1")
-                    .endHeartbeatConnector()
-                    .withTopicsPattern(".*")
-                    .withGroupsPattern(".*")
-                .endMirror()
-            .endSpec().build(),
-            // MM2 Active (S) <-> Active (T) // direction S <- T mirroring
-            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(mm2SrcTrgName, kafkaClusterSourceName, kafkaClusterTargetName, 1, false)
+                    .editFirstMirror()
+                        .editSourceConnector()
+                            .addToConfig(sourceConnectorConfig)
+                        .endSourceConnector()
+                        .editCheckpointConnector()
+                            .addToConfig(checkpointConnectorConfig)
+                        .endCheckpointConnector()
+                        .editHeartbeatConnector()
+                            .addToConfig(heartbeatConnectorConfig)
+                        .endHeartbeatConnector()
+                        .withTopicsPattern(".*")
+                        .withGroupsPattern(".*")
+                    .endMirror()
+                .endSpec()
+                .build(),
+            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(kafkaClusterTargetName, kafkaClusterSourceName, kafkaClusterTargetName, 1, false)
                 .editSpec()
-                .editFirstMirror()
-                    .editSourceConnector()
-                        .addToConfig("refresh.topics.interval.seconds", "1")
-                        .addToConfig("replication.factor", "1")
-                        .addToConfig("offset-syncs.topic.replication.factor", "1")
-                    .endSourceConnector()
-                    .editCheckpointConnector()
-                        .addToConfig("refresh.groups.interval.seconds", "1")
-                        .addToConfig("sync.group.offsets.enabled", "true")
-                        .addToConfig("sync.group.offsets.interval.seconds", syncGroupOffsetsIntervalSeconds)
-                        .addToConfig("emit.checkpoints.enabled", "true")
-                        .addToConfig("emit.checkpoints.interval.seconds", "1")
-                        .addToConfig("checkpoints.topic.replication.factor", "1")
-                    .endCheckpointConnector()
-                    .editHeartbeatConnector()
-                        .addToConfig("heartbeats.topic.replication.factor", "1")
-                    .endHeartbeatConnector()
-                    .withTopicsPattern(".*")
-                    .withGroupsPattern(".*")
-                .endMirror()
-            .endSpec().build(),
-            // deploy topic
-            KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceNameMirrored, 3).build());
+                    .editFirstMirror()
+                        .editSourceConnector()
+                            .addToConfig(sourceConnectorConfig)
+                        .endSourceConnector()
+                        .editCheckpointConnector()
+                            .addToConfig(checkpointConnectorConfig)
+                        .endCheckpointConnector()
+                        .editHeartbeatConnector()
+                            .addToConfig(heartbeatConnectorConfig)
+                        .endHeartbeatConnector()
+                        .withTopicsPattern(".*")
+                        .withGroupsPattern(".*")
+                    .endMirror()
+                .endSpec()
+                .build(),
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build()
+        );
 
         KafkaClients initialInternalClientSourceJob = new KafkaClientsBuilder()
                 .withProducerName(sourceProducerName)
                 .withConsumerName(sourceConsumerName)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
-                .withTopicName(topicSourceNameMirrored)
+                .withTopicName(testStorage.getTopicName())
                 .withMessageCount(MESSAGE_COUNT)
                 .withMessage("Producer A")
                 .withConsumerGroup(consumerGroup)
-                .withNamespaceName(namespaceName)
+                .withNamespaceName(testStorage.getNamespaceName())
                 .build();
 
         KafkaClients initialInternalClientTargetJob = new KafkaClientsBuilder()
                 .withProducerName(targetProducerName)
                 .withConsumerName(targetConsumerName)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
-                .withTopicName(topicTargetNameMirrored)
+                .withTopicName(sourceMirroredTopicName)
                 .withMessageCount(MESSAGE_COUNT)
                 .withConsumerGroup(consumerGroup)
-                .withNamespaceName(namespaceName)
+                .withNamespaceName(testStorage.getNamespaceName())
                 .build();
 
         LOGGER.info("Send & receive {} messages to/from Source cluster.", MESSAGE_COUNT);
@@ -1083,35 +845,34 @@ class MirrorMaker2IsolatedST extends AbstractST {
             initialInternalClientSourceJob.producerStrimzi(),
             initialInternalClientSourceJob.consumerStrimzi());
 
-        ClientUtils.waitForClientSuccess(sourceProducerName, namespaceName, MESSAGE_COUNT);
-        ClientUtils.waitForClientSuccess(sourceConsumerName, namespaceName, MESSAGE_COUNT);
+        ClientUtils.waitForClientsSuccess(sourceProducerName, sourceConsumerName, testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Send {} messages to Source cluster.", MESSAGE_COUNT);
         KafkaClients internalClientSourceJob = new KafkaClientsBuilder(initialInternalClientSourceJob).withMessage("Producer B").build();
 
         resourceManager.createResource(extensionContext,
             internalClientSourceJob.producerStrimzi());
-        ClientUtils.waitForClientSuccess(sourceProducerName, namespaceName, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(sourceProducerName, testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Wait 1 second as 'sync.group.offsets.interval.seconds=1'. As this is insignificant wait, we're skipping it");
 
         LOGGER.info("Receive {} messages from mirrored topic on Target cluster.", MESSAGE_COUNT);
         resourceManager.createResource(extensionContext,
             initialInternalClientTargetJob.consumerStrimzi());
-        ClientUtils.waitForClientSuccess(targetConsumerName, namespaceName, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(targetConsumerName, testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Send 50 messages to Source cluster");
         internalClientSourceJob = new KafkaClientsBuilder(internalClientSourceJob).withMessageCount(50).withMessage("Producer C").build();
         resourceManager.createResource(extensionContext,
             internalClientSourceJob.producerStrimzi());
-        ClientUtils.waitForClientSuccess(sourceProducerName, namespaceName, 50);
+        ClientUtils.waitForClientSuccess(sourceProducerName, testStorage.getNamespaceName(), 50);
 
         LOGGER.info("Wait 1 second as 'sync.group.offsets.interval.seconds=1'. As this is insignificant wait, we're skipping it");
         LOGGER.info("Receive 10 msgs from source cluster");
         internalClientSourceJob = new KafkaClientsBuilder(internalClientSourceJob).withMessageCount(10).withAdditionalConfig("max.poll.records=10").build();
         resourceManager.createResource(extensionContext,
             internalClientSourceJob.consumerStrimzi());
-        ClientUtils.waitForClientSuccess(sourceConsumerName, namespaceName, 10);
+        ClientUtils.waitForClientSuccess(sourceConsumerName, testStorage.getNamespaceName(), 10);
 
         LOGGER.info("Wait 1 second as 'sync.group.offsets.interval.seconds=1'. As this is insignificant wait, we're skipping it");
 
@@ -1119,27 +880,27 @@ class MirrorMaker2IsolatedST extends AbstractST {
         KafkaClients internalClientTargetJob = new KafkaClientsBuilder(initialInternalClientTargetJob).withMessageCount(40).build();
         resourceManager.createResource(extensionContext,
             internalClientTargetJob.consumerStrimzi());
-        ClientUtils.waitForClientSuccess(targetConsumerName, namespaceName, 40);
+        ClientUtils.waitForClientSuccess(targetConsumerName, testStorage.getNamespaceName(), 40);
 
         LOGGER.info("There should be no more messages to read. Try to consume at least 1 message. " +
                 "This client job should fail on timeout.");
         resourceManager.createResource(extensionContext,
             initialInternalClientTargetJob.consumerStrimzi());
-        assertDoesNotThrow(() -> ClientUtils.waitForClientTimeout(targetConsumerName, namespaceName, 1));
+        assertDoesNotThrow(() -> ClientUtils.waitForClientTimeout(targetConsumerName, testStorage.getNamespaceName(), 1));
 
         LOGGER.info("As it's Active-Active MM2 mode, there should be no more messages to read from Source cluster" +
                 " topic. This client job should fail on timeout.");
         resourceManager.createResource(extensionContext,
             initialInternalClientSourceJob.consumerStrimzi());
-        assertDoesNotThrow(() -> ClientUtils.waitForClientTimeout(sourceConsumerName, namespaceName, 1));
+        assertDoesNotThrow(() -> ClientUtils.waitForClientTimeout(sourceConsumerName, testStorage.getNamespaceName(), 1));
     }
 
     @ParallelNamespaceTest
     void testKafkaMirrorMaker2ReflectsConnectorsState(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
         String errorMessage = "One or more connectors are in FAILED state";
 
         resourceManager.createResource(extensionContext,
@@ -1147,7 +908,7 @@ class MirrorMaker2IsolatedST extends AbstractST {
             KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
 
         resourceManager.createResource(extensionContext, false,
-            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
+            KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, false)
                 .editSpec()
                     .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterSourceName))
                         // typo in bootstrap name, connectors should not connect and MM2 should be in NotReady state with error
@@ -1156,15 +917,15 @@ class MirrorMaker2IsolatedST extends AbstractST {
                 .endSpec()
                 .build());
 
-        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2StatusMessage(namespaceName, clusterName, errorMessage);
+        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2StatusMessage(testStorage.getNamespaceName(), testStorage.getClusterName(), errorMessage);
 
-        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(clusterName, mm2 ->
+        KafkaMirrorMaker2Resource.replaceKafkaMirrorMaker2ResourceInSpecificNamespace(testStorage.getClusterName(), mm2 ->
             mm2.getSpec().getClusters().stream().filter(mm2ClusterSpec -> mm2ClusterSpec.getAlias().equals(kafkaClusterSourceName))
-                .findFirst().get().setBootstrapServers(KafkaUtils.namespacedPlainBootstrapAddress(kafkaClusterSourceName, namespaceName)), namespaceName);
+                .findFirst().get().setBootstrapServers(KafkaUtils.namespacedPlainBootstrapAddress(kafkaClusterSourceName, testStorage.getNamespaceName())), testStorage.getNamespaceName());
 
-        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(namespaceName, clusterName);
+        KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(testStorage.getNamespaceName(), testStorage.getClusterName());
 
-        KafkaMirrorMaker2Status kmm2Status = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(namespaceName).withName(clusterName).get().getStatus();
+        KafkaMirrorMaker2Status kmm2Status = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus();
         assertFalse(kmm2Status.getConditions().stream().anyMatch(condition -> condition.getMessage() != null && condition.getMessage().contains(errorMessage)));
     }
 
@@ -1174,19 +935,16 @@ class MirrorMaker2IsolatedST extends AbstractST {
      */
     @ParallelNamespaceTest
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void testKMM2RollAfterSecretsCertsUpdateScramsha(ExtensionContext extensionContext) {
+    void testKMM2RollAfterSecretsCertsUpdateScramSha(ExtensionContext extensionContext) {
         TestStorage testStorage = new TestStorage(extensionContext);
 
         String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
         String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
-        String topicSourceNameA = MIRRORMAKER2_TOPIC_NAME + "-a-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicSourceNameB = MIRRORMAKER2_TOPIC_NAME + "-b-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicTargetNameA = kafkaClusterSourceName + "." + topicSourceNameA;
-        String topicTargetNameB = kafkaClusterSourceName + "." + topicSourceNameB;
 
-        String kafkaUserSourceName = testStorage.getClusterName() + "-my-user-source";
-        String kafkaUserTargetName = testStorage.getClusterName() + "-my-user-target";
-        String kafkaTlsScramListenerName = "tlsscram";
+        String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
+
+        String kafkaUserSourceName = testStorage.getUserName() + "-source";
+        String kafkaUserTargetName = testStorage.getUserName() + "-target";
 
         // Deploy source kafka with tls listener and SCRAM-SHA authentication
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1, 1)
@@ -1194,19 +952,13 @@ class MirrorMaker2IsolatedST extends AbstractST {
                 .editKafka()
                     .withListeners(
                         new GenericKafkaListenerBuilder()
-                            .withName(kafkaTlsScramListenerName)
+                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
                             .withPort(9093)
                             .withType(KafkaListenerType.INTERNAL)
                             .withTls(true)
                             .withAuth(new KafkaListenerAuthenticationScramSha512())
-                            .build(),
-                        new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9094)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationTls())
-                            .build())
+                            .build()
+                    )
                 .endKafka()
             .endSpec()
             .build());
@@ -1217,33 +969,22 @@ class MirrorMaker2IsolatedST extends AbstractST {
                 .editKafka()
                     .withListeners(
                         new GenericKafkaListenerBuilder()
-                            .withName(kafkaTlsScramListenerName)
+                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
                             .withPort(9093)
                             .withType(KafkaListenerType.INTERNAL)
                             .withTls(true)
                             .withAuth(new KafkaListenerAuthenticationScramSha512())
-                            .build(),
-                        new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9094)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationTls())
-                            .build())
+                            .build()
+                    )
                 .endKafka()
             .endSpec()
             .build());
 
-        // Deploy topic
         resourceManager.createResource(extensionContext,
-            KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceNameA).build(),
-            KafkaTopicTemplates.topic(kafkaClusterTargetName, topicSourceNameB).build()
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName()).build(),
+            KafkaUserTemplates.scramShaUser(kafkaClusterSourceName, kafkaUserSourceName).build(),
+            KafkaUserTemplates.scramShaUser(kafkaClusterTargetName, kafkaUserTargetName).build()
         );
-
-        // Create Kafka user for source and target cluster
-        KafkaUser userSource = KafkaUserTemplates.scramShaUser(kafkaClusterSourceName, kafkaUserSourceName).build();
-        KafkaUser userTarget = KafkaUserTemplates.scramShaUser(kafkaClusterTargetName, kafkaUserTargetName).build();
-        resourceManager.createResource(extensionContext, userSource, userTarget);
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in Source/Target MirrorMaker2 spec
         PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
@@ -1264,81 +1005,67 @@ class MirrorMaker2IsolatedST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
-        // Deploy client
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(testStorage.getNamespaceName(), true, testStorage.getKafkaClientsName(), userSource, userTarget).build());
-        String kafkaClientsPodName = kubeClient().listPodsByPrefixInName(testStorage.getKafkaClientsName()).get(0).getMetadata().getName();
-
-        KafkaMirrorMaker2ClusterSpec sourceClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder()
-            .withAlias(kafkaClusterSourceName)
-            .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
-            .withNewKafkaClientAuthenticationScramSha512()
-                .withUsername(kafkaUserSourceName)
-                .withPasswordSecret(passwordSecretSource)
-            .endKafkaClientAuthenticationScramSha512()
-            .withNewTls()
-                .withTrustedCertificates(certSecretSource)
-            .endTls()
-            .build();
-
-        KafkaMirrorMaker2ClusterSpec targetClusterWithScramSha512Auth = new KafkaMirrorMaker2ClusterSpecBuilder()
-            .withAlias(kafkaClusterTargetName)
-            .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
-            .withNewKafkaClientAuthenticationScramSha512()
-                .withUsername(kafkaUserTargetName)
-                .withPasswordSecret(passwordSecretTarget)
-            .endKafkaClientAuthenticationScramSha512()
-            .withNewTls()
-                .withTrustedCertificates(certSecretTarget)
-            .endTls()
-            .addToConfig("config.storage.replication.factor", -1)
-            .addToConfig("offset.storage.replication.factor", -1)
-            .addToConfig("status.storage.replication.factor", -1)
-            .build();
-
         resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
-                .withClusters(targetClusterWithScramSha512Auth, sourceClusterWithScramSha512Auth)
-                    .editFirstMirror()
-                        .editSourceConnector()
-                            .addToConfig("refresh.topics.interval.seconds", 1)
-                        .endSourceConnector()
-                    .endMirror()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterSourceName))
+                    .withNewKafkaClientAuthenticationScramSha512()
+                        .withUsername(kafkaUserSourceName)
+                        .withPasswordSecret(passwordSecretSource)
+                    .endKafkaClientAuthenticationScramSha512()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretSource)
+                    .endTls()
+                .endCluster()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterTargetName))
+                    .withNewKafkaClientAuthenticationScramSha512()
+                        .withUsername(kafkaUserTargetName)
+                        .withPasswordSecret(passwordSecretTarget)
+                    .endKafkaClientAuthenticationScramSha512()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretTarget)
+                    .endTls()
+                .endCluster()
             .endSpec()
             .build());
 
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicSourceNameA)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
             .withNamespaceName(testStorage.getNamespaceName())
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(kafkaUserSourceName)
-            .withMessageCount(messagesCount)
-            .withListenerName(kafkaTlsScramListenerName)
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        int sent = internalKafkaClient.sendMessagesTls();
-        internalKafkaClient.checkProducedAndConsumedMessages(sent, internalKafkaClient.receiveMessagesTls());
+        resourceManager.createResource(extensionContext, clients.producerScramShaTlsStrimzi(kafkaClusterSourceName), clients.consumerScramShaTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetNameA)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(kafkaUserTargetName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
         LOGGER.info("Now messages should be mirrored to target topic and cluster");
-        internalKafkaClient.checkProducedAndConsumedMessages(sent, internalKafkaClient.receiveMessagesTls());
+
+        resourceManager.createResource(extensionContext, clients.consumerScramShaTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
         LOGGER.info("Messages successfully mirrored");
 
         String kmm2DeploymentName = KafkaMirrorMaker2Resources.deploymentName(testStorage.getClusterName());
         Map<String, String> mmSnapshot = DeploymentUtils.depSnapshot(testStorage.getNamespaceName(), kmm2DeploymentName);
+
         LOGGER.info("Changing KafkaUser sha-password on KMM2 Source and make sure it rolled");
+
         Secret passwordSource = new SecretBuilder()
             .withNewMetadata()
                 .withName(kafkaUserSourceName)
             .endMetadata()
             .addToData("password", "c291cmNlLXBhc3N3b3Jk")
             .build();
+
         kubeClient().patchSecret(testStorage.getNamespaceName(), kafkaUserSourceName, passwordSource);
         mmSnapshot = DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), kmm2DeploymentName, 1, mmSnapshot);
 
@@ -1349,32 +1076,30 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .endMetadata()
             .addToData("password", "dGFyZ2V0LXBhc3N3b3Jk")
             .build();
+
         kubeClient().patchSecret(testStorage.getNamespaceName(), kafkaUserTargetName, passwordTarget);
         DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), kmm2DeploymentName, 1, mmSnapshot);
 
-        LOGGER.info("Recreate kafkaClients pod with new passwords.");
-        resourceManager.deleteResource(kubeClient().namespace(testStorage.getNamespaceName()).getDeployment(testStorage.getKafkaClientsName()));
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(testStorage.getNamespaceName(), true, testStorage.getKafkaClientsName(), userSource, userTarget).build());
-        kafkaClientsPodName = kubeClient().listPodsByPrefixInName(testStorage.getKafkaClientsName()).get(0).getMetadata().getName();
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicSourceNameB)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(kafkaUserSourceName)
-            .withListenerName(kafkaTlsScramListenerName)
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(testStorage.getTopicName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
             .build();
-        sent = internalKafkaClient.sendMessagesTls();
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetNameB)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(kafkaUserTargetName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        resourceManager.createResource(extensionContext, clients.producerScramShaTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
         LOGGER.info("Now messages should be mirrored to target topic and cluster");
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(sent);
+
+        resourceManager.createResource(extensionContext, clients.consumerScramShaTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
         LOGGER.info("Messages successfully mirrored");
     }
 
@@ -1385,14 +1110,11 @@ class MirrorMaker2IsolatedST extends AbstractST {
 
         String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
         String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
-        String topicSourceNameA = MIRRORMAKER2_TOPIC_NAME + "-a-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicSourceNameB = MIRRORMAKER2_TOPIC_NAME + "-b-" + rng.nextInt(Integer.MAX_VALUE);
-        String topicTargetNameA = kafkaClusterSourceName + "." + topicSourceNameA;
-        String topicTargetNameB = kafkaClusterSourceName + "." + topicSourceNameB;
-        String kafkaUserSourceName = testStorage.getClusterName() + "-my-user-source";
-        String kafkaUserTargetName = testStorage.getClusterName() + "-my-user-target";
-        String kafkaTlsScramListenerName = "tlsscram";
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+
+        String sourceMirroredTopicName = kafkaClusterSourceName + "." + testStorage.getTopicName();
+
+        String kafkaUserSourceName = testStorage.getUserName() + "-source";
+        String kafkaUserTargetName = testStorage.getUserName() + "-target";
 
         // Deploy source kafka with tls listener and mutual tls auth
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1)
@@ -1426,44 +1148,11 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .endSpec()
             .build());
 
-        // Deploy topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceNameA, 1).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceNameB, 1).build());
-
-        // Create Kafka user
-        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build();
-        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build();
-
-        resourceManager.createResource(extensionContext, userSource);
-        resourceManager.createResource(extensionContext, userTarget);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(testStorage.getNamespaceName(), true, kafkaClientsName, userSource, userTarget).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(testStorage.getNamespaceName(), kafkaClientsName).get(0).getMetadata().getName();
-
-        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicTestName1 = baseTopic + "-test-1";
-        String topicTestName2 = baseTopic + "-test-2";
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterTargetName, topicTestName2).build());
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicTestName1)
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(kafkaUserSourceName)
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .build();
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .withTopicName(topicTestName2)
-            .withKafkaUsername(kafkaUserTargetName)
-            .build();
-
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), 3).build(),
+            KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaUserSourceName).build(),
+            KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaUserTargetName).build()
+        );
 
         // Initialize CertSecretSource with certificate and secret names for source
         CertSecretSource certSecretSource = new CertSecretSource();
@@ -1475,75 +1164,72 @@ class MirrorMaker2IsolatedST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
-        // Deploy Mirror Maker 2.0 with tls listener and mutual tls auth
-        KafkaMirrorMaker2ClusterSpec sourceClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-            .withAlias(kafkaClusterSourceName)
-            .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
-            .withNewKafkaClientAuthenticationTls()
-                .withNewCertificateAndKey()
-                    .withSecretName(kafkaUserSourceName)
-                    .withCertificate("user.crt")
-                    .withKey("user.key")
-                .endCertificateAndKey()
-            .endKafkaClientAuthenticationTls()
-            .withNewTls()
-                .withTrustedCertificates(certSecretSource)
-            .endTls()
-            .build();
-
-        KafkaMirrorMaker2ClusterSpec targetClusterWithTlsAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
-            .withAlias(kafkaClusterTargetName)
-            .withBootstrapServers(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
-            .withNewKafkaClientAuthenticationTls()
-                .withNewCertificateAndKey()
-                    .withSecretName(kafkaUserTargetName)
-                    .withCertificate("user.crt")
-                    .withKey("user.key")
-                .endCertificateAndKey()
-            .endKafkaClientAuthenticationTls()
-            .withNewTls()
-                .withTrustedCertificates(certSecretTarget)
-            .endTls()
-            .addToConfig("config.storage.replication.factor", -1)
-            .addToConfig("offset.storage.replication.factor", -1)
-            .addToConfig("status.storage.replication.factor", -1)
-            .build();
-
         resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, 1, true)
             .editSpec()
-                .withClusters(targetClusterWithTlsAuth, sourceClusterWithTlsAuth)
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterSourceName))
+                    .withNewKafkaClientAuthenticationTls()
+                        .withNewCertificateAndKey()
+                            .withSecretName(kafkaUserSourceName)
+                            .withCertificate("user.crt")
+                            .withKey("user.key")
+                        .endCertificateAndKey()
+                    .endKafkaClientAuthenticationTls()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretSource)
+                    .endTls()
+                .endCluster()
+                .editMatchingCluster(spec -> spec.getAlias().equals(kafkaClusterTargetName))
+                    .withNewKafkaClientAuthenticationTls()
+                        .withNewCertificateAndKey()
+                            .withSecretName(kafkaUserTargetName)
+                            .withCertificate("user.crt")
+                            .withKey("user.key")
+                        .endCertificateAndKey()
+                    .endKafkaClientAuthenticationTls()
+                    .withNewTls()
+                        .withTrustedCertificates(certSecretTarget)
+                    .endTls()
+                .endCluster()
                 .editFirstMirror()
-                    .withTopicsPattern(MIRRORMAKER2_TOPIC_NAME + ".*")
                         .editSourceConnector()
                             .addToConfig("refresh.topics.interval.seconds", 1)
                         .endSourceConnector()
                 .endMirror()
             .endSpec()
             .build());
+
         String mm2DeploymentName = KafkaMirrorMaker2Resources.deploymentName(testStorage.getClusterName());
         Map<String, String> mmSnapshot = DeploymentUtils.depSnapshot(testStorage.getNamespaceName(), mm2DeploymentName);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceNameA)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(kafkaUserSourceName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(kafkaClusterSourceName), clients.consumerTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetNameA)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(kafkaUserTargetName)
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
-        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
-        assertThat(internalKafkaClient.receiveMessagesTls(), is(messagesCount));
+        LOGGER.info("Consumer in target cluster and topic should receive {} messages", MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
         LOGGER.info("Messages successfully mirrored");
 
         LabelSelector zkSourceSelector = KafkaResource.getLabelSelector(kafkaClusterSourceName, KafkaResources.zookeeperStatefulSetName(kafkaClusterSourceName));
         LabelSelector kafkaSourceSelector = KafkaResource.getLabelSelector(kafkaClusterSourceName, KafkaResources.kafkaStatefulSetName(kafkaClusterSourceName));
+
         LabelSelector zkTargetSelector = KafkaResource.getLabelSelector(kafkaClusterTargetName, KafkaResources.zookeeperStatefulSetName(kafkaClusterTargetName));
         LabelSelector kafkaTargetSelector = KafkaResource.getLabelSelector(kafkaClusterTargetName, KafkaResources.kafkaStatefulSetName(kafkaClusterTargetName));
 
@@ -1552,7 +1238,7 @@ class MirrorMaker2IsolatedST extends AbstractST {
         Map<String, String> eoSourcePods = DeploymentUtils.depSnapshot(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(kafkaClusterSourceName));
         Map<String, String> kafkaTargetPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaTargetSelector);
         Map<String, String> zkTargetPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), zkTargetSelector);
-        Map<String, String> eoTargetPods = DeploymentUtils.depSnapshot(KafkaResources.entityOperatorDeploymentName(kafkaClusterTargetName));
+        Map<String, String> eoTargetPods = DeploymentUtils.depSnapshot(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(kafkaClusterTargetName));
 
         LOGGER.info("Renew Clients CA secret for Source cluster via annotation");
         String sourceClientsCaSecretName = KafkaResources.clientsCaCertificateSecretName(kafkaClusterSourceName);
@@ -1567,63 +1253,85 @@ class MirrorMaker2IsolatedST extends AbstractST {
         mmSnapshot = DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), mm2DeploymentName, 1, mmSnapshot);
 
         LOGGER.info("Send and receive messages after clients certs were removed");
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceNameA)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(kafkaUserSourceName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(testStorage.getTopicName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(messagesCount);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetNameA)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(kafkaUserTargetName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        LOGGER.info("Consumer in target cluster and topic should receive {} messages", MESSAGE_COUNT);
+
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
-        LOGGER.info("Consumer in target cluster and topic should receive {} messages", (2 * messagesCount));
-        assertThat(internalKafkaClient.receiveMessagesTls(), is(2 * messagesCount));
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
         LOGGER.info("Messages successfully mirrored");
 
         LOGGER.info("Renew Cluster CA secret for Source clusters via annotation");
         String sourceClusterCaSecretName = KafkaResources.clusterCaCertificateSecretName(kafkaClusterSourceName);
         SecretUtils.annotateSecret(testStorage.getNamespaceName(), sourceClusterCaSecretName, Ca.ANNO_STRIMZI_IO_FORCE_RENEW, "true");
-        zkSourcePods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), zkSourceSelector, 1, zkSourcePods);
-        kafkaSourcePods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), kafkaSourceSelector, 1, kafkaSourcePods);
-        eoSourcePods = DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(kafkaClusterSourceName), 1, eoSourcePods);
+
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), zkSourceSelector, 1, zkSourcePods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), kafkaSourceSelector, 1, kafkaSourcePods);
+        DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(kafkaClusterSourceName), 1, eoSourcePods);
         mmSnapshot = DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), mm2DeploymentName, 1, mmSnapshot);
 
         LOGGER.info("Renew Cluster CA secret for Target clusters via annotation");
         String targetClusterCaSecretName = KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName);
         SecretUtils.annotateSecret(testStorage.getNamespaceName(), targetClusterCaSecretName, Ca.ANNO_STRIMZI_IO_FORCE_RENEW, "true");
-        zkTargetPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), zkTargetSelector, 1, zkTargetPods);
-        kafkaTargetPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), kafkaTargetSelector, 1, kafkaTargetPods);
-        eoTargetPods = DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(kafkaClusterTargetName), 1, eoTargetPods);
+
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), zkTargetSelector, 1, zkTargetPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), kafkaTargetSelector, 1, kafkaTargetPods);
+        DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(kafkaClusterTargetName), 1, eoTargetPods);
         DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), mm2DeploymentName, 1, mmSnapshot);
 
         LOGGER.info("Send and receive messages after clients certs were removed");
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceNameB)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(kafkaUserSourceName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(testStorage.getTopicName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withUserName(kafkaUserSourceName)
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(messagesCount);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTargetNameB)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(kafkaUserTargetName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        LOGGER.info("Consumer in target cluster and topic should receive {} messages", MESSAGE_COUNT);
+
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(sourceMirroredTopicName)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaUserTargetName)
             .build();
 
-        LOGGER.info("Consumer in target cluster and topic should receive {} messages", messagesCount);
-        assertThat(internalKafkaClient.receiveMessagesTls(), is(messagesCount));
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
         LOGGER.info("Messages successfully mirrored");
+    }
+
+    private void testDockerImagesForKafkaMirrorMaker2(String clusterName, String clusterOperatorNamespace, String mirrorMakerNamespace) {
+        LOGGER.info("Verifying docker image names");
+        // we must use INFRA_NAMESPACE because there is CO deployed
+        Map<String, String> imgFromDeplConf = getImagesFromConfig(clusterOperatorNamespace);
+        // Verifying docker image for kafka mirrormaker2
+        String mirrormaker2ImageName = PodUtils.getFirstContainerImageNameFromPod(mirrorMakerNamespace, kubeClient(mirrorMakerNamespace).listPods(mirrorMakerNamespace, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND)
+            .get(0).getMetadata().getName());
+
+        String mirrormaker2Version = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(mirrorMakerNamespace).withName(clusterName).get().getSpec().getVersion();
+        if (mirrormaker2Version == null) {
+            mirrormaker2Version = Environment.ST_KAFKA_VERSION;
+        }
+
+        assertThat(TestUtils.parseImageMap(imgFromDeplConf.get(KAFKA_MIRROR_MAKER_2_IMAGE_MAP)).get(mirrormaker2Version), is(mirrormaker2ImageName));
+        LOGGER.info("Docker images verified");
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerIsolatedST.java
@@ -10,7 +10,6 @@ import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.PasswordSecretSource;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationScramSha512;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationTls;
@@ -23,11 +22,12 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMakerResource;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaMirrorMakerTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.rmi.UnexpectedException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -64,6 +65,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(REGRESSION)
 @Tag(MIRROR_MAKER)
@@ -73,51 +75,37 @@ public class MirrorMakerIsolatedST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(MirrorMakerIsolatedST.class);
 
-    private final int messagesCount = 200;
-
     @ParallelNamespaceTest
     void testMirrorMaker(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
 
         Map<String, String> jvmOptionsXX = new HashMap<>();
         jvmOptionsXX.put("UseG1GC", "true");
 
-        String topicSourceName = TOPIC_NAME + "-source" + "-" + rng.nextInt(Integer.MAX_VALUE);
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build()
+        );
 
-        // Deploy source kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        // Deploy target kafka
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
-        // Deploy Topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName).build());
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName()).build());
 
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName("topic-for-test-broker-1")
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        // Check brokers availability
-        internalKafkaClient.produceAndConsumesPlainMessagesUntilBothOperationsAreSuccessful();
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName("topic-for-test-broker-2")
-            .withClusterName(kafkaClusterTargetName)
-            .build();
-
-        internalKafkaClient.produceAndConsumesPlainMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Deploy Mirror Maker
-        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false)
+        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false)
             .editSpec()
             .withResources(new ResourceRequirementsBuilder()
                     .addToLimits("memory", new Quantity("400M"))
@@ -133,38 +121,31 @@ public class MirrorMakerIsolatedST extends AbstractST {
             .endSpec()
             .build());
 
-        verifyLabelsOnPods(namespaceName, clusterName, "mirror-maker", "KafkaMirrorMaker");
-        verifyLabelsForService(namespaceName, clusterName, "mirror-maker", "KafkaMirrorMaker");
+        verifyLabelsOnPods(testStorage.getNamespaceName(), testStorage.getClusterName(), "mirror-maker", KafkaMirrorMaker.RESOURCE_KIND);
+        verifyLabelsForService(testStorage.getNamespaceName(), testStorage.getClusterName(), "mirror-maker", KafkaMirrorMaker.RESOURCE_KIND);
 
-        verifyLabelsForConfigMaps(namespaceName, kafkaClusterSourceName, null, kafkaClusterTargetName);
-        verifyLabelsForServiceAccounts(namespaceName, kafkaClusterSourceName, null);
+        verifyLabelsForConfigMaps(testStorage.getNamespaceName(), kafkaClusterSourceName, null, kafkaClusterTargetName);
+        verifyLabelsForServiceAccounts(testStorage.getNamespaceName(), kafkaClusterSourceName, null);
 
-        String mirrorMakerPodName = kubeClient(namespaceName).listPodsByPrefixInName(KafkaMirrorMakerResources.deploymentName(clusterName)).get(0).getMetadata().getName();
-        String kafkaMirrorMakerLogs = kubeClient(namespaceName).logs(mirrorMakerPodName);
+        String mmDepName = KafkaMirrorMakerResources.deploymentName(testStorage.getClusterName());
+        String mirrorMakerPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(mmDepName).get(0).getMetadata().getName();
+        String kafkaMirrorMakerLogs = kubeClient(testStorage.getNamespaceName()).logs(mirrorMakerPodName);
 
         assertThat(kafkaMirrorMakerLogs,
             not(containsString("keytool error: java.io.FileNotFoundException: /opt/kafka/consumer-oauth-certs/**/* (No such file or directory)")));
 
-        String podName = kubeClient(namespaceName).listPodsByNamespace(namespaceName, clusterName).stream().filter(n -> n.getMetadata().getName().startsWith(KafkaMirrorMakerResources.deploymentName(clusterName))).findFirst().orElseThrow().getMetadata().getName();
-        assertResources(namespaceName, podName, clusterName.concat("-mirror-maker"),
+        String podName = kubeClient(testStorage.getNamespaceName()).listPodsByNamespace(testStorage.getNamespaceName(), testStorage.getClusterName()).stream().filter(n -> n.getMetadata().getName().startsWith(KafkaMirrorMakerResources.deploymentName(testStorage.getClusterName()))).findFirst().orElseThrow().getMetadata().getName();
+        assertResources(testStorage.getNamespaceName(), podName, mmDepName,
                 "400M", "2", "300M", "1");
-        assertExpectedJavaOpts(namespaceName, podName, KafkaMirrorMakerResources.deploymentName(clusterName),
+        assertExpectedJavaOpts(testStorage.getNamespaceName(), podName, KafkaMirrorMakerResources.deploymentName(testStorage.getClusterName()),
                 "-Xmx200m", "-Xms200m", "-XX:+UseG1GC");
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceName)
-            .withClusterName(kafkaClusterSourceName)
+        clients = new KafkaClientsBuilder(clients)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
-        int sent = internalKafkaClient.sendMessagesPlain();
-
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .build();
-
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     /**
@@ -173,14 +154,14 @@ public class MirrorMakerIsolatedST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void testMirrorMakerTlsAuthenticated(ExtensionContext extensionContext) throws Exception {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String topicSourceName = TOPIC_NAME + "-source" + "-" + rng.nextInt(Integer.MAX_VALUE);
-        String kafkaSourceUserName = clusterName + "-my-user-source";
-        String kafkaTargetUserName = clusterName + "-my-user-target";
+    void testMirrorMakerTlsAuthenticated(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String kafkaSourceUserName = testStorage.getUserName() + "-source";
+        String kafkaTargetUserName = testStorage.getUserName() + "-target";
 
         // Deploy source kafka with tls listener and mutual tls auth
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
@@ -212,15 +193,11 @@ public class MirrorMakerIsolatedST extends AbstractST {
             .endSpec()
             .build());
 
-        // Deploy topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicSourceName).build());
-
-        // createAndWaitForReadiness Kafka user
-        KafkaUser userSource = KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaSourceUserName).build();
-        KafkaUser userTarget = KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaTargetUserName).build();
-
-        resourceManager.createResource(extensionContext, userSource);
-        resourceManager.createResource(extensionContext, userTarget);
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName()).build(),
+            KafkaUserTemplates.tlsUser(kafkaClusterSourceName, kafkaSourceUserName).build(),
+            KafkaUserTemplates.tlsUser(kafkaClusterTargetName, kafkaTargetUserName).build()
+        );
 
         // Initialize CertSecretSource with certificate and secret names for consumer
         CertSecretSource certSecretSource = new CertSecretSource();
@@ -232,41 +209,21 @@ public class MirrorMakerIsolatedST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicTestName1 = baseTopic + "-test-1";
-        String topicTestName2 = baseTopic + "-test-2";
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName2).build());
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicTestName1)
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withUserName(kafkaSourceUserName)
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        // Check brokers availability
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTestName2)
-            .withClusterName(kafkaClusterTargetName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(kafkaClusterSourceName), clients.consumerTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Deploy Mirror Maker with tls listener and mutual tls auth
-        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
+        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
             .editSpec()
                 .editConsumer()
                     .withNewTls()
@@ -295,20 +252,13 @@ public class MirrorMakerIsolatedST extends AbstractST {
             .endSpec()
             .build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicSourceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
+        clients = new KafkaClientsBuilder(clients)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaTargetUserName)
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(internalKafkaClient.getMessageCount());
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     /**
@@ -317,13 +267,13 @@ public class MirrorMakerIsolatedST extends AbstractST {
     @ParallelNamespaceTest
     @SuppressWarnings("checkstyle:methodlength")
     void testMirrorMakerTlsScramSha(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
-        String kafkaUserSource = clusterName + "-my-user-source";
-        String kafkaUserTarget = clusterName + "-my-user-target";
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
+
+        String kafkaSourceUserName = testStorage.getUserName() + "-source";
+        String kafkaTargetUserName = testStorage.getUserName() + "-target";
 
         // Deploy source kafka with tls listener and SCRAM-SHA authentication
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1)
@@ -356,24 +306,20 @@ public class MirrorMakerIsolatedST extends AbstractST {
             .build());
 
         // Deploy topic
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicName).build());
-
-        // createAndWaitForReadiness Kafka user for source cluster
-        KafkaUser userSource = KafkaUserTemplates.scramShaUser(kafkaClusterSourceName, kafkaUserSource).build();
-        // createAndWaitForReadiness Kafka user for target cluster
-        KafkaUser userTarget = KafkaUserTemplates.scramShaUser(kafkaClusterTargetName, kafkaUserTarget).build();
-
-        resourceManager.createResource(extensionContext, userSource);
-        resourceManager.createResource(extensionContext, userTarget);
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName()).build(),
+            KafkaUserTemplates.scramShaUser(kafkaClusterSourceName, kafkaSourceUserName).build(),
+            KafkaUserTemplates.scramShaUser(kafkaClusterTargetName, kafkaTargetUserName).build()
+        );
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in Mirror Maker spec
         PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
-        passwordSecretSource.setSecretName(kafkaUserSource);
+        passwordSecretSource.setSecretName(kafkaSourceUserName);
         passwordSecretSource.setPassword("password");
 
         // Initialize PasswordSecretSource to set this as PasswordSecret in Mirror Maker spec
         PasswordSecretSource passwordSecretTarget = new PasswordSecretSource();
-        passwordSecretTarget.setSecretName(kafkaUserTarget);
+        passwordSecretTarget.setSecretName(kafkaTargetUserName);
         passwordSecretTarget.setPassword("password");
 
         // Initialize CertSecretSource with certificate and secret names for consumer
@@ -386,46 +332,25 @@ public class MirrorMakerIsolatedST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(kafkaClusterTargetName));
 
-        // Deploy client
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, true, clusterName + "-" + Constants.KAFKA_CLIENTS, userSource, userTarget).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        String baseTopic = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String topicTestName1 = baseTopic + "-test-1";
-        String topicTestName2 = baseTopic + "-test-2";
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName1).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicTestName2).build());
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicTestName1)
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
-            .withMessageCount(messagesCount)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withUserName(kafkaSourceUserName)
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        // Check brokers availability
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
-
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicTestName2)
-            .withClusterName(kafkaClusterTargetName)
-            .withKafkaUsername(userTarget.getMetadata().getName())
-            .build();
-
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerScramShaTlsStrimzi(kafkaClusterSourceName), clients.consumerScramShaTlsStrimzi(kafkaClusterSourceName));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Deploy Mirror Maker with TLS and ScramSha512
-        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
+        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, true)
             .editSpec()
                 .editConsumer()
                     .withNewKafkaClientAuthenticationScramSha512()
-                        .withUsername(kafkaUserSource)
+                        .withUsername(kafkaSourceUserName)
                         .withPasswordSecret(passwordSecretSource)
                     .endKafkaClientAuthenticationScramSha512()
                     .withNewTls()
@@ -434,7 +359,7 @@ public class MirrorMakerIsolatedST extends AbstractST {
                 .endConsumer()
                 .editProducer()
                     .withNewKafkaClientAuthenticationScramSha512()
-                        .withUsername(kafkaUserTarget)
+                        .withUsername(kafkaTargetUserName)
                         .withPasswordSecret(passwordSecretTarget)
                     .endKafkaClientAuthenticationScramSha512()
                     .withNewTls()
@@ -444,100 +369,79 @@ public class MirrorMakerIsolatedST extends AbstractST {
             .endSpec()
             .build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName(topicName)
-            .withClusterName(kafkaClusterSourceName)
-            .withKafkaUsername(userSource.getMetadata().getName())
+        clients = new KafkaClientsBuilder(clients)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(kafkaClusterTargetName))
+            .withUserName(kafkaTargetUserName)
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
-        InternalKafkaClient newInternalKafkaClient = internalKafkaClient.toBuilder()
-                .withClusterName(kafkaClusterTargetName)
-                .withKafkaUsername(userTarget.getMetadata().getName())
-                .build();
-        newInternalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(internalKafkaClient.getMessageCount());
+        resourceManager.createResource(extensionContext, clients.consumerScramShaTlsStrimzi(kafkaClusterTargetName));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     @ParallelNamespaceTest
-    void testIncludeList(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+    void testIncludeList(ExtensionContext extensionContext) throws UnexpectedException {
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
 
         String topicName = "included-topic";
         String topicNotIncluded = "not-included-topic";
 
-        LOGGER.info("Creating kafka source cluster {}", kafkaClusterSourceName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        LOGGER.info("Creating kafka target cluster {}", kafkaClusterTargetName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build()
+        );
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicName).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(kafkaClusterSourceName, topicNotIncluded).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, topicName).build(),
+            KafkaTopicTemplates.topic(kafkaClusterSourceName, topicNotIncluded).build()
+        );
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, false, clusterName + "-" + Constants.KAFKA_CLIENTS).build());
-
-        String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, clusterName + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName("topic-example-10")
-            .withNamespaceName(namespaceName)
-            .withClusterName(kafkaClusterSourceName)
-            .withMessageCount(messagesCount)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterSourceName))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
             .build();
 
-        // Check brokers availability
-        internalKafkaClient.produceAndConsumesPlainMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withTopicName("topic-example-11")
-            .withClusterName(kafkaClusterTargetName)
+        clients = new KafkaClientsBuilder(clients)
+            .withTopicName(topicNotIncluded)
             .build();
 
-        internalKafkaClient.produceAndConsumesPlainMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(clusterName, kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false)
+        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), kafkaClusterSourceName, kafkaClusterTargetName, ClientUtils.generateRandomConsumerGroup(), 1, false)
             .editMetadata()
-                .withNamespace(namespaceName)
+                .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .editSpec()
                 .withInclude(topicName)
-            .endSpec().build());
+            .endSpec()
+            .build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(topicName)
-            .withClusterName(kafkaClusterSourceName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaClusterTargetName))
             .build();
 
-        int sent = internalKafkaClient.sendMessagesPlain();
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .build();
-
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(topicNotIncluded)
-            .withClusterName(kafkaClusterSourceName)
             .build();
 
-        sent = internalKafkaClient.sendMessagesPlain();
+        LOGGER.info("Becuase {} is not included, we should not receive any message", topicNotIncluded);
 
-        internalKafkaClient.consumesPlainMessagesUntilOperationIsSuccessful(sent);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withClusterName(kafkaClusterTargetName)
-            .build();
-
-        assertThat("Received 0 messages in target kafka because topic " + topicNotIncluded + " is not included",
-            internalKafkaClient.receiveMessagesPlain(), is(0));
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientTimeout(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     @ParallelNamespaceTest
@@ -665,75 +569,63 @@ public class MirrorMakerIsolatedST extends AbstractST {
 
     @ParallelNamespaceTest
     @Tag(SCALABILITY)
-    void testScaleMirrorMakerSubresource(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+    void testScaleMirrorMakerUpAndDownToZero(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
-        LOGGER.info("Creating kafka source cluster {}", kafkaClusterSourceName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        LOGGER.info("Creating kafka target cluster {}", kafkaClusterTargetName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
+        String kafkaClusterSourceName = testStorage.getClusterName() + "-source";
+        String kafkaClusterTargetName = testStorage.getClusterName() + "-target";
 
-        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 1, false).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build(),
+            KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build()
+        );
+
+        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), kafkaClusterTargetName, kafkaClusterSourceName, ClientUtils.generateRandomConsumerGroup(), 1, false).build());
 
         int scaleTo = 2;
-        long mmObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration();
-        String mmGenName = kubeClient(namespaceName).listPods(namespaceName, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND).get(0).getMetadata().getGenerateName();
+        long mmObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getObservedGeneration();
+        String mmDepName = KafkaMirrorMakerResources.deploymentName(testStorage.getClusterName());
+        String mmGenName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND).get(0).getMetadata().getGenerateName();
 
-        LOGGER.info("-------> Scaling KafkaMirrorMaker subresource <-------");
+        LOGGER.info("-------> Scaling KafkaMirrorMaker up <-------");
+
         LOGGER.info("Scaling subresource replicas to {}", scaleTo);
-        cmdKubeClient().namespace(namespaceName).scaleByName(KafkaMirrorMaker.RESOURCE_KIND, clusterName, scaleTo);
-        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, KafkaMirrorMakerResources.deploymentName(clusterName), scaleTo);
+        cmdKubeClient().namespace(testStorage.getNamespaceName()).scaleByName(KafkaMirrorMaker.RESOURCE_KIND, testStorage.getClusterName(), scaleTo);
+        DeploymentUtils.waitForDeploymentAndPodsReady(testStorage.getNamespaceName(), KafkaMirrorMakerResources.deploymentName(testStorage.getClusterName()), scaleTo);
 
         LOGGER.info("Check if replicas is set to {}, naming prefix should be same and observed generation higher", scaleTo);
-        List<String> mmPods = kubeClient(namespaceName).listPodNames(namespaceName, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
-        assertThat(mmPods.size(), is(2));
-        assertThat(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getReplicas(), is(2));
-        assertThat(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getReplicas(), is(2));
+        List<String> mmPods = kubeClient().listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
+        assertThat(mmPods.size(), is(scaleTo));
+        assertThat(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getSpec().getReplicas(), is(scaleTo));
+        assertThat(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getReplicas(), is(scaleTo));
         /*
         observed generation should be higher than before scaling -> after change of spec and successful reconciliation,
         the observed generation is increased
         */
-        assertThat(mmObsGen < KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration(), is(true));
+        long actualObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getObservedGeneration();
+        assertTrue(mmObsGen < actualObsGen);
+
         for (String pod : mmPods) {
-            assertThat(pod.contains(mmGenName), is(true));
+            assertTrue(pod.contains(mmGenName));
         }
-    }
 
-    @ParallelNamespaceTest
-    @Tag(SCALABILITY)
-    void testScaleMirrorMakerToZero(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(INFRA_NAMESPACE, extensionContext);
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String kafkaClusterSourceName = clusterName + "-source";
-        String kafkaClusterTargetName = clusterName + "-target";
+        mmObsGen = actualObsGen;
 
-        LOGGER.info("Creating kafka source cluster {}", kafkaClusterSourceName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterSourceName, 1, 1).build());
-        LOGGER.info("Creating kafka target cluster {}", kafkaClusterTargetName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaClusterTargetName, 1, 1).build());
-
-        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(clusterName, kafkaClusterTargetName, kafkaClusterSourceName, "my-group" + rng.nextInt(Integer.MAX_VALUE), 3, false).build());
-
-        long oldObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration();
-        String mmDepName = KafkaMirrorMakerResources.deploymentName(clusterName);
-        List<String> mmPods = kubeClient(namespaceName).listPodNames(clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
-        assertThat(mmPods.size(), is(3));
+        LOGGER.info("-------> Scaling KafkaMirrorMaker down <-------");
 
         LOGGER.info("Scaling MirrorMaker to zero");
-        KafkaMirrorMakerResource.replaceMirrorMakerResourceInSpecificNamespace(clusterName, mm -> mm.getSpec().setReplicas(0), namespaceName);
+        KafkaMirrorMakerResource.replaceMirrorMakerResourceInSpecificNamespace(testStorage.getClusterName(), mm -> mm.getSpec().setReplicas(0), testStorage.getNamespaceName());
 
-        PodUtils.waitForPodsReady(namespaceName, kubeClient(namespaceName).getDeploymentSelectors(mmDepName), 0, true);
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), kubeClient().getDeploymentSelectors(testStorage.getNamespaceName(), mmDepName), 0, true);
 
-        mmPods = kubeClient(namespaceName).listPodNames(clusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
-        KafkaMirrorMakerStatus mmStatus = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getStatus();
-        long actualObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getObservedGeneration();
+        mmPods = kubeClient().listPodNames(testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
+        KafkaMirrorMakerStatus mmStatus = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus();
+        actualObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getObservedGeneration();
 
         assertThat(mmPods.size(), is(0));
         assertThat(mmStatus.getConditions().get(0).getType(), is(Ready.toString()));
-        assertThat(actualObsGen, is(not(oldObsGen)));
+        assertThat(actualObsGen, is(not(mmObsGen)));
+
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacIsolatedST.java
@@ -14,7 +14,6 @@ import io.strimzi.systemtest.enums.ClusterOperatorRBACType;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
@@ -112,7 +111,6 @@ public class ClusterOperatorRbacIsolatedST extends AbstractST {
         assertTrue(kafkaStatusCondition.getMessage().contains("Configured service account doesn't have access."));
         assertThat(kafkaStatusCondition.getType(), is(NotReady.toString()));
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(kafkaClientsName).build());
         resourceManager.createResource(extensionContext, false, KafkaConnectTemplates.kafkaConnect(extensionContext, clusterName, clusterName, 1)
             .editSpec()
                 .withNewRack(rackKey)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusIsolatedST.java
@@ -49,7 +49,6 @@ import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaBridgeTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaMirrorMaker2Templates;
@@ -543,7 +542,6 @@ class CustomResourceStatusIsolatedST extends AbstractST {
 
         resourceManager.createResource(extensionContext, kafkaBuilder.build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(CUSTOM_RESOURCE_STATUS_CLUSTER_NAME, TOPIC_NAME).build());
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
 
         topicOperatorReconciliationInterval = KafkaResource.kafkaClient().inNamespace(Constants.INFRA_NAMESPACE).withName(CUSTOM_RESOURCE_STATUS_CLUSTER_NAME).get()
             .getSpec().getEntityOperator().getTopicOperator().getReconciliationIntervalSeconds() * 1_000 * 2 + 5_000;

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -23,7 +23,6 @@ import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaRebalanceTemplates;
@@ -92,7 +91,6 @@ public class ReconciliationST extends AbstractST {
         RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, kafkaSelector, SCALE_TO);
 
         LOGGER.info("Deploying KafkaConnect with pause annotation from the start, no pods should appear");
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
         resourceManager.createResource(extensionContext, false, KafkaConnectTemplates.kafkaConnect(extensionContext, clusterName, 1)
             .editOrNewMetadata()
                 .addToAnnotations(PAUSE_ANNO)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -21,7 +21,6 @@ import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.rollingupdate.KafkaRollerIsolatedST;
 import io.strimzi.systemtest.templates.crd.KafkaBridgeTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
@@ -308,10 +307,8 @@ class RecoveryIsolatedST extends AbstractST {
             .runInstallation();
 
         sharedClusterName = generateRandomNameOfKafka("recovery-cluster");
-        String kafkaClientsName = Constants.KAFKA_CLIENTS + "-" + sharedClusterName;
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(sharedClusterName, KAFKA_REPLICAS).build());
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName).build());
         resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridge(sharedClusterName, KafkaResources.plainBootstrapAddress(sharedClusterName), 1).build());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.operators.topic;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
@@ -15,13 +16,15 @@ import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
@@ -48,15 +51,15 @@ import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(REGRESSION)
@@ -304,55 +307,31 @@ public class TopicST extends AbstractST {
     @ParallelTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testSendingMessagesToNonExistingTopic(ExtensionContext extensionContext) {
-        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        int sent = 0;
-
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, TOPIC_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS)
-            .editMetadata()
-                .withNamespace(namespace)
-            .endMetadata()
-            .build());
-
-        String defaultKafkaClientsPodName =
-                ResourceManager.kubeClient().listPodsByPrefixInName(namespace, TOPIC_CLUSTER_NAME + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(defaultKafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespace)
-            .withClusterName(TOPIC_CLUSTER_NAME)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(TOPIC_CLUSTER_NAME))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
             .build();
 
-        LOGGER.info("Checking if {} is on topic list", topicName);
-        boolean created = hasTopicInKafka(topicName, TOPIC_CLUSTER_NAME);
-        assertThat(created, is(false));
-        LOGGER.info("Topic with name {} is not created yet", topicName);
+        LOGGER.info("Checking if {} is on topic list", testStorage.getTopicName());
+        assertFalse(hasTopicInKafka(testStorage.getTopicName(), TOPIC_CLUSTER_NAME));
+        LOGGER.info("Topic with name {} is not created yet", testStorage.getTopicName());
 
-        LOGGER.info("Trying to send messages to non-existing topic {}", topicName);
-        // Try produce multiple times in case first try will fail because topic is not exists yet
-        for (int retry = 0; retry < 3; retry++) {
-            sent = internalKafkaClient.sendMessagesPlain();
-            if (MESSAGE_COUNT == sent) {
-                break;
-            }
-        }
+        LOGGER.info("Trying to send messages to non-existing topic {}", testStorage.getTopicName());
 
-        assertThat(sent, greaterThan(0));
+        resourceManager.createResource(extensionContext, clients.producerStrimzi(), clients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient.assertSentAndReceivedMessages(
-                sent,
-                internalKafkaClient.receiveMessagesPlain()
-        );
+        LOGGER.info("Checking if {} is on topic list", testStorage.getTopicName());
+        assertTrue(hasTopicInKafka(testStorage.getTopicName(), TOPIC_CLUSTER_NAME));
 
-        LOGGER.info("Checking if {} is on topic list", topicName);
-        created = hasTopicInKafka(topicName, TOPIC_CLUSTER_NAME);
-        assertThat(created, is(true));
-
-        KafkaTopicUtils.waitForKafkaTopicCreation(namespace, topicName);
-        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespace).withName(topicName).get();
+        KafkaTopicUtils.waitForKafkaTopicCreation(namespace, testStorage.getTopicName());
+        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespace).withName(testStorage.getTopicName()).get();
         assertThat(kafkaTopic, notNullValue());
 
         assertThat(kafkaTopic.getStatus(), notNullValue());
@@ -365,11 +344,9 @@ public class TopicST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     @Tag(INTERNAL_CLIENTS_USED)
     void testDeleteTopicEnableFalse(ExtensionContext extensionContext) {
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        String isolatedKafkaCluster = clusterName + "-isolated";
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(isolatedKafkaCluster, 1, 1)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 1, 1)
             .editMetadata()
                 .withNamespace(namespace)
             .endMetadata()
@@ -380,39 +357,31 @@ public class TopicST extends AbstractST {
             .endSpec()
             .build());
 
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(false, isolatedKafkaCluster + "-" + Constants.KAFKA_CLIENTS)
-            .editMetadata()
-                .withNamespace(namespace)
-            .endMetadata()
-            .build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(isolatedKafkaCluster, topicName, namespace).build());
-
-        String kafkaClientsPodName = kubeClient(namespace).listPodsByPrefixInName(namespace, isolatedKafkaCluster + "-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespace)
-            .withClusterName(isolatedKafkaCluster)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
             .build();
 
-        int sent = internalKafkaClient.sendMessagesPlain();
+        resourceManager.createResource(extensionContext, clients.producerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        String topicUid = KafkaTopicUtils.topicSnapshot(namespace, topicName);
-        LOGGER.info("Deleting KafkaTopic: {}", topicName);
-        KafkaTopicResource.kafkaTopicClient().inNamespace(namespace).withName(topicName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        LOGGER.info("KafkaTopic {} deleted", topicName);
+        String topicUid = KafkaTopicUtils.topicSnapshot(namespace, testStorage.getTopicName());
+        LOGGER.info("Deleting KafkaTopic: {}", testStorage.getTopicName());
+        KafkaTopicResource.kafkaTopicClient().inNamespace(namespace).withName(testStorage.getTopicName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+        LOGGER.info("KafkaTopic {} deleted", testStorage.getTopicName());
 
-        KafkaTopicUtils.waitTopicHasRolled(namespace, topicName, topicUid);
+        KafkaTopicUtils.waitTopicHasRolled(namespace, testStorage.getTopicName(), topicUid);
 
-        LOGGER.info("Wait KafkaTopic {} recreation", topicName);
-        KafkaTopicUtils.waitForKafkaTopicCreation(namespace, topicName);
-        LOGGER.info("KafkaTopic {} recreated", topicName);
+        LOGGER.info("Wait KafkaTopic {} recreation", testStorage.getTopicName());
+        KafkaTopicUtils.waitForKafkaTopicCreation(namespace, testStorage.getTopicName());
+        LOGGER.info("KafkaTopic {} recreated", testStorage.getTopicName());
 
-        int received = internalKafkaClient.receiveMessagesPlain();
-        assertThat(received, is(sent));
+        resourceManager.createResource(extensionContext, clients.consumerStrimzi());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -23,18 +23,19 @@ import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.annotations.ParallelTest;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.ExecResult;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -304,15 +305,13 @@ class UserST extends AbstractST {
 
     @ParallelNamespaceTest
     void testCreatingUsersWithSecretPrefix(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
         final String secretPrefix = "top-secret-";
         final String tlsUserName = "encrypted-leopold";
         final String scramShaUserName = "scramed-leopold";
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3)
             .editSpec()
                 .editKafka()
                     .withListeners(new GenericKafkaListenerBuilder()
@@ -340,75 +339,57 @@ class UserST extends AbstractST {
             .endSpec()
             .build());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build(),
+            KafkaUserTemplates.tlsUser(testStorage.getClusterName(), tlsUserName).build(),
+            KafkaUserTemplates.scramShaUser(testStorage.getClusterName(), scramShaUserName).build()
+        );
 
-        KafkaUser tlsUser = KafkaUserTemplates.tlsUser(clusterName, tlsUserName).build();
-        KafkaUser scramShaUser =  KafkaUserTemplates.scramShaUser(clusterName, scramShaUserName).build();
-
-        resourceManager.createResource(extensionContext, tlsUser);
-        resourceManager.createResource(extensionContext, scramShaUser);
-
-        LOGGER.info("Deploying KafkaClients pod for TLS listener");
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, true, clusterName + "-tls-" + Constants.KAFKA_CLIENTS, true, Constants.TLS_LISTENER_DEFAULT_NAME, secretPrefix, tlsUser).build());
-        String tlsKafkaClientsName = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, clusterName + "-tls-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        LOGGER.info("Deploying KafkaClients pod for PLAIN listener");
-        resourceManager.createResource(extensionContext, KafkaClientsTemplates.kafkaClients(namespaceName, false, clusterName + "-plain-" + Constants.KAFKA_CLIENTS, true, Constants.PLAIN_LISTENER_DEFAULT_NAME, secretPrefix, scramShaUser).build());
-        String plainKafkaClientsName = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, clusterName + "-plain-" + Constants.KAFKA_CLIENTS).get(0).getMetadata().getName();
-
-        Secret tlsSecret = kubeClient(namespaceName).getSecret(secretPrefix + tlsUserName);
-        Secret scramShaSecret = kubeClient(namespaceName).getSecret(secretPrefix + scramShaUserName);
+        Secret tlsSecret = kubeClient().getSecret(testStorage.getNamespaceName(), secretPrefix + tlsUserName);
+        Secret scramShaSecret = kubeClient().getSecret(testStorage.getNamespaceName(), secretPrefix + scramShaUserName);
 
         LOGGER.info("Checking if user secrets with secret prefixes exists");
         assertNotNull(tlsSecret);
         assertNotNull(scramShaSecret);
 
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(tlsKafkaClientsName)
-            .withNamespaceName(namespaceName)
-            .withTopicName(TOPIC_NAME)
-            .withKafkaUsername(tlsUserName)
-            .withSecurityProtocol(SecurityProtocol.SASL_SSL)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
-            .withClusterName(clusterName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withSecretPrefix(secretPrefix)
+            .withUserName(secretPrefix + tlsUserName)
             .build();
 
         LOGGER.info("Checking if TLS user is able to send messages");
-        internalKafkaClient.assertSentAndReceivedMessages(
-            internalKafkaClient.sendMessagesTls(),
-            internalKafkaClient.receiveMessagesTls()
-        );
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withUsingPodName(plainKafkaClientsName)
-            .withSecurityProtocol(SecurityProtocol.SASL_PLAINTEXT)
-            .withListenerName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
-            .withKafkaUsername(scramShaUserName)
+        clients = new KafkaClientsBuilder(clients)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withUserName(secretPrefix + scramShaUserName)
             .build();
 
         LOGGER.info("Checking if SCRAM-SHA user is able to send messages");
-        internalKafkaClient.assertSentAndReceivedMessages(
-            internalKafkaClient.sendMessagesPlain(),
-            internalKafkaClient.receiveMessagesPlain()
-        );
+        resourceManager.createResource(extensionContext, clients.producerScramShaPlainStrimzi(), clients.consumerScramShaPlainStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Checking owner reference - if the secret will be deleted when we delete KafkaUser");
 
         LOGGER.info("Deleting KafkaUser:{}", tlsUserName);
-        KafkaUserResource.kafkaUserClient().inNamespace(namespaceName).withName(tlsUserName).delete();
-        KafkaUserUtils.waitForKafkaUserDeletion(namespaceName, tlsUserName);
+        KafkaUserResource.kafkaUserClient().inNamespace(testStorage.getNamespaceName()).withName(tlsUserName).delete();
+        KafkaUserUtils.waitForKafkaUserDeletion(testStorage.getNamespaceName(), tlsUserName);
 
         LOGGER.info("Deleting KafkaUser:{}", scramShaUserName);
-        KafkaUserResource.kafkaUserClient().inNamespace(namespaceName).withName(scramShaUserName).delete();
-        KafkaUserUtils.waitForKafkaUserDeletion(namespaceName, scramShaUserName);
+        KafkaUserResource.kafkaUserClient().inNamespace(testStorage.getNamespaceName()).withName(scramShaUserName).delete();
+        KafkaUserUtils.waitForKafkaUserDeletion(testStorage.getNamespaceName(), scramShaUserName);
 
         LOGGER.info("Checking if secrets are deleted");
-        SecretUtils.waitForSecretDeletion(namespaceName, tlsSecret.getMetadata().getName());
-        SecretUtils.waitForSecretDeletion(namespaceName, scramShaSecret.getMetadata().getName());
-        assertNull(kubeClient(namespaceName).getSecret(namespaceName, tlsSecret.getMetadata().getName()));
-        assertNull(kubeClient(namespaceName).getSecret(namespaceName, scramShaSecret.getMetadata().getName()));
+        SecretUtils.waitForSecretDeletion(testStorage.getNamespaceName(), tlsSecret.getMetadata().getName());
+        SecretUtils.waitForSecretDeletion(testStorage.getNamespaceName(), scramShaSecret.getMetadata().getName());
+        assertNull(kubeClient().getSecret(testStorage.getNamespaceName(), tlsSecret.getMetadata().getName()));
+        assertNull(kubeClient().getSecret(testStorage.getNamespaceName(), scramShaSecret.getMetadata().getName()));
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
@@ -21,11 +20,10 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
@@ -33,7 +31,6 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -73,139 +70,130 @@ class AlternativeReconcileTriggersST extends AbstractST {
     @ParallelNamespaceTest
     @SuppressWarnings("checkstyle:MethodLength")
     void testManualTriggeringRollingUpdate(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
+
         final String continuousTopicName = "continuous-topic";
+        final String continuousProducerName = "continuous-" + testStorage.getProducerName();
+        final String continuousConsumerName = "continuous-" + testStorage.getConsumerName();
+
         // 500 messages will take 500 seconds in that case
         final int continuousClientsMessageCount = 500;
-        final String producerName = "hello-world-producer";
-        final String consumerName = "hello-world-consumer";
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3).build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3).build());
 
-        String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
-        String zkName = KafkaResources.zookeeperStatefulSetName(clusterName);
+        String kafkaName = KafkaResources.kafkaStatefulSetName(testStorage.getClusterName());
+        String zkName = KafkaResources.zookeeperStatefulSetName(testStorage.getClusterName());
 
-        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, kafkaName);
-        LabelSelector zkSelector = KafkaResource.getLabelSelector(clusterName, zkName);
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
+        Map<String, String> zkPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getZookeeperSelector());
 
-        Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
-        Map<String, String> zkPods = PodUtils.podSnapshot(namespaceName, zkSelector);
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName, namespaceName).build());
         // ##############################
         // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
         // ##############################
         // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, continuousTopicName, 3, 3, 2).build());
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), continuousTopicName, 3, 3, 2).build());
+
         String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
+
         // Add transactional id to make producer transactional
         producerAdditionConfiguration = producerAdditionConfiguration.concat("\ntransactional.id=" + continuousTopicName + ".1");
         producerAdditionConfiguration = producerAdditionConfiguration.concat("\nenable.idempotence=true");
 
-        KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-            .withProducerName(producerName)
-            .withConsumerName(consumerName)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+        KafkaClients continuousClients = new KafkaClientsBuilder()
+            .withProducerName(continuousProducerName)
+            .withConsumerName(continuousConsumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
             .withTopicName(continuousTopicName)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
             .withDelayMs(1000)
-            .withNamespaceName(namespaceName)
+            .withNamespaceName(testStorage.getNamespaceName())
             .build();
 
-        resourceManager.createResource(extensionContext, kafkaBasicClientJob.producerStrimzi());
-        resourceManager.createResource(extensionContext, kafkaBasicClientJob.consumerStrimzi());
+        resourceManager.createResource(extensionContext, continuousClients.producerStrimzi(), continuousClients.consumerStrimzi());
         // ##############################
 
-        String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserTemplates.tlsUser(clusterName, userName).build();
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(testStorage.getClusterName(), testStorage.getUserName()).build());
 
-        resourceManager.createResource(extensionContext, user);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(true, kafkaClientsName, user).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(clusterName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(userName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withUserName(testStorage.getUserName())
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // rolling update for kafka
         // set annotation to trigger Kafka rolling update
         LOGGER.info("Annotate Kafka {} {} with manual rolling update annotation",
             Environment.isStrimziPodSetEnabled() ? StrimziPodSet.RESOURCE_KIND : Constants.STATEFUL_SET, kafkaName);
 
-        StUtils.annotateStatefulSetOrStrimziPodSet(namespaceName, kafkaName, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
+        StUtils.annotateStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), kafkaName, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
 
         // check annotation to trigger rolling update
-        assertThat(Boolean.parseBoolean(StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(namespaceName, kafkaName)
+        assertThat(Boolean.parseBoolean(StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), kafkaName)
             .get(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE)), is(true));
 
-        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaPods);
 
         // wait when annotation will be removed
         TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.GLOBAL_TIMEOUT,
-                () -> StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(namespaceName, zkName) == null
-                        || !StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(namespaceName, zkName).containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
+                () -> StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), zkName) == null
+                        || !StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), zkName).containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
 
-        int received = internalKafkaClient.receiveMessagesTls();
-        assertThat(received, is(MESSAGE_COUNT));
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // rolling update for zookeeper
         // set annotation to trigger Zookeeper rolling update
         LOGGER.info("Annotate Zookeeper {} {} with manual rolling update annotation",
             Environment.isStrimziPodSetEnabled() ? StrimziPodSet.RESOURCE_KIND : Constants.STATEFUL_SET, zkName);
 
-        StUtils.annotateStatefulSetOrStrimziPodSet(namespaceName, zkName, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
+        StUtils.annotateStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), zkName, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
 
         // check annotation to trigger rolling update
-        assertThat(Boolean.parseBoolean(StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(namespaceName, zkName)
+        assertThat(Boolean.parseBoolean(StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), zkName)
             .get(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE)), is(true));
 
-        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, zkSelector, 3, zkPods);
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), 3, zkPods);
 
         // wait when annotation will be removed
         TestUtils.waitFor("CO removes rolling update annotation", Constants.WAIT_FOR_ROLLING_UPDATE_INTERVAL, Constants.GLOBAL_TIMEOUT,
-                () -> StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(namespaceName, zkName) == null
-                        || !StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(namespaceName, zkName).containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
+                () -> StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), zkName) == null
+                        || !StUtils.getAnnotationsOfStatefulSetOrStrimziPodSet(testStorage.getNamespaceName(), zkName).containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        received = internalKafkaClient.receiveMessagesTls();
-        assertThat(received, is(MESSAGE_COUNT));
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, newTopicName, 1, 1).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), newTopicName, 1, 1).build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(newTopicName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        int sent = internalKafkaClient.sendMessagesTls();
-        assertThat(sent, is(MESSAGE_COUNT));
-
-        received = internalKafkaClient.receiveMessagesTls();
-        assertThat(received, is(sent));
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, namespaceName, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(continuousProducerName, continuousConsumerName, testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -338,98 +326,97 @@ class AlternativeReconcileTriggersST extends AbstractST {
      */
     @ParallelNamespaceTest
     void testAddingAndRemovingJbodVolumes(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
+
         final String continuousTopicName = "continuous-topic";
+        final String continuousProducerName = "continuous-" + testStorage.getProducerName();
+        final String continuousConsumerName = "continuous-" + testStorage.getConsumerName();
+
         // 500 messages will take 500 seconds in that case
         final int continuousClientsMessageCount = 500;
-        final String producerName = "hello-world-producer";
-        final String consumerName = "hello-world-consumer";
 
         PersistentClaimStorage vol0 = new PersistentClaimStorageBuilder().withId(0).withSize("1Gi").withDeleteClaim(true).build();
         PersistentClaimStorage vol1 = new PersistentClaimStorageBuilder().withId(1).withSize("1Gi").withDeleteClaim(true).build();
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaJBOD(clusterName, 3, 3, new JbodStorageBuilder().addToVolumes(vol0).build()).build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaJBOD(testStorage.getClusterName(), 3, 3, new JbodStorageBuilder().addToVolumes(vol0).build()).build());
 
-        final String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
-        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, kafkaName);
+        final String kafkaName = KafkaResources.kafkaStatefulSetName(testStorage.getClusterName());
 
-        Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build());
+
         // ##############################
         // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
         // ##############################
         // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, continuousTopicName, 3, 3, 2).build());
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), continuousTopicName, 3, 3, 2).build());
+
         String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
         // Add transactional id to make producer transactional
         producerAdditionConfiguration = producerAdditionConfiguration.concat("\ntransactional.id=" + continuousTopicName + ".1");
         producerAdditionConfiguration = producerAdditionConfiguration.concat("\nenable.idempotence=true");
 
         KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-            .withProducerName(producerName)
-            .withConsumerName(consumerName)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+            .withProducerName(continuousProducerName)
+            .withConsumerName(continuousConsumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
             .withTopicName(continuousTopicName)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
             .withDelayMs(1000)
-            .withNamespaceName(namespaceName)
+            .withNamespaceName(testStorage.getNamespaceName())
             .build();
 
-        resourceManager.createResource(extensionContext, kafkaBasicClientJob.producerStrimzi());
-        resourceManager.createResource(extensionContext, kafkaBasicClientJob.consumerStrimzi());
+        resourceManager.createResource(extensionContext, kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());
+
         // ##############################
 
-        String userName = KafkaUserUtils.generateRandomNameOfKafkaUser();
-        KafkaUser user = KafkaUserTemplates.tlsUser(clusterName, userName).build();
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(testStorage.getClusterName(), testStorage.getUserName()).build());
 
-        resourceManager.createResource(extensionContext, user);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(true, kafkaClientsName, user).build());
-
-        final String kafkaClientsPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(kafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(clusterName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(userName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withUserName(testStorage.getUserName())
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Add Jbod volume to Kafka => triggers RU
         LOGGER.info("Add JBOD volume to the Kafka cluster {}", kafkaName);
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             JbodStorage storage = (JbodStorage) kafka.getSpec().getKafka().getStorage();
             storage.getVolumes().add(vol1);
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
         // Wait util it rolls
-        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaPods);
 
         // Remove Jbod volume to Kafka => triggers RU
         LOGGER.info("Remove JBOD volume to the Kafka cluster {}", kafkaName);
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             JbodStorage storage = (JbodStorage) kafka.getSpec().getKafka().getStorage();
             storage.getVolumes().remove(vol1);
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
         // Wait util it rolls
-        RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaPods);
+
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, namespaceName, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(continuousProducerName, continuousConsumerName, testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -18,22 +18,22 @@ import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
-import io.strimzi.systemtest.kafkaclients.clients.InternalKafkaClient;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.metrics.MetricsCollector;
 import io.strimzi.systemtest.resources.ComponentType;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
-import io.strimzi.systemtest.templates.crd.KafkaClientsTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
@@ -81,397 +81,378 @@ class RollingUpdateST extends AbstractST {
 
     @ParallelNamespaceTest
     @Tag(ROLLING_UPDATE)
-    void testRecoveryDuringZookeeperRollingUpdate(ExtensionContext extensionContext) throws Exception {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        final String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final LabelSelector zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
+    void testRecoveryDuringZookeeperRollingUpdate(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
         resourceManager.createResource(extensionContext,
-            KafkaTemplates.kafkaPersistent(clusterName, 3, 3).build(),
-            KafkaTopicTemplates.topic(clusterName, topicName, 2, 2).build());
+            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3).build(),
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), 2, 2).build(),
+            KafkaUserTemplates.tlsUser(testStorage.getClusterName(), testStorage.getUserName()).build()
+        );
 
-        KafkaUser user = KafkaUserTemplates.tlsUser(namespaceName, clusterName, userName).build();
-
-        resourceManager.createResource(extensionContext,  user);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(true, kafkaClientsName, user).build());
-
-        final String defaultKafkaClientsPodName =
-            PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(defaultKafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(clusterName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(userName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .withUserName(testStorage.getUserName())
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Update resources for pods");
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
             k.getSpec()
                 .getZookeeper()
                 .setResources(new ResourceRequirementsBuilder()
                     .addToRequests("cpu", new Quantity("100000m"))
                     .build());
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
-        ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        PodUtils.waitForPendingPod(namespaceName, KafkaResources.zookeeperStatefulSetName(clusterName));
+        PodUtils.waitForPendingPod(testStorage.getNamespaceName(), KafkaResources.zookeeperStatefulSetName(testStorage.getClusterName()));
         LOGGER.info("Verifying stability of zookeeper pods except the one, which is in pending phase");
-        PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.zookeeperStatefulSetName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.zookeeperStatefulSetName(testStorage.getClusterName()));
 
         LOGGER.info("Verifying stability of kafka pods");
-        PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
             k.getSpec()
                 .getZookeeper()
                 .setResources(new ResourceRequirementsBuilder()
                     .addToRequests("cpu", new Quantity("200m"))
                     .build());
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, zkSelector, 3);
+        RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), 3);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        int received = internalKafkaClient.receiveMessagesTls();
-        assertThat(received, is(MESSAGE_COUNT));
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, newTopicName).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), newTopicName).build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(newTopicName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        int sent = internalKafkaClient.sendMessagesTls();
-        assertThat(sent, is(MESSAGE_COUNT));
-        received = internalKafkaClient.receiveMessagesTls();
-        assertThat(received, is(sent));
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     @ParallelNamespaceTest
     @Tag(ROLLING_UPDATE)
-    void testRecoveryDuringKafkaRollingUpdate(ExtensionContext extensionContext) throws Exception {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        final String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
+    void testRecoveryDuringKafkaRollingUpdate(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3).build(),
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), 2, 2).build(),
+            KafkaUserTemplates.tlsUser(testStorage.getClusterName(), testStorage.getUserName()).build()
+        );
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName, 2, 3).build());
-
-        KafkaUser user = KafkaUserTemplates.tlsUser(clusterName, userName).build();
-
-        resourceManager.createResource(extensionContext, user);
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(true, kafkaClientsName, user).build());
-
-        final String defaultKafkaClientsPodName =
-            PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(defaultKafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(clusterName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(userName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .withUserName(testStorage.getUserName())
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         LOGGER.info("Update resources for pods");
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
             k.getSpec()
                 .getKafka()
                 .setResources(new ResourceRequirementsBuilder()
                     .addToRequests("cpu", new Quantity("100000m"))
                     .build());
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
-        ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        PodUtils.waitForPendingPod(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
+        PodUtils.waitForPendingPod(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));
         LOGGER.info("Verifying stability of kafka pods except the one, which is in pending phase");
-        PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.kafkaStatefulSetName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));
 
         LOGGER.info("Verifying stability of zookeeper pods");
-        PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.zookeeperStatefulSetName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.zookeeperStatefulSetName(testStorage.getClusterName()));
 
-        ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
             k.getSpec()
                 .getKafka()
                 .setResources(new ResourceRequirementsBuilder()
                     .addToRequests("cpu", new Quantity("200m"))
                     .build());
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
         // This might need to wait for the previous reconciliation to timeout and for the KafkaRoller to timeout.
         // Therefore we use longer timeout.
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, kafkaSelector, 3);
+        RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        ClientUtils.waitUntilClientReceivedMessagesTls(internalKafkaClient, MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, newTopicName).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), newTopicName).build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(newTopicName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
     @Tag(SCALABILITY)
     void testKafkaAndZookeeperScaleUpScaleDown(ExtensionContext extensionContext) {
-        final TestStorage ts = new TestStorage(extensionContext);
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(ts.getClusterName(), 3, 1)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
             .editSpec()
                 .editKafka()
                     .addToConfig(singletonMap("default.replication.factor", 1))
                     .addToConfig("auto.create.topics.enable", "false")
                 .endKafka()
             .endSpec()
-            .build());
+            .build(),
+            KafkaUserTemplates.tlsUser(testStorage.getClusterName(), testStorage.getUserName()).build()
+        );
 
-        KafkaUser user = KafkaUserTemplates.tlsUser(ts.getNamespaceName(), ts.getClusterName(), ts.getUserName()).build();
-        resourceManager.createResource(extensionContext, user);
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
 
-        testDockerImagesForKafkaCluster(ts.getClusterName(), clusterOperator.getDeploymentNamespace(), ts.getNamespaceName(), 3, 1, false);
-        // kafka cluster already deployed
+        testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false);
 
-        LOGGER.info("Running kafkaScaleUpScaleDown {}", ts.getClusterName());
+        LOGGER.info("Running kafkaScaleUpScaleDown {}", testStorage.getClusterName());
 
-        final int initialReplicas = kubeClient(ts.getNamespaceName()).getClient().pods().inNamespace(ts.getNamespaceName()).withLabelSelector(ts.getKafkaSelector()).list().getItems().size();
+        final int initialReplicas = kubeClient().getClient().pods().inNamespace(testStorage.getNamespaceName()).withLabelSelector(testStorage.getKafkaSelector()).list().getItems().size();
         assertEquals(3, initialReplicas);
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(ts.getClusterName(), ts.getTopicName(), 3, initialReplicas, initialReplicas).build());
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(true, ts.getKafkaClientsName(), user).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), 3, initialReplicas, initialReplicas).build());
 
-        final String defaultKafkaClientsPodName =
-            PodUtils.getPodsByPrefixInNameWithDynamicWait(ts.getNamespaceName(), ts.getKafkaClientsName()).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(defaultKafkaClientsPodName)
-            .withTopicName(ts.getTopicName())
-            .withNamespaceName(ts.getNamespaceName())
-            .withClusterName(ts.getClusterName())
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(ts.getUserName())
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .withUserName(testStorage.getUserName())
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // scale up
         final int scaleTo = initialReplicas + 4;
         LOGGER.info("Scale up Kafka to {}", scaleTo);
-        // Create snapshot of current cluster
-        Map<String, String> kafkaPods = PodUtils.podSnapshot(ts.getNamespaceName(), ts.getKafkaSelector());
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(ts.getClusterName(), kafka -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             kafka.getSpec().getKafka().setReplicas(scaleTo);
-        }, ts.getNamespaceName());
+        }, testStorage.getNamespaceName());
 
-        kafkaPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(ts.getNamespaceName(), ts.getKafkaSelector(), scaleTo, kafkaPods);
+        kafkaPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), scaleTo, kafkaPods);
 
         LOGGER.info("Kafka scale up to {} finished", scaleTo);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        assertThat((int) kubeClient(ts.getNamespaceName()).listPersistentVolumeClaims().stream().filter(
-            pvc -> pvc.getMetadata().getName().contains(KafkaResources.kafkaStatefulSetName(ts.getClusterName()))).count(), is(scaleTo));
+        assertThat((int) kubeClient().listPersistentVolumeClaims().stream().filter(
+            pvc -> pvc.getMetadata().getName().contains(KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()))).count(), is(scaleTo));
 
         final int zookeeperScaleTo = initialReplicas + 2;
-        Map<String, String> zooKeeperPods = PodUtils.podSnapshot(ts.getNamespaceName(), ts.getKafkaSelector());
+        Map<String, String> zooKeeperPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
 
         LOGGER.info("Scale up Zookeeper to {}", zookeeperScaleTo);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(ts.getClusterName(), k -> k.getSpec().getZookeeper().setReplicas(zookeeperScaleTo), ts.getNamespaceName());
 
-        zooKeeperPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(ts.getNamespaceName(), ts.getZookeeperSelector(), zookeeperScaleTo, zooKeeperPods);
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> k.getSpec().getZookeeper().setReplicas(zookeeperScaleTo), testStorage.getNamespaceName());
+        zooKeeperPods = RollingUpdateUtils.waitForComponentScaleUpOrDown(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), zookeeperScaleTo, zooKeeperPods);
 
         LOGGER.info("Kafka scale up to {} finished", zookeeperScaleTo);
 
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // scale down
         LOGGER.info("Scale down Kafka to {}", initialReplicas);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(ts.getClusterName(), k -> k.getSpec().getKafka().setReplicas(initialReplicas), ts.getNamespaceName());
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> k.getSpec().getKafka().setReplicas(initialReplicas), testStorage.getNamespaceName());
 
-        RollingUpdateUtils.waitForComponentScaleUpOrDown(ts.getNamespaceName(), ts.getKafkaSelector(), initialReplicas, kafkaPods);
+        RollingUpdateUtils.waitForComponentScaleUpOrDown(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), initialReplicas, kafkaPods);
 
         LOGGER.info("Kafka scale down to {} finished", initialReplicas);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        assertThat(kubeClient(ts.getNamespaceName()).listPersistentVolumeClaims(ts.getNamespaceName(), ts.getClusterName()).stream()
-            .filter(pvc -> pvc.getMetadata().getName().contains("data-" + KafkaResources.kafkaStatefulSetName(ts.getClusterName()))).collect(Collectors.toList()).size(), is(initialReplicas));
+        assertThat(kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getClusterName()).stream()
+            .filter(pvc -> pvc.getMetadata().getName().contains("data-" + KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()))).collect(Collectors.toList()).size(), is(initialReplicas));
 
         // Create new topic to ensure, that ZK is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(ts.getClusterName(), newTopicName).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), newTopicName).build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(newTopicName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
     }
 
     @ParallelNamespaceTest
     @Tag(SCALABILITY)
     void testZookeeperScaleUpScaleDown(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-        final String userName = mapWithTestUsers.get(extensionContext.getDisplayName());
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final LabelSelector zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3).build());
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
-
-        KafkaUser user = KafkaUserTemplates.tlsUser(namespaceName, clusterName, userName).build();
-
-        resourceManager.createResource(extensionContext, user);
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3).build(),
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build(),
+            KafkaUserTemplates.tlsUser(testStorage.getClusterName(), testStorage.getUserName()).build()
+        );
 
         // kafka cluster already deployed
-        LOGGER.info("Running zookeeperScaleUpScaleDown with cluster {}", clusterName);
-        final int initialZkReplicas = kubeClient(namespaceName).getClient().pods().inNamespace(namespaceName).withLabelSelector(zkSelector).list().getItems().size();
+        LOGGER.info("Running zookeeperScaleUpScaleDown with cluster {}", testStorage.getClusterName());
+        final int initialZkReplicas = kubeClient().getClient().pods().inNamespace(testStorage.getNamespaceName()).withLabelSelector(testStorage.getZookeeperSelector()).list().getItems().size();
         assertThat(initialZkReplicas, is(3));
 
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(true, kafkaClientsName, user).build());
-
-        final String defaultKafkaClientsPodName =
-            PodUtils.getPodsByPrefixInNameWithDynamicWait(namespaceName, kafkaClientsName).get(0).getMetadata().getName();
-
-        InternalKafkaClient internalKafkaClient = new InternalKafkaClient.Builder()
-            .withUsingPodName(defaultKafkaClientsPodName)
-            .withTopicName(topicName)
-            .withNamespaceName(namespaceName)
-            .withClusterName(clusterName)
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
-            .withKafkaUsername(userName)
-            .withListenerName(Constants.TLS_LISTENER_DEFAULT_NAME)
+            .withUserName(testStorage.getUserName())
             .build();
 
-        internalKafkaClient.produceTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         final int scaleZkTo = initialZkReplicas + 4;
         final List<String> newZkPodNames = new ArrayList<String>() {{
                 for (int i = initialZkReplicas; i < scaleZkTo; i++) {
-                    add(KafkaResources.zookeeperPodName(clusterName, i));
+                    add(KafkaResources.zookeeperPodName(testStorage.getClusterName(), i));
                 }
             }};
 
         LOGGER.info("Scale up Zookeeper to {}", scaleZkTo);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getZookeeper().setReplicas(scaleZkTo), namespaceName);
-        int received = internalKafkaClient.receiveMessagesTls();
-        assertThat(received, is(MESSAGE_COUNT));
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> k.getSpec().getZookeeper().setReplicas(scaleZkTo), testStorage.getNamespaceName());
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, zkSelector, scaleZkTo);
-        // check the new node is either in leader or follower state
-        KafkaUtils.waitForZkMntr(namespaceName, clusterName, ZK_SERVER_STATE, 0, 1, 2, 3, 4, 5, 6);
-
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
+        RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), scaleZkTo);
+        // check the new node is either in leader or follower state
+        KafkaUtils.waitForZkMntr(testStorage.getNamespaceName(), testStorage.getClusterName(), ZK_SERVER_STATE, 0, 1, 2, 3, 4, 5, 6);
+
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
+            .build();
+
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Create new topic to ensure, that ZK is working properly
         String scaleUpTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
 
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, scaleUpTopicName, 1, 1).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), scaleUpTopicName, 1, 1).build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(scaleUpTopicName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
+
         // scale down
         LOGGER.info("Scale down Zookeeper to {}", initialZkReplicas);
         // Get zk-3 uid before deletion
-        String uid = kubeClient(namespaceName).getPodUid(newZkPodNames.get(3));
+        String uid = kubeClient(testStorage.getNamespaceName()).getPodUid(newZkPodNames.get(3));
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getZookeeper().setReplicas(initialZkReplicas), namespaceName);
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> k.getSpec().getZookeeper().setReplicas(initialZkReplicas), testStorage.getNamespaceName());
 
-        RollingUpdateUtils.waitForComponentAndPodsReady(namespaceName, zkSelector, initialZkReplicas);
+        RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), initialZkReplicas);
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+        clients = new KafkaClientsBuilder(clients)
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
         // Wait for one zk pods will became leader and others follower state
-        KafkaUtils.waitForZkMntr(namespaceName, clusterName, ZK_SERVER_STATE, 0, 1, 2);
+        KafkaUtils.waitForZkMntr(testStorage.getNamespaceName(), testStorage.getClusterName(), ZK_SERVER_STATE, 0, 1, 2);
 
-        internalKafkaClient.consumesTlsMessagesUntilOperationIsSuccessful(MESSAGE_COUNT);
+        resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         // Create new topic to ensure, that ZK is working properly
         String scaleDownTopicName = KafkaTopicUtils.generateRandomNameOfTopic();
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, scaleDownTopicName, 1, 1).build());
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), scaleDownTopicName, 1, 1).build());
 
-        internalKafkaClient = internalKafkaClient.toBuilder()
+        clients = new KafkaClientsBuilder(clients)
             .withTopicName(scaleDownTopicName)
-            .withConsumerGroupName(ClientUtils.generateRandomConsumerGroup())
+            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
             .build();
 
-        internalKafkaClient.produceAndConsumesTlsMessagesUntilBothOperationsAreSuccessful();
+        resourceManager.createResource(extensionContext, clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
         //Test that the second pod has event 'Killing'
-        assertThat(kubeClient(namespaceName).listEventsByResourceUid(uid), hasAllOfReasons(Killing));
+        assertThat(kubeClient(testStorage.getNamespaceName()).listEventsByResourceUid(uid), hasAllOfReasons(Killing));
     }
 
     @ParallelNamespaceTest
@@ -639,10 +620,7 @@ class RollingUpdateST extends AbstractST {
     @Tag(ROLLING_UPDATE)
     @SuppressWarnings("checkstyle:MethodLength")
     void testMetricsChange(ExtensionContext extensionContext) throws JsonProcessingException {
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        final String kafkaClientsName = mapWithKafkaClientNames.get(extensionContext.getDisplayName());
-        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
-        final LabelSelector zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
         //Kafka
         Map<String, Object> kafkaRule = new HashMap<>();
@@ -661,7 +639,7 @@ class RollingUpdateST extends AbstractST {
         ConfigMap metricsCMK = new ConfigMapBuilder()
                 .withNewMetadata()
                     .withName(metricsCMNameK)
-                    .withNamespace(namespace)
+                    .withNamespace(testStorage.getNamespaceName())
                 .endMetadata()
                 .withData(singletonMap("metrics-config.yml", yaml))
                 .build();
@@ -693,7 +671,7 @@ class RollingUpdateST extends AbstractST {
         ConfigMap metricsCMZk = new ConfigMapBuilder()
                 .withNewMetadata()
                     .withName(metricsCMNameZk)
-                    .withNamespace(namespace)
+                    .withNamespace(testStorage.getNamespaceName())
                 .endMetadata()
                 .withData(singletonMap("metrics-config.yml", mapper.writeValueAsString(zookeeperMetrics)))
                 .build();
@@ -708,12 +686,12 @@ class RollingUpdateST extends AbstractST {
                 .endValueFrom()
                 .build();
 
-        kubeClient(namespace).getClient().configMaps().inNamespace(namespace).createOrReplace(metricsCMK);
-        kubeClient(namespace).getClient().configMaps().inNamespace(namespace).createOrReplace(metricsCMZk);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMK);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMZk);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3, 3)
             .editMetadata()
-                .withNamespace(namespace)
+                .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .editSpec()
                 .editKafka()
@@ -727,20 +705,16 @@ class RollingUpdateST extends AbstractST {
             .endSpec()
             .build());
 
-        Map<String, String> kafkaPods = PodUtils.podSnapshot(namespace, kafkaSelector);
-        Map<String, String> zkPods = PodUtils.podSnapshot(namespace, zkSelector);
+        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
+        Map<String, String> zkPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getZookeeperSelector());
 
-        resourceManager.createResource(extensionContext, false, KafkaClientsTemplates.kafkaClients(false, kafkaClientsName)
-            .editMetadata()
-                .withNamespace(namespace)
-            .endMetadata()
-            .build());
+        resourceManager.createResource(extensionContext, ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build());
 
-        String metricsScraperPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(namespace, kafkaClientsName).get(0).getMetadata().getName();
+        String metricsScraperPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(testStorage.getNamespaceName(), testStorage.getScraperName()).get(0).getMetadata().getName();
         MetricsCollector metricsCollector = new MetricsCollector.Builder()
-            .withNamespaceName(namespace)
+            .withNamespaceName(testStorage.getNamespaceName())
             .withScraperPodName(metricsScraperPodName)
-            .withComponentName(clusterName)
+            .withComponentName(testStorage.getClusterName())
             .withComponentType(ComponentType.Kafka)
             .build();
 
@@ -770,7 +744,7 @@ class RollingUpdateST extends AbstractST {
         metricsCMZk = new ConfigMapBuilder()
                 .withNewMetadata()
                     .withName(metricsCMNameZk)
-                    .withNamespace(namespace)
+                    .withNamespace(testStorage.getNamespaceName())
                 .endMetadata()
                 .withData(singletonMap("metrics-config.yml", mapper.writeValueAsString(zookeeperMetrics)))
                 .build();
@@ -778,33 +752,33 @@ class RollingUpdateST extends AbstractST {
         metricsCMK = new ConfigMapBuilder()
                 .withNewMetadata()
                     .withName(metricsCMNameK)
-                    .withNamespace(namespace)
+                    .withNamespace(testStorage.getNamespaceName())
                 .endMetadata()
                 .withData(singletonMap("metrics-config.yml", mapper.writeValueAsString(kafkaMetrics)))
                 .build();
 
-        kubeClient(namespace).getClient().configMaps().inNamespace(namespace).createOrReplace(metricsCMK);
-        kubeClient(namespace).getClient().configMaps().inNamespace(namespace).createOrReplace(metricsCMZk);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMK);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMZk);
 
-        PodUtils.verifyThatRunningPodsAreStable(namespace, KafkaResources.zookeeperStatefulSetName(clusterName));
-        PodUtils.verifyThatRunningPodsAreStable(namespace, KafkaResources.kafkaStatefulSetName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.zookeeperStatefulSetName(testStorage.getClusterName()));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));
 
         LOGGER.info("Check if Kafka and Zookeeper pods didn't roll");
-        assertThat(PodUtils.podSnapshot(namespace, zkSelector), is(zkPods));
-        assertThat(PodUtils.podSnapshot(namespace, kafkaSelector), is(kafkaPods));
+        assertThat(PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getZookeeperSelector()), is(zkPods));
+        assertThat(PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector()), is(kafkaPods));
 
         LOGGER.info("Check if Kafka and Zookeeper metrics are changed");
         ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
-        String kafkaMetricsConf = kubeClient(namespace).getClient().configMaps().inNamespace(namespace).withName(metricsCMNameK).get().getData().get("metrics-config.yml");
-        String zkMetricsConf = kubeClient(namespace).getClient().configMaps().inNamespace(namespace).withName(metricsCMNameZk).get().getData().get("metrics-config.yml");
+        String kafkaMetricsConf = kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).withName(metricsCMNameK).get().getData().get("metrics-config.yml");
+        String zkMetricsConf = kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).withName(metricsCMNameZk).get().getData().get("metrics-config.yml");
         Object kafkaMetricsJsonToYaml = yamlReader.readValue(kafkaMetricsConf, Object.class);
         Object zkMetricsJsonToYaml = yamlReader.readValue(zkMetricsConf, Object.class);
         ObjectMapper jsonWriter = new ObjectMapper();
-        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
-            assertThat(kubeClient(namespace).getClient().configMaps().inNamespace(namespace).withName(cmName).get().getData().get(Constants.METRICS_CONFIG_JSON_NAME),
+        for (String cmName : StUtils.getKafkaConfigurationConfigMaps(testStorage.getClusterName(), 3)) {
+            assertThat(kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).withName(cmName).get().getData().get(Constants.METRICS_CONFIG_JSON_NAME),
                     is(jsonWriter.writeValueAsString(kafkaMetricsJsonToYaml)));
         }
-        assertThat(kubeClient(namespace).getClient().configMaps().inNamespace(namespace).withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(clusterName)).get().getData().get(Constants.METRICS_CONFIG_JSON_NAME),
+        assertThat(kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(testStorage.getClusterName())).get().getData().get(Constants.METRICS_CONFIG_JSON_NAME),
                 is(jsonWriter.writeValueAsString(zkMetricsJsonToYaml)));
 
         LOGGER.info("Check if metrics are present in pod of Kafka and Zookeeper");
@@ -820,14 +794,14 @@ class RollingUpdateST extends AbstractST {
 
         LOGGER.info("Removing metrics from Kafka and Zookeeper and setting them to null");
 
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             kafka.getSpec().getKafka().setMetricsConfig(null);
             kafka.getSpec().getZookeeper().setMetricsConfig(null);
-        }, namespace);
+        }, testStorage.getNamespaceName());
 
         LOGGER.info("Wait if Kafka and Zookeeper pods will roll");
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespace, zkSelector, 3, zkPods);
-        RollingUpdateUtils.waitTillComponentHasRolled(namespace, kafkaSelector, 3, kafkaPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), 3, zkPods);
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaPods);
 
         LOGGER.info("Check if metrics are not existing in pods");
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

3rd test clients exchange PR, which removes the original `test-client` usage inside `mirrormaker`, `olm`, `operators` and `rollingupdate` packages. Also, this PR contains several fixes for flaky tests and little bit refactoring of the `MirrorMaker2IsolatedST` and `MirrorMakerIsolatedST` suites.

### Checklist

- [x] Make sure all tests pass
