### PR TITLE
[ST] Add option to specify worker node count for multinode cluster annotation in system tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MultiNodeClusterOnly.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MultiNodeClusterOnly.java
@@ -15,4 +15,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(MultiNodeClusterOnlyCondition.class)
 public @interface MultiNodeClusterOnly {
+    int workerNodeCount() default 1;
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MultiNodeClusterOnlyCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MultiNodeClusterOnlyCondition.java
@@ -11,14 +11,21 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Optional;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
 public class MultiNodeClusterOnlyCondition implements ExecutionCondition {
     private static final Logger LOGGER = LogManager.getLogger(MultiNodeClusterOnlyCondition.class);
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        Optional<MultiNodeClusterOnly> annotation = findAnnotation(extensionContext.getElement(), MultiNodeClusterOnly.class);
+        int expectedNodeCount = annotation.get().workerNodeCount();
+
         KubeClusterResource clusterResource = KubeClusterResource.getInstance();
 
-        if (clusterResource.client().getClusterNodes().size() > 1) {
+        if (clusterResource.client().getClusterWorkers().size() > expectedNodeCount) {
             return ConditionEvaluationResult.enabled("Test is enabled");
         } else {
             LOGGER.info("{} is @MultiNodeClusterOnly, but the running cluster is not multi-node cluster: Ignoring {}",

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerIsolatedST.java
@@ -122,7 +122,8 @@ public class DrainCleanerIsolatedST extends AbstractST {
     }
 
     @IsolatedTest
-    @MultiNodeClusterOnly
+    // We refer to 6 worker nodes to have always 2 nodes with same labels to properly evacuate pods from one node to another
+    @MultiNodeClusterOnly(workerNodeCount = 6)
     void testDrainCleanerWithComponentsDuringNodeDraining(ExtensionContext extensionContext) {
         TestStorage testStorage = new TestStorage(extensionContext, Constants.DRAIN_CLEANER_NAMESPACE);
 


### PR DESCRIPTION


Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR improves `@MultiNodeClusterOnly` annotation with the option to specify the expected worker node count. Some tests needed specific cluster configuration and we should specify by this annotation to run the tests only on proper envs.

### Checklist

- [ ] Make sure all tests pass
