### PR TITLE
Refactoring kafka_tls_prepare_certificates.sh file

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -4,20 +4,6 @@ set -e
 # Load predefined functions for preparing trust- and keystores
 source ./tls_utils.sh
 
-# Searches the directory with the CAs and finds the CA matching our key.
-# This is useful during certificate renewals
-#
-# Parameters:
-# $1: The directory with the CA certificates
-# $2: Public key to be imported
-function find_ca {
-    for ca in "$1"/*; do
-        if openssl verify -CAfile "$ca" "$2" &> /dev/null; then
-            echo "$ca"
-        fi
-    done
-}
-
 echo "Preparing truststore for replication listener"
 # Add each certificate to the trust store
 STORE=/tmp/kafka/cluster.truststore.p12


### PR DESCRIPTION
Signed-off-by: j4real2208 <jojojohnsonibm@gmail.com>

### Type of change

_Select the type of your PR_

- Refactoring


### Description

At the current moment I believe the find_ca function is loaded from the docker-images/kafka-based/kafka/scripts/tls_utils.sh file. Therefore it seems like we to need to refactor the code in kafka_tls_prepare_certificates.sh to reflect the same as it is a duplicate effort to define it again owing to the fact both the implementations are the same.



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

