### PR TITLE
Add network capacity overrides for CC capacity config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.30.0
 
 * Remove Kafka 3.0.0 and 3.0.1
+* Add network capacity overrides for Cruise Control capacity config
 
 ## 0.29.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacity.java
@@ -100,7 +100,7 @@ public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     @JsonInclude(content = JsonInclude.Include.NON_NULL, value = JsonInclude.Include.NON_EMPTY)
     @Description("Overrides for individual brokers. " +
-            "The `overrides` field allows to specify a different configuration for different brokers.")
+            "The `overrides` property lets you specify a different configuration for different brokers.")
     public List<BrokerCapacityOverride> getOverrides() {
         return overrides;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacity.java
@@ -100,7 +100,7 @@ public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     @JsonInclude(content = JsonInclude.Include.NON_NULL, value = JsonInclude.Include.NON_EMPTY)
     @Description("Overrides for individual brokers. " +
-            "The `overrides` property lets you specify a different configuration for different brokers.")
+            "The `overrides` property lets you specify a different capacity configuration for different brokers.")
     public List<BrokerCapacityOverride> getOverrides() {
         return overrides;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacityOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacityOverride.java
@@ -5,13 +5,11 @@
 package io.strimzi.api.kafka.model.balancing;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.Maximum;
-import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -22,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Representation of the Cruise Control broker capacity settings.
+ * Representation of the Cruise Control broker capacity settings for specific brokers.
  */
 @Buildable(
         editableEnabled = false,
@@ -30,46 +28,26 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"disk", "cpuUtilization", "inboundNetwork", "outboundNetwork", "overrides"})
+@JsonPropertyOrder({"brokers", "inboundNetwork", "outboundNetwork"})
 @EqualsAndHashCode
-public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
-
+public class BrokerCapacityOverride implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String disk;
-    private Integer cpuUtilization;
+    private List<Integer> brokers;
     private String inboundNetwork;
     private String outboundNetwork;
