### PR TITLE
Remove GSON as a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
         <junit.platform.version>1.8.2</junit.platform.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
-        <gson.version>2.8.2</gson.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <netty.version>4.1.77.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>
@@ -620,12 +619,6 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We seem to have Gson as a test dependency. But it does not seem to be used anywhere. So I think we can remove it.