### PR TITLE
docs: single cruise control config example

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -11,6 +11,7 @@ import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.balancing.BrokerCapacity;
 import io.strimzi.api.kafka.model.template.CruiseControlTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import java.io.Serializable;
@@ -18,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 
+@DescriptionFile
 @Buildable(
         editableEnabled = false,
         generateBuilderPackage = false,

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -1,23 +1,62 @@
-// Module included in the following assemblies:
-//
-// assembly-cruise-control-concepts.adoc
+Configures a Cruise Control cluster.
 
-[id='ref-cruise-control-configuration-{context}']
-= Cruise Control configuration
+Configuration options relate to:
 
-The `config` property in `Kafka.spec.cruiseControl` contains configuration options as keys with values as one of the following JSON types:
+* Goals configuration
+* Capacity limits for resource distribution goals
+
+[id='property-cruise-control-config-{context}']
+=== `config`
+
+Use the `config` properties to configure Cruise Control options as keys.
+
+Standard Cruise Control configuration may be provided, restricted to those properties not managed directly by Strimzi.
+
+Configuration options that cannot be configured relate to the following:
+
+* Security (Encryption, Authentication, and Authorization)
+* Connection to the Kafka cluster
+* Client ID configuration
+* ZooKeeper connectivity
+* Web server configuration
+* Anomaly detection
+
+The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-You can specify and configure all the options listed in the "Configurations" section of the {CruiseControlConfigDocs}, apart from those managed directly by Strimzi.
-Specifically, you *cannot* modify configuration options with keys equal to or starting with one of the keys mentioned xref:type-CruiseControlSpec-reference[here].
+You can specify and configure the options listed in the {CruiseControlConfigDocs} with the exception of those options that are managed directly by Strimzi.
+Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
 
-If restricted options are specified, they are ignored and a warning message is printed to the Cluster Operator log file.
-All the supported options are passed to Cruise Control.
+* `bootstrap.servers`
+* `client.id`
+* `zookeeper.`
+* `network.`
+* `security.`
+* `failed.brokers.zk.path`
+* `webserver.http.`
+* `webserver.api.urlprefix`
+* `webserver.session.path`
+* `webserver.accesslog.`
+* `two.step.`
+* `request.reason.required`
+* `metric.reporter.sampler.bootstrap.servers`
+* `capacity.config.file`
+* `self.healing.`
+* `ssl.`
+* `kafka.broker.failure.detection.enable`
+* `topic.config.provider.class`
 
-.An example Cruise Control configuration
+When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
+All other supported options are passed to Cruise Control.
+
+There are exceptions to the forbidden options.
+For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+You can also configure `webserver` properties to enable Cross-Origin Resource Sharing (CORS).
+
+.Example Cruise Control configuration
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -30,24 +69,29 @@ spec:
     # ...
     config:
       default.goals: >
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal
       cpu.balance.threshold: 1.1
       metadata.max.age.ms: 300000
       send.buffer.bytes: 131072
+      webserver.http.cors.enabled: true
+      webserver.http.cors.origin: "*"
+      webserver.http.cors.exposeheaders: "User-Task-ID,Content-Type"
     # ...
 ----
 
-[[cors-configuration]]
-[discrete]
-== Cross-Origin Resource Sharing configuration
+[id='property-cruise-control-config-cors-{context}']
+=== Cross-Origin Resource Sharing (CORS)
 
-Cross-Origin Resource Sharing (CORS) allows you to specify allowed methods and originating URLs for accessing REST APIs.
+Cross-Origin Resource Sharing (CORS) is a HTTP mechanism for controlling access through the APIs.
+Restrictions can be on access methods or originating URLs.
+You can enable CORS with Cruise Control using `webserver` properties in the `config`.
+CORS permits read-only access by applications, which can be in a different location to Strimzi.
+Applications can use `GET` requests to fetch information through the Cruise Control API.
+For example, applications can fetch information on the current cluster load or the most recent optimization proposal.
+`POST` requests are not permitted.
 
-By default, CORS is disabled for the Cruise Control REST API.
-When enabled, only `GET` requests for read-only access to the Kafka cluster state are allowed.
-This means that external applications, which are running in different origins than the Strimzi components, cannot make `POST` requests to the Cruise Control API.
-However, those applications can make `GET` requests to access read-only information about the Kafka cluster, such as the current cluster load or the most recent optimization proposal.
+NOTE: For more information on using CORS with Cruise Control, see {CruiseControlApiDocs}.
 
 .Enabling CORS for Cruise Control
 
@@ -63,19 +107,47 @@ spec:
   cruiseControl:
     # ...
     config:
-      webserver.http.cors.enabled: true
-      webserver.http.cors.origin: "*"
-      webserver.http.cors.exposeheaders: "User-Task-ID,Content-Type"
+      webserver.http.cors.enabled: true # <1>
+      webserver.http.cors.origin: "*" # <2>
+      webserver.http.cors.exposeheaders: "User-Task-ID,Content-Type" # <3>
+
     # ...
 ----
+<1> Enables CORS.
+<2> Specifies permitted origins for the `Access-Control-Allow-Origin` HTTP response header. You can use a wildcard or specify a single origin as a URL. If you use a wildcard, a response is returned following requests from any origin.
+<3> Exposes specified header names for the `Access-Control-Expose-Headers` HTTP response header. Applications in permitted origins can read responses with the specified headers.
 
-For more information, see {CruiseControlApiDocs}.
+=== Cruise Control REST API security
 
-[[capacity-configuration]]
-[discrete]
-== Capacity configuration
+The Cruise Control REST API is secured with HTTP Basic authentication and SSL to protect the cluster against potentially destructive Cruise Control operations, such as decommissioning Kafka brokers.
+We recommend that Cruise Control in Strimzi is **only used with these settings enabled**.
 
-Cruise Control uses _capacity limits_ to determine if optimization goals for resource distribution are being broken.
+However, it is possible to disable these settings by specifying the following Cruise Control configuration:
+
+* To disable the built-in HTTP Basic authentication, set `webserver.security.enable` to `false`.
+* To disable the built-in SSL, set `webserver.ssl.enable` to `false`.
+
+.Cruise Control configuration to disable API authorization, authentication, and SSL
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  # ...
+  cruiseControl:
+    config:
+      webserver.security.enable: false
+      webserver.ssl.enable: false
+# ...
+----
+
+
+[id='property-cruise-control-broker-capacity-{context}']
+=== brokerCapacity
+
+Cruise Control uses capacity limits to determine if optimization goals for resource distribution are being broken.
 There are four goals of this type:
 
 * `DiskUsageDistributionGoal`            - Disk utilization distribution
@@ -101,7 +173,7 @@ That way, all CPU resources are reserved upfront and are always available.
 This configuration allows Cruise Control to properly evaluate the CPU utilization when preparing the rebalance proposals based on CPU goals.
 ====
 
-.An example Cruise Control brokerCapacity configuration using bibyte units
+.Example Cruise Control brokerCapacity configuration using bibyte units
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -162,7 +234,7 @@ Cruise Control has its own configurable logger:
 
 * `rootLogger.level`
 
-Cruise Control uses the Apache `log4j 2` logger implementation.
+Cruise Control uses the Apache `log4j2` logger implementation.
 
 Use the `logging` property to configure loggers and logger levels.
 
@@ -204,30 +276,6 @@ spec:
     # ...
 ----
 
-[[api-security-configuration]]
-[discrete]
-== Cruise Control REST API security
+.Garbage collector (GC)
 
-The Cruise Control REST API is secured with HTTP Basic authentication and SSL to protect the cluster against potentially destructive Cruise Control operations, such as decommissioning Kafka brokers.
-
-We recommend that Cruise Control in Strimzi is **only used with these settings enabled**.
-You should not disable the built-in HTTP Basic authentication or SSL settings described below.
-
-* To disable the built-in HTTP Basic authentication, set `webserver.security.enable` to `false`.
-* To disable the built-in SSL, set `webserver.ssl.enable` to `false`.
-
-.Example Cruise Control configuration to disable API authorization, authentication, and SSL
-[source,yaml,subs="attributes+"]
-----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
-metadata:
-  name: my-cluster
-spec:
-  # ...
-  cruiseControl:
-    config:
-      webserver.security.enable: false
-      webserver.ssl.enable: false
-# ...
-----
+Garbage collector logging can also be enabled (or disabled) using the xref:con-common-configuration-garbage-collection-reference[`jvmOptions` property].

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -171,7 +171,8 @@ spec:
     # ...
 ----
 
-== Capacity overrides
+[id='property-cruise-control-capacity-overrides-{context}']
+=== Capacity overrides
 
 Brokers might be running on nodes with heterogeneous network resources.
 If that's the case, specify `overrides` that set the network capacity limits for each broker.
@@ -204,12 +205,10 @@ spec:
         outboundNetwork: 30000KiB/s
 ----
 
-.Additional resources
-For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapacity schema reference^].
+For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapacity schema reference].
 
-[[logging-configuration]]
-[discrete]
-== Logging configuration
+[id='property-cruise-control-logging-{context}']
+=== Logging configuration
 
 Cruise Control has its own configurable logger:
 

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -19,7 +19,7 @@ Configuration options that cannot be configured relate to the following:
 * Client ID configuration
 * ZooKeeper connectivity
 * Web server configuration
-* Anomaly detection
+* Self healing
 
 The values can be one of the following JSON types:
 
@@ -28,26 +28,7 @@ The values can be one of the following JSON types:
 * Boolean
 
 You can specify and configure the options listed in the {CruiseControlConfigDocs} with the exception of those options that are managed directly by Strimzi.
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
-
-* `bootstrap.servers`
-* `client.id`
-* `zookeeper.`
-* `network.`
-* `security.`
-* `failed.brokers.zk.path`
-* `webserver.http.`
-* `webserver.api.urlprefix`
-* `webserver.session.path`
-* `webserver.accesslog.`
-* `two.step.`
-* `request.reason.required`
-* `metric.reporter.sampler.bootstrap.servers`
-* `capacity.config.file`
-* `self.healing.`
-* `ssl.`
-* `kafka.broker.failure.detection.enable`
-* `topic.config.provider.class`
+See the description of the `config` property for a list of forbidden prefixes.
 
 When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
 All other supported options are passed to Cruise Control.
@@ -83,11 +64,11 @@ spec:
 [id='property-cruise-control-config-cors-{context}']
 === Cross-Origin Resource Sharing (CORS)
 
-Cross-Origin Resource Sharing (CORS) is a HTTP mechanism for controlling access through the APIs.
-Restrictions can be on access methods or originating URLs.
-You can enable CORS with Cruise Control using `webserver` properties in the `config`.
-CORS permits read-only access by applications, which can be in a different location to Strimzi.
-Applications can use `GET` requests to fetch information through the Cruise Control API.
+Cross-Origin Resource Sharing (CORS) is a HTTP mechanism for controlling access to REST APIs.
+Restrictions can be on access methods or originating URLs of client applications.
+You can enable CORS with Cruise Control using the `webserver.http.cors.enabled` property in the `config`.
+When enabled, CORS permits read access to the Cruise Control REST API from applications that have different originating URLs than Strimzi.
+This allows applications from specified origins to use `GET` requests to fetch information about the Kafka cluster through the Cruise Control API.
 For example, applications can fetch information on the current cluster load or the most recent optimization proposal.
 `POST` requests are not permitted.
 
@@ -224,7 +205,7 @@ spec:
 ----
 
 .Additional resources
-For more information, refer to the xref:type-BrokerCapacity-reference[].
+For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapacity schema reference^].
 
 [[logging-configuration]]
 [discrete]

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -58,7 +58,7 @@ For more information on configuring logging for specific Kafka components or ope
 * xref:property-kafka-connect-logging-reference[Kafka Connect and Mirror Maker 2.0 logging]
 * xref:property-mm-loggers-reference[MirrorMaker logging]
 * xref:property-kafka-bridge-logging-reference[Kafka Bridge logging]
-* xref:ref-cruise-control-configuration-str[Cruise Control logging]
+* xref:property-cruise-control-logging-reference[Cruise Control logging]
 
 .Operator logging
 

--- a/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
+++ b/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
@@ -16,7 +16,7 @@ Strimzi utilizes the REST API to support the following Cruise Control features:
 
 * Rebalancing a Kafka cluster based on an optimization proposal.
 
-Other Cruise Control features are not currently supported, including anomaly detection, notifications, write-your-own goals, and changing the topic replication factor.
+Other Cruise Control features are not currently supported, including self healing, notifications, write-your-own goals, and changing the topic replication factor.
 
 Strimzi provides link:{BookURLDeploying}#deploy-examples-{context}[example configuration files].
 Example YAML configuration files for Cruise Control are provided in `examples/cruise-control/`.

--- a/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
+++ b/documentation/assemblies/cruise-control/assembly-cruise-control-concepts.adoc
@@ -29,9 +29,7 @@ include::../../modules/cruise-control/con-optimization-proposals.adoc[leveloffse
 
 include::../../modules/cruise-control/con-rebalance-performance.adoc[leveloffset=+1]
 
-include::../../modules/cruise-control/ref-cruise-control-configuration.adoc[leveloffset=+1]
-
-include::../../modules/cruise-control/proc-deploying-cruise-control.adoc[leveloffset=+1]
+include::../../modules/cruise-control/proc-configuring-deploying-cruise-control.adoc[leveloffset=+1]
 
 include::../../modules/cruise-control/proc-generating-optimization-proposals.adoc[leveloffset=+1]
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1304,6 +1304,13 @@ Configuration of how TLS certificates are used within the cluster. This applies 
 
 Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 
+xref:type-CruiseControlSpec-schema-{context}[Full list of `CruiseControlSpec` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc[leveloffset=+1]
+
+[id='type-CruiseControlSpec-schema-{context}']
+==== `CruiseControlSpec` schema properties
+
 
 [options="header"]
 |====

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -191,7 +191,7 @@ spec:
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes]. If your cluster already has topics defined, you can
 xref:scaling-clusters-{context}[scale clusters].
 <2> Kafka version, which can be changed to a supported version by following link:{BookURLDeploying}#assembly-upgrade-str[the upgrade procedure].
-<3> Specified xref:property-kafka-logging-reference[Kafka loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<3> xref:property-kafka-logging-reference[Kafka loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <4> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
 <5> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <6> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka.
@@ -206,7 +206,7 @@ xref:scaling-clusters-{context}[scale clusters].
 <15> External listener configuration specifies xref:assembly-accessing-kafka-outside-cluster-str[how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`].
 <16> Optional configuration for a xref:kafka-listener-certificates-str[Kafka listener certificate] managed by an external Certificate Authority. The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates on any listener with enabled TLS encryption.
 <17> Authorization xref:con-securing-kafka-authorization-str[enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
-<18> The `config` specifies the broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
+<18> Broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
 <19> xref:con-common-configuration-ssl-reference[SSL properties for listeners with TLS encryption enabled to enable a specific _cipher suite_ or TLS version].
 <20> xref:assembly-storage-{context}[Storage] is configured as `ephemeral`, `persistent-claim` or `jbod`.
 <21> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -5,24 +5,27 @@
 [id='con-optimization-goals-{context}']
 = Optimization goals overview
 
-To rebalance a Kafka cluster, Cruise Control uses optimization goals to generate xref:con-optimization-proposals-{context}[optimization proposals], which you can approve or reject.  
+To rebalance a Kafka cluster, Cruise Control uses optimization goals to generate xref:con-optimization-proposals-{context}[optimization proposals], which you can approve or reject.
 
-Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster. 
-Strimzi supports most of the optimization goals developed in the Cruise Control project. 
+Optimization goals are constraints on workload redistribution and resource utilization across a Kafka cluster.
+Strimzi supports most of the optimization goals developed in the Cruise Control project.
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
 . Minimum number of leader replicas per broker for a set of topics
 . Replica capacity
-. _Capacity_: Disk capacity, Network inbound capacity, Network outbound capacity, CPU capacity
+. Capacity goals
+** Disk capacity
+** Network inbound capacity
+** Network outbound capacity
+** CPU capacity
 . Replica distribution
 . Potential network output
-. _Resource distribution_: Disk utilization distribution, Network inbound utilization distribution, Network outbound utilization distribution, CPU utilization distribution
-+
-[NOTE]
-====
-The resource distribution goals are controlled using xref:capacity-configuration[capacity limits] on broker resources.
-====
+. Resource distribution goals
+** Disk utilization distribution
+** Network inbound utilization distribution
+** Network outbound utilization distribution
+** CPU utilization distribution
 . Leader bytes-in rate distribution
 . Topic replica distribution
 . Leader replica distribution
@@ -34,11 +37,15 @@ For more information on each optimization goal, see link:https://github.com/link
 
 NOTE: "Write your own" goals and Kafka assigner goals are not yet supported.
 
-[discrete]
 == Goals configuration in Strimzi custom resources
 
-You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources. Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:main-goals[main], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals. 
-Optimization goals for resource distribution (disk, network inbound, network outbound, and CPU) are subject to xref:capacity-configuration[capacity limits] on broker resources.
+You configure optimization goals in `Kafka` and `KafkaRebalance` custom resources.
+Cruise Control has configurations for xref:hard-soft-goals[hard] optimization goals that must be satisfied, as well as xref:main-goals[main], xref:#default-goals[default], and xref:#user-provided-goals[user-provided] optimization goals.
+
+[NOTE]
+====
+Resource distribution goals are subject to xref:property-cruise-control-broker-capacity-reference[capacity limits] on broker resources.
+====
 
 The following sections describe each goal configuration in more detail.
 
@@ -46,15 +53,15 @@ The following sections describe each goal configuration in more detail.
 [discrete]
 === Hard goals and soft goals
 
-Hard goals are goals that _must_ be satisfied in optimization proposals. 
-Goals that are not configured as hard goals are known as _soft goals_. 
+Hard goals are goals that _must_ be satisfied in optimization proposals.
+Goals that are not configured as hard goals are known as _soft goals_.
 You can think of soft goals as _best effort_ goals: they do _not_ need to be satisfied in optimization proposals, but are included in optimization calculations.
 An optimization proposal that violates one or more soft goals, but satisfies all hard goals, is valid.
 
-Cruise Control will calculate optimization proposals that satisfy all the hard goals and as many soft goals as possible (in their priority order). 
+Cruise Control will calculate optimization proposals that satisfy all the hard goals and as many soft goals as possible (in their priority order).
 An optimization proposal that does _not_ satisfy all the hard goals is rejected by Cruise Control and not sent to the user for approval.
 
-NOTE: For example, you might have a soft goal to distribute a topic's replicas evenly across the cluster (the topic replica distribution goal). 
+NOTE: For example, you might have a soft goal to distribute a topic's replicas evenly across the cluster (the topic replica distribution goal).
 Cruise Control will ignore this goal if doing so enables all the configured hard goals to be met.
 
 In Cruise Control, the following xref:main-goals[main optimization goals] are preset as hard goals:
@@ -96,7 +103,7 @@ spec:
 
 Increasing the number of configured hard goals will reduce the likelihood of Cruise Control generating valid optimization proposals.
 
-If `skipHardGoalCheck: true` is specified in the `KafkaRebalance` custom resource, Cruise Control does _not_ check that the list of user-provided optimization goals (in `KafkaRebalance.spec.goals`) contains _all_ the configured hard goals (`hard.goals`). 
+If `skipHardGoalCheck: true` is specified in the `KafkaRebalance` custom resource, Cruise Control does _not_ check that the list of user-provided optimization goals (in `KafkaRebalance.spec.goals`) contains _all_ the configured hard goals (`hard.goals`).
 Therefore, if some, but not all, of the user-provided optimization goals are in the `hard.goals` list, Cruise Control will still treat them as hard goals even if `skipHardGoalCheck: true` is specified.
 
 [[main-goals]]
@@ -106,7 +113,7 @@ Therefore, if some, but not all, of the user-provided optimization goals are in 
 The _main optimization goals_ are available to all users.
 Goals that are not listed in the main optimization goals are not available for use in Cruise Control operations.
 
-Unless you change the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following main optimization goals from Cruise Control, in descending priority order:
+Unless you change the Cruise Control xref:proc-configuring-deploying-cruise-control-{context}[deployment configuration], Strimzi will inherit the following main optimization goals from Cruise Control, in descending priority order:
 
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal; ReplicaDistributionGoal; PotentialNwOutGoal; DiskUsageDistributionGoal; NetworkInboundUsageDistributionGoal; NetworkOutboundUsageDistributionGoal; CpuUsageDistributionGoal; TopicReplicaDistributionGoal; LeaderReplicaDistributionGoal; LeaderBytesInDistributionGoal; PreferredLeaderElectionGoal
@@ -128,18 +135,18 @@ NOTE: If you change the inherited main optimization goals, you must ensure that 
 === Default optimization goals
 
 Cruise Control uses the _default optimization goals_ to generate the _cached optimization proposal_.
-For more information about the cached optimization proposal, see xref:con-optimization-proposals-{context}[]. 
+For more information about the cached optimization proposal, see xref:con-optimization-proposals-{context}[].
 
 You can override the default optimization goals by setting xref:user-provided-goals[user-provided optimization goals] in a `KafkaRebalance` custom resource.
 
-Unless you specify `default.goals` in the Cruise Control xref:proc-deploying-cruise-control-{context}[deployment configuration], the main optimization goals are used as the default optimization goals. 
+Unless you specify `default.goals` in the Cruise Control xref:proc-configuring-deploying-cruise-control-{context}[deployment configuration], the main optimization goals are used as the default optimization goals.
 In this case, the cached optimization proposal is generated using the main optimization goals.
 
 * To use the main optimization goals as the default goals, do not specify the `default.goals` property in `Kafka.spec.cruiseControl.config`.
 
 * To modify the default optimization goals, edit the `default.goals` property in `Kafka.spec.cruiseControl.config`.
 You must use a subset of the main optimization goals.
- 
+
 .Example `Kafka` configuration for default optimization goals
 
 [source,yaml,subs="attributes+"]
@@ -162,10 +169,10 @@ spec:
       outboundNetwork: 10000KB/s
     config:
       default.goals: >
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal
-      # ...         
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal
+      # ...
 ----
 
 If no default optimization goals are specified, the cached proposal is generated using the main optimization goals.
@@ -174,7 +181,7 @@ If no default optimization goals are specified, the cached proposal is generated
 [discrete]
 === User-provided optimization goals
 
-_User-provided optimization goals_ narrow down the configured default goals for a particular optimization proposal. 
+_User-provided optimization goals_ narrow down the configured default goals for a particular optimization proposal.
 You can set them, as required, in `spec.goals` in a `KafkaRebalance` custom resource:
 
 ----
@@ -182,7 +189,7 @@ KafkaRebalance.spec.goals
 ----
 
 User-provided optimization goals can generate optimization proposals for different scenarios.
-For example, you might want to optimize leader replica distribution across the Kafka cluster without considering disk capacity or disk utilization. 
+For example, you might want to optimize leader replica distribution across the Kafka cluster without considering disk capacity or disk utilization.
 So, you create a `KafkaRebalance` custom resource containing a single user-provided goal for leader replica distribution.
 
 User-provided optimization goals must:
@@ -190,10 +197,10 @@ User-provided optimization goals must:
 * Include all configured xref:hard-soft-goals[hard goals], or an error occurs
 * Be a subset of the main optimization goals
 
-To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource. See xref:proc-generating-optimization-proposals-{context}[]. 
+To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource. See xref:proc-generating-optimization-proposals-{context}[].
 
+[role="_abstract"]
 .Additional resources
 
-* xref:ref-cruise-control-configuration-{context}[]
-
+* xref:proc-configuring-deploying-cruise-control-{context}[Configuring and deploying Cruise Control with Kafka]
 * link:https://github.com/linkedin/cruise-control/wiki/Configurations[Configurations^] in the Cruise Control Wiki.

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -7,7 +7,7 @@
 = Optimization proposals overview
 
 An _optimization proposal_ is a summary of proposed changes that would produce a more balanced Kafka cluster, with partition workloads distributed more evenly among the brokers.
-Each optimization proposal is based on the set of xref:con-optimization-goals-{context}[optimization goals] that was used to generate it, subject to any configured xref:capacity-configuration[capacity limits on broker resources].
+Each optimization proposal is based on the set of xref:con-optimization-goals-{context}[optimization goals] that was used to generate it, subject to any configured xref:property-cruise-control-broker-capacity-reference[capacity limits on broker resources].
 
 All optimization proposals are _estimates_ of the impact of a proposed rebalance.
 You can approve or reject a proposal.

--- a/documentation/modules/cruise-control/con-rebalance-performance.adoc
+++ b/documentation/modules/cruise-control/con-rebalance-performance.adoc
@@ -56,7 +56,7 @@ Cruise Control does not perform inter-broker and intra-broker balancing at the s
 == Rebalance tuning options
 
 Cruise Control provides several configuration options for tuning the rebalance parameters discussed above.
-You can set these tuning options at either the xref:ref-cruise-control-configuration-{context}[Cruise Control server] or xref:proc-generating-optimization-proposals-{context}[optimization proposal] levels:
+You can set these tuning options when xref:proc-configuring-deploying-cruise-control-{context}[configuring and deploying Cruise Control with Kafka] or xref:proc-generating-optimization-proposals-{context}[optimization proposal] levels:
 
 * The Cruise Control server setting can be set in the Kafka custom resource under `Kafka.spec.cruiseControl.config`.
 * The individual rebalance performance configurations can be set under `KafkaRebalance.spec`.

--- a/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
@@ -2,13 +2,16 @@
 //
 // assembly-cruise-control-concepts.adoc
 
-[id='proc-deploying-cruise-control-{context}']
-= Deploying Cruise Control
+[id='proc-configuring-deploying-cruise-control-{context}']
+= Configuring and deploying Cruise Control with Kafka
 
 [role="_abstract"]
-To deploy Cruise Control to your Strimzi cluster, define the configuration using the `cruiseControl` property in the `Kafka` resource, and then create or update the resource.
-
+Through `Kafka` resource configuration, the Cluster Operator can deploy Cruise Control when deploying a Kafka cluster.
+You can use the `cruiseControl` properties of the `Kafka` resource to configure the deployment.
 Deploy one instance of Cruise Control per Kafka cluster.
+
+Use `goals` configuration in the Cruise Control `config` to specify optimization goals for generating optimization proposals.
+You can use `brokerCapacity` to change the default capacity limits for goals related to resource distribution.
 
 .Prerequisites
 
@@ -17,7 +20,7 @@ Deploy one instance of Cruise Control per Kafka cluster.
 
 .Procedure
 
-. Edit the `Kafka` resource and add the `cruiseControl` property.
+. Edit the `cruiseControl` property for the `Kafka` resource.
 +
 The properties you can configure are shown in this example configuration:
 +
@@ -35,26 +38,34 @@ spec:
       outboundNetwork: 10000KB/s
       # ...
     config: # <2>
-      default.goals: >
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
-         com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal
-         # ...
+      default.goals: > # <3>
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal
+        # ...
+      hard.goals: >
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,
+        com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal
+        # ...
       cpu.balance.threshold: 1.1
       metadata.max.age.ms: 300000
       send.buffer.bytes: 131072
+      webserver.http.cors.enabled: true # <4>
+      webserver.http.cors.origin: "*"
+      webserver.http.cors.exposeheaders: "User-Task-ID,Content-Type"
       # ...
-    resources: # <3>
+    resources: # <5>
       requests:
         cpu: 1
         memory: 512Mi
       limits:
         cpu: 2
         memory: 2Gi
-    logging: # <4>
+    logging: # <6>
         type: inline
         loggers:
           rootLogger.level: "INFO"
-    template: # <5>
+    template: # <7>
       pod:
         metadata:
           labels:
@@ -63,23 +74,29 @@ spec:
           runAsUser: 1000001
           fsGroup: 0
         terminationGracePeriodSeconds: 120
-    readinessProbe: # <6>
+    readinessProbe: # <8>
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    livenessProbe: # <7>
+    livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
+    metricsConfig: # <9>
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: cruise-control-metrics
+          key: metrics-config.yml
 # ...
 ----
-<1> Specifies capacity limits for broker resources. For more information, see xref:capacity-configuration[Capacity configuration].
-<2> Defines the Cruise Control configuration, including the default optimization goals (in `default.goals`) and any customizations to the main optimization goals (in `goals`) or the hard goals (in `hard.goals`).
-You can provide any xref:ref-cruise-control-configuration-{context}[standard Cruise Control configuration option] apart from those managed directly by Strimzi.
-For more information on configuring optimization goals, see xref:con-optimization-goals-{context}[].
-<3> CPU and memory resources reserved for Cruise Control. For more information, see xref:con-common-configuration-resources-reference[].
-<4> Defined loggers and log levels added directly (inline) or indirectly (external) through a ConfigMap. A custom ConfigMap must be placed under the log4j.properties key. Cruise Control has a single logger named `rootLogger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF. For more information, see xref:logging-configuration[Logging configuration].
-<5> xref:assembly-customizing-kubernetes-resources-str[Customization of deployment templates and pods].
-<6> xref:con-common-configuration-healthchecks-reference[Healthcheck readiness probes].
-<7> xref:con-common-configuration-healthchecks-reference[Healthcheck liveness probes].
+<1> xref:property-cruise-control-broker-capacity-reference[Capacity limits for broker resources].
+<2> Cruise Control configuration. xref:property-kafka-config-reference[Standard Cruise Control configuration may be provided, restricted to those properties not managed directly by Strimzi].
+<3> xref:con-optimization-goals-{context}[Optimization goals configuration], which can include configuration for default optimization goals (`default.goals`), main optimization goals (`goals`), and hard goals (`hard.goals`).
+<4> xref:property-cruise-control-config-cors-reference[CORS enabled and configured] for read-only access through the Cruise Control API.
+<5> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<6> xref:property-cruise-control-logging-reference[Cruise Control loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. Cruise Control has a single logger named `rootLogger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<7> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with additional security attributes.
+<8> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<9> xref:con-common-configuration-prometheus-reference[Prometheus metrics] enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
 
 . Create or update the resource:
 +
@@ -147,4 +164,5 @@ After configuring and deploying Cruise Control, you can xref:proc-generating-opt
 
 [role="_additional-resources"]
 .Additional resources
-* xref:type-CruiseControlTemplate-reference[].
+* xref:con-optimization-goals-{context}[Optimization goals overview]
+* xref:type-CruiseControlSpec-reference[`CruiseControlSpec` `schema reference]

--- a/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
@@ -12,6 +12,7 @@ Deploy one instance of Cruise Control per Kafka cluster.
 
 Use `goals` configuration in the Cruise Control `config` to specify optimization goals for generating optimization proposals.
 You can use `brokerCapacity` to change the default capacity limits for goals related to resource distribution.
+If brokers are running on nodes with heterogeneous network resources, you can use `overrides` to set network capacity limits for each broker.
 
 .Prerequisites
 
@@ -36,9 +37,16 @@ spec:
     brokerCapacity: # <1>
       inboundNetwork: 10000KB/s
       outboundNetwork: 10000KB/s
+      overrides: # <2>
+      - brokers: [0]
+        inboundNetwork: 20000KiB/s
+        outboundNetwork: 20000KiB/s
+      - brokers: [1, 2]
+        inboundNetwork: 30000KiB/s
+        outboundNetwork: 30000KiB/s
       # ...
-    config: # <2>
-      default.goals: > # <3>
+    config: # <3>
+      default.goals: > # <4>
         com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
         com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,
         com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal
@@ -50,22 +58,22 @@ spec:
       cpu.balance.threshold: 1.1
       metadata.max.age.ms: 300000
       send.buffer.bytes: 131072
-      webserver.http.cors.enabled: true # <4>
+      webserver.http.cors.enabled: true # <5>
       webserver.http.cors.origin: "*"
       webserver.http.cors.exposeheaders: "User-Task-ID,Content-Type"
       # ...
-    resources: # <5>
+    resources: # <6>
       requests:
         cpu: 1
         memory: 512Mi
       limits:
         cpu: 2
         memory: 2Gi
-    logging: # <6>
+    logging: # <7>
         type: inline
         loggers:
           rootLogger.level: "INFO"
-    template: # <7>
+    template: # <8>
       pod:
         metadata:
           labels:
@@ -74,13 +82,13 @@ spec:
           runAsUser: 1000001
           fsGroup: 0
         terminationGracePeriodSeconds: 120
-    readinessProbe: # <8>
+    readinessProbe: # <9>
       initialDelaySeconds: 15
       timeoutSeconds: 5
     livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    metricsConfig: # <9>
+    metricsConfig: # <10>
       type: jmxPrometheusExporter
       valueFrom:
         configMapKeyRef:
@@ -89,14 +97,15 @@ spec:
 # ...
 ----
 <1> xref:property-cruise-control-broker-capacity-reference[Capacity limits for broker resources].
-<2> Cruise Control configuration. xref:property-kafka-config-reference[Standard Cruise Control configuration may be provided, restricted to those properties not managed directly by Strimzi].
-<3> xref:con-optimization-goals-{context}[Optimization goals configuration], which can include configuration for default optimization goals (`default.goals`), main optimization goals (`goals`), and hard goals (`hard.goals`).
-<4> xref:property-cruise-control-config-cors-reference[CORS enabled and configured] for read-only access through the Cruise Control API.
-<5> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<6> xref:property-cruise-control-logging-reference[Cruise Control loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. Cruise Control has a single logger named `rootLogger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<7> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with additional security attributes.
-<8> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<9> xref:con-common-configuration-prometheus-reference[Prometheus metrics] enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
+<2> xref:property-cruise-control-capacity-overrides-reference[Overrides set network capacity limits] for specific brokers when running on nodes with heterogeneous network resources.
+<3> Cruise Control configuration. xref:property-kafka-config-reference[Standard Cruise Control configuration may be provided, restricted to those properties not managed directly by Strimzi].
+<4> xref:con-optimization-goals-{context}[Optimization goals configuration], which can include configuration for default optimization goals (`default.goals`), main optimization goals (`goals`), and hard goals (`hard.goals`).
+<5> xref:property-cruise-control-config-cors-reference[CORS enabled and configured] for read-only access through the Cruise Control API.
+<6> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<7> xref:property-cruise-control-logging-reference[Cruise Control loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. Cruise Control has a single logger named `rootLogger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<8> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with additional security attributes.
+<9> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<10> xref:con-common-configuration-prometheus-reference[Prometheus metrics] enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
 
 . Create or update the resource:
 +

--- a/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-configuring-deploying-cruise-control.adoc
@@ -100,7 +100,7 @@ spec:
 <2> xref:property-cruise-control-capacity-overrides-reference[Overrides set network capacity limits] for specific brokers when running on nodes with heterogeneous network resources.
 <3> Cruise Control configuration. xref:property-kafka-config-reference[Standard Cruise Control configuration may be provided, restricted to those properties not managed directly by Strimzi].
 <4> xref:con-optimization-goals-{context}[Optimization goals configuration], which can include configuration for default optimization goals (`default.goals`), main optimization goals (`goals`), and hard goals (`hard.goals`).
-<5> xref:property-cruise-control-config-cors-reference[CORS enabled and configured] for read-only access through the Cruise Control API.
+<5> xref:property-cruise-control-config-cors-reference[CORS enabled and configured] for read-only access to the Cruise Control API.
 <6> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
 <7> xref:property-cruise-control-logging-reference[Cruise Control loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. Cruise Control has a single logger named `rootLogger.level`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <8> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with additional security attributes.

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -22,9 +22,8 @@ For more information, see xref:con-optimization-proposals-modes-{context}[Rebala
 
 .Prerequisites
 
-* You have xref:proc-deploying-cruise-control-{context}[deployed Cruise Control] to your Strimzi cluster.
-
-* You have configured xref:con-optimization-goals-{context}[optimization goals] and, optionally, xref:capacity-configuration[capacity limits on broker resources].
+* You have xref:proc-configuring-deploying-cruise-control-{context}[deployed Cruise Control] to your Strimzi cluster.
+* You have configured xref:con-optimization-goals-{context}[optimization goals] and, optionally, xref:property-cruise-control-broker-capacity-reference[capacity limits on broker resources].
 
 .Procedure
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updates the [Cruise Control configuration](https://strimzi.io/docs/operators/in-development/configuring.html#ref-cruise-control-configuration-str) content in the _Configuring_ guide. 

- Brings the configuration options into a single example as part of the deployment procedure.
- Callouts in the example reference common configuration and the `CruiseControlSpec` schema reference to make the section consistent with other component configuration sections.
- Includes some additional content to try and make the config instructions clearer, particularly around CORs

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

