### PR TITLE
[systemtest] Add 0.29.0 to upgrade/downgrade tests and remove unused method

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -108,55 +108,6 @@ public class AbstractUpgradeST extends AbstractST {
         }
     }
 
-    protected static Map<String, JsonObject> buildMidStepUpgradeData(JsonObject jsonData) {
-        List<TestKafkaVersion> testKafkaVersions = TestKafkaVersion.getSupportedKafkaVersions();
-        TestKafkaVersion testKafkaVersion = testKafkaVersions.get(testKafkaVersions.size() - 1);
-
-        Map<String, JsonObject> steps = new HashMap<>();
-
-        String midStepUrl = jsonData.getString("urlFrom");
-        String midStepVersion = jsonData.getString("fromVersion");
-        String midStepExamples = jsonData.getString("fromExamples");
-
-        JsonObject conversionTool = jsonData.getJsonObject("conversionTool");
-
-        // X -> 0.22.0 data
-        JsonObject midStep = JsonObject.mapFrom(jsonData);
-        JsonObject afterMidStep = JsonObject.mapFrom(jsonData);
-        if (jsonData.getString("prevVersion").isEmpty()) {
-            midStep.put("urlFrom", jsonData.getString("urlFrom"));
-            midStep.put("fromVersion", jsonData.getString("fromVersion"));
-            midStep.put("fromExamples", jsonData.getString("fromExamples"));
-            afterMidStep.put("urlFrom", "HEAD");
-            afterMidStep.put("fromVersion", "HEAD");
-            afterMidStep.put("fromExamples", "HEAD");
-        } else {
-            midStep.put("urlFrom", jsonData.getString("urlPrevVersion"));
-            midStep.put("fromVersion", jsonData.getString("prevVersion"));
-            midStep.put("fromExamples", jsonData.getString("prevVersionExamples"));
-            afterMidStep.put("urlFrom", midStepUrl);
-            afterMidStep.put("fromVersion", midStepVersion);
-            afterMidStep.put("fromExamples", midStepExamples);
-        }
-
-        midStep.put("urlTo", midStepUrl);
-        midStep.put("toVersion", midStepVersion);
-        midStep.put("toExamples", midStepExamples);
-        midStep.put("urlToConversionTool", conversionTool.getString("urlToConversionTool"));
-        midStep.put("toConversionTool", conversionTool.getString("toConversionTool"));
-
-        JsonObject midStepProcedures = new JsonObject();
-        midStepProcedures.put("kafkaVersion", testKafkaVersion.version());
-        midStepProcedures.put("logMessageVersion", testKafkaVersion.messageVersion());
-        midStepProcedures.put("interBrokerProtocolVersion", testKafkaVersion.protocolVersion());
-        midStep.put("proceduresAfterOperatorUpgrade", midStepProcedures);
-
-        steps.put("midStep", midStep);
-        steps.put("toHEAD", afterMidStep);
-
-        return steps;
-    }
-
     protected static Stream<Arguments> loadJsonUpgradeData() {
         JsonArray upgradeData = readUpgradeJson(UPGRADE_JSON_FILE);
         List<Arguments> parameters = new LinkedList<>();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -47,7 +47,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;

--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.json
@@ -1,21 +1,21 @@
 [
   {
     "fromVersion":"HEAD",
-    "toVersion":"0.28.0",
+    "toVersion":"0.29.0",
     "fromExamples":"HEAD",
-    "toExamples":"strimzi-0.28.0",
+    "toExamples":"strimzi-0.29.0",
     "urlFrom":"HEAD",
-    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.28.0/strimzi-0.28.0.zip",
+    "urlTo":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.29.0/strimzi-0.29.0.zip",
     "generateTopics": true,
     "additionalTopics": 2,
     "oldestKafka": "3.0.0",
     "imagesAfterOperatorDowngrade": {
-      "zookeeper": "strimzi/kafka:0.28.0-kafka-3.1.0",
-      "kafka": "strimzi/kafka:0.28.0-kafka-3.1.0",
-      "topicOperator": "strimzi/operator:0.28.0",
-      "userOperator": "strimzi/operator:0.28.0"
+      "zookeeper": "strimzi/kafka:0.29.0-kafka-3.2.0",
+      "kafka": "strimzi/kafka:0.29.0-kafka-3.2.0",
+      "topicOperator": "strimzi/operator:0.29.0",
+      "userOperator": "strimzi/operator:0.29.0"
     },
-    "deployKafkaVersion": "3.1.0",
+    "deployKafkaVersion": "3.2.0",
     "client": {
       "continuousClientsMessages": 500
     },

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.json
@@ -30,9 +30,9 @@
     "strimziFeatureGatesFlagsAfter": "-ControlPlaneListener"
   },
   {
-    "fromVersion":"0.28.0",
-    "fromExamples":"strimzi-0.28.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.28.0/strimzi-0.28.0.zip",
+    "fromVersion":"0.29.0",
+    "fromExamples":"strimzi-0.29.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.29.0/strimzi-0.29.0.zip",
     "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",
@@ -60,9 +60,9 @@
     "strimziFeatureGatesFlagsAfter": "+UseStrimziPodSets"
   },
   {
-    "fromVersion":"0.28.0",
-    "fromExamples":"strimzi-0.28.0",
-    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.28.0/strimzi-0.28.0.zip",
+    "fromVersion":"0.29.0",
+    "fromExamples":"strimzi-0.29.0",
+    "urlFrom":"https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.29.0/strimzi-0.29.0.zip",
     "convertCRDs": false,
     "conversionTool": {
       "urlToConversionTool": "",


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test check
- Small cleanup

### Description

This PR adds `0.29.0` version to our upgrade and downgrade tests.
Also removes `buildMidStepUpgradeData`, as it is not used for anything.

### Checklist

- [ ] Make sure all tests pass
