### PR TITLE
Fix logging errors and updating KafkaRebalance status

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -302,18 +302,14 @@ public class KafkaRebalanceAssemblyOperator
             if (desiredStatus.getConditions() != null) {
                 previous = desiredStatus.getConditions().stream().filter(condition -> condition != cond).collect(Collectors.toList());
             }
-            String rebalanceType = rebalanceStateConditionType(desiredStatus);
 
             // If a throwable is supplied, it is set in the status with priority
             if (e != null) {
                 StatusUtils.setStatusConditionAndObservedGeneration(kafkaRebalance, desiredStatus, KafkaRebalanceState.NotReady.toString(), e);
                 desiredStatus.setConditions(Stream.concat(desiredStatus.getConditions().stream(), previous.stream()).collect(Collectors.toList()));
-            } else if (rebalanceType != null) {
-                // Rebalance in NotReady state means error that has to stay as it is
-                if (!KafkaRebalanceState.NotReady.toString().equals(rebalanceType)) {
-                    StatusUtils.setStatusConditionAndObservedGeneration(kafkaRebalance, desiredStatus, rebalanceType);
-                    desiredStatus.setConditions(Stream.concat(desiredStatus.getConditions().stream(), previous.stream()).collect(Collectors.toList()));
-                }
+            } else if (cond != null) {
+                StatusUtils.setStatusConditionAndObservedGeneration(kafkaRebalance, desiredStatus, cond);
+                desiredStatus.setConditions(Stream.concat(desiredStatus.getConditions().stream(), previous.stream()).collect(Collectors.toList()));
             } else {
                 throw new IllegalArgumentException("Status related exception and the Status condition's type cannot both be null");
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -191,9 +191,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 // ... or one or more brokers doesn't exist on a add/remove brokers rebalance request
                                 } else if (json.getString(CC_REST_API_ERROR_KEY).contains("IllegalArgumentException") &&
                                             json.getString(CC_REST_API_ERROR_KEY).contains("does not exist.")) {
-                                    CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                                    ccResponse.setBrokersNotExist(true);
-                                    result.complete(ccResponse);
+                                    result.fail(new IllegalArgumentException("Some/all brokers specified don't exist"));
                                 } else {
                                     // If there was any other kind of error propagate this to the operator
                                     result.fail(new CruiseControlRestException(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceResponse.java
@@ -10,7 +10,6 @@ public class CruiseControlRebalanceResponse extends CruiseControlResponse {
 
     private boolean isNotEnoughDataForProposal;
     private boolean isProposalStillCalculating;
-    private boolean isBrokersNotExist;
 
     CruiseControlRebalanceResponse(String userTaskId, JsonObject json) {
         super(userTaskId, json);
@@ -20,8 +19,6 @@ public class CruiseControlRebalanceResponse extends CruiseControlResponse {
         // Proposal is not in progress unless response from Cruise Control says otherwise
         // Sourced from the "progress" field in the response with value "proposalStillCalaculating"
         this.isProposalStillCalculating = false;
-        // One or more brokers provided during a rebalance with add/remove broker endpoints don't exist
-        this.isBrokersNotExist = false;
     }
 
     public boolean isNotEnoughDataForProposal() {
@@ -38,13 +35,5 @@ public class CruiseControlRebalanceResponse extends CruiseControlResponse {
 
     public void setProposalStillCalculating(boolean proposalStillCalculating) {
         this.isProposalStillCalculating = proposalStillCalculating;
-    }
-
-    public boolean isBrokersNotExist() {
-        return this.isBrokersNotExist;
-    }
-
-    public void setBrokersNotExist(boolean brokersNotExist) {
-        this.isBrokersNotExist = brokersNotExist;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -26,6 +26,8 @@ import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.Cruise
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(VertxExtension.class)
 public class CruiseControlClientTest {
@@ -180,7 +182,8 @@ public class CruiseControlClientTest {
                 .build();
         this.ccBrokerDoesNotExist(vertx, context, options, CruiseControlEndpoints.ADD_BROKER,
                 result -> {
-                    assertThat(result.isBrokersNotExist(), is(true));
+                    assertThat(result, instanceOf(IllegalArgumentException.class));
+                    assertTrue(result.getMessage().contains("Some/all brokers specified don't exist"));
                 });
     }
 
@@ -238,7 +241,8 @@ public class CruiseControlClientTest {
                 .build();
         this.ccBrokerDoesNotExist(vertx, context, options, CruiseControlEndpoints.REMOVE_BROKER,
                 result -> {
-                    assertThat(result.isBrokersNotExist(), is(true));
+                    assertThat(result, instanceOf(IllegalArgumentException.class));
+                    assertTrue(result.getMessage().contains("Some/all brokers specified don't exist"));
                 });
     }
 
@@ -366,7 +370,7 @@ public class CruiseControlClientTest {
         }
     }
 
-    private void ccBrokerDoesNotExist(Vertx vertx, VertxTestContext context, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<CruiseControlRebalanceResponse> assertion) throws IOException, URISyntaxException {
+    private void ccBrokerDoesNotExist(Vertx vertx, VertxTestContext context, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<Throwable> assertion) throws IOException, URISyntaxException {
         MockCruiseControl.setupCCBrokerDoesNotExist(ccServer, endpoint);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
@@ -375,14 +379,14 @@ public class CruiseControlClientTest {
         switch (endpoint) {
             case ADD_BROKER:
                 client.addBroker(HOST, PORT, (AddBrokerOptions) options, MockCruiseControl.BROKERS_NOT_EXIST_ERROR)
-                        .onComplete(context.succeeding(result -> context.verify(() -> {
+                        .onComplete(context.failing(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case REMOVE_BROKER:
                 client.removeBroker(HOST, PORT, (RemoveBrokerOptions) options, MockCruiseControl.BROKERS_NOT_EXIST_ERROR)
-                        .onComplete(context.succeeding(result -> context.verify(() -> {
+                        .onComplete(context.failing(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -122,6 +122,13 @@ public class StatusUtils {
         setStatusConditionAndObservedGeneration(resource, status, type, "True");
     }
 
+    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, Condition condition) {
+        if (resource.getMetadata().getGeneration() != null)    {
+            status.setObservedGeneration(resource.getMetadata().getGeneration());
+        }
+        status.setConditions(Collections.singletonList(condition));
+    }
+
     public static Condition getPausedCondition() {
         return new ConditionBuilder()
                 .withLastTransitionTime(StatusUtils.iso8601Now())


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #6824.
It also change the Cruise Control API because the "brokers not exist" error coming from CC when `brokers` list contains broker ids not in the cluster, should be treated as an unrecoverable error which needs user intervention (and not like not enough data in window or proposal not ready).
Finally, the PR also adds a fix to the status condition removed reason and message when the resource is in the NotReady state (which is not related to the issue but is more general). Maybe this last point would need a better refactoring of the update status code.

### Checklist

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging