### PR TITLE
fix NPE on connector deletion fails

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -1613,6 +1613,7 @@ public class ConnectorMockTest {
     public void testConnectorDeleteFailsOnConnectReconciliation() {
         String connectName = "cluster";
 
+        // this connector should be deleted on connect reconciliation
         when(api.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(List.of("connector")));
         when(api.delete(any(), anyString(), anyInt(), anyString())).thenReturn(Future.failedFuture(new RuntimeException("deletion error")));
 


### PR DESCRIPTION
Signed-off-by: abushmin <diskbu@yandex.ru>

### Type of change

- Bugfix
### Description

There was NullPointerException if on connector deleting exection was thrown:

```
java.lang.NullPointerException: Cannot invoke "io.strimzi.api.kafka.model.KafkaConnector.getMetadata()" because "connector" is null
	at io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator.maybeUpdateConnectorStatus(AbstractConnectOperator.java:726) ~[classes/:?]
	at io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator.lambda$reconcileConnectorAndHandleResult$16(AbstractConnectOperator.java:432) ~[classes/:?]
	at io.vertx.core.impl.future.FailedFuture.onComplete(FailedFuture.java:76) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator.reconcileConnectorAndHandleResult(AbstractConnectOperator.java:418) ~[classes/:?]
	at io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator.lambda$reconcileConnectors$7(AbstractConnectOperator.java:369) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1689) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310) ~[?:?]
	at java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator.lambda$reconcileConnectors$9(AbstractConnectOperator.java:376) ~[classes/:?]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.CompositeFutureImpl.complete(CompositeFutureImpl.java:172) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.CompositeFutureImpl.lambda$join$3(CompositeFutureImpl.java:109) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[vertx-core-4.2.4.jar:4.2.4]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) ~[netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) ~[netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) ~[netty-transport-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.74.Final.jar:4.1.74.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.74.Final.jar:4.1.74.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

Connect reconciliation fails and connect transited to `NotReady` state.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

