### PR TITLE
docs: updates to archive links

### DIFF
--- a/documentation/assemblies/managing/assembly-drain-cleaner.adoc
+++ b/documentation/assemblies/managing/assembly-drain-cleaner.adoc
@@ -64,13 +64,7 @@ webhooks:
 
 To deploy and use the Strimzi Drain Cleaner, you need to download the deployment files.
 
-ifdef::Downloading[]
-The Strimzi Drain Cleaner deployment files are accessible from the link:{ReleaseDownload} release archive.
-endif::Downloading[]
-
-ifndef::Downloading[]
-The Strimzi Drain Cleaner deployment files are provided with the downloadable release artifacts from the {ZipDownload}.
-endif::Downloading[]
+The Strimzi Drain Cleaner deployment files are available from the link:{ReleaseDownload}.
 
 //steps for deploying drain cleaner
 include::modules/proc-drain-cleaner-deploying.adoc[leveloffset=+1]

--- a/documentation/modules/deploying/con-deploy-examples.adoc
+++ b/documentation/modules/deploying/con-deploy-examples.adoc
@@ -11,15 +11,11 @@ Example configuration files for custom resources contain important properties an
 
 == Example files location
 
-ifdef::Downloading[]
-The example files are provided with the downloadable release artifacts from {ReleaseDownload}.
+The example files are provided with the downloadable release artifacts from the {ReleaseDownload}.
 
+ifdef::Downloading[]
 You can also access the example files directly from the
 link:https://github.com/strimzi/strimzi-kafka-operator/tree/{GithubVersion}/examples/[`examples` directory^].
-endif::Downloading[]
-
-ifndef::Downloading[]
-The example files are provided with the downloadable release artifacts from the {ZipDownload}.
 endif::Downloading[]
 
 You can download and apply the examples using the `kubectl` command-line tool.

--- a/documentation/modules/deploying/con-deploy-product-downloads.adoc
+++ b/documentation/modules/deploying/con-deploy-product-downloads.adoc
@@ -7,12 +7,12 @@
 
 [role="_abstract"]
 ifdef::Downloading[]
-To use deployment files to install Strimzi, download the release artifacts from {ReleaseDownload}.
+To use deployment files to install Strimzi, download and extract the `strimzi-_<version>_.zip` file from the {ReleaseDownload}.
 
 Download the `strimzi-_<version>_.zip` or `strimzi-_<version>_.tar.gz` archive file.
 endif::Downloading[]
 ifndef::Downloading[]
-To use deployment files to install Strimzi, download and extract the *{ProductName} _<version>_ installation and example files* archive from the {ZipDownload}.
+To use deployment files to install Strimzi, download and extract the *{ProductName} _<version>_ installation and example files* archive from the {ReleaseDownload}.
 endif::Downloading[]
 
 Strimzi release artifacts include sample YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations,

--- a/documentation/modules/deploying/con-deploy-product-downloads.adoc
+++ b/documentation/modules/deploying/con-deploy-product-downloads.adoc
@@ -6,14 +6,7 @@
 = Downloading Strimzi release artifacts
 
 [role="_abstract"]
-ifdef::Downloading[]
-To use deployment files to install Strimzi, download and extract the `strimzi-_<version>_.zip` file from the {ReleaseDownload}.
-
-Download the `strimzi-_<version>_.zip` or `strimzi-_<version>_.tar.gz` archive file.
-endif::Downloading[]
-ifndef::Downloading[]
-To use deployment files to install Strimzi, download and extract the *{ProductName} _<version>_ installation and example files* archive from the {ReleaseDownload}.
-endif::Downloading[]
+To use deployment files to install Strimzi, download and extract the files from the {ReleaseDownload}.
 
 Strimzi release artifacts include sample YAML files to help you deploy the components of Strimzi to Kubernetes, perform common operations,
 and configure your Kafka cluster.

--- a/documentation/modules/deploying/con-strimzi-installation-methods.adoc
+++ b/documentation/modules/deploying/con-strimzi-installation-methods.adoc
@@ -15,7 +15,7 @@ You can install Strimzi on Kubernetes {KubernetesVersion} in three ways.
 |Description
 
 |xref:deploy-tasks_str[Installation artifacts (YAML files)]
-a|Download the release artifacts from {ReleaseDownload}.
+a|Download the release artifacts from the {ReleaseDownload}.
 
 Download the `strimzi-_<version>_.zip` or `strimzi-_<version>_.tar.gz` archive file.
 The archive file contains installation artifacts and example configuration files.

--- a/documentation/modules/quickstart/proc-downloading-product.adoc
+++ b/documentation/modules/quickstart/proc-downloading-product.adoc
@@ -9,7 +9,7 @@ The resources and artifacts required to install Strimzi, along with examples for
 
 .Procedure
 
-. Download the `strimzi-x.y.z.zip` file from {ReleaseDownload}.
+. Download the `strimzi-_<version>_.zip` file from the {ReleaseDownload}.
 
 . Unzip the file to any destination.
 +
@@ -22,5 +22,5 @@ Extract the ZIP file with this command:
 +
 [source, shell, subs=+quotes]
 ----
-unzip strimzi-xyz.zip
+unzip strimzi-_<version>_.zip
 ----

--- a/documentation/modules/quickstart/ref-install-prerequisites.adoc
+++ b/documentation/modules/quickstart/ref-install-prerequisites.adoc
@@ -6,4 +6,4 @@
 = Prerequisites
 
 * {Minikube}.
-* You need to be able to access Strimzi {ReleaseDownload}.
+* You need to be able to access the {ReleaseDownload}.

--- a/documentation/modules/upgrading/con-upgrade-sequence.adoc
+++ b/documentation/modules/upgrading/con-upgrade-sequence.adoc
@@ -41,4 +41,4 @@ Using a Helm chart:: If you deployed the Cluster Operator using a Helm chart, us
 +
 The `helm upgrade` command does not upgrade the {HelmCustomResourceDefinitions}.
 Install the new CRDs manually after upgrading the Cluster Operator.
-You can access the CRDs from {ReleaseDownload} or find them in the `crd` subdirectory inside the Helm Chart.
+You can access the CRDs from the {ReleaseDownload} or find them in the `crd` subdirectory inside the Helm Chart.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -36,7 +36,7 @@
 :InterBrokerVersionHigher: 3.1
 
 // Source and download links
-:ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub^]
+:ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub release archive^]
 :supported-configurations: https://strimzi.io/downloads/
 
 //Monitoring links

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -36,7 +36,7 @@
 :InterBrokerVersionHigher: 3.1
 
 // Source and download links
-:ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub release archive^]
+:ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub releases page^]
 :supported-configurations: https://strimzi.io/downloads/
 
 //Monitoring links


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
- Updates the links to the Strimzi release archive
- Removes the unused {ZipDownload} attribute

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