-    private List<BrokerCapacityOverride> overrides;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Deprecated
-    @DeprecatedProperty(description = "The Cruise Control disk capacity setting has been deprecated, is ignored, and will be removed in the future")
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    @Pattern("^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$")
-    @Description("Broker capacity for disk in bytes. " +
-            "Use a number value with either standard Kubernetes byte units (K, M, G, or T), their bibyte (power of two) equivalents (Ki, Mi, Gi, or Ti), or a byte value with or without E notation. " +
-            "For example, 100000M, 100000Mi, 104857600000, or 1e+11.")
-    public String getDisk() {
-        return disk;
+    @JsonInclude(content = JsonInclude.Include.NON_NULL, value = JsonInclude.Include.NON_EMPTY)
+    @Pattern("^\\[[0-9,]*\\]$")
+    @Description("List of the kafka brokers (broker identifiers)")
+    @JsonProperty(required = true)
+    public List<Integer> getBrokers() {
+        return brokers;
     }
 
-    public void setDisk(String disk) {
-        this.disk = disk;
-    }
-
-    @Deprecated
-    @DeprecatedProperty(description = "The Cruise Control CPU capacity setting has been deprecated, is ignored, and will be removed in the future")
-    @Minimum(0)
-    @Maximum(100)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("Broker capacity for CPU resource utilization as a percentage (0 - 100).")
-    public Integer getCpuUtilization() {
-        return cpuUtilization;
-    }
-
-    public void setCpuUtilization(Integer cpuUtilization) {
-        this.cpuUtilization = cpuUtilization;
+    public void setBrokers(List<Integer> brokers) {
+        this.brokers = brokers;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -96,17 +74,6 @@ public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     public void setOutboundNetwork(String outboundNetwork) {
         this.outboundNetwork = outboundNetwork;
-    }
-
-    @JsonInclude(content = JsonInclude.Include.NON_NULL, value = JsonInclude.Include.NON_EMPTY)
-    @Description("Overrides for individual brokers. " +
-            "The `overrides` field allows to specify a different configuration for different brokers.")
-    public List<BrokerCapacityOverride> getOverrides() {
-        return overrides;
-    }
-
-    public void setOverrides(List<BrokerCapacityOverride> overrides) {
-        this.overrides = overrides;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacityOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/BrokerCapacityOverride.java
@@ -40,7 +40,7 @@ public class BrokerCapacityOverride implements UnknownPropertyPreserving, Serial
 
     @JsonInclude(content = JsonInclude.Include.NON_NULL, value = JsonInclude.Include.NON_EMPTY)
     @Pattern("^\\[[0-9,]*\\]$")
-    @Description("List of the kafka brokers (broker identifiers)")
+    @Description("List of Kafka brokers (broker identifiers).")
     @JsonProperty(required = true)
     public List<Integer> getBrokers() {
         return brokers;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -399,7 +399,7 @@ public class CruiseControl extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         varList.add(buildEnvVar(ENV_VAR_MIN_INSYNC_REPLICAS, String.valueOf(minInsyncReplicas)));
 
-        varList.add(buildEnvVar(ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION, capacity.generateCapacityConfig()));
+        varList.add(buildEnvVar(ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION, capacity.toString()));
 
         varList.add(buildEnvVar(ENV_VAR_API_SSL_ENABLED,  String.valueOf(this.sslEnabled)));
         varList.add(buildEnvVar(ENV_VAR_API_AUTH_ENABLED,  String.valueOf(this.authEnabled)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Broker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Broker.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+public class Broker {
+    // CC allows specifying a generic "default" broker entry in the capacity configuration to apply to all brokers without a specific broker entry.
+    // CC designates the id of this default broker entry as "-1".
+    public static final int DEFAULT_BROKER_ID = -1;
+    public static final String DEFAULT_BROKER_DOC = "This is the default capacity. Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB.";
+
+    public static final String DEFAULT_CPU_UTILIZATION_CAPACITY = "100";  // as a percentage (0-100)
+    public static final String DEFAULT_DISK_CAPACITY_IN_MIB = "100000";  // in MiB
+    public static final String DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";  // in KiB/s
+    public static final String DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";  // in KiB/s
+
+    private Integer id;
+    private String cpu;
+    private String disk;
+    private String inboundNetworkKiBPerSecond;
+    private String outboundNetworkKiBPerSecond;
+    private String doc;
+
+    public Broker(int brokerId, String cpu, String disk, String inboundNetworkKiBPerSecond, String outboundNetworkKiBPerSecond) {
+        this.id = brokerId;
+        this.cpu = cpu;
+        this.disk = disk;
+        this.inboundNetworkKiBPerSecond = inboundNetworkKiBPerSecond;
+        this.outboundNetworkKiBPerSecond = outboundNetworkKiBPerSecond;
+        this.doc = brokerId == -1 ? DEFAULT_BROKER_DOC : "Capacity for Broker " + brokerId;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getCpu() {
+        return cpu;
+    }
+
+    public String getDisk() {
+        return disk;
+    }
+
+    public String getInboundNetworkKiBPerSecond() {
+        return inboundNetworkKiBPerSecond;
+    }
+
+    public String getOutboundNetworkKiBPerSecond() {
+        return outboundNetworkKiBPerSecond;
+    }
+
+    public String getDoc() {
+        return doc;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setCpu(String cpu) {
+        this.cpu = cpu;
+    }
+
+    public void setDisk(String disk) {
+        this.disk = disk;
+    }
+
+    public void setInboundNetworkKiBPerSecond(String inboundNetworkKiBPerSecond) {
+        this.inboundNetworkKiBPerSecond = inboundNetworkKiBPerSecond;
+    }
+
+    public void setOutboundNetworkKiBPerSecond(String outboundNetworkKiBPerSecond) {
+        this.outboundNetworkKiBPerSecond = outboundNetworkKiBPerSecond;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
@@ -18,16 +18,16 @@ public class BrokerCapacity {
     private int id;
     private String cpu;
     private String disk;
-    private String inboundNetworkKiBPerSecond;
-    private String outboundNetworkKiBPerSecond;
+    private String inboundNetwork;
+    private String outboundNetwork;
     private final String doc;
 
-    public BrokerCapacity(int brokerId, String cpu, String disk, String inboundNetworkKiBPerSecond, String outboundNetworkKiBPerSecond) {
+    public BrokerCapacity(int brokerId, String cpu, String disk, String inboundNetwork, String outboundNetwork) {
         this.id = brokerId;
         this.cpu = cpu;
         this.disk = disk;
-        this.inboundNetworkKiBPerSecond = inboundNetworkKiBPerSecond;
-        this.outboundNetworkKiBPerSecond = outboundNetworkKiBPerSecond;
+        this.inboundNetwork = inboundNetwork;
+        this.outboundNetwork = outboundNetwork;
         this.doc = brokerId == -1 ? DEFAULT_BROKER_DOC : "Capacity for Broker " + brokerId;
     }
 
@@ -43,12 +43,12 @@ public class BrokerCapacity {
         return disk;
     }
 
-    public String getInboundNetworkKiBPerSecond() {
-        return inboundNetworkKiBPerSecond;
+    public String getInboundNetwork() {
+        return inboundNetwork;
     }
 
-    public String getOutboundNetworkKiBPerSecond() {
-        return outboundNetworkKiBPerSecond;
+    public String getOutboundNetwork() {
+        return outboundNetwork;
     }
 
     public String getDoc() {
@@ -67,11 +67,11 @@ public class BrokerCapacity {
         this.disk = disk;
     }
 
-    public void setInboundNetworkKiBPerSecond(String inboundNetworkKiBPerSecond) {
-        this.inboundNetworkKiBPerSecond = inboundNetworkKiBPerSecond;
+    public void setInboundNetwork(String inboundNetwork) {
+        this.inboundNetwork = inboundNetwork;
     }
 
-    public void setOutboundNetworkKiBPerSecond(String outboundNetworkKiBPerSecond) {
-        this.outboundNetworkKiBPerSecond = outboundNetworkKiBPerSecond;
+    public void setOutboundNetwork(String outboundNetwork) {
+        this.outboundNetwork = outboundNetwork;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
@@ -17,12 +17,12 @@ public class BrokerCapacity {
 
     private int id;
     private String cpu;
-    private Object disk;
+    private DiskCapacity disk;
     private String inboundNetwork;
     private String outboundNetwork;
     private final String doc;
 
-    public BrokerCapacity(int brokerId, String cpu, Object disk, String inboundNetwork, String outboundNetwork) {
+    public BrokerCapacity(int brokerId, String cpu, DiskCapacity disk, String inboundNetwork, String outboundNetwork) {
         this.id = brokerId;
         this.cpu = cpu;
         this.disk = disk;
@@ -39,7 +39,7 @@ public class BrokerCapacity {
         return cpu;
     }
 
-    public Object getDisk() {
+    public DiskCapacity getDisk() {
         return disk;
     }
 
@@ -63,7 +63,7 @@ public class BrokerCapacity {
         this.cpu = cpu;
     }
 
-    public void setDisk(Object disk) {
+    public void setDisk(DiskCapacity disk) {
         this.disk = disk;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
@@ -4,25 +4,25 @@
  */
 package io.strimzi.operator.cluster.model.cruisecontrol;
 
-public class Broker {
+public class BrokerCapacity {
     // CC allows specifying a generic "default" broker entry in the capacity configuration to apply to all brokers without a specific broker entry.
     // CC designates the id of this default broker entry as "-1".
     public static final int DEFAULT_BROKER_ID = -1;
-    public static final String DEFAULT_BROKER_DOC = "This is the default capacity. Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB.";
+    public static final String DEFAULT_BROKER_DOC = "This is the default capacity. Capacity unit used for disk is in MiB, cpu is in percentage, network throughput is in KiB.";
 
     public static final String DEFAULT_CPU_UTILIZATION_CAPACITY = "100";  // as a percentage (0-100)
-    public static final String DEFAULT_DISK_CAPACITY_IN_MIB = "100000";  // in MiB
-    public static final String DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";  // in KiB/s
-    public static final String DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";  // in KiB/s
+    public static final String DEFAULT_DISK_CAPACITY_IN_MIB = "100000";
+    public static final String DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";
+    public static final String DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";
 
-    private Integer id;
+    private int id;
     private String cpu;
     private String disk;
     private String inboundNetworkKiBPerSecond;
     private String outboundNetworkKiBPerSecond;
-    private String doc;
+    private final String doc;
 
-    public Broker(int brokerId, String cpu, String disk, String inboundNetworkKiBPerSecond, String outboundNetworkKiBPerSecond) {
+    public BrokerCapacity(int brokerId, String cpu, String disk, String inboundNetworkKiBPerSecond, String outboundNetworkKiBPerSecond) {
         this.id = brokerId;
         this.cpu = cpu;
         this.disk = disk;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
@@ -17,12 +17,12 @@ public class BrokerCapacity {
 
     private int id;
     private String cpu;
-    private String disk;
+    private Object disk;
     private String inboundNetwork;
     private String outboundNetwork;
     private final String doc;
 
-    public BrokerCapacity(int brokerId, String cpu, String disk, String inboundNetwork, String outboundNetwork) {
+    public BrokerCapacity(int brokerId, String cpu, Object disk, String inboundNetwork, String outboundNetwork) {
         this.id = brokerId;
         this.cpu = cpu;
         this.disk = disk;
@@ -39,7 +39,7 @@ public class BrokerCapacity {
         return cpu;
     }
 
-    public String getDisk() {
+    public Object getDisk() {
         return disk;
     }
 
@@ -63,7 +63,7 @@ public class BrokerCapacity {
         this.cpu = cpu;
     }
 
-    public void setDisk(String disk) {
+    public void setDisk(Object disk) {
         this.disk = disk;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.model.cruisecontrol;
 
 import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.balancing.BrokerCapacity;
+import io.strimzi.api.kafka.model.balancing.BrokerCapacityOverride;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
@@ -14,27 +15,107 @@ import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.VolumeUtils;
+import io.strimzi.operator.common.ReconciliationLogger;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.TreeMap;
 
+/*
+Uses information in a Kafka Custom Resource to generate a capacity configuration file to be used for
+Cruise Control's Broker Capacity File Resolver.
+
+For example, takes a Kafka Custom Resource like the following:
+
+spec:
+ kafka:
+    replicas: 3
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+      - id: 1
+        type: persistent-claim
+        size: 200Gi
+        deleteClaim: false
+ cruiseControl:
+   brokerCapacity:
+    inboundNetwork: 10000KB/s
+    outboundNetwork: 10000KB/s
+    overrides:
+      - brokers: [0]
+      outboundNetwork: 40000KB/s
+      - brokers: [1, 2]
+      inboundNetwork: 60000KB/s
+      outboundNetwork: 20000KB/s
+
+and uses the information to create Cruise Control BrokerCapacityFileResolver config file like the following:
+
+{
+  "brokerCapacities":[
+    {
+      "brokerId": "-1",
+      "capacity": {
+        "DISK": {
+            "/var/lib/kafka0/kafka-log-1": "100000",
+            "/var/lib/kafka1/kafka-log-1": "200000"
+         },
+        "CPU": "100",
+        "NW_IN": "10000",
+        "NW_OUT": "10000"
+      },
+      "doc": "This is the default capacity. Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
+    },
+    {
+      "brokerId": "0",
+      "capacity": {
+        "DISK": {
+            "/var/lib/kafka0/kafka-log0": "100000",
+            "/var/lib/kafka1/kafka-log0": "200000"
+         },
+        "CPU": "100",
+        "NW_IN": "10000",
+        "NW_OUT": "40000"
+      },
+      "doc": "Capacity for Broker 0"
+    },
+    {
+      "brokerId": "1",
+      "capacity": {
+        "DISK": {
+            "/var/lib/kafka0/kafka-log1": "100000",
+            "/var/lib/kafka1/kafka-log1": "200000"
+          },
+        "CPU": "100",
+        "NW_IN": "60000",
+        "NW_OUT": "20000"
+      },
+      "doc": "Capacity for Broker 1"
+    },
+      "brokerId": "2",
+      "capacity": {
+        "DISK": {
+            "/var/lib/kafka0/kafka-log1": "100000",
+            "/var/lib/kafka1/kafka-log1": "200000"
+          },
+        "CPU": "100",
+        "NW_IN": "60000",
+        "NW_OUT": "20000"
+      },
+      "doc": "Capacity for Broker 2"
+    }
+  ]
+}
+*/
 public class Capacity {
-    // CC allows specifying a generic "default" broker entry in the capacity configuration to apply to all brokers without a specific broker entry.
-    // CC designates the id of this default broker entry as "-1".
-    // When using a non-JBOD disk configuration, we use a "default" broker entry to configure all brokers
-    private static final int DEFAULT_BROKER_ID = -1;
-    private static final String DEFAULT_BROKER_DOC = "This is the default capacity. Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB.";
+    protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(Capacity.class.getName());
 
-    private static final double DEFAULT_BROKER_DISK_CAPACITY_IN_MIB = 100_000;  // in MiB
-    private static final int DEFAULT_BROKER_CPU_UTILIZATION_CAPACITY = 100;  // as a percentage (0-100)
-    private static final double DEFAULT_BROKER_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = 10_000;  // in KiB/s
-    private static final double DEFAULT_BROKER_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = 10_000;  // in KiB/s
-
-    private Double diskMiB;
-    private Integer cpuUtilization;
-    private Double inboundNetworkKiBPerSecond;
-    private Double outboundNetworkKiBPerSecond;
+    private TreeMap<Integer, Broker> capacityEntries;
 
     private int replicas;
     private Storage storage;
@@ -42,34 +123,43 @@ public class Capacity {
     public Capacity(KafkaSpec spec, Storage storage) {
         BrokerCapacity bc = spec.getCruiseControl().getBrokerCapacity();
 
+        this.capacityEntries = new TreeMap<Integer, Broker>();
         this.replicas = spec.getKafka().getReplicas();
         this.storage = storage;
 
-        this.diskMiB = generateDiskCapacity(storage);
-        this.cpuUtilization = DEFAULT_BROKER_CPU_UTILIZATION_CAPACITY;
-        this.inboundNetworkKiBPerSecond = bc != null && bc.getInboundNetwork() != null ? getThroughputInKiB(bc.getInboundNetwork()) : DEFAULT_BROKER_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
-        this.outboundNetworkKiBPerSecond = bc != null && bc.getOutboundNetwork() != null ? getThroughputInKiB(bc.getOutboundNetwork()) : DEFAULT_BROKER_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
+        processCapacityEntries(bc, storage);
     }
 
-    /**
-     * Generate broker capacity entry for capacity configuration.
-     *
-     * @param brokerId Id of broker
-     * @param diskCapacity Disk capacity configuration
-     * @param doc Documentation for broker entry
-     * @return Broker entry as a JsonObject
-     */
-    private JsonObject generateBrokerCapacity(int brokerId, JsonObject diskCapacity, String doc) {
-        JsonObject brokerCapacity = new JsonObject()
-            .put("brokerId", brokerId)
-            .put("capacity", new JsonObject()
-                .put("DISK", diskCapacity.getValue("DISK"))
-                .put("CPU", Integer.toString(cpuUtilization))
-                .put("NW_IN", Double.toString(inboundNetworkKiBPerSecond))
-                .put("NW_OUT", Double.toString(outboundNetworkKiBPerSecond))
-            )
-            .put("doc", doc);
-        return brokerCapacity;
+    public static String processCpu() {
+        return Broker.DEFAULT_CPU_UTILIZATION_CAPACITY;
+    }
+
+    public static String processDisk(Storage storage, int brokerId) {
+        if (storage instanceof  JbodStorage) {
+            return generateJbodDiskCapacity(storage, brokerId).encodePrettily();
+        } else {
+            return generateDiskCapacity(storage);
+        }
+    }
+
+    public static String processInboundNetwork(BrokerCapacity bc, BrokerCapacityOverride override) {
+        if (override != null && override.getInboundNetwork() != null) {
+            return getThroughputInKiB(override.getInboundNetwork());
+        } else if (bc != null && bc.getInboundNetwork() != null) {
+            return getThroughputInKiB(bc.getInboundNetwork());
+        } else {
+            return Broker.DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
+        }
+    }
+
+    public static String processOutboundNetwork(BrokerCapacity bc, BrokerCapacityOverride override) {
+        if (override != null && override.getOutboundNetwork() != null) {
+            return getThroughputInKiB(override.getOutboundNetwork());
+        } else if (bc != null && bc.getOutboundNetwork() != null) {
+            return getThroughputInKiB(bc.getOutboundNetwork());
+        } else {
+            return Broker.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND;
+        }
     }
 
     /**
@@ -79,8 +169,8 @@ public class Capacity {
      * @param idx Index of the broker
      * @return Disk capacity configuration value as a JsonObject for broker idx
      */
-    private JsonObject generateJbodDiskCapacity(Storage storage, int idx) {
-        JsonObject json = new JsonObject();
+    private static JsonObject generateJbodDiskCapacity(Storage storage, int idx) {
+        JsonObject disks = new JsonObject();
         String size = "";
 
         for (SingleVolumeStorage volume : ((JbodStorage) storage).getVolumes()) {
@@ -88,13 +178,13 @@ public class Capacity {
             String path = AbstractModel.KAFKA_MOUNT_PATH + "/" + name + "/" + AbstractModel.KAFKA_LOG_DIR + idx;
 
             if (volume instanceof PersistentClaimStorage) {
-                size =  ((PersistentClaimStorage) volume).getSize();
+                size = ((PersistentClaimStorage) volume).getSize();
             } else if (volume instanceof EphemeralStorage) {
                 size = ((EphemeralStorage) volume).getSizeLimit();
             }
-            json.put(path, String.valueOf(Capacity.getSizeInMiB(size)));
+            disks.put(path, String.valueOf(getSizeInMiB(size)));
         }
-        return json;
+        return disks;
     }
 
     /**
@@ -103,58 +193,18 @@ public class Capacity {
      * @param storage Storage configuration for Kafka cluster
      * @return Disk capacity per broker as a Double
      */
-    public static Double generateDiskCapacity(Storage storage) {
+    public static String generateDiskCapacity(Storage storage) {
         if (storage instanceof PersistentClaimStorage) {
             return getSizeInMiB(((PersistentClaimStorage) storage).getSize());
         } else if (storage instanceof EphemeralStorage) {
             if (((EphemeralStorage) storage).getSizeLimit() != null) {
                 return getSizeInMiB(((EphemeralStorage) storage).getSizeLimit());
             } else {
-                return DEFAULT_BROKER_DISK_CAPACITY_IN_MIB;
+                return Broker.DEFAULT_DISK_CAPACITY_IN_MIB;
             }
-        } else if (storage instanceof JbodStorage) {
-            // The value generated here for JBOD storage is used for tracking the total
-            // disk capacity per broker. This will NOT be used for the final disk capacity
-            // configuration since JBOD storage requires a special disk configuration.
-            List<SingleVolumeStorage> volumeList = ((JbodStorage) storage).getVolumes();
-            double size = 0;
-            for (SingleVolumeStorage volume : volumeList) {
-                size += generateDiskCapacity(volume);
-            }
-            return size;
         } else {
             throw new IllegalStateException("The declared storage '" + storage.getType() + "' is not supported");
         }
-    }
-
-    /**
-     * Generate a capacity configuration for cluster
-     *
-     * @return Cruise Control capacity configuration as a String
-     */
-    public String generateCapacityConfig() {
-        JsonArray brokerList = new JsonArray();
-        if (storage instanceof JbodStorage) {
-            // A capacity configuration for a cluster with a JBOD configuration
-            // requires a distinct broker capacity entry for every broker because the
-            // Kafka volume paths are not homogeneous across brokers and include
-            // the broker pod index in their names.
-            for (int idx = 0; idx < replicas; idx++) {
-                JsonObject diskConfig = new JsonObject().put("DISK", generateJbodDiskCapacity(storage, idx));
-                JsonObject brokerEntry = generateBrokerCapacity(idx, diskConfig, "Capacity for Broker " + idx);
-                brokerList.add(brokerEntry);
-            }
-        } else {
-            // A capacity configuration for a cluster without a JBOD configuration
-            // can rely on a generic broker entry for all brokers
-            JsonObject diskConfig = new JsonObject().put("DISK", String.valueOf(diskMiB));
-            JsonObject defaultBrokerCapacity = generateBrokerCapacity(DEFAULT_BROKER_ID, diskConfig, DEFAULT_BROKER_DOC);
-            brokerList.add(defaultBrokerCapacity);
-        }
-        JsonObject config = new JsonObject();
-        config.put("brokerCapacities", brokerList);
-
-        return config.encodePrettily();
     }
 
     /*
@@ -164,11 +214,11 @@ public class Capacity {
      * @param size The String representation of the volume size.
      * @return The equivalent number of mebibytes.
      */
-    public static Double getSizeInMiB(String size) {
+    public static String getSizeInMiB(String size) {
         if (size == null) {
-            return DEFAULT_BROKER_DISK_CAPACITY_IN_MIB;
+            return Broker.DEFAULT_DISK_CAPACITY_IN_MIB;
         }
-        return StorageUtils.convertTo(size, "Mi");
+        return String.valueOf(StorageUtils.convertTo(size, "Mi"));
     }
 
     /*
@@ -178,8 +228,120 @@ public class Capacity {
      * @param throughput The String representation of the throughput.
      * @return The equivalent number of kibibytes.
      */
-    public static Double getThroughputInKiB(String throughput) {
+    public static String getThroughputInKiB(String throughput) {
         String size = throughput.substring(0, throughput.indexOf("B"));
-        return StorageUtils.convertTo(size, "Ki");
+        return String.valueOf(StorageUtils.convertTo(size, "Ki"));
+    }
+
+    public static void main(String[] args) {
+        System.out.println(getThroughputInKiB("10000KiB/s"));
+        System.out.println(removeKibSuffix("10000KiB/s"));
+
+    }
+
+    private static Double removeKibSuffix(String s) {
+        return Double.valueOf(s.substring(0, s.length() - 5));
+    }
+
+    private void processCapacityEntries(BrokerCapacity bc, Storage s) {
+        String cpu = processCpu();
+        String disk = processDisk(storage, Broker.DEFAULT_BROKER_ID);
+        String inboundNetwork = processInboundNetwork(bc, null);
+        String outboundNetwork = processOutboundNetwork(bc, null);
+
+        // Default broker entry
+        Broker defaultBroker = new Broker(Broker.DEFAULT_BROKER_ID, cpu, disk, inboundNetwork, outboundNetwork);
+        capacityEntries.put(Broker.DEFAULT_BROKER_ID, defaultBroker);
+
+        if (storage instanceof JbodStorage) {
+            // A capacity configuration for a cluster with a JBOD configuration
+            // requires a distinct broker capacity entry for every broker because the
+            // Kafka volume paths are not homogeneous across brokers and include
+            // the broker pod index in their names.
+            for (int id = 0; id < replicas; id++) {
+                disk = processDisk(storage, id);
+                Broker broker = new Broker(id, cpu, disk, inboundNetwork, outboundNetwork);
+                capacityEntries.put(id, broker);
+            }
+        }
+
+        if (bc != null) {
+            // For checking for duplicate brokerIds
+            HashSet<Integer> overrideIds = new HashSet<>();
+            List<BrokerCapacityOverride> overrides = bc.getOverrides();
+            // Override broker entries
+            if (overrides != null) {
+                if (overrides.isEmpty()) {
+                    LOGGER.warnOp("Ignoring empty overrides list");
+                } else {
+                    for (BrokerCapacityOverride override : overrides) {
+                        List<Integer> ids = override.getBrokers();
+                        inboundNetwork = processInboundNetwork(bc, override);
+                        outboundNetwork = processOutboundNetwork(bc, override);
+                        for (Integer id : ids) {
+                            if (id == Broker.DEFAULT_BROKER_ID) {
+                                LOGGER.warnOp("Ignoring broker capacity override with illegal broker id -1.");
+                            } else {
+                                disk = processDisk(storage, id);
+                                if (capacityEntries.containsKey(id)) {
+                                    if (overrideIds.contains(id)) {
+                                        LOGGER.warnOp("Duplicate broker id %d found in overrides, using last occurrence.", id);
+                                    } else {
+                                        overrideIds.add(id);
+                                    }
+                                    Broker broker = capacityEntries.get(id);
+                                    broker.setInboundNetworkKiBPerSecond(inboundNetwork);
+                                    broker.setOutboundNetworkKiBPerSecond(outboundNetwork);
+                                } else {
+                                    Broker broker = new Broker(id, cpu, disk, inboundNetwork, outboundNetwork);
+                                    capacityEntries.put(id, broker);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Generate broker capacity entry for capacity configuration.
+     *
+     * @param broker Broker capacity object
+     * @return Broker entry as a JsonObject
+     */
+    private JsonObject generateBrokerCapacity(Broker broker) {
+        JsonObject brokerCapacity = new JsonObject()
+            .put("brokerId", broker.getId())
+            .put("capacity", new JsonObject()
+                .put("DISK", broker.getDisk())
+                .put("CPU", broker.getCpu())
+                .put("NW_IN", broker.getInboundNetworkKiBPerSecond())
+                .put("NW_OUT", broker.getOutboundNetworkKiBPerSecond())
+            )
+            .put("doc", broker.getDoc());
+        return brokerCapacity;
+    }
+
+    /**
+     * Generate a capacity configuration for cluster
+     *
+     * @return Cruise Control capacity configuration as a String
+     */
+    public String generateCapacityConfig() {
+        JsonArray brokerList = new JsonArray();
+        for (Broker broker : capacityEntries.values()) {
+            JsonObject brokerEntry = generateBrokerCapacity(broker);
+            brokerList.add(brokerEntry);
+        }
+
+        JsonObject config = new JsonObject();
+        config.put("brokerCapacities", brokerList);
+
+        return config.encodePrettily();
+    }
+
+    public TreeMap<Integer, Broker> getCapacityEntries() {
+        return capacityEntries;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -315,9 +315,9 @@ public class Capacity {
     /**
      * Generate a capacity configuration for cluster
      *
-     * @return Cruise Control capacity configuration as a String
+     * @return Cruise Control capacity configuration as a JsonObject
      */
-    public String generateCapacityConfig() {
+    public JsonObject generateCapacityConfig() {
         JsonArray brokerList = new JsonArray();
         for (BrokerCapacity brokerCapacity : capacityEntries.values()) {
             JsonObject brokerEntry = generateBrokerCapacity(brokerCapacity);
@@ -327,7 +327,11 @@ public class Capacity {
         JsonObject config = new JsonObject();
         config.put("brokerCapacities", brokerList);
 
-        return config.encodePrettily();
+        return config;
+    }
+
+    public String toString() {
+        return generateCapacityConfig().encodePrettily();
     }
 
     public TreeMap<Integer, BrokerCapacity> getCapacityEntries() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -210,7 +210,7 @@ public class Capacity {
 
     /*
      * Parse a K8S-style representation of a disk size, such as {@code 100Gi},
-     * into the equivalent number of mebibytes represented as a Double.
+     * into the equivalent number of mebibytes represented as a String.
      *
      * @param size The String representation of the volume size.
      * @return The equivalent number of mebibytes.
@@ -224,7 +224,7 @@ public class Capacity {
 
     /*
      * Parse Strimzi representation of throughput, such as {@code 10000KB/s},
-     * into the equivalent number of kibibytes represented as a Double.
+     * into the equivalent number of kibibytes represented as a String.
      *
      * @param throughput The String representation of the throughput.
      * @return The equivalent number of kibibytes.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -273,7 +273,6 @@ public class Capacity {
                             if (id == Broker.DEFAULT_BROKER_ID) {
                                 LOGGER.warnOp("Ignoring broker capacity override with illegal broker id -1.");
                             } else {
-                                disk = processDisk(storage, id);
                                 if (capacityEntries.containsKey(id)) {
                                     if (overrideIds.contains(id)) {
                                         LOGGER.warnOp("Duplicate broker id %d found in overrides, using last occurrence.", id);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -167,16 +167,16 @@ public class Capacity {
      * Generate JBOD disk capacity configuration for a broker using the supplied storage configuration
      *
      * @param storage Storage configuration for Kafka cluster
-     * @param idx Index of the broker
-     * @return Disk capacity configuration value as a JsonObject for broker idx
+     * @param brokerId Id of the broker
+     * @return Disk capacity configuration value as a JsonObject for broker brokerId
      */
-    private static JsonObject generateJbodDiskCapacity(Storage storage, int idx) {
+    private static JsonObject generateJbodDiskCapacity(Storage storage, int brokerId) {
         JsonObject disks = new JsonObject();
         String size = "";
 
         for (SingleVolumeStorage volume : ((JbodStorage) storage).getVolumes()) {
             String name = VolumeUtils.createVolumePrefix(volume.getId(), true);
-            String path = AbstractModel.KAFKA_MOUNT_PATH + "/" + name + "/" + AbstractModel.KAFKA_LOG_DIR + idx;
+            String path = AbstractModel.KAFKA_MOUNT_PATH + "/" + name + "/" + AbstractModel.KAFKA_LOG_DIR + brokerId;
 
             if (volume instanceof PersistentClaimStorage) {
                 size = ((PersistentClaimStorage) volume).getSize();
@@ -192,7 +192,7 @@ public class Capacity {
      * Generate total disk capacity using the supplied storage configuration
      *
      * @param storage Storage configuration for Kafka cluster
-     * @return Disk capacity per broker as a Double
+     * @return Disk capacity per broker as a String
      */
     public static String generateDiskCapacity(Storage storage) {
         if (storage instanceof PersistentClaimStorage) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -276,8 +276,8 @@ public class Capacity {
                                 if (capacityEntries.containsKey(id)) {
                                     if (overrideIds.add(id)) {
                                         BrokerCapacity brokerCapacityEntry = capacityEntries.get(id);
-                                        brokerCapacityEntry.setInboundNetworkKiBPerSecond(inboundNetwork);
-                                        brokerCapacityEntry.setOutboundNetworkKiBPerSecond(outboundNetwork);
+                                        brokerCapacityEntry.setInboundNetwork(inboundNetwork);
+                                        brokerCapacityEntry.setOutboundNetwork(outboundNetwork);
                                     } else {
                                         LOGGER.warnOp("Duplicate broker id %d found in overrides, using first occurrence.", id);
                                     }
@@ -306,8 +306,8 @@ public class Capacity {
             .put("capacity", new JsonObject()
                 .put("DISK", brokerCapacity.getDisk())
                 .put("CPU", brokerCapacity.getCpu())
-                .put("NW_IN", brokerCapacity.getInboundNetworkKiBPerSecond())
-                .put("NW_OUT", brokerCapacity.getOutboundNetworkKiBPerSecond())
+                .put("NW_IN", brokerCapacity.getInboundNetwork())
+                .put("NW_OUT", brokerCapacity.getOutboundNetwork())
             )
             .put("doc", brokerCapacity.getDoc());
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -135,9 +135,9 @@ public class Capacity {
         return BrokerCapacity.DEFAULT_CPU_UTILIZATION_CAPACITY;
     }
 
-    public static String processDisk(Storage storage, int brokerId) {
+    public static Object processDisk(Storage storage, int brokerId) {
         if (storage instanceof JbodStorage) {
-            return generateJbodDiskCapacity(storage, brokerId).encodePrettily();
+            return generateJbodDiskCapacity(storage, brokerId);
         } else {
             return generateDiskCapacity(storage);
         }
@@ -236,7 +236,7 @@ public class Capacity {
 
     private void processCapacityEntries(io.strimzi.api.kafka.model.balancing.BrokerCapacity brokerCapacity) {
         String cpu = processCpu();
-        String disk = processDisk(storage, BrokerCapacity.DEFAULT_BROKER_ID);
+        Object disk = processDisk(storage, BrokerCapacity.DEFAULT_BROKER_ID);
         String inboundNetwork = processInboundNetwork(brokerCapacity, null);
         String outboundNetwork = processOutboundNetwork(brokerCapacity, null);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/DiskCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/DiskCapacity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+import io.vertx.core.json.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DiskCapacity {
+    private static final String SINGLE_DISK = "";
+    private Map<String, String> map;
+
+    public DiskCapacity() {
+        map = new HashMap<>(1);
+    }
+
+    private DiskCapacity(String size) {
+        this();
+        map.put(SINGLE_DISK, size);
+    }
+
+    public static DiskCapacity of(String size) {
+        return new DiskCapacity(size);
+    }
+
+    public void add(String path, String size) {
+        if (path == null || SINGLE_DISK.equals(path)) {
+            throw new IllegalArgumentException("The disk path cannot be null or empty");
+        }
+        map.put(path, size);
+    }
+
+    public Object getJson() {
+        if (map.size() == 1 && map.containsKey(SINGLE_DISK)) {
+            return map.get(SINGLE_DISK);
+        } else {
+            JsonObject disks = new JsonObject();
+            for (Map.Entry<String, String> e : map.entrySet()) {
+                disks.put(e.getKey(), e.getValue());
+            }
+            return disks;
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -279,17 +279,17 @@ public class CruiseControlTest {
         capacity = new Capacity(resource.getSpec(), kafkaStorage);
 
         TreeMap<Integer, BrokerCapacity> capacityEntries = capacity.getCapacityEntries();
-        assertThat(capacityEntries.get(BrokerCapacity.DEFAULT_BROKER_ID).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetwork)));
-        assertThat(capacityEntries.get(BrokerCapacity.DEFAULT_BROKER_ID).getOutboundNetworkKiBPerSecond(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        assertThat(capacityEntries.get(BrokerCapacity.DEFAULT_BROKER_ID).getInboundNetwork(), is(Capacity.getThroughputInKiB(inboundNetwork)));
+        assertThat(capacityEntries.get(BrokerCapacity.DEFAULT_BROKER_ID).getOutboundNetwork(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
-        assertThat(capacityEntries.get(broker0).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
-        assertThat(capacityEntries.get(broker0).getOutboundNetworkKiBPerSecond(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        assertThat(capacityEntries.get(broker0).getInboundNetwork(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(capacityEntries.get(broker0).getOutboundNetwork(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
         // When the same broker id is specified in brokers list of multiple overrides, use the value specified in the first override.
-        assertThat(capacityEntries.get(broker1).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
-        assertThat(capacityEntries.get(broker1).getOutboundNetworkKiBPerSecond(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        assertThat(capacityEntries.get(broker1).getInboundNetwork(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(capacityEntries.get(broker1).getOutboundNetwork(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
-        assertThat(capacityEntries.get(broker2).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(capacityEntries.get(broker2).getInboundNetwork(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
 
         assertThat(getCapacityConfigurationFromEnvVar(resource, ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION), is(capacity.generateCapacityConfig()));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
@@ -205,7 +204,7 @@ public class CruiseControlTest {
     }
 
     private static boolean isJBOD(Map<String, Object> brokerCapacity) {
-        return brokerCapacity.get("DISK") instanceof Map;
+        return brokerCapacity.get(Capacity.DISK_KEY) instanceof JsonObject;
     }
 
     @ParallelTest
@@ -253,9 +252,9 @@ public class CruiseControlTest {
         
         capacity = new Capacity(resource.getSpec(), jbodStorage);
 
-        JsonArray brokerEntries = capacity.generateCapacityConfig().getJsonArray("brokerCapacities");
+        JsonArray brokerEntries = capacity.generateCapacityConfig().getJsonArray(Capacity.CAPACITIES_KEY);
         for (Object brokerEntry : brokerEntries) {
-            HashMap<String, Object> brokerCapacity = new ObjectMapper().readValue(((JsonObject) brokerEntry).getJsonObject("capacity").toString(), HashMap.class);
+            Map<String, Object> brokerCapacity = ((JsonObject) brokerEntry).getJsonObject(Capacity.CAPACITY_KEY).getMap();
             assertThat(isJBOD(brokerCapacity), is(true));
         }
 
@@ -293,9 +292,9 @@ public class CruiseControlTest {
         resource = createKafka(cruiseControlSpec);
         capacity = new Capacity(resource.getSpec(), kafkaStorage);
 
-        brokerEntries = capacity.generateCapacityConfig().getJsonArray("brokerCapacities");
+        brokerEntries = capacity.generateCapacityConfig().getJsonArray(Capacity.CAPACITIES_KEY);
         for (Object brokerEntry : brokerEntries) {
-            HashMap<String, Object> brokerCapacity = new ObjectMapper().readValue(((JsonObject) brokerEntry).getJsonObject("capacity").toString(), HashMap.class);
+            Map<String, Object> brokerCapacity = ((JsonObject) brokerEntry).getJsonObject(Capacity.CAPACITY_KEY).getMap();
             assertThat(isJBOD(brokerCapacity), is(false));
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -42,7 +42,6 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.MetricsConfig;
 import io.strimzi.api.kafka.model.SystemPropertyBuilder;
-import io.strimzi.api.kafka.model.balancing.BrokerCapacity;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
@@ -52,7 +51,7 @@ import io.strimzi.api.kafka.model.template.IpFamily;
 import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.cruisecontrol.Broker;
+import io.strimzi.operator.cluster.model.cruisecontrol.BrokerCapacity;
 import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.operator.common.Reconciliation;
@@ -204,7 +203,7 @@ public class CruiseControlTest {
     @ParallelTest
     public void testBrokerCapacities() {
         // Test user defined capacities
-        BrokerCapacity userDefinedBrokerCapacity = new BrokerCapacity();
+        io.strimzi.api.kafka.model.balancing.BrokerCapacity userDefinedBrokerCapacity = new io.strimzi.api.kafka.model.balancing.BrokerCapacity();
         userDefinedBrokerCapacity.setInboundNetwork("50000KB/s");
         userDefinedBrokerCapacity.setOutboundNetwork("50000KB/s");
 
@@ -253,9 +252,9 @@ public class CruiseControlTest {
         String inboundNetworkOverride1 = "10000KiB/s";
         String outboundNetworkOverride1 = "15000KB/s";
 
-        Integer broker0 = 0;
-        Integer broker1 = 1;
-        Integer broker2 = 2;
+        int broker0 = 0;
+        int broker1 = 1;
+        int broker2 = 2;
 
         List<Integer> overrideList0 = List.of(broker0, broker1, broker2, broker0);
         List<Integer> overrideList1 = List.of(broker1);
@@ -279,16 +278,16 @@ public class CruiseControlTest {
         resource = createKafka(cruiseControlSpec);
         capacity = new Capacity(resource.getSpec(), kafkaStorage);
 
-        TreeMap<Integer, Broker> capacityEntries = capacity.getCapacityEntries();
-        assertThat(capacityEntries.get(Broker.DEFAULT_BROKER_ID).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetwork)));
-        assertThat(capacityEntries.get(Broker.DEFAULT_BROKER_ID).getOutboundNetworkKiBPerSecond(), is(Broker.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        TreeMap<Integer, BrokerCapacity> capacityEntries = capacity.getCapacityEntries();
+        assertThat(capacityEntries.get(BrokerCapacity.DEFAULT_BROKER_ID).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetwork)));
+        assertThat(capacityEntries.get(BrokerCapacity.DEFAULT_BROKER_ID).getOutboundNetworkKiBPerSecond(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
         assertThat(capacityEntries.get(broker0).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
-        assertThat(capacityEntries.get(broker0).getOutboundNetworkKiBPerSecond(), is(Broker.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
+        assertThat(capacityEntries.get(broker0).getOutboundNetworkKiBPerSecond(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
-        // When the same broker id is specified in brokers list of multiple overrides, use the value specified in the latest override.
-        assertThat(capacityEntries.get(broker1).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride1)));
-        assertThat(capacityEntries.get(broker1).getOutboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(outboundNetworkOverride1)));
+        // When the same broker id is specified in brokers list of multiple overrides, use the value specified in the first override.
+        assertThat(capacityEntries.get(broker1).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
+        assertThat(capacityEntries.get(broker1).getOutboundNetworkKiBPerSecond(), is(BrokerCapacity.DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND));
 
         assertThat(capacityEntries.get(broker2).getInboundNetworkKiBPerSecond(), is(Capacity.getThroughputInKiB(inboundNetworkOverride0)));
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1376,7 +1376,7 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 |string
 |outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string
-|overrides        1.2+<.<a|Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+|overrides        1.2+<.<a|Overrides for individual brokers. The `overrides` property lets you specify a different configuration for different brokers.
 |xref:type-BrokerCapacityOverride-{context}[`BrokerCapacityOverride`] array
 |====
 
@@ -1389,7 +1389,7 @@ Used in: xref:type-BrokerCapacity-{context}[`BrokerCapacity`]
 [options="header"]
 |====
 |Property                |Description
-|brokers          1.2+<.<a|List of the kafka brokers (broker identifiers).
+|brokers          1.2+<.<a|List of Kafka brokers (broker identifiers).
 |integer array
 |inboundNetwork   1.2+<.<a|Broker capacity for inbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1376,7 +1376,7 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 |string
 |outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string
-|overrides        1.2+<.<a|Overrides for individual brokers. The `overrides` property lets you specify a different configuration for different brokers.
+|overrides        1.2+<.<a|Overrides for individual brokers. The `overrides` property lets you specify a different capacity configuration for different brokers.
 |xref:type-BrokerCapacityOverride-{context}[`BrokerCapacityOverride`] array
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1376,6 +1376,25 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 |string
 |outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string
+|overrides        1.2+<.<a|Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+|xref:type-BrokerCapacityOverride-{context}[`BrokerCapacityOverride`] array
+|====
+
+[id='type-BrokerCapacityOverride-{context}']
+### `BrokerCapacityOverride` schema reference
+
+Used in: xref:type-BrokerCapacity-{context}[`BrokerCapacity`]
+
+
+[options="header"]
+|====
+|Property                |Description
+|brokers          1.2+<.<a|List of the kafka brokers (broker identifiers).
+|integer array
+|inboundNetwork   1.2+<.<a|Broker capacity for inbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
+|string
+|outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
+|string
 |====
 
 [id='type-JmxTransSpec-{context}']

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -118,6 +118,38 @@ spec:
     # ...
 ----
 
+== Capacity overrides
+
+For accurate rebalances between brokers running on nodes with heterogeneous network resources, one must manually override the network capacity limit settings of individual brokers.
+You specify capacity limit overrides for lists of individual Kafka brokers in the `overrides` property in `Kafka.spec.cruiseControl.brokerCapacity`.
+Override capacity limits can be set for the following broker resources:
+
+* `inboundNetwork`  - Inbound network throughput in byte units per second (Default: 10000KiB/s)
+* `outboundNetwork` - Outbound network throughput in byte units per second (Default: 10000KiB/s)
+
+.An example of Cruise Control capacity overrides configuration using bibyte units
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  # ...
+  cruiseControl:
+    # ...
+    brokerCapacity:
+      inboundNetwork: 10000KiB/s
+      outboundNetwork: 10000KiB/s
+      overrides:
+      - brokers: [0]
+        inboundNetwork: 20000KiB/s
+        outboundNetwork: 20000KiB/s
+      - brokers: [1, 2]
+        inboundNetwork: 30000KiB/s
+        outboundNetwork: 30000KiB/s
+----
+
 .Additional resources
 For more information, refer to the xref:type-BrokerCapacity-reference[].
 

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -120,8 +120,9 @@ spec:
 
 == Capacity overrides
 
-For accurate rebalances between brokers running on nodes with heterogeneous network resources, one must manually override the network capacity limit settings of individual brokers.
-You specify capacity limit overrides for lists of individual Kafka brokers in the `overrides` property in `Kafka.spec.cruiseControl.brokerCapacity`.
+Brokers might be running on nodes with heterogeneous network resources.
+If that's the case, specify `overrides` that set the network capacity limits for each broker.
+The overrides ensure an accurate rebalance between the brokers.
 Override capacity limits can be set for the following broker resources:
 
 * `inboundNetwork`  - Inbound network throughput in byte units per second (Default: 10000KiB/s)

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -4655,6 +4655,27 @@ spec:
                           type: string
                           pattern: "^[0-9]+([KMG]i?)?B/s$"
                           description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
+                        overrides:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              brokers:
+                                type: array
+                                items:
+                                  type: integer
+                                description: List of the kafka brokers (broker identifiers).
+                              inboundNetwork:
+                                type: string
+                                pattern: "^[0-9]+([KMG]i?)?B/s$"
+                                description: "Broker capacity for inbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
+                              outboundNetwork:
+                                type: string
+                                pattern: "^[0-9]+([KMG]i?)?B/s$"
+                                description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
+                            required:
+                              - brokers
+                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                       description: The Cruise Control `brokerCapacity` configuration.
                     config:
                       x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -4664,7 +4664,7 @@ spec:
                                 type: array
                                 items:
                                   type: integer
-                                description: List of the kafka brokers (broker identifiers).
+                                description: List of Kafka brokers (broker identifiers).
                               inboundNetwork:
                                 type: string
                                 pattern: "^[0-9]+([KMG]i?)?B/s$"
@@ -4675,7 +4675,7 @@ spec:
                                 description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
                             required:
                               - brokers
-                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` property lets you specify a different configuration for different brokers.
                       description: The Cruise Control `brokerCapacity` configuration.
                     config:
                       x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -4675,7 +4675,7 @@ spec:
                                 description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
                             required:
                               - brokers
-                          description: Overrides for individual brokers. The `overrides` property lets you specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` property lets you specify a different capacity configuration for different brokers.
                       description: The Cruise Control `brokerCapacity` configuration.
                     config:
                       x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -4663,7 +4663,7 @@ spec:
                               type: array
                               items:
                                 type: integer
-                              description: List of the kafka brokers (broker identifiers).
+                              description: List of Kafka brokers (broker identifiers).
                             inboundNetwork:
                               type: string
                               pattern: "^[0-9]+([KMG]i?)?B/s$"
@@ -4674,7 +4674,7 @@ spec:
                               description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
                           required:
                           - brokers
-                        description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                        description: Overrides for individual brokers. The `overrides` property lets you specify a different configuration for different brokers.
                     description: The Cruise Control `brokerCapacity` configuration.
                   config:
                     x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -4654,6 +4654,27 @@ spec:
                         type: string
                         pattern: "^[0-9]+([KMG]i?)?B/s$"
                         description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
+                      overrides:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            brokers:
+                              type: array
+                              items:
+                                type: integer
+                              description: List of the kafka brokers (broker identifiers).
+                            inboundNetwork:
+                              type: string
+                              pattern: "^[0-9]+([KMG]i?)?B/s$"
+                              description: "Broker capacity for inbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
+                            outboundNetwork:
+                              type: string
+                              pattern: "^[0-9]+([KMG]i?)?B/s$"
+                              description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
+                          required:
+                          - brokers
+                        description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                     description: The Cruise Control `brokerCapacity` configuration.
                   config:
                     x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -4674,7 +4674,7 @@ spec:
                               description: "Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s."
                           required:
                           - brokers
-                        description: Overrides for individual brokers. The `overrides` property lets you specify a different configuration for different brokers.
+                        description: Overrides for individual brokers. The `overrides` property lets you specify a different capacity configuration for different brokers.
                     description: The Cruise Control `brokerCapacity` configuration.
                   config:
                     x-kubernetes-preserve-unknown-fields: true

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -178,4 +178,15 @@ public class CruiseControlUtils {
                     "com.linkedin.cruisecontrol.exception.NotEnoughValidWindowsException: ");
             });
     }
+
+    /**
+     * Returns user defined network capacity value without KiB/s suffix.
+     *
+     * @param userCapacity User defined network capacity with KiB/s suffix.
+     *
+     * @return User defined network capacity without KiB/s as a Double.
+     */
+    public static Double removeNetworkCapacityKibSuffix(String userCapacity) {
+        return Double.valueOf(userCapacity.substring(0, userCapacity.length() - 5));
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -54,6 +54,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(REGRESSION)
@@ -82,14 +83,14 @@ public class CruiseControlConfigurationST extends AbstractST {
         String inboundNetworkOverride1 = "40000KiB/s";
         String outboundNetworkOverride1 = "400000KiB/s";
 
-        Integer broker0 = 0;
-        Integer broker1 = 1;
-        Integer broker2 = 2;
+        int broker0 = 0;
+        int broker1 = 1;
+        int broker2 = 2;
 
         List<Integer> overrideList0 = List.of(broker0, broker1, broker2, broker0);
         List<Integer> overrideList1 = List.of(broker1);
 
-        Kafka kr = KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3)
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3)
             .editOrNewSpec()
                 .editCruiseControl()
                     .withNewBrokerCapacity()
@@ -106,9 +107,7 @@ public class CruiseControlConfigurationST extends AbstractST {
                     .endBrokerCapacity()
                 .endCruiseControl()
             .endSpec()
-            .build();
-
-        resourceManager.createResource(extensionContext, kr);
+            .build());
 
         String cruiseControlPodName = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, clusterName + "-cruise-control-").get(0).getMetadata().getName();
 
@@ -124,7 +123,7 @@ public class CruiseControlConfigurationST extends AbstractST {
 
         JsonObject defaultBroker = brokerCapacities.getJsonObject(0);
         assertThat(defaultBroker.getString("brokerId"), is("-1"));
-        assertThat(defaultBroker.getString("doc"), not(nullValue()));
+        assertThat(defaultBroker.getString("doc"), notNullValue());
 
         LOGGER.info("Verifying default cruise control capacities");
         JsonObject defaultBrokerCapacity = defaultBroker.getJsonObject("capacity");

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
 import io.strimzi.api.kafka.model.CruiseControlSpecBuilder;
-import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.systemtest.AbstractST;

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -140,8 +140,8 @@ public class CruiseControlConfigurationST extends AbstractST {
         assertThat(Double.valueOf(broker0Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride0)));
         assertThat(Double.valueOf(broker0Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));
 
-        assertThat(Double.valueOf(broker1Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride1)));
-        assertThat(Double.valueOf(broker1Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetworkOverride1)));
+        assertThat(Double.valueOf(broker1Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride0)));
+        assertThat(Double.valueOf(broker1Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));
 
         assertThat(Double.valueOf(broker2Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride0)));
         assertThat(Double.valueOf(broker2Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -65,10 +65,6 @@ public class CruiseControlConfigurationST extends AbstractST {
 
     private final String namespace = testSuiteNamespaceManager.getMapOfAdditionalNamespaces().get(CruiseControlConfigurationST.class.getSimpleName()).stream().findFirst().get();
 
-    private static Double removeKibSuffix(String s) {
-        return Double.valueOf(s.substring(0, s.length() - 5));
-    }
-
     @ParallelNamespaceTest
     void testCapacityFile(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
@@ -128,22 +124,22 @@ public class CruiseControlConfigurationST extends AbstractST {
         JsonObject defaultBrokerCapacity = defaultBroker.getJsonObject("capacity");
         assertThat(Double.valueOf(defaultBrokerCapacity.getString("DISK")), is(disk));
         assertThat(Double.valueOf(defaultBrokerCapacity.getString("CPU")), is(cpu));
-        assertThat(Double.valueOf(defaultBrokerCapacity.getString("NW_IN")), is(removeKibSuffix(inboundNetwork)));
-        assertThat(Double.valueOf(defaultBrokerCapacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));
+        assertThat(Double.valueOf(defaultBrokerCapacity.getString("NW_IN")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(inboundNetwork)));
+        assertThat(Double.valueOf(defaultBrokerCapacity.getString("NW_OUT")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(outboundNetwork)));
 
         LOGGER.info("Verifying cruise control capacity overrides");
         JsonObject broker0Capacity = brokerCapacities.getJsonObject(1).getJsonObject("capacity");
         JsonObject broker1Capacity = brokerCapacities.getJsonObject(2).getJsonObject("capacity");
         JsonObject broker2Capacity = brokerCapacities.getJsonObject(3).getJsonObject("capacity");
 
-        assertThat(Double.valueOf(broker0Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride0)));
-        assertThat(Double.valueOf(broker0Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));
+        assertThat(Double.valueOf(broker0Capacity.getString("NW_IN")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(inboundNetworkOverride0)));
+        assertThat(Double.valueOf(broker0Capacity.getString("NW_OUT")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(outboundNetwork)));
 
-        assertThat(Double.valueOf(broker1Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride0)));
-        assertThat(Double.valueOf(broker1Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));
+        assertThat(Double.valueOf(broker1Capacity.getString("NW_IN")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(inboundNetworkOverride0)));
+        assertThat(Double.valueOf(broker1Capacity.getString("NW_OUT")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(outboundNetwork)));
 
-        assertThat(Double.valueOf(broker2Capacity.getString("NW_IN")), is(removeKibSuffix(inboundNetworkOverride0)));
-        assertThat(Double.valueOf(broker2Capacity.getString("NW_OUT")), is(removeKibSuffix(outboundNetwork)));
+        assertThat(Double.valueOf(broker2Capacity.getString("NW_IN")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(inboundNetworkOverride0)));
+        assertThat(Double.valueOf(broker2Capacity.getString("NW_OUT")), is(CruiseControlUtils.removeNetworkCapacityKibSuffix(outboundNetwork)));
     }
 
     @ParallelNamespaceTest


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

For accurate rebalances between brokers running on nodes with heterogeneous network resources, Cruise Control must know the network capacity limit of individual brokers. This PR allows users to specify capacity limit overrides for lists of individual Kafka brokers in the `overrides` property in `Kafka.spec.cruiseControl.brokerCapacity`.

This PR addresses the network capacity issues of https://github.com/strimzi/strimzi-kafka-operator/issues/6265.  The CPU overrides will be handled in a separate PR.

```
apiVersion: {KafkaApiVersion}
kind: Kafka
metadata:
  name: my-cluster
spec:
  # ...
  cruiseControl:
    # ...
    brokerCapacity:
      inboundNetwork: 10000KiB/s
      outboundNetwork: 10000KiB/s
      overrides:
      - brokers: [0]
        inboundNetwork: 20000KiB/s
        outboundNetwork: 20000KiB/s
      - brokers: [1, 2]
        inboundNetwork: 30000KiB/s
        outboundNetwork: 30000KiB/s
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

