### PR TITLE
Add additional printer columns to the KafkaRebalance CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -54,6 +54,26 @@ import static java.util.Collections.unmodifiableList;
                 name = "Cluster",
                 description = "The name of the Kafka cluster this resource rebalances",
                 jsonPath = ".metadata.labels.strimzi\\.io/cluster",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "PendingProposal",
+                description = "A proposal has been requested from Cruise Control",
+                jsonPath = ".status.conditions[?(@.type==\"PendingProposal\")].status",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "ProposalReady",
+                description = "A proposal is ready and waiting for approval",
+                jsonPath = ".status.conditions[?(@.type==\"ProposalReady\")].status",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "Rebalancing",
+                description = "Cruise Control is doing the rebalance",
+                jsonPath = ".status.conditions[?(@.type==\"Rebalancing\")].status",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "Ready",
+                description = "The rebalance is complete",
+                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
                 type = "string")
         }
     )

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -31,6 +31,22 @@ spec:
           description: The name of the Kafka cluster this resource rebalances
           jsonPath: .metadata.labels.strimzi\.io/cluster
           type: string
+        - name: PendingProposal
+          description: A proposal has been requested from Cruise Control
+          jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
+          type: string
+        - name: ProposalReady
+          description: A proposal is ready and waiting for approval
+          jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
+          type: string
+        - name: Rebalancing
+          description: Cruise Control is doing the rebalance
+          jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
+          type: string
+        - name: Ready
+          description: The rebalance is complete
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+          type: string
       schema:
         openAPIV3Schema:
           type: object

--- a/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -30,6 +30,22 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       jsonPath: .metadata.labels.strimzi\.io/cluster
       type: string
+    - name: PendingProposal
+      description: A proposal has been requested from Cruise Control
+      jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
+      type: string
+    - name: ProposalReady
+      description: A proposal is ready and waiting for approval
+      jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
+      type: string
+    - name: Rebalancing
+      description: Cruise Control is doing the rebalance
+      jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
+      type: string
+    - name: Ready
+      description: The rebalance is complete
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When doing a rebalance, it passes through different state:
* After you create it, it is in `ProposalPending`
* Then it transitions to `ProposalReady`
* After the approval to `Rebalancing` etc.

User needs to follow the states to know how is the rebalance progressing. Right now, the user needs to inspect the resource YAML. This PR adds the most important states to the additional printer columns. That way, the user can follow the progress even without inspecting the YAML - just with `kubectl get kafkarebalance -o wide -w` and see the progress. That should improve the usablity.

![Screenshot 2022-04-28 at 22 54 19](https://user-images.githubusercontent.com/5658439/165856732-23fce531-8300-49c5-b270-a57e72ce2fcf.png)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Supply screenshots for visual changes, such as Grafana dashboards

