### PR TITLE
Fix remaining Connect tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -282,11 +282,11 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
         resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
         ClientUtils.waitForClientSuccess(consumerName, INFRA_NAMESPACE, MESSAGE_COUNT);
 
-        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnectWithFilePlugin(extensionContext, clusterName, INFRA_NAMESPACE, oauthClusterName, 1)
+        KafkaConnect connect = KafkaConnectTemplates.kafkaConnectWithFilePlugin(extensionContext, clusterName, INFRA_NAMESPACE, oauthClusterName, 1)
             .editMetadata()
                 .withNamespace(INFRA_NAMESPACE)
             .endMetadata()
-            .withNewSpec()
+            .editOrNewSpec()
                 .withReplicas(1)
                 .withBootstrapServers(KafkaResources.plainBootstrapAddress(oauthClusterName))
                 .withConfig(connectorConfig)
@@ -304,13 +304,16 @@ public class OauthPlainIsolatedST extends OauthAbstractST {
                     .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
                     .withReadTimeoutSeconds(READ_TIMEOUT_S)
                 .endKafkaClientAuthenticationOAuth()
-                .withTls(null)
                 .withNewInlineLogging()
                     // needed for a verification of oauth configuration
                     .addToLoggers("connect.root.logger.level", "DEBUG")
                 .endInlineLogging()
             .endSpec()
-            .build());
+            .build();
+        // This is required to be able to remove the TLS setting, the builder cannot remove it
+        connect.getSpec().setTls(null);
+
+        resourceManager.createResource(extensionContext, connect);
 
         final String kafkaConnectPodName = kubeClient(INFRA_NAMESPACE).listPods(INFRA_NAMESPACE, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the remaining tests using the FileStream connectors which do not use the Kafka Connect Build yet.

### Checklist

- [x] Make sure all tests pass