### PR TITLE
Fix Connect and Cruise Control examples

### DIFF
--- a/packaging/examples/connect/kafka-connect-build.yaml
+++ b/packaging/examples/connect/kafka-connect-build.yaml
@@ -8,7 +8,7 @@ metadata:
 #  # needing to call the Connect REST API directly
 #    strimzi.io/use-connector-resources: "true"
 spec:
-  version: 3.1.0
+  version: 3.2.0
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9093
   tls:
@@ -33,11 +33,11 @@ spec:
       # it should not happen that you pull someone else's container image. However, we
       # recommend changing this to your own container registry or using a different
       # image name for any other than demo purposes.
-      image: ttl.sh/strimzi-connect-example-3.1.0:24h
+      image: ttl.sh/strimzi-connect-example-3.2.0:24h
     plugins:
       - name: kafka-connect-file
         artifacts:
           - type: maven
             group: org.apache.kafka
             artifact: connect-file
-            version: 3.1.0
+            version: 3.2.0

--- a/packaging/examples/cruise-control/kafka-cruise-control.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/cruise-control/kafka-rebalance-add-brokers.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-add-brokers.yaml
@@ -6,5 +6,5 @@ metadata:
     strimzi.io/cluster: my-cluster
 # no goals specified, using the default goals from the Cruise Control configuration
 spec:
-  mode: add-broker
+  mode: add-brokers
   brokers: [3, 4]

--- a/packaging/examples/cruise-control/kafka-rebalance-remove-brokers.yaml
+++ b/packaging/examples/cruise-control/kafka-rebalance-remove-brokers.yaml
@@ -6,5 +6,5 @@ metadata:
     strimzi.io/cluster: my-cluster
 # no goals specified, using the default goals from the Cruise Control configuration
 spec:
-  mode: remove-broker
+  mode: remove-brokers
   brokers: [3, 4]

--- a/packaging/examples/kafka/kafka-ephemeral-single.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral-single.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/kafka/kafka-ephemeral.yaml
+++ b/packaging/examples/kafka/kafka-ephemeral.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/kafka/kafka-jbod.yaml
+++ b/packaging/examples/kafka/kafka-jbod.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/kafka/kafka-persistent-single.yaml
+++ b/packaging/examples/kafka/kafka-persistent-single.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/kafka/kafka-persistent.yaml
+++ b/packaging/examples/kafka/kafka-persistent.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/packaging/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
     jmxOptions:

--- a/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/packaging/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -19,7 +19,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -27,7 +27,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
+++ b/packaging/examples/security/keycloak-authorization/kafka-ephemeral-oauth-single-keycloak-authz.yaml
@@ -40,7 +40,7 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
   zookeeper:

--- a/packaging/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/kafka.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:
@@ -63,7 +63,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/security/tls-auth/kafka.yaml
+++ b/packaging/examples/security/tls-auth/kafka.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -21,7 +21,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:
@@ -63,7 +63,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I found several issues in the examples for Connect and Cruise Control:
* `inter.broker.protocol.version` in Kafka examples
* The Connect Build example uses Kafka 3.1.0, probably because it was don ein parallel while Kafka 3.2.0 was being added
* The Cruise Control example use singular for the mode instead of plural and don't work

These changes should be picked for the 0.29.0 release.