### PR TITLE
Added metrics configuration to the Cruise Control configuration doc

### DIFF
--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -171,6 +171,34 @@ spec:
     # ...
 ----
 
+[[metrics-configuration]]
+[discrete]
+== Metrics configuration
+
+Cruise Control expose metrics to provide information about the Kafka cluster as well as its internal components.
+Metrics about rebalancing executions, disk and broker failures, optimization proposals and REST API requests could be valuable to monitor your cluster.
+You can find more information on the official Cruise Control https://github.com/linkedin/cruise-control/wiki/Sensors[Sensors] Wiki page.
+
+You can find more information see the xref:con-common-configuration-prometheus-reference[metricsConfig].
+
+.Metrics configuration
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+# ...
+spec:
+  cruiseControl:
+    # ...
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: cruise-control-metrics
+          key: metrics-config.yml
+    # ...
+----
+
 [[api-security-configuration]]
 [discrete]
 == Cruise Control REST API security


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Currently we have some information about metrics configuration for Cruise Control in the deploying guide [here](https://strimzi.io/docs/operators/in-development/deploying.html#con-metrics-cruise-control-str).
Anyway, as a user I would expect some information in the more specific Cruise Control [configuration](https://strimzi.io/docs/operators/latest/configuring.html#ref-cruise-control-configuration-str) section, where we have logging and other stuff but metrics section is missing.
This trivial PR adds this short section to provide an introduction and linking to the common metrics config which is the same for all the components.

### Checklist

- [x] Update documentation
