### PR TITLE
docs: adds additional reasources tags

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.KafkaJmxOptions.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaJmxOptions.adoc
@@ -69,5 +69,7 @@ spec:
     # ...
 ----
 
+[role="_additional-resources"]
 .Additional resources
+
  * For more information on the Kafka component metrics exposed using JMX, see the {kafkaDoc}.

--- a/documentation/modules/configuring/con-customizing-image-pull-policy.adoc
+++ b/documentation/modules/configuring/con-customizing-image-pull-policy.adoc
@@ -21,6 +21,7 @@ Container images are never pulled from the registry.
 The image pull policy can be currently customized only for all Kafka, Kafka Connect, and Kafka MirrorMaker clusters at once.
 Changing the policy will result in a rolling update of all your Kafka, Kafka Connect, and Kafka MirrorMaker clusters.
 
+[role="_additional-resources"]
 .Additional resources
 
 * For more information about Cluster Operator configuration, see xref:using-the-cluster-operator-{context}[].

--- a/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
+++ b/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
@@ -24,6 +24,7 @@ NOTE: Strimzi does not schedule maintenance operations exactly according to the 
 This means that the start of maintenance operations within a given time window can be delayed by up to the Cluster Operator reconciliation interval.
 Maintenance time windows must therefore be at least this long.
 
+[role="_additional-resources"]
 .Additional resources
 
 * For more information about the Cluster Operator configuration, see xref:ref-operator-cluster-str[].

--- a/documentation/modules/configuring/proc-adding-volumes-to-jbod-storage.adoc
+++ b/documentation/modules/configuring/proc-adding-volumes-to-jbod-storage.adoc
@@ -58,6 +58,7 @@ kubectl apply -f _<kafka_configuration_file>_
 
 . Create new topics or reassign existing partitions to the new disks.
 
+[role="_additional-resources"]
 .Additional resources
 
 For more information about reassigning topics, see xref:con-partition-reassignment-{context}[].

--- a/documentation/modules/configuring/proc-configuring-maintenance-time-windows.adoc
+++ b/documentation/modules/configuring/proc-configuring-maintenance-time-windows.adoc
@@ -38,6 +38,7 @@ spec:
 [source,shell,subs=+quotes]
 kubectl apply -f _<kafka_configuration_file>_
 
+[role="_additional-resources"]
 .Additional resources
 
 Performing rolling updates:

--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -19,7 +19,7 @@ This procedure describes how to manually trigger a restart of a Kafka MirrorMake
 kubectl get KafkaMirrorMaker2
 ----
 
-. Find the name of the Kafka MirrorMaker 2.0 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource. 
+. Find the name of the Kafka MirrorMaker 2.0 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource.
 Task IDs are non-negative integers, starting from 0.
 +
 [source,shell,subs="+quotes"]
@@ -27,7 +27,7 @@ Task IDs are non-negative integers, starting from 0.
 kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
 ----
 
-. To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
+. To restart the connector task, annotate the `KafkaMirrorMaker2` resource in Kubernetes.
 In this example, `kubectl annotate` restarts task _0_ of a connector named `+my-source->my-target.MirrorSourceConnector+`:
 +
 [source,shell,subs="+quotes"]
@@ -37,9 +37,10 @@ kubectl annotate KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_ "strimzi.io/restart
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 +
-The Kafka MirrorMaker 2.0 connector task is restarted, as long as the annotation was detected by the reconciliation process. 
+The Kafka MirrorMaker 2.0 connector task is restarted, as long as the annotation was detected by the reconciliation process.
 When the restart task request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2.0 cluster configuration].

--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector.adoc
@@ -26,7 +26,7 @@ kubectl get KafkaMirrorMaker2
 kubectl describe KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_
 ----
 
-. To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes. 
+. To restart the connector, annotate the `KafkaMirrorMaker2` resource in Kubernetes.
 In this example, `kubectl annotate` restarts a connector named `+my-source->my-target.MirrorSourceConnector+`:
 +
 [source,shell,subs="+quotes"]
@@ -36,9 +36,10 @@ kubectl annotate KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_ "strimzi.io/restart
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 +
-The Kafka MirrorMaker 2.0 connector is restarted, as long as the annotation was detected by the reconciliation process. 
+The Kafka MirrorMaker 2.0 connector is restarted, as long as the annotation was detected by the reconciliation process.
 When the restart request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2.0 cluster configuration].

--- a/documentation/modules/configuring/proc-removing-volumes-from-jbod-storage.adoc
+++ b/documentation/modules/configuring/proc-removing-volumes-from-jbod-storage.adoc
@@ -52,6 +52,7 @@ spec:
 [source,shell,subs=+quotes]
 kubectl apply -f _<kafka_configuration_file>_
 
+[role="_additional-resources"]
 .Additional resources
 
 For more information about reassigning topics, see xref:con-partition-reassignment-{context}[].

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -25,6 +25,7 @@ The affinity configuration can include different types of affinity:
 NOTE: On Kubernetes 1.16 and 1.17, the support for `topologySpreadConstraint` is disabled by default.
 In order to use `topologySpreadConstraint`, you have to enable the `EvenPodsSpread` feature gate in Kubernetes API server and scheduler.
 
+[role="_additional-resources"]
 .Additional resources
 
 * {K8sAffinity}

--- a/documentation/modules/cruise-control/con-cruise-control-overview.adoc
+++ b/documentation/modules/cruise-control/con-cruise-control-overview.adoc
@@ -16,12 +16,13 @@ Partitions that handle large amounts of message traffic might be unevenly distri
 To rebalance the cluster, administrators must monitor the load on brokers and manually reassign busy partitions to brokers with spare capacity.
 
 Cruise Control automates the cluster rebalancing process.
-It constructs a _workload model_ of resource utilization for the cluster--based on CPU, disk, and network load--and generates optimization proposals (that you can approve or reject) for more balanced partition assignments. 
+It constructs a _workload model_ of resource utilization for the cluster--based on CPU, disk, and network load--and generates optimization proposals (that you can approve or reject) for more balanced partition assignments.
 A set of configurable optimization goals is used to calculate these proposals.
 
-When you approve an optimization proposal, Cruise Control applies it to your Kafka cluster. 
+When you approve an optimization proposal, Cruise Control applies it to your Kafka cluster.
 When the cluster rebalancing operation is complete, the broker pods are used more effectively and the Kafka cluster is more evenly balanced.
 
+[role="_additional-resources"]
 .Additional resources
 
 * link:https://github.com/linkedin/cruise-control/wiki[Cruise Control Wiki^]

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -199,7 +199,7 @@ User-provided optimization goals must:
 
 To ignore the configured hard goals when generating an optimization proposal, add the `skipHardGoalCheck: true` property to the `KafkaRebalance` custom resource. See xref:proc-generating-optimization-proposals-{context}[].
 
-[role="_abstract"]
+[role="_additional-resources"]
 .Additional resources
 
 * xref:proc-configuring-deploying-cruise-control-{context}[Configuring and deploying Cruise Control with Kafka]

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -271,6 +271,7 @@ Use the `add-brokers` and `remove-brokers` modes only if you want to scale your 
 The procedure to run a rebalance is actually the same across the three different modes.
 The only difference is with specifying a mode through the `spec.mode` property and, if needed, listing brokers that have been added or will be removed through the `spec.brokers` property.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:con-optimization-goals-{context}[]

--- a/documentation/modules/cruise-control/con-rebalance-performance.adoc
+++ b/documentation/modules/cruise-control/con-rebalance-performance.adoc
@@ -108,6 +108,7 @@ d| -
 Changing the default settings affects the length of time that the rebalance takes to complete, as well as the load placed on the Kafka cluster during the rebalance.
 Using lower values reduces the load but increases the amount of time taken, and vice versa.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:type-CruiseControlSpec-reference[].

--- a/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
+++ b/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
@@ -66,16 +66,17 @@ kubectl describe kafkarebalance _rebalance-cr-name_
 
 . Cruise Control returns one of three statuses:
 
-** Rebalancing: The cluster rebalance operation is in progress. 
+** Rebalancing: The cluster rebalance operation is in progress.
 
 ** Ready: The cluster rebalancing operation completed successfully.
 To use the same `KafkaRebalance` custom resource to generate another optimization proposal, apply the `refresh` annotation to the custom resource.
 This moves the custom resource to the `PendingProposal` or `ProposalReady` state. You can then review the optimization proposal and approve it, if desired.
 
-** NotReady: An error occurred--see xref:proc-fixing-problems-with-kafkarebalance-{context}[].  
+** NotReady: An error occurred--see xref:proc-fixing-problems-with-kafkarebalance-{context}[].
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:con-optimization-proposals-{context}[]
 
-* xref:proc-stopping-cluster-rebalance-{context}[] 
+* xref:proc-stopping-cluster-rebalance-{context}[]

--- a/documentation/modules/cruise-control/proc-fixing-problems-with-kafkarebalance.adoc
+++ b/documentation/modules/cruise-control/proc-fixing-problems-with-kafkarebalance.adoc
@@ -6,7 +6,7 @@
 
 = Fixing problems with a `KafkaRebalance` resource
 
-If an issue occurs when creating a `KafkaRebalance` resource or interacting with Cruise Control, the error is reported in the resource status, along with details of how to fix it. 
+If an issue occurs when creating a `KafkaRebalance` resource or interacting with Cruise Control, the error is reported in the resource status, along with details of how to fix it.
 The resource also moves to the `NotReady` state.
 
 To continue with the cluster rebalance operation, you must fix the problem in the `KafkaRebalance` resource itself or with the overall Cruise Control deployment.
@@ -15,7 +15,7 @@ Problems might include the following:
 * A misconfigured parameter in the `KafkaRebalance` resource.
 * The `strimzi.io/cluster` label for specifying the Kafka cluster in the `KafkaRebalance` resource is missing.
 * The Cruise Control server is not deployed as the `cruiseControl` property in the `Kafka` resource is missing.
-* The Cruise Control server is not reachable. 
+* The Cruise Control server is not reachable.
 
 After fixing the issue, you need to add the `refresh` annotation to the `KafkaRebalance` resource.
 During a “refresh”, a new optimization proposal is requested from the Cruise Control server.
@@ -53,6 +53,7 @@ kubectl describe kafkarebalance _rebalance-cr-name_
 
 . Wait until the status changes to `PendingProposal`, or directly to `ProposalReady`.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:con-optimization-proposals-{context}[]

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -223,6 +223,7 @@ This has no effect on the rebalance behavior, since the ratio between CPU utiliz
 
 xref:proc-approving-optimization-proposal-{context}[]
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:con-optimization-proposals-{context}[]

--- a/documentation/modules/cruise-control/proc-stopping-cluster-rebalance.adoc
+++ b/documentation/modules/cruise-control/proc-stopping-cluster-rebalance.adoc
@@ -6,18 +6,18 @@
 
 = Stopping a cluster rebalance
 
-Once started, a cluster rebalance operation might take some time to complete and affect the overall performance of the Kafka cluster.  
+Once started, a cluster rebalance operation might take some time to complete and affect the overall performance of the Kafka cluster.
 
-If you want to stop a cluster rebalance operation that is in progress, apply the `stop` annotation to the `KafkaRebalance` custom resource. 
+If you want to stop a cluster rebalance operation that is in progress, apply the `stop` annotation to the `KafkaRebalance` custom resource.
 This instructs Cruise Control to finish the current batch of partition reassignments and then stop the rebalance.
 When the rebalance has stopped, completed partition reassignments have already been applied; therefore, the state of the Kafka cluster is different when compared to prior to the start of the rebalance operation.
-If further rebalancing is required, you should generate a new optimization proposal. 
+If further rebalancing is required, you should generate a new optimization proposal.
 
 NOTE: The performance of the Kafka cluster in the intermediate (stopped) state might be worse than in the initial state.
 
 .Prerequisites
 
-* You have xref:proc-approving-optimization-proposal-{context}[approved the optimization proposal] by annotating the `KafkaRebalance` custom resource with `approve`. 
+* You have xref:proc-approving-optimization-proposal-{context}[approved the optimization proposal] by annotating the `KafkaRebalance` custom resource with `approve`.
 
 * The status of the `KafkaRebalance` custom resource is `Rebalancing`.
 
@@ -39,7 +39,7 @@ kubectl describe kafkarebalance _rebalance-cr-name_
 
 . Wait until the status changes to `Stopped`.
 
-
+[role="_additional-resources"]
 .Additional resources
 
 * xref:con-optimization-proposals-{context}[]

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -100,6 +100,7 @@ or
 +
 * In the `install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_KAFKA_CONNECT_IMAGES` variable to point to the new container image, and then reinstall the Cluster Operator.
 
+[role="_additional-resources"]
 .Additional resources
 
 * link:{BookURLUsing}#con-common-configuration-images-reference[Container image configuration and the `KafkaConnect.spec.image property`^]

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -63,6 +63,7 @@ $ kubectl apply -f _KAFKA-CONNECT-CONFIG-FILE_
 
 . Use the Kafka Connect REST API or the KafkaConnector custom resources to use the connector plugins you added.
 
+[role="_additional-resources"]
 .Additional resources
 
 See the _Using Strimzi_ guide for more information on:

--- a/documentation/modules/managing/proc-accessing-resource-status.adoc
+++ b/documentation/modules/managing/proc-accessing-resource-status.adoc
@@ -23,6 +23,7 @@ kubectl get kafka _<kafka_resource_name>_ -o jsonpath='{.status}'
 +
 This expression returns all the status information for the specified custom resource. You can use dot notation, such as `status.listeners` or `status.observedGeneration`, to fine-tune the status information you wish to see.
 
+[role="_additional-resources"]
 .Additional resources
 * xref:con-custom-resources-status-{context}[]
 * For more information about using JSONPath, see {K8SJsonPath}.

--- a/documentation/modules/managing/proc-pausing-reconciliation.adoc
+++ b/documentation/modules/managing/proc-pausing-reconciliation.adoc
@@ -70,6 +70,7 @@ status:
 
 * To resume reconciliation, you can set the annotation to `false`, or remove the annotation.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:assembly-customizing-kubernetes-resources-str[Customizing Kubernetes resources]

--- a/documentation/modules/metrics/con_metrics-kafka-mini-kube.adoc
+++ b/documentation/modules/metrics/con_metrics-kafka-mini-kube.adoc
@@ -10,6 +10,7 @@ When adding Prometheus and Grafana servers to an Apache Kafka deployment using M
 
 For information on how to increase the default amount of memory, see xref:deploy-kubernetes-{context}[]
 
+[role="_additional-resources"]
 .Additional resources
 
 * https://kubernetes.io/docs/tasks/debug-application-cluster/resource-usage-monitoring/[Prometheus - Monitoring Docker Container Metrics using cAdvisor] describes how to use cAdvisor (short for container Advisor) metrics with Prometheus to analyze and expose resource usage (CPU, Memory, and Disk) and performance data from running containers within pods on Kubernetes.

--- a/documentation/modules/oauth/con-oauth-authentication-flow.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-flow.adoc
@@ -97,6 +97,7 @@ If the `password` is set as the access token, the `username` must be set to the 
 You can specify username extraction options in your listener using the `userNameClaim`, `fallbackUserNameClaim`, `fallbackUsernamePrefix`, and `userInfoEndpointUri` properties.
 The username extraction process also depends on your authorization server; in particular, how it maps client IDs to account names.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:proc-oauth-authentication-broker-config-{context}[]

--- a/documentation/modules/oauth/con-oauth-authorization-intro.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-intro.adoc
@@ -21,6 +21,7 @@ ZooKeeper stores ACL rules that grant or deny access to resources based on _user
 However, OAuth 2.0 token-based authorization with  Keycloak offers far greater flexibility on how you wish to implement access control to Kafka brokers.
 In addition, you can configure your Kafka brokers to use OAuth 2.0 authorization and ACLs.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:assembly-oauth-authentication_str[Using OAuth 2.0 token-based authentication]

--- a/documentation/modules/oauth/con-oauth-reauthentication.adoc
+++ b/documentation/modules/oauth/con-oauth-reauthentication.adoc
@@ -5,18 +5,18 @@
 [id='{context}']
 = Session re-authentication for Kafka brokers
 
-You can configure `oauth` listeners to use Kafka _session re-authentication_ for OAuth 2.0 sessions between Kafka clients and Kafka brokers. 
-This mechanism enforces the expiry of an authenticated session between the client and the broker after a defined period of time. 
+You can configure `oauth` listeners to use Kafka _session re-authentication_ for OAuth 2.0 sessions between Kafka clients and Kafka brokers.
+This mechanism enforces the expiry of an authenticated session between the client and the broker after a defined period of time.
 When a session expires, the client immediately starts a new session by reusing the existing connection rather than dropping it.
 
-Session re-authentication is disabled by default. 
-To enable it, you set a time value for `maxSecondsWithoutReauthentication` in the `oauth` listener configuration. 
-The same property is used to configure session re-authentication for OAUTHBEARER and PLAIN authentication. 
+Session re-authentication is disabled by default.
+To enable it, you set a time value for `maxSecondsWithoutReauthentication` in the `oauth` listener configuration.
+The same property is used to configure session re-authentication for OAUTHBEARER and PLAIN authentication.
 For an example configuration, see xref:proc-oauth-authentication-broker-config-{context}[].
 
-Session re-authentication must be supported by the Kafka client libraries used by the client. 
+Session re-authentication must be supported by the Kafka client libraries used by the client.
 
-Session re-authentication can be used with _fast local JWT_ or _introspection endpoint_ token validation. 
+Session re-authentication can be used with _fast local JWT_ or _introspection endpoint_ token validation.
 
 .Client re-authentication
 
@@ -26,8 +26,8 @@ If token validation is successful, a new client session is started using the exi
 If the client fails to re-authenticate, the broker will close the connection if further attempts are made to send or receive messages.
 Java clients that use Kafka client library 2.2 or later automatically re-authenticate if the re-authentication mechanism is enabled on the broker.
 
-Session re-authentication also applies to refresh tokens, if used. 
-When the session expires, the client refreshes the access token by using its refresh token. 
+Session re-authentication also applies to refresh tokens, if used.
+When the session expires, the client refreshes the access token by using its refresh token.
 The client then uses the new access token to re-authenticate to the existing session.
 
 .Session expiry for OAUTHBEARER and PLAIN
@@ -38,19 +38,20 @@ For OAUTHBEARER and PLAIN, using the client ID and secret method:
 
 * The broker's authenticated session will expire at the configured `maxSecondsWithoutReauthentication`.
 
-* The session will expire earlier if the access token expires before the configured time. 
+* The session will expire earlier if the access token expires before the configured time.
 
 For PLAIN using the long-lived access token method:
 
-* The broker's authenticated session will expire at the configured `maxSecondsWithoutReauthentication`. 
+* The broker's authenticated session will expire at the configured `maxSecondsWithoutReauthentication`.
 
-* Re-authentication will fail if the access token expires before the configured time. 
+* Re-authentication will fail if the access token expires before the configured time.
 Although session re-authentication is attempted, PLAIN has no mechanism for refreshing tokens.
 
-If `maxSecondsWithoutReauthentication` is _not_ configured, OAUTHBEARER and PLAIN clients can remain connected to brokers indefinitely, without needing to re-authenticate. 
-Authenticated sessions do not end with access token expiry. 
+If `maxSecondsWithoutReauthentication` is _not_ configured, OAUTHBEARER and PLAIN clients can remain connected to brokers indefinitely, without needing to re-authenticate.
+Authenticated sessions do not end with access token expiry.
 However, this can be considered when configuring authorization, for example, by using `keycloak` authorization or installing a custom authorizer.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:con-oauth-authentication-broker-{context}[]

--- a/documentation/modules/overview/con-configuration-points-bridge.adoc
+++ b/documentation/modules/overview/con-configuration-points-bridge.adoc
@@ -49,5 +49,6 @@ spec:
   # ...
 ----
 
+[role="_additional-resources"]
 .Additional resources
 * {external-cors-link}

--- a/documentation/modules/security/proc-installing-certs-per-listener.adoc
+++ b/documentation/modules/security/proc-installing-certs-per-listener.adoc
@@ -87,6 +87,7 @@ The Cluster Operator starts a rolling update of the Kafka cluster, which updates
 +
 NOTE: A rolling update is also started if you update a Kafka listener certificate in a `Secret` that is already used by a TLS or external listener.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:ref-alternative-subjects-certs-for-listeners-{context}[Alternative subjects in server certificates for Kafka listeners]

--- a/documentation/modules/security/proc-renewing-ca-certs-manually.adoc
+++ b/documentation/modules/security/proc-renewing-ca-certs-manually.adoc
@@ -75,6 +75,7 @@ notAfter=Jun 30 09:43:54 2021 GMT
 When components are using the new certificates, older certificates might still be active.
 Delete the old certificates to remove any potential security risk.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:certificates-and-secrets-str[]

--- a/documentation/modules/security/proc-replacing-private-keys.adoc
+++ b/documentation/modules/security/proc-replacing-private-keys.adoc
@@ -49,6 +49,7 @@ If maintenance time windows are configured, the Cluster Operator will generate t
 
 Client applications must reload the cluster and clients CA certificates that were renewed by the Cluster Operator.
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:certificates-and-secrets-str[]

--- a/documentation/modules/security/ref-alternative-subjects-certs-for-listeners.adoc
+++ b/documentation/modules/security/ref-alternative-subjects-certs-for-listeners.adoc
@@ -69,12 +69,13 @@ m¦loadbalancer
 You can use a matching wildcard name.
 
 m¦NodePort
-¦Addresses of all Kubernetes worker nodes that the Kafka broker pods might be scheduled to. 
+¦Addresses of all Kubernetes worker nodes that the Kafka broker pods might be scheduled to.
 
 You can use a matching wildcard name.
 
 |===
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:proc-installing-certs-per-listener-{context}[]

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -380,6 +380,7 @@ spec:
 # ...
 ----
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:type-CertificateAuthority-reference[`CertificateAuthority` schema reference]

--- a/documentation/modules/tracing/con-overview-opentracing-jaeger.adoc
+++ b/documentation/modules/tracing/con-overview-opentracing-jaeger.adoc
@@ -23,8 +23,8 @@ Jaeger is a tracing system for microservices-based distributed systems.
 
 image:image_con-overview-distributed-tracing.png[The Jaeger user interface showing a simple query]
 
+[role="_additional-resources"]
 .Additional resources
 
 * {OpenTracingHome}
-
 * {JaegerHome}

--- a/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
+++ b/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
@@ -122,6 +122,7 @@ spec:
 kubectl apply -f your-file
 ----
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:type-ContainerTemplate-reference[]

--- a/documentation/modules/tracing/ref-tracing-environment-variables.adoc
+++ b/documentation/modules/tracing/ref-tracing-environment-variables.adoc
@@ -89,6 +89,7 @@ The value can also refer to an environment variable using the format `${envVarNa
 
 |===
 
+[role="_additional-resources"]
 .Additional resources
 
 * xref:proc-configuring-jaeger-tracer-kafka-clients-{context}[]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>
**Documentation**
Adds missing _[role="_additional-resources"]_ tags to the docs

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

