### PR TITLE
Add more kafka connect metrics pattern in source/sink-task-metrics

### DIFF
--- a/packaging/examples/metrics/kafka-connect-metrics.yaml
+++ b/packaging/examples/metrics/kafka-connect-metrics.yaml
@@ -116,7 +116,7 @@ data:
     #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
     #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
     #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-    - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+    - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-seq-no|.+-rate|.+-max|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
       name: kafka_connect_$1_$4
       labels:
         connector: "$2"


### PR DESCRIPTION
### Type of change

- Documentation

### Description
I found some new metrics added (like `sink-record-read-rate` ...) when using the new version of Kafka connect.
These metrics are detailed in official documents <https://docs.confluent.io/platform/current/connect/monitoring.html#sink-task-metrics>
So I think we should these metrics pattern in source/sink-task-metrics.

### Checklist

![image](https://user-images.githubusercontent.com/12069428/167526947-e7045bbe-20ca-485a-b92a-b2dfba440d10.png)

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

