### PR TITLE
Added NotReady column for KafkaRebalance kubectl get wide output

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -74,6 +74,11 @@ import static java.util.Collections.unmodifiableList;
                 name = "Ready",
                 description = "The rebalance is complete",
                 jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "NotReady",
+                description = "There is an error on the custom resource",
+                jsonPath = ".status.conditions[?(@.type==\"NotReady\")].status",
                 type = "string")
         }
     )

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -47,6 +47,10 @@ spec:
           description: The rebalance is complete
           jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
           type: string
+        - name: NotReady
+          description: There is an error on the custom resource
+          jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
+          type: string
       schema:
         openAPIV3Schema:
           type: object

--- a/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -46,6 +46,10 @@ spec:
       description: The rebalance is complete
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
       type: string
+    - name: NotReady
+      description: There is an error on the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
+      type: string
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As follow up of #6746 I think that showing the `NotReady` state for the `KafkaRebalance` resource is even useful through the `kubectl get -o wide -w` command.
It shows the possibility that there is any error related to the rebalancing, communication with Cruise Control or more.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
