### PR TITLE
Disable the `SessionStartupDoesNotBlockMainThreadTest` tests

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/SessionStartupDoesNotBlockMainThreadTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/SessionStartupDoesNotBlockMainThreadTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -43,6 +44,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+// Disabled because they were flaky in some environments.
+// Should be re-enabled after Vert.x 4.3.0 upgrade => https://github.com/strimzi/strimzi-kafka-operator/issues/6741
+@Disabled
 public class SessionStartupDoesNotBlockMainThreadTest {
 
     @Mock


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR disables the `SessionStartupDoesNotBlockMainThreadTest` which are flaky in some environments because of how they check the main thread being blocked. The tests should be fixed and re-enabled after Vert.x 4.3.0 release which brings better options how to detect main thread being blocked. The re-enablement is covered by issue #6741.