### PR TITLE
Move `ServiceAccountPatching` feature gate to GA

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
 
@@ -15,7 +15,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
 
@@ -25,7 +25,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
 
@@ -35,7 +35,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
 
@@ -45,7 +45,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
 
@@ -55,7 +55,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
 
@@ -65,6 +65,6 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
@@ -20,7 +20,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
@@ -32,7 +32,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
@@ -44,7 +44,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
@@ -56,7 +56,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
@@ -68,7 +68,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
@@ -80,5 +80,5 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-ControlPlaneListener,-ServiceAccountPatching,+UseStrimziPodSets'
+      strimzi_feature_gates: '-ControlPlaneListener,+UseStrimziPodSets'
       releaseVersion: '${{ parameters.releaseVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Remove Kafka 3.0.0 and 3.0.1
 * Add network capacity overrides for Cruise Control capacity config
+* The `ServiceAccountPatching` feature gate moves to GA.
+  It cannot be disabled anymore and will be permanently enabled.
 
 ## 0.29.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -17,13 +17,11 @@ public class FeatureGates {
     public static final FeatureGates NONE = new FeatureGates("");
 
     private static final String CONTROL_PLANE_LISTENER = "ControlPlaneListener";
-    private static final String SERVICE_ACCOUNT_PATCHING = "ServiceAccountPatching";
     private static final String USE_STRIMZI_POD_SETS = "UseStrimziPodSets";
     private static final String USE_KRAFT = "UseKRaft";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate controlPlaneListener = new FeatureGate(CONTROL_PLANE_LISTENER, true);
-    private final FeatureGate serviceAccountPatching = new FeatureGate(SERVICE_ACCOUNT_PATCHING, true);
     private final FeatureGate useStrimziPodSets = new FeatureGate(USE_STRIMZI_POD_SETS, false);
     private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, false);
 
@@ -49,9 +47,6 @@ public class FeatureGates {
                 switch (featureGate) {
                     case CONTROL_PLANE_LISTENER:
                         setValueOnlyOnce(controlPlaneListener, value);
-                        break;
-                    case SERVICE_ACCOUNT_PATCHING:
-                        setValueOnlyOnce(serviceAccountPatching, value);
                         break;
                     case USE_STRIMZI_POD_SETS:
                         setValueOnlyOnce(useStrimziPodSets, value);
@@ -102,13 +97,6 @@ public class FeatureGates {
     }
 
     /**
-     * @return  Returns true when the ServiceAccountPatching feature gate is enabled
-     */
-    public boolean serviceAccountPatchingEnabled() {
-        return serviceAccountPatching.isEnabled();
-    }
-
-    /**
      * @return  Returns true when the UseStrimziPodSets feature gate is enabled
      */
     public boolean useStrimziPodSetsEnabled() {
@@ -130,7 +118,6 @@ public class FeatureGates {
     /*test*/ List<FeatureGate> allFeatureGates()  {
         return List.of(
                 controlPlaneListener,
-                serviceAccountPatching,
                 useStrimziPodSets,
                 useKRaft
         );
@@ -140,7 +127,6 @@ public class FeatureGates {
     public String toString() {
         return "FeatureGates(" +
                 "controlPlaneListener=" + controlPlaneListener.isEnabled() + "," +
-                "ServiceAccountPatching=" + serviceAccountPatching.isEnabled() + "," +
                 "UseStrimziPodSets=" + useStrimziPodSets.isEnabled() + "," +
                 "UseKRaft=" + useKRaft.isEnabled() +
                 ")";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -105,7 +105,7 @@ public class Main {
     static CompositeFuture run(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config) {
         Util.printEnvInfo();
 
-        ResourceOperatorSupplier resourceOperatorSupplier = new ResourceOperatorSupplier(vertx, client, pfa, config.featureGates(), config.getOperationTimeoutMs());
+        ResourceOperatorSupplier resourceOperatorSupplier = new ResourceOperatorSupplier(vertx, client, pfa, config.getOperationTimeoutMs());
 
         KafkaAssemblyOperator kafkaClusterOperations = null;
         KafkaConnectAssemblyOperator kafkaConnectClusterOperations = null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -20,7 +20,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.operator.PlatformFeaturesAvailability;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
@@ -89,7 +88,7 @@ public class ResourceOperatorSupplier {
     public final AdminClientProvider adminClientProvider;
     public final ZookeeperLeaderFinder zookeeperLeaderFinder;
 
-    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, FeatureGates gates, long operationTimeoutMs) {
+    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(vertx, client,
             new ZookeeperLeaderFinder(vertx,
             // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
@@ -97,12 +96,12 @@ public class ResourceOperatorSupplier {
                     new DefaultAdminClientProvider(),
                     new DefaultZookeeperScalerProvider(),
                     new MicrometerMetricsProvider(),
-                    pfa, gates, operationTimeoutMs);
+                    pfa, operationTimeoutMs);
     }
 
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, ZookeeperLeaderFinder zlf,
                                     AdminClientProvider adminClientProvider, ZookeeperScalerProvider zkScalerProvider,
-                                    MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, FeatureGates gates, long operationTimeoutMs) {
+                                    MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, long operationTimeoutMs) {
         this(new ServiceOperator(vertx, client),
                 pfa.hasRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 new StatefulSetOperator(vertx, client, operationTimeoutMs),
@@ -110,7 +109,7 @@ public class ResourceOperatorSupplier {
                 new SecretOperator(vertx, client),
                 new PvcOperator(vertx, client),
                 new DeploymentOperator(vertx, client),
-                new ServiceAccountOperator(vertx, client, gates.serviceAccountPatchingEnabled()),
+                new ServiceAccountOperator(vertx, client),
                 new RoleBindingOperator(vertx, client),
                 new RoleOperator(vertx, client),
                 new ClusterRoleBindingOperator(vertx, client),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
@@ -61,13 +61,13 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testFeatureGatesParsing() {
         assertThat(new FeatureGates("+ControlPlaneListener").controlPlaneListenerEnabled(), is(true));
-        assertThat(new FeatureGates("+ServiceAccountPatching").serviceAccountPatchingEnabled(), is(true));
-        assertThat(new FeatureGates("+ControlPlaneListener,-ServiceAccountPatching").controlPlaneListenerEnabled(), is(true));
-        assertThat(new FeatureGates("+ControlPlaneListener,-ServiceAccountPatching").serviceAccountPatchingEnabled(), is(false));
-        assertThat(new FeatureGates("  +ControlPlaneListener    ,    +ServiceAccountPatching").controlPlaneListenerEnabled(), is(true));
-        assertThat(new FeatureGates("  +ControlPlaneListener    ,    +ServiceAccountPatching").serviceAccountPatchingEnabled(), is(true));
-        assertThat(new FeatureGates("+ServiceAccountPatching,-ControlPlaneListener").controlPlaneListenerEnabled(), is(false));
-        assertThat(new FeatureGates("+ServiceAccountPatching,-ControlPlaneListener").serviceAccountPatchingEnabled(), is(true));
+        assertThat(new FeatureGates("+UseStrimziPodSets").useStrimziPodSetsEnabled(), is(true));
+        assertThat(new FeatureGates("+ControlPlaneListener,-UseStrimziPodSets").controlPlaneListenerEnabled(), is(true));
+        assertThat(new FeatureGates("+ControlPlaneListener,-UseStrimziPodSets").useStrimziPodSetsEnabled(), is(false));
+        assertThat(new FeatureGates("  +ControlPlaneListener    ,    +UseStrimziPodSets").controlPlaneListenerEnabled(), is(true));
+        assertThat(new FeatureGates("  +ControlPlaneListener    ,    +UseStrimziPodSets").useStrimziPodSetsEnabled(), is(true));
+        assertThat(new FeatureGates("+UseStrimziPodSets,-ControlPlaneListener").controlPlaneListenerEnabled(), is(false));
+        assertThat(new FeatureGates("+UseStrimziPodSets,-ControlPlaneListener").useStrimziPodSetsEnabled(), is(true));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -27,7 +27,6 @@ import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
@@ -166,7 +165,7 @@ public class ConnectorMockTest {
                 new DefaultAdminClientProvider(),
                 new DefaultZookeeperScalerProvider(),
                 metricsProvider,
-                pfa, FeatureGates.NONE, 10_000);
+                pfa, 10_000);
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(map(
             ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, KafkaVersionTestUtils.getKafkaImagesEnvVarString(),
             ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -20,7 +20,6 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -136,7 +135,7 @@ public class JbodStorageMockTest {
                 new ResourceOperatorSupplier(this.vertx, this.client,
                         ResourceUtils.zookeeperLeaderFinder(this.vertx, this.client),
                         ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
-                        ResourceUtils.metricsProvider(), pfa, FeatureGates.NONE, 60_000L);
+                        ResourceUtils.metricsProvider(), pfa, 60_000L);
 
         this.operator = new KafkaAssemblyOperator(this.vertx, pfa, new MockCertManager(),
                 new PasswordGenerator(10, "a", "a"), ros,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -23,7 +23,6 @@ import io.strimzi.certs.CertManager;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.ClientsCa;
@@ -126,7 +125,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
         client.secrets().inNamespace(namespace).create(secret);
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, client, mock(ZookeeperLeaderFinder.class),
                 mock(AdminClientProvider.class), mock(ZookeeperScalerProvider.class),
-                mock(MetricsProvider.class), new PlatformFeaturesAvailability(false, KubernetesVersion.V1_20), FeatureGates.NONE, 10000);
+                mock(MetricsProvider.class), new PlatformFeaturesAvailability(false, KubernetesVersion.V1_20), 10000);
 
         operator = new MockKafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, kubernetesVersion),
                 certManager,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -34,7 +34,6 @@ import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
@@ -291,8 +290,7 @@ public class KafkaAssemblyOperatorMockTest {
         ZookeeperLeaderFinder leaderFinder = ResourceUtils.zookeeperLeaderFinder(vertx, client);
         return new ResourceOperatorSupplier(vertx, client, leaderFinder,
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
-                ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, kubernetesVersion),
-                FeatureGates.NONE, 2_000);
+                ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, kubernetesVersion), 2_000);
     }
 
     private void assertResourceRequirements(VertxTestContext context, String statefulSetName) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -16,7 +16,6 @@ import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -114,7 +113,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 new DefaultAdminClientProvider(),
                 new DefaultZookeeperScalerProvider(),
                 ResourceUtils.metricsProvider(),
-                pfa, FeatureGates.NONE, 60_000L);
+                pfa, 60_000L);
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
         this.kco = new KafkaConnectAssemblyOperator(vertx, pfa, supplier, config, foo -> kafkaConnectApi);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.operator.resource.DefaultZookeeperScalerProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -139,7 +138,7 @@ public class KafkaConnectorIT {
                 new DefaultAdminClientProvider(),
                 new DefaultZookeeperScalerProvider(),
                 metrics,
-                pfa, FeatureGates.NONE, 10_000);
+                pfa, 10_000);
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa, ros,
                 ClusterOperatorConfig.fromMap(Collections.emptyMap(), KafkaVersionTestUtils.getKafkaVersionLookup()),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -16,7 +16,6 @@ import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -114,7 +113,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 new DefaultAdminClientProvider(),
                 new DefaultZookeeperScalerProvider(),
                 ResourceUtils.metricsProvider(),
-                pfa, FeatureGates.NONE, 60_000L);
+                pfa, 60_000L);
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
         kco = new KafkaMirrorMaker2AssemblyOperator(vertx, pfa,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -17,7 +17,6 @@ import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaCluster;
@@ -128,7 +127,7 @@ public class KafkaUpgradeDowngradeMockTest {
         mockKube.start();
 
         ResourceOperatorSupplier supplier =  new ResourceOperatorSupplier(vertx, client, ResourceUtils.zookeeperLeaderFinder(vertx, client),
-                ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(), ResourceUtils.metricsProvider(), pfa, FeatureGates.NONE, 2_000);
+                ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(), ResourceUtils.metricsProvider(), pfa, 2_000);
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
@@ -156,7 +155,7 @@ public class PartialRollingUpdateMockTest {
                 ResourceUtils.zookeeperLeaderFinder(vertx, bootstrapClient),
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
                 ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16),
-                FeatureGates.NONE, 60_000L);
+                60_000L);
     }
 
     private void updateStatefulSetGeneration(String stsName, String annotation, String generation)  {

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -18,7 +18,7 @@ GA stage features are stable and should not change in the future.
 Alpha and beta stage features are removed if they do not prove to be useful.
 
 * The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27 and is expected to remain in the beta stage until Strimzi 0.31.
-* The `ServiceAccountPatching` feature gate moved to beta stage in Strimzi 0.27 and is expected to remain in the beta stage until Strimzi 0.30.
+* The `ServiceAccountPatching` feature gate moved to GA stage in Strimzi 0.30. It is now permanently enabled and cannot be disabled.
 * The `UseStrimziPodSets` feature gate is currently planned to move to the beta stage in Strimzi 0.30.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 
@@ -41,7 +41,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`ServiceAccountPatching`
 ¦0.24
 ¦0.27
-¦ -
+¦0.30
 
 ¦`UseStrimziPodSets`
 ¦0.28

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -46,14 +46,9 @@ IMPORTANT: The `ControlPlaneListener` feature gate must be disabled when upgradi
 
 == ServiceAccountPatching feature gate
 
-The `ServiceAccountPatching` feature gate has a default state of _enabled_.
-
-By default, the Cluster Operator reconciles service accounts and updates them when needed.
-For example, you can change service account labels and annotations after the operands are already created.
-To disable service account patching, disable the `ServiceAccountPatching` feature gate.
-
-.Disabling the ServiceAccountPatching feature gate
-To disable the `ServiceAccountPatching` feature gate, specify `-ServiceAccountPatching` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+The `ServiceAccountPatching` feature gate has moved to GA stage in Strimzi 0.30 and is permanently enabled without the possibility to disable it.
+The Cluster Operator now always reconciles service accounts and updates them when needed.
+For example, when you change the desired service account labels or annotations using the `template` property of our custom resources, the operator will automatically update them on the existing service account resources.
 
 [id='ref-operator-use-strimzi-pod-sets-feature-gate-{context}']
 == UseStrimziPodSets feature gate

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -46,9 +46,9 @@ IMPORTANT: The `ControlPlaneListener` feature gate must be disabled when upgradi
 
 == ServiceAccountPatching feature gate
 
-The `ServiceAccountPatching` feature gate has moved to GA stage in Strimzi 0.30 and is permanently enabled without the possibility to disable it.
-The Cluster Operator now always reconciles service accounts and updates them when needed.
-For example, when you change the desired service account labels or annotations using the `template` property of our custom resources, the operator will automatically update them on the existing service account resources.
+The `ServiceAccountPatching` feature gate has moved to GA, which means it is now permanently enabled and cannot be disabled.
+With `ServiceAccountPatching` enabled, the Cluster Operator always reconciles service accounts and updates them when needed.
+For example, when you change service account labels or annotations using the `template` property of a custom resource, the operator automatically updates them on the existing service account resources.
 
 [id='ref-operator-use-strimzi-pod-sets-feature-gate-{context}']
 == UseStrimziPodSets feature gate

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class ServiceAccountOperatorIT extends AbstractResourceOperatorIT<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
     @Override
     protected AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> operator() {
-        return new ServiceAccountOperator(vertx, client, true);
+        return new ServiceAccountOperator(vertx, client);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class ServiceAccountOperatorIT extends AbstractResourceOperatorIT<Kuberne
     @Override
     public void testCreateModifyDelete(VertxTestContext context)    {
         Checkpoint async = context.checkpoint();
-        ServiceAccountOperator op = new ServiceAccountOperator(vertx, client, true);
+        ServiceAccountOperator op = new ServiceAccountOperator(vertx, client);
 
         ServiceAccount newResource = getOriginal();
         ServiceAccount modResource = getModified();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -160,7 +160,7 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
         KubernetesClient mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        ServiceAccountOperator op = new ServiceAccountOperator(vertx, mockClient, true);
+        ServiceAccountOperator op = new ServiceAccountOperator(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, desired)


### PR DESCRIPTION
### Type of change

- Task

### Description

According to the plan from the [SP#26](https://github.com/strimzi/proposals/blob/main/026-service-account-patching.md), the `ServiceAccountPatching` feature gate moves to GA in Strimzi 0.30.0. This PR removes the feature gate and updates to code to make _always enabled_. The related sections of the documentation are updated to reflect the move to GA. But the feature gate remains to be covered in the docs for the time being to allow users to find out wht changed etc.

This feature gate has no impact on any downgrade or upgrade process.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md