### PR TITLE
[MO] - [system test] -> Cluster stability check

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/exceptions/KubernetesClusterUnstableException.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/exceptions/KubernetesClusterUnstableException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.exceptions;
+
+/**
+ * Provides an exception, which is used in cases where cluster may not be responding and its most likely broken.
+ * This could be caused by network or out of memory problem.
+ */
+public class KubernetesClusterUnstableException extends RuntimeException {
+
+    public KubernetesClusterUnstableException(String message) {
+        super(message);
+    }
+}
+

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.exceptions.KubernetesClusterUnstableException;
 import io.strimzi.systemtest.interfaces.IndicativeSentences;
 import io.strimzi.systemtest.listeners.ExecutionListener;
 import io.strimzi.systemtest.logs.TestExecutionWatcher;
@@ -533,7 +534,7 @@ public abstract class AbstractST implements TestSeparator {
                 parallelSuiteController.removeParallelTest(extensionContext);
             }
         } else {
-            throw new RuntimeException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
+            throw new KubernetesClusterUnstableException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
         }
     }
 
@@ -575,7 +576,7 @@ public abstract class AbstractST implements TestSeparator {
                 clusterOperator.rollbackToDefaultConfiguration();
             }
         } else {
-            throw new RuntimeException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
+            throw new KubernetesClusterUnstableException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
         }
     }
 
@@ -627,7 +628,7 @@ public abstract class AbstractST implements TestSeparator {
                 parallelSuiteController.waitUntilAllowedNumberTestCasesParallel(extensionContext);
             }
         } else {
-            throw new RuntimeException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
+            throw new KubernetesClusterUnstableException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
         }
     }
 
@@ -654,7 +655,7 @@ public abstract class AbstractST implements TestSeparator {
                 clusterOperator = SetupClusterOperator.getInstanceHolder();
             }
         } else {
-            throw new RuntimeException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
+            throw new KubernetesClusterUnstableException("Cluster is not responding and its probably un-stable (i.e., caused by network, OOM problem)");
         }
     }
 


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

Implements `2.approach` from https://github.com/strimzi/strimzi-kafka-operator/issues/6650.

This PR solves issues when for instance during verification a cluster crashes and our tests continue deploying resources, which results in waiting. Now before and after all, test cases or test suites we check if the cluster is available (i.e., we can use Kubernetes API without any problem). If the cluster crashes, then we throw `KubernetesClusterUnstableException` and we also skip the collecting of the Pods (which in this case is not reasonable).
 
### Checklist

- [x] Make sure all tests pass