### PR TITLE
ST: Make MetricsST more robust in case we run it in parallel

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -88,6 +88,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -389,7 +390,8 @@ public class MetricsIsolatedST extends AbstractST {
         cmdKubeClient().list("KafkaTopic").forEach(topicName -> {
             LOGGER.info("KafkaTopic: {}", topicName);
         });
-        assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) getExpectedTopics().size()));
+        // We use greater than in that case to avoid potential collisions with other tests from this class which could run in parallel
+        assertThat(values.stream().mapToDouble(i -> i).sum(), greaterThanOrEqualTo((double) getExpectedTopics().size()));
     }
 
     @ParallelTest


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

In some cases when we executed `MetricsST` in parallel, the tests created more topics than was expected in `testsTopicOperatorMetrics`. This PR should solve it by changing assert on topic count from `equal` to `greaterOrEqual`.

### Checklist

- [x] Make sure all tests pass


