### PR TITLE
Fix typo in mirror-maker-2 metrics

### DIFF
--- a/examples/metrics/kafka-mirror-maker-2-metrics.yaml
+++ b/examples/metrics/kafka-mirror-maker-2-metrics.yaml
@@ -71,8 +71,8 @@ data:
       help: "Kafka $1 JMX metric info version and commit-id"
       type: GAUGE
 
-    #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}", partition="{partition}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}", partition="{partition}"
     - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
       name: kafka_$2_$6
       labels:
@@ -83,7 +83,7 @@ data:
       type: GAUGE
 
     #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
-    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+    #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"
     - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
       name: kafka_$2_$5
       labels:


### PR DESCRIPTION
I just stumbled across this typo while adding some more metrics I wanted here. 

What do you think about also adding `.-+max` everywhere, `fetch-rate` for the consumer and  `record-retry-rate` for the producer in upstream as well? They are recommended for MirrorMaker 2 Performance tuning in Chapter 10 of "Kafka: The definitive Guide" by Shapira, Palino, Sivaram, Petty in addition to the metrics that are already in here.

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

