### PR TITLE
[ST] Fix error handling when internal registry service is missing

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NodeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NodeUtils.java
@@ -43,7 +43,7 @@ public class NodeUtils {
     public static void drainNode(String nodeName) {
         List<String> cmd = new ArrayList<>();
 
-        if (KubeClusterResource.getInstance().isNotKubernetes()) {
+        if (KubeClusterResource.getInstance().isOpenShift()) {
             cmd.add("adm");
         }
 
@@ -59,7 +59,7 @@ public class NodeUtils {
         LOGGER.info("Set {} schedule {}", node, schedule);
         List<String> cmd = new ArrayList<>();
 
-        if (KubeClusterResource.getInstance().isNotKubernetes()) {
+        if (KubeClusterResource.getInstance().isOpenShift()) {
             cmd.add("adm");
         }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -367,7 +367,7 @@ public class KubeClusterResource {
         return cluster().defaultOlmNamespace();
     }
 
-    public boolean isNotKubernetes() {
+    public boolean isOpenShift() {
         return kubeClusterResource.cluster() instanceof OpenShift;
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the internal registry service is missing, the code currently throws an NPE instead of some proper error message. This PR fixes it to throw a new `RuntimeException`. It also renames the method `isNotKubernetes` to more appropriate `isOpenShift`.