### PR TITLE
Fix missing space in the unallowed storage changes warning

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -316,7 +316,7 @@ public class KafkaCluster extends AbstractModel {
                 LOGGER.warnCr(reconciliation, "Only the following changes to Kafka storage are allowed: " +
                         "changing the deleteClaim flag, " +
                         "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
-                        "changing overrides to nodes which do not exist yet" +
+                        "changing overrides to nodes which do not exist yet " +
                         "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 LOGGER.warnCr(reconciliation, "The desired Kafka storage configuration in the custom resource {}/{} contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a missing space in the warning message about un-allwoed storage changes for a Kafka cluster:
```
2022-05-25 12:37:17 WARN AbstractModel:327 - Reconciliation #10(timer) Kafka(myproject/my-cluster): Only the following changes to Kafka storage are allowed: changing the deleteClaim flag, adding volumes to Jbod storage or removing volumes from Jbod storage, changing overrides to nodes which do not exist **yetand** increasing size of persistent claim volumes (depending on the volume type and used storage class).
```

It adds a space into the `yetand` to change it to `yet and`.