### PR TITLE
docs: updates the cluster operator install verification

### DIFF
--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -68,8 +68,8 @@ kubectl get deployments -n _<my_cluster_operator_namespace>_
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                                READY  UP-TO-DATE  AVAILABLE
-strimzi-cluster-operator-<version>  1/1    1           1
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-cluster-operator  1/1    1           1
 ----
 +
 `READY` shows the number of replicas that are ready/expected.

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
@@ -36,8 +36,8 @@ kubectl get deployments -n _<my_cluster_operator_namespace>_
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                                READY  UP-TO-DATE  AVAILABLE
-strimzi-cluster-operator-<version>  1/1    1           1
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-cluster-operator  1/1    1           1
 ----
 +
 `READY` shows the number of replicas that are ready/expected.

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -68,8 +68,8 @@ kubectl get deployments -n _<my_cluster_operator_namespace>_
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                                READY  UP-TO-DATE  AVAILABLE
-strimzi-cluster-operator-<version>  1/1    1           1
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-cluster-operator  1/1    1           1
 ----
 +
 `READY` shows the number of replicas that are ready/expected.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation update**
Updates the procedures in [Deploying the Cluster Operator](https://strimzi.io/docs/operators/in-development/deploying.html#cluster-operator-str). Verification of deployment shows the operator name without the version

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

