### PR TITLE
[ST Enhancement] Deletion of remaining pvcs after tests.

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -24,6 +24,7 @@ public interface Constants {
 
     long TIMEOUT_TEARDOWN = Duration.ofSeconds(10).toMillis();
     long GLOBAL_TIMEOUT = Duration.ofMinutes(5).toMillis();
+    long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(2).toMillis();
     long GLOBAL_CMD_CLIENT_TIMEOUT = Duration.ofMinutes(5).toMillis();
     long GLOBAL_STATUS_TIMEOUT = Duration.ofMinutes(3).toMillis();
     long GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1).toMillis();

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.platform.commons.util.Preconditions;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -79,9 +80,14 @@ public class KafkaResource implements ResourceType<Kafka> {
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
         // additional deletion of pvcs with specification deleteClaim set to false which were not deleted prior this method
-        for (PersistentVolumeClaim pvc : kubeClient().listPersistentVolumeClaims(namespaceName, clusterName)) {
-            kubeClient().deletePersistentVolumeClaim(namespaceName, pvc.getMetadata().getName());
-            PersistentVolumeClaimUtils.waitForPersistentVolumeClaimDeletion(namespaceName, pvc.getMetadata().getName());
+        List<PersistentVolumeClaim> persistentVolumeClaimsList = kubeClient().listPersistentVolumeClaims(namespaceName, clusterName);
+
+        for (PersistentVolumeClaim persistentVolumeClaim : persistentVolumeClaimsList) {
+            kubeClient().deletePersistentVolumeClaim(namespaceName, persistentVolumeClaim.getMetadata().getName());
+        }
+
+        for (PersistentVolumeClaim persistentVolumeClaim : persistentVolumeClaimsList) {
+            PersistentVolumeClaimUtils.waitForPersistentVolumeClaimDeletion(namespaceName, persistentVolumeClaim.getMetadata().getName());
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -80,8 +80,8 @@ public class KafkaResource implements ResourceType<Kafka> {
 
         // additional deletion of pvcs with specification deleteClam set to false which were not deleted prior this method
         for (PersistentVolumeClaim pvc : kubeClient().listPersistentVolumeClaims(namespaceName, clusterName)) {
-            kubeClient().deletePVC(namespaceName, pvc.getMetadata().getName());
-            PersistentVolumeClaimUtils.waitForPVCDeletion(namespaceName, pvc.getMetadata().getName());
+            kubeClient().deletePvc(namespaceName, pvc.getMetadata().getName());
+            PersistentVolumeClaimUtils.waitForPvcDeletion(namespaceName, pvc.getMetadata().getName());
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -81,7 +81,7 @@ public class KafkaResource implements ResourceType<Kafka> {
         // additional deletion of pvcs with specification deleteClaim set to false which were not deleted prior this method
         for (PersistentVolumeClaim pvc : kubeClient().listPersistentVolumeClaims(namespaceName, clusterName)) {
             kubeClient().deletePersistentVolumeClaim(namespaceName, pvc.getMetadata().getName());
-            PersistentVolumeClaimUtils.waitForPvcDeletion(namespaceName, pvc.getMetadata().getName());
+            PersistentVolumeClaimUtils.waitForPersistentVolumeClaimDeletion(namespaceName, pvc.getMetadata().getName());
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -78,7 +78,7 @@ public class KafkaResource implements ResourceType<Kafka> {
         kafkaClient().inNamespace(namespaceName).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
-        // additional deletion of pvcs with specification deleteClam set to false which were not deleted prior this method
+        // additional deletion of pvcs with specification deleteClaim set to false which were not deleted prior this method
         for (PersistentVolumeClaim pvc : kubeClient().listPersistentVolumeClaims(namespaceName, clusterName)) {
             kubeClient().deletePersistentVolumeClaim(namespaceName, pvc.getMetadata().getName());
             PersistentVolumeClaimUtils.waitForPvcDeletion(namespaceName, pvc.getMetadata().getName());

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -80,7 +80,7 @@ public class KafkaResource implements ResourceType<Kafka> {
 
         // additional deletion of pvcs with specification deleteClam set to false which were not deleted prior this method
         for (PersistentVolumeClaim pvc : kubeClient().listPersistentVolumeClaims(namespaceName, clusterName)) {
-            kubeClient().deletePvc(namespaceName, pvc.getMetadata().getName());
+            kubeClient().deletePersistentVolumeClaims(namespaceName, pvc.getMetadata().getName());
             PersistentVolumeClaimUtils.waitForPvcDeletion(namespaceName, pvc.getMetadata().getName());
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -80,7 +80,7 @@ public class KafkaResource implements ResourceType<Kafka> {
 
         // additional deletion of pvcs with specification deleteClam set to false which were not deleted prior this method
         for (PersistentVolumeClaim pvc : kubeClient().listPersistentVolumeClaims(namespaceName, clusterName)) {
-            kubeClient().deletePersistentVolumeClaims(namespaceName, pvc.getMetadata().getName());
+            kubeClient().deletePersistentVolumeClaim(namespaceName, pvc.getMetadata().getName());
             PersistentVolumeClaimUtils.waitForPvcDeletion(namespaceName, pvc.getMetadata().getName());
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -68,8 +68,8 @@ public class PersistentVolumeClaimUtils {
     }
 
     public static void waitForPvcDeletion(String namespaceName, String pvcName) {
-        TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(3).toMillis(), () -> {
-            if (kubeClient(namespaceName).getPersistentVolumeClaim(namespaceName, pvcName) != null) {
+        TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.GLOBAL_TIMEOUT_SHORT, () -> {
+            if (kubeClient().getPersistentVolumeClaim(namespaceName, pvcName) != null) {
                 LOGGER.warn("PVC {} is not deleted yet! Triggering force delete by cmd client!", pvcName);
                 cmdKubeClient(namespaceName).deleteByName("pvc", pvcName);
                 return false;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -67,7 +67,7 @@ public class PersistentVolumeClaimUtils {
         LOGGER.info("PVC annotation has changed {}", newAnnotation.toString());
     }
 
-    public static void waitForPvcDeletion(String namespaceName, String pvcName) {
+    public static void waitForPersistentVolumeClaimDeletion(String namespaceName, String pvcName) {
         TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Constants.GLOBAL_TIMEOUT_SHORT, () -> {
             if (kubeClient().getPersistentVolumeClaim(namespaceName, pvcName) != null) {
                 LOGGER.warn("PVC {} is not deleted yet! Triggering force delete by cmd client!", pvcName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -69,22 +69,22 @@ public class PersistentVolumeClaimUtils {
 
     public static void waitForPvcDeletion(String namespaceName, String pvcName) {
         TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(3).toMillis(), () -> {
-            if (kubeClient(namespaceName).getPvc(namespaceName, pvcName) == null) {
-                return true;
-            } else {
+            if (kubeClient(namespaceName).getPersistentVolumeClaim(namespaceName, pvcName) != null) {
                 LOGGER.warn("PVC {} is not deleted yet! Triggering force delete by cmd client!", pvcName);
                 cmdKubeClient(namespaceName).deleteByName("pvc", pvcName);
                 return false;
             }
+
+            return true;
         });
     }
 
-    public static void waitForJbodDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
+    public static void waitForJbodStorageDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
         int numberOfPVCWhichShouldBeDeleted = jbodStorage.getVolumes().stream().filter(
             singleVolumeStorage -> ((PersistentClaimStorage) singleVolumeStorage).isDeleteClaim()
         ).collect(Collectors.toList()).size();
 
-        TestUtils.waitFor("Wait for JBOD deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(6).toMillis(), () -> {
+        TestUtils.waitFor("Wait for JBOD storage deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(6).toMillis(), () -> {
             List<String> pvcs = kubeClient(namespaceName).listPersistentVolumeClaims(namespaceName, clusterName).stream()
                 .filter(pvc -> pvc.getMetadata().getName().contains(clusterName))
                 .map(pvc -> pvc.getMetadata().getName())

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class PersistentVolumeClaimUtils {
@@ -66,12 +67,24 @@ public class PersistentVolumeClaimUtils {
         LOGGER.info("PVC annotation has changed {}", newAnnotation.toString());
     }
 
-    public static void waitForPVCDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
+    public static void waitForPVCDeletion(String namespaceName, String pvcName) {
+        TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(3).toMillis(), () -> {
+            if (kubeClient(namespaceName).getPVC(namespaceName, pvcName) == null) {
+                return true;
+            } else {
+                LOGGER.warn("PVC {} is not deleted yet! Triggering force delete by cmd client!", pvcName);
+                cmdKubeClient(namespaceName).deleteByName("pvc", pvcName);
+                return false;
+            }
+        });
+    }
+
+    public static void waitForJBODDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
         int numberOfPVCWhichShouldBeDeleted = jbodStorage.getVolumes().stream().filter(
             singleVolumeStorage -> ((PersistentClaimStorage) singleVolumeStorage).isDeleteClaim()
         ).collect(Collectors.toList()).size();
 
-        TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(6).toMillis(), () -> {
+        TestUtils.waitFor("Wait for JBOD deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(6).toMillis(), () -> {
             List<String> pvcs = kubeClient(namespaceName).listPersistentVolumeClaims(namespaceName, clusterName).stream()
                 .filter(pvc -> pvc.getMetadata().getName().contains(clusterName))
                 .map(pvc -> pvc.getMetadata().getName())

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -67,9 +67,9 @@ public class PersistentVolumeClaimUtils {
         LOGGER.info("PVC annotation has changed {}", newAnnotation.toString());
     }
 
-    public static void waitForPVCDeletion(String namespaceName, String pvcName) {
+    public static void waitForPvcDeletion(String namespaceName, String pvcName) {
         TestUtils.waitFor("Wait for PVC deletion", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, Duration.ofMinutes(3).toMillis(), () -> {
-            if (kubeClient(namespaceName).getPVC(namespaceName, pvcName) == null) {
+            if (kubeClient(namespaceName).getPvc(namespaceName, pvcName) == null) {
                 return true;
             } else {
                 LOGGER.warn("PVC {} is not deleted yet! Triggering force delete by cmd client!", pvcName);
@@ -79,7 +79,7 @@ public class PersistentVolumeClaimUtils {
         });
     }
 
-    public static void waitForJBODDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
+    public static void waitForJbodDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
         int numberOfPVCWhichShouldBeDeleted = jbodStorage.getVolumes().stream().filter(
             singleVolumeStorage -> ((PersistentClaimStorage) singleVolumeStorage).isDeleteClaim()
         ).collect(Collectors.toList()).size();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -884,7 +884,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForJbodDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest
@@ -908,7 +908,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForJbodDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest
@@ -932,7 +932,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForJbodDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -884,7 +884,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForPVCDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJBODDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest
@@ -908,7 +908,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForPVCDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJBODDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest
@@ -932,7 +932,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForPVCDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJBODDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -884,7 +884,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForJBODDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJbodDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest
@@ -908,7 +908,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForJBODDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJbodDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest
@@ -932,7 +932,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Waiting for PVC deletion");
-        PersistentVolumeClaimUtils.waitForJBODDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
+        PersistentVolumeClaimUtils.waitForJbodDeletion(namespaceName, volumesCount, jbodStorage, clusterName);
     }
 
     @ParallelNamespaceTest

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -232,11 +232,11 @@ public class KubeClient {
             .collect(Collectors.toList());
     }
 
-    public PersistentVolumeClaim getPvc(String namespaceName, String pvcName) {
+    public PersistentVolumeClaim getPersistentVolumeClaim(String namespaceName, String pvcName) {
         return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).get();
     }
 
-    public boolean deletePvc(String namespaceName, String pvcName) {
+    public boolean deletePersistentVolumeClaims(String namespaceName, String pvcName) {
         return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).delete();
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -232,6 +232,14 @@ public class KubeClient {
             .collect(Collectors.toList());
     }
 
+    public PersistentVolumeClaim getPVC(String namespaceName, String pvcName) {
+        return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).get();
+    }
+
+    public boolean deletePVC(String namespaceName, String pvcName) {
+        return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).delete();
+    }
+
     public List<PersistentVolumeClaim> listPersistentVolumeClaims(String namespaceName, String clusterName) {
         return client.persistentVolumeClaims().inNamespace(namespaceName).list().getItems().stream()
             .filter(persistentVolumeClaim -> persistentVolumeClaim.getMetadata().getName().contains(clusterName))

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -232,11 +232,11 @@ public class KubeClient {
             .collect(Collectors.toList());
     }
 
-    public PersistentVolumeClaim getPVC(String namespaceName, String pvcName) {
+    public PersistentVolumeClaim getPvc(String namespaceName, String pvcName) {
         return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).get();
     }
 
-    public boolean deletePVC(String namespaceName, String pvcName) {
+    public boolean deletePvc(String namespaceName, String pvcName) {
         return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).delete();
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -236,7 +236,7 @@ public class KubeClient {
         return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).get();
     }
 
-    public boolean deletePersistentVolumeClaims(String namespaceName, String pvcName) {
+    public boolean deletePersistentVolumeClaim(String namespaceName, String pvcName) {
         return client.persistentVolumeClaims().inNamespace(namespaceName).withName(pvcName).delete();
     }
 


### PR DESCRIPTION
Signed-off-by: jkalinic <jkalinic@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR consists of simple enhancement for system tests. PVCs that have annotation 'deletionClaim' set to false, won't be deleted by default after the tests. So this PR contains deletion strategy for those PVCs as we want to clear every resources afterwards.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

