### PR TITLE
[systemtest] Add tests for `add_broker` and `remove_broker` features in CC

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -66,6 +66,9 @@ public class Environment {
     private static final String TEST_HTTP_PRODUCER_IMAGE_ENV = "TEST_HTTP_PRODUCER_IMAGE";
     private static final String TEST_HTTP_CONSUMER_IMAGE_ENV = "TEST_HTTP_CONSUMER_IMAGE";
     private static final String TEST_CLIENTS_VERSION_ENV = "TEST_CLIENTS_VERSION";
+
+    private static final String SCRAPER_IMAGE_ENV = "SCRAPER_IMAGE";
+
     /**
      * Specify kafka bridge image used in system tests.
      */
@@ -195,12 +198,17 @@ public class Environment {
     private static final String TEST_ADMIN_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + TEST_CLIENTS_ORG_DEFAULT + "/test-client-kafka-admin:" + TEST_CLIENTS_VERSION + "-kafka-" + CLIENTS_KAFKA_VERSION;
     private static final String TEST_HTTP_PRODUCER_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + TEST_CLIENTS_ORG_DEFAULT + "/test-client-http-producer:" + TEST_CLIENTS_VERSION;
     private static final String TEST_HTTP_CONSUMER_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + TEST_CLIENTS_ORG_DEFAULT + "/test-client-http-consumer:" + TEST_CLIENTS_VERSION;
+
     public static final String TEST_PRODUCER_IMAGE = getOrDefault(TEST_PRODUCER_IMAGE_ENV, TEST_PRODUCER_IMAGE_DEFAULT);
     public static final String TEST_CONSUMER_IMAGE = getOrDefault(TEST_CONSUMER_IMAGE_ENV, TEST_CONSUMER_IMAGE_DEFAULT);
     public static final String TEST_STREAMS_IMAGE = getOrDefault(TEST_STREAMS_IMAGE_ENV, TEST_STREAMS_IMAGE_DEFAULT);
     public static final String TEST_ADMIN_IMAGE = getOrDefault(TEST_ADMIN_IMAGE_ENV, TEST_ADMIN_IMAGE_DEFAULT);
     public static final String TEST_HTTP_PRODUCER_IMAGE = getOrDefault(TEST_HTTP_PRODUCER_IMAGE_ENV, TEST_HTTP_PRODUCER_IMAGE_DEFAULT);
     public static final String TEST_HTTP_CONSUMER_IMAGE = getOrDefault(TEST_HTTP_CONSUMER_IMAGE_ENV, TEST_HTTP_CONSUMER_IMAGE_DEFAULT);
+
+    private static final String SCRAPER_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
+    public static final String SCRAPER_IMAGE = getOrDefault(SCRAPER_IMAGE_ENV, SCRAPER_IMAGE_DEFAULT);
+
     // variables for kafka bridge image
     private static final String BRIDGE_IMAGE_DEFAULT = "latest-released";
     public static final String BRIDGE_IMAGE = getOrDefault(BRIDGE_IMAGE_ENV, BRIDGE_IMAGE_DEFAULT);

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
@@ -46,7 +46,7 @@ public class ScraperTemplates {
                         .withContainers(
                             new ContainerBuilder()
                                 .withName(podName)
-                                .withImage("registry.access.redhat.com/ubi8/openjdk-11:latest")
+                                .withImage(Environment.SCRAPER_IMAGE)
                                 .withCommand("sleep")
                                 .withArgs("infinity")
                                 .withImagePullPolicy(Environment.COMPONENTS_IMAGE_PULL_POLICY)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -14,6 +14,7 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -242,5 +243,14 @@ public class KafkaTopicUtils {
         LOGGER.info("Waiting for all topics with prefix {} will be deleted from Kafka", prefix);
         TestUtils.waitFor(String.format("all topics with prefix %s deletion", prefix), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
             () -> !KafkaCmdClient.listTopicsUsingPodCliWithConfigProperties(namespace, bootstrapName, kafkaPodName, properties).contains(prefix));
+    }
+
+    public static List<String> getKafkaTopicReplicasForEachPartition(String namespaceName, String topicName, String podName, String bootstrapServer) {
+        return Arrays.stream(describeTopicViaKafkaPod(namespaceName, topicName, podName, bootstrapServer)
+            .replaceFirst("Topic.*\n", "")
+            .replaceAll(".*Replicas: ", "")
+            .replaceAll("\tIsr.*", "")
+            .split("\n"))
+            .collect(Collectors.toList());
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -53,9 +53,13 @@ public class CruiseControlUtils {
         HTTPS
     }
 
+    public static String callApi(String namespaceName, SupportedHttpMethods method, CruiseControlEndpoints endpoint, SupportedSchemes scheme, Boolean withCredentials) {
+        return callApi(namespaceName, method, endpoint, scheme, withCredentials, "");
+    }
+
     @SuppressWarnings("Regexp")
     @SuppressFBWarnings("DM_CONVERT_CASE")
-    public static String callApi(String namespaceName, SupportedHttpMethods method, CruiseControlEndpoints endpoint, SupportedSchemes scheme, Boolean withCredentials) {
+    public static String callApi(String namespaceName, SupportedHttpMethods method, CruiseControlEndpoints endpoint, SupportedSchemes scheme, Boolean withCredentials, String endpointSuffix) {
         String ccPodName = PodUtils.getFirstPodNameContaining(namespaceName, CONTAINER_NAME);
         String args = " -k ";
 
@@ -65,7 +69,7 @@ public class CruiseControlUtils {
         }
 
         return cmdKubeClient(namespaceName).execInPodContainer(Level.DEBUG, ccPodName, CONTAINER_NAME, "/bin/bash", "-c",
-            "curl -X" + method.name() + args + " " + scheme + "://localhost:" + CRUISE_CONTROL_DEFAULT_PORT + endpoint.toString()).out();
+            "curl -X " + method.name() + args + " " + scheme + "://localhost:" + CRUISE_CONTROL_DEFAULT_PORT + endpoint.toString() + endpointSuffix).out();
     }
 
     @SuppressWarnings("Regexp")

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/JmxUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/JmxUtils.java
@@ -40,7 +40,7 @@ public class JmxUtils {
         String[] cmd = new String[] {
             "java",
             "-jar",
-            "jmxterm/jmxterm.jar",
+            "/tmp/jmxterm.jar",
             "-i",
             "/tmp/" + serviceName + ".sh"
         };
@@ -50,19 +50,11 @@ public class JmxUtils {
 
     public static void downloadJmxTermToPod(String namespace, String podName) {
         String[] cmd = new String[] {
-            "mkdir",
-            "jmxterm",
-
-        };
-
-        cmdKubeClient().namespace(namespace).execInPod(podName, cmd);
-
-        cmd = new String[] {
             "curl",
             "-L",
             "https://github.com/jiaqi/jmxterm/releases/download/v1.0.2/jmxterm-1.0.2-uber.jar",
             "-o",
-            "jmxterm/jmxterm.jar"
+            "/tmp/jmxterm.jar"
         };
 
         cmdKubeClient().namespace(namespace).execInPod(podName, cmd);

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -155,7 +155,7 @@ public class CruiseControlApiST extends AbstractST {
     void testCruiseControlAPIForScalingBrokersUpAndDown(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(testStorage.getClusterName(), 4, 3).build());
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(testStorage.getClusterName(), 5, 3).build());
 
         LOGGER.info("Checking if we are able to execute GET request on {} and {} endpoints", CruiseControlEndpoints.ADD_BROKER, CruiseControlEndpoints.REMOVE_BROKER);
 
@@ -172,15 +172,15 @@ public class CruiseControlApiST extends AbstractST {
         LOGGER.info("Waiting for CC will have for enough metrics to be recorded to make a proposal ");
         CruiseControlUtils.waitForRebalanceEndpointIsReady(testStorage.getNamespaceName());
 
-        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.ADD_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true, "?brokerid=2");
+        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.ADD_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true, "?brokerid=3,4");
 
         assertCCGoalsInResponse(response);
-        assertThat(response, containsString("Cluster load after adding broker [2]"));
+        assertThat(response, containsString("Cluster load after adding broker [3, 4]"));
 
-        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.REMOVE_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true, "?brokerid=2");
+        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.REMOVE_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true, "?brokerid=3,4");
 
         assertCCGoalsInResponse(response);
-        assertThat(response, containsString("Cluster load after removing broker [2]"));
+        assertThat(response, containsString("Cluster load after removing broker [3, 4]"));
     }
 
     private void assertCCGoalsInResponse(String response) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
@@ -78,21 +79,7 @@ public class CruiseControlApiST extends AbstractST {
         response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.REBALANCE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         // all goals stats that contains
-        assertThat(response, containsString("RackAwareGoal"));
-        assertThat(response, containsString("ReplicaCapacityGoal"));
-        assertThat(response, containsString("DiskCapacityGoal"));
-        assertThat(response, containsString("NetworkInboundCapacityGoal"));
-        assertThat(response, containsString("NetworkOutboundCapacityGoal"));
-        assertThat(response, containsString("CpuCapacityGoal"));
-        assertThat(response, containsString("ReplicaDistributionGoal"));
-        assertThat(response, containsString("DiskUsageDistributionGoal"));
-        assertThat(response, containsString("NetworkInboundUsageDistributionGoal"));
-        assertThat(response, containsString("NetworkOutboundUsageDistributionGoal"));
-        assertThat(response, containsString("CpuUsageDistributionGoal"));
-        assertThat(response, containsString("TopicReplicaDistributionGoal"));
-        assertThat(response, containsString("LeaderReplicaDistributionGoal"));
-        assertThat(response, containsString("LeaderBytesInDistributionGoal"));
-        assertThat(response, containsString("PreferredLeaderElectionGoal"));
+        assertCCGoalsInResponse(response);
 
         assertThat(response, containsString("Cluster load after rebalance"));
 
@@ -141,13 +128,14 @@ public class CruiseControlApiST extends AbstractST {
     void testCruiseControlBasicAPIRequestsWithSecurityDisabled(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
 
+        Map<String, Object> config = new HashMap<>();
+        config.put("webserver.security.enable", "false");
+        config.put("webserver.ssl.enable", "false");
+
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(cruiseControlApiClusterName, 3, 3)
             .editOrNewSpec()
-                .withNewCruiseControl().withConfig(
-                        new HashMap<String, Object>() {{
-                            put("webserver.security.enable", "false");
-                            put("webserver.ssl.enable", "false");
-                        }})
+                .withNewCruiseControl()
+                    .withConfig(config)
                 .endCruiseControl()
             .endSpec()
             .build());
@@ -161,5 +149,55 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(response, not(containsString("404")));
         assertThat(response, containsString("RUNNING"));
         assertThat(response, containsString("NO_TASK_IN_PROGRESS"));
+    }
+
+    @ParallelNamespaceTest
+    void testCruiseControlAPIForScalingBrokersUpAndDown(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext);
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(testStorage.getClusterName(), 4, 3).build());
+
+        LOGGER.info("Checking if we are able to execute GET request on {} and {} endpoints", CruiseControlEndpoints.ADD_BROKER, CruiseControlEndpoints.REMOVE_BROKER);
+
+        String response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.ADD_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+
+        assertThat(response, is("Unrecognized endpoint in request '/add_broker'\n" +
+            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
+
+        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REMOVE_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
+
+        assertThat(response, is("Unrecognized endpoint in request '/remove_broker'\n" +
+            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
+
+        LOGGER.info("Waiting for CC will have for enough metrics to be recorded to make a proposal ");
+        CruiseControlUtils.waitForRebalanceEndpointIsReady(testStorage.getNamespaceName());
+
+        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.ADD_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true, "?brokerid=2");
+
+        assertCCGoalsInResponse(response);
+        assertThat(response, containsString("Cluster load after adding broker [2]"));
+
+        response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.REMOVE_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true, "?brokerid=2");
+
+        assertCCGoalsInResponse(response);
+        assertThat(response, containsString("Cluster load after removing broker [2]"));
+    }
+
+    private void assertCCGoalsInResponse(String response) {
+        assertThat(response, containsString("RackAwareGoal"));
+        assertThat(response, containsString("ReplicaCapacityGoal"));
+        assertThat(response, containsString("DiskCapacityGoal"));
+        assertThat(response, containsString("NetworkInboundCapacityGoal"));
+        assertThat(response, containsString("NetworkOutboundCapacityGoal"));
+        assertThat(response, containsString("CpuCapacityGoal"));
+        assertThat(response, containsString("ReplicaDistributionGoal"));
+        assertThat(response, containsString("DiskUsageDistributionGoal"));
+        assertThat(response, containsString("NetworkInboundUsageDistributionGoal"));
+        assertThat(response, containsString("NetworkOutboundUsageDistributionGoal"));
+        assertThat(response, containsString("CpuUsageDistributionGoal"));
+        assertThat(response, containsString("TopicReplicaDistributionGoal"));
+        assertThat(response, containsString("LeaderReplicaDistributionGoal"));
+        assertThat(response, containsString("LeaderBytesInDistributionGoal"));
+        assertThat(response, containsString("PreferredLeaderElectionGoal"));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -359,7 +359,7 @@ public class CruiseControlST extends AbstractST {
 
     @IsolatedTest
     void testCruiseControlDuringBrokerScaleUpAndDown(ExtensionContext extensionContext) {
-        final TestStorage testStorage = new TestStorage(extensionContext);
+        final TestStorage testStorage = new TestStorage(extensionContext, namespace);
         final int initialReplicas = 3;
         final int scaleTo = 5;
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests

### Description

This PR adds two new tests for the new CC features - `add_broker` and `remove_broker` mods.
First tests checking that we are able to use the `add_broker`/`remove_broker` endpoints (as other tests in the `CruiseControlApiST`), second is actually using the `KafkaRebalance` resource during Kafka scaling up and down.

Also, this PR changes image of `Scraper` pod, which will now contain our Kafka image - for using Kafka scripts from different pod than the Kafka one.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

