### PR TITLE
Fixed check on missing cluster-ca-cert-generation annotation on pods

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -477,7 +477,10 @@ public class CaReconciler {
                     // only if all Kafka related components pods are updated to the new cluster CA cert generation,
                     // there is the possibility that we should remove the older cluster CA from the Secret and stores
                     for (Pod pod : pods) {
-                        int podClusterCaCertGeneration = Integer.parseInt(pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION));
+                        int podClusterCaCertGeneration =
+                                pod.getMetadata().getAnnotations() != null && pod.getMetadata().getAnnotations().containsKey(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION) ?
+                                        Integer.parseInt(pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION)) :
+                                        clusterCaCertGeneration;
                         LOGGER.debugCr(reconciliation, "Pod {} cluster CA cert generation {}", pod.getMetadata().getName(), podClusterCaCertGeneration);
 
                         if (clusterCaCertGeneration != podClusterCaCertGeneration) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -30,6 +30,7 @@ import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.ZooKeeperRoller;
 import io.strimzi.operator.cluster.operator.resource.ZookeeperLeaderFinder;
 import io.strimzi.operator.common.AdminClientProvider;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
@@ -477,10 +478,7 @@ public class CaReconciler {
                     // only if all Kafka related components pods are updated to the new cluster CA cert generation,
                     // there is the possibility that we should remove the older cluster CA from the Secret and stores
                     for (Pod pod : pods) {
-                        int podClusterCaCertGeneration =
-                                pod.getMetadata().getAnnotations() != null && pod.getMetadata().getAnnotations().containsKey(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION) ?
-                                        Integer.parseInt(pod.getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION)) :
-                                        clusterCaCertGeneration;
+                        int podClusterCaCertGeneration = Annotations.intAnnotation(pod, Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, clusterCaCertGeneration);
                         LOGGER.debugCr(reconciliation, "Pod {} cluster CA cert generation {}", pod.getMetadata().getName(), podClusterCaCertGeneration);
 
                         if (clusterCaCertGeneration != podClusterCaCertGeneration) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #6763.
It sets the `strimzi.io/cluster-ca-cert-generation` on the pod where it's missing by using the current generation.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging