### PR TITLE
docs: updates for standalone operator env vars

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -17,7 +17,7 @@ But you can deploy and use the Topic Operator and User Operator as standalone co
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
 The Topic Operator and User Operator watch for `KafkaTopics` and `KafkaUsers` in the single namespace of the Kafka cluster deployment.
 
-.Deploying a Kafka cluster with the Topic Operator and User Operator
+== Deploying a Kafka cluster with the Topic Operator and User Operator
 
 Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster managed by Strimzi.
 
@@ -27,7 +27,7 @@ Perform these deployment steps if you want to use the Topic Operator and User Op
 .. xref:deploying-the-topic-operator-using-the-cluster-operator-{context}[Topic Operator]
 .. xref:deploying-the-user-operator-using-the-cluster-operator-{context}[User Operator]
 
-.Deploying a standalone Topic Operator and User Operator
+== Deploying a standalone Topic Operator and User Operator
 
 Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster that is *not managed* by Strimzi.
 

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -17,8 +17,7 @@ But you can deploy and use the Topic Operator and User Operator as standalone co
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
 The Topic Operator and User Operator watch for `KafkaTopics` and `KafkaUsers` in the single namespace of the Kafka cluster deployment.
 
-[discrete]
-== Deploying a Kafka cluster with the Topic Operator and User Operator
+.Deploying a Kafka cluster with the Topic Operator and User Operator
 
 Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster managed by Strimzi.
 
@@ -28,8 +27,7 @@ Perform these deployment steps if you want to use the Topic Operator and User Op
 .. xref:deploying-the-topic-operator-using-the-cluster-operator-{context}[Topic Operator]
 .. xref:deploying-the-user-operator-using-the-cluster-operator-{context}[User Operator]
 
-[discrete]
-== Deploying a standalone Topic Operator and User Operator
+.Deploying a standalone Topic Operator and User Operator
 
 Perform these deployment steps if you want to use the Topic Operator and User Operator with a Kafka cluster that is *not managed* by Strimzi.
 

--- a/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
@@ -5,13 +5,27 @@
 [id='using-the-topic-operator-{context}']
 = Using the Topic Operator
 
+[role="_abstract"]
 When you create, modify or delete a topic using the `KafkaTopic` resource,
 the Topic Operator ensures those changes are reflected in the Kafka cluster.
 
-The _Deploying and Upgrading Strimzi_ guide provides instructions to deploy the Topic Operator:
+For more information on the `KafkaTopic` resource, see the xref:type-KafkaTopic-reference[`KafkaTopic` schema reference].
 
-* link:{BookURLDeploying}#deploying-the-topic-operator-using-the-cluster-operator-{context}[Using the Cluster Operator (recommended)^]
-* link:{BookURLDeploying}#deploying-the-topic-operator-standalone-{context}[Standalone to operate with Kafka clusters not managed by Strimzi^]
+.Deploying the Topic Operator
+
+You can deploy the Topic Operator using the Cluster Operator or as a standalone operator.
+You would use a standalone Topic Operator with a Kafka cluster that is not managed by the Cluster Operator.
+
+For deployment instructions, see the following:
+
+* link:{BookURLDeploying}#deploying-the-topic-operator-using-the-cluster-operator-{context}[Deploying the Topic Operator using the Cluster Operator (recommended)^]
+* link:{BookURLDeploying}#deploying-the-topic-operator-standalone-{context}[Deploying the standalone Topic Operator^]
+
+[IMPORTANT]
+====
+To deploy the standalone Topic Operator, you need to set environment variables to connect to a Kafka cluster.
+These environment variables are internal to Strimzi and do not need to be set if you are deploying the Topic Operator using the Cluster Operator.
+====
 
 include::../../modules/operators/ref-operator-topic.adoc[leveloffset=+1]
 include::../../modules/operators/con-topic-operator-store.adoc[leveloffset=+1]

--- a/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
@@ -24,7 +24,7 @@ For deployment instructions, see the following:
 [IMPORTANT]
 ====
 To deploy the standalone Topic Operator, you need to set environment variables to connect to a Kafka cluster.
-These environment variables are internal to Strimzi and do not need to be set if you are deploying the Topic Operator using the Cluster Operator.
+These environment variables do not need to be set if you are deploying the Topic Operator using the Cluster Operator as they will be set by the Cluster Operator.
 ====
 
 include::../../modules/operators/ref-operator-topic.adoc[leveloffset=+1]

--- a/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
@@ -5,15 +5,27 @@
 [id='assembly-using-the-user-operator-{context}']
 = Using the User Operator
 
+[role="_abstract"]
 When you create, modify or delete a user using the `KafkaUser` resource,
 the User Operator ensures those changes are reflected in the Kafka cluster.
 
-The _Deploying and Upgrading Strimzi_ guide provides instructions to deploy the User Operator:
+For more information on the `KafkaUser` resource, see the xref:type-KafkaUser-reference[`KafkaUser` schema reference].
 
-* link:{BookURLDeploying}#deploying-the-user-operator-using-the-cluster-operator-{context}[Using the Cluster Operator (recommended)^]
-* link:{BookURLDeploying}#deploying-the-user-operator-standalone-{context}[Standalone to operate with Kafka clusters not managed by Strimzi^]
+.Deploying the User Operator
 
-For more information about the schema, see xref:type-KafkaUser-reference[`KafkaUser` schema reference].
+You can deploy the User Operator using the Cluster Operator or as a standalone operator.
+You would use a standalone User Operator with a Kafka cluster that is not managed by the Cluster Operator.
+
+For deployment instructions, see the following:
+
+* link:{BookURLDeploying}#deploying-the-user-operator-using-the-cluster-operator-{context}[Deploying the User Operator using the Cluster Operator (recommended)^]
+* link:{BookURLDeploying}#deploying-the-user-operator-standalone-{context}[Deploying the standalone User Operator^]
+
+[IMPORTANT]
+====
+To deploy the standalone User Operator, you need to set environment variables to connect to a Kafka cluster.
+These environment variables are internal to Strimzi and do not need to be set if you are deploying the User Operator using the Cluster Operator.
+====
 
 .Authenticating and authorizing access to Kafka
 Use `KafkaUser` to enable the authentication and authorization mechanisms that a specific client uses to access Kafka.

--- a/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
@@ -24,7 +24,7 @@ For deployment instructions, see the following:
 [IMPORTANT]
 ====
 To deploy the standalone User Operator, you need to set environment variables to connect to a Kafka cluster.
-These environment variables are internal to Strimzi and do not need to be set if you are deploying the User Operator using the Cluster Operator.
+These environment variables do not need to be set if you are deploying the User Operator using the Cluster Operator as they will be set by the Cluster Operator.
 ====
 
 .Authenticating and authorizing access to Kafka

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -87,7 +87,11 @@ spec:
 <1> The Kubernetes namespace for the Topic Operator to watch for `KafkaTopic` resources. Specify the namespace of the Kafka cluster.
 <2> The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
 Use a comma-separated list to specify two or three broker addresses in case a server is down.
-<3> The label selector to identify the `KafkaTopic` resources managed by the Topic Operator.
+<3> The label to identify the name of the `KafkaTopic` resources managed by the Topic Operator.
+This does not have to be the name of the Kafka cluster.
+It can be the label assigned to the `KafkaTopic` resource.
+If you deploy more than one Topic Operator, the labels must be unique for each.
+That is, the operators cannot manage the same resources.
 <4> The host and port pair of the address to connect to the ZooKeeper cluster.
 This must be the same ZooKeeper cluster that your Kafka cluster is using.
 <5> The ZooKeeper session timeout, in milliseconds.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -87,7 +87,7 @@ spec:
 <1> The Kubernetes namespace for the Topic Operator to watch for `KafkaTopic` resources. Specify the namespace of the Kafka cluster.
 <2> The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
 Use a comma-separated list to specify two or three broker addresses in case a server is down.
-<3> The label to identify the name of the `KafkaTopic` resources managed by the Topic Operator.
+<3> The label to identify the `KafkaTopic` resources managed by the Topic Operator.
 This does not have to be the name of the Kafka cluster.
 It can be the label assigned to the `KafkaTopic` resource.
 If you deploy more than one Topic Operator, the labels must be unique for each.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -83,7 +83,7 @@ spec:
 Use a comma-separated list to specify two or three broker addresses in case a server is down.
 <3> The Kubernetes `Secret` that contains the public key (`ca.crt`) value of the Certificate Authority that signs new user certificates for TLS client authentication.
 <4> The Kubernetes `Secret` that contains the private key (`ca.key`) value of the Certificate Authority that signs new user certificates for TLS client authentication.
-<5> The label to identify the name of the `KafkaUser` resources managed by the User Operator.
+<5> The label to identify the `KafkaUser` resources managed by the User Operator.
 This does not have to be the name of the Kafka cluster.
 It can be the label assigned to the `KafkaUser` resource.
 If you deploy more than one User Operator, the labels must be unique for each.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -83,7 +83,11 @@ spec:
 Use a comma-separated list to specify two or three broker addresses in case a server is down.
 <3> The Kubernetes `Secret` that contains the public key (`ca.crt`) value of the Certificate Authority that signs new user certificates for TLS client authentication.
 <4> The Kubernetes `Secret` that contains the private key (`ca.key`) value of the Certificate Authority that signs new user certificates for TLS client authentication.
-<5> The label selector used to identify the `KafkaUser` resources managed by the User Operator.
+<5> The label to identify the name of the `KafkaUser` resources managed by the User Operator.
+This does not have to be the name of the Kafka cluster.
+It can be the label assigned to the `KafkaUser` resource.
+If you deploy more than one User Operator, the labels must be unique for each.
+That is, the operators cannot manage the same resources.
 <6> The interval between periodic reconciliations, in milliseconds.
 The default is `120000` (2 minutes).
 <7> The level for printing logging messages.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

- Updates the standalone operator deployment instructions in the _Deploying_ guide to clarify how the _labels_ environment variables should be used. 
- Notes the requirement for configuring the environment variables in the operator sections of the _Configuring_ guide.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

