### PR TITLE
Change tags for upgrade testing properly in Azure

### DIFF
--- a/.azure/scripts/setup_upgrade.sh
+++ b/.azure/scripts/setup_upgrade.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
+set -x
+
+RELEASE=$(cat release.version)
+
 sed -i "s#:latest#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 # Change tag in format [0-9].[0-9].[0-9] to tag specified by release version (affects only release runs)
-sed -i "s#:[0-9]+\.[0-9]+\.[0-9]+#${DOCKER_TAG}/kafka#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#:${RELEASE}#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/kafka#${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/operator#${DOCKER_REGISTRY}/${DOCKER_ORG}/operator#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/jmxtrans#${DOCKER_REGISTRY}/${DOCKER_ORG}/jmxtrans#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml

--- a/.azure/scripts/setup_upgrade.sh
+++ b/.azure/scripts/setup_upgrade.sh
@@ -4,10 +4,14 @@ set -x
 
 RELEASE=$(cat release.version)
 
+# The commands 1) and 2) are used for change tag in installation files for CO. For each branch only of them match and apply changes
+# 1) The following command is applied only for branches, where release.version contains *SNAPSHOT* (main + others)
 sed -i "s#:latest#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-# Change tag in format [0-9].[0-9].[0-9] to tag specified by release version (affects only release runs)
+# 2) The following command is applied only for release branches, where release.version contains a final version like 0.29.0
 sed -i "s#:${RELEASE}#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+
+# Change registry and org
+sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/kafka#${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/operator#${DOCKER_REGISTRY}/${DOCKER_ORG}/operator#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/jmxtrans#${DOCKER_REGISTRY}/${DOCKER_ORG}/jmxtrans#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR solves the issue with upgrade pipeline for release. Currently, the tag for upgrade is always set to a final release like `0.29.0` instead of `0.29.0-rc1`. Because the final release version is also in install files, we should get the version from `release.version` and replace it in the install files with proper tag. \

This PR shouldn't affect main or other branches.

### Checklist

- [x] Make sure all tests pass

