### PR TITLE
[systemtest] Disable tests containing forbidden settings of `KafkaTopic`

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusIsolatedST.java
@@ -72,6 +72,7 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -454,6 +455,7 @@ class CustomResourceStatusIsolatedST extends AbstractST {
 
     @ParallelTest
     @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test class")
+    @Disabled("TopicOperator allows forbidden settings - https://github.com/strimzi/strimzi-kafka-operator/issues/6884")
     void testKafkaTopicDecreaseStatus(ExtensionContext extensionContext) throws InterruptedException {
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
@@ -479,6 +481,7 @@ class CustomResourceStatusIsolatedST extends AbstractST {
 
     @ParallelTest
     @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test class")
+    @Disabled("TopicOperator allows forbidden settings - https://github.com/strimzi/strimzi-kafka-operator/issues/6884")
     void testKafkaTopicChangingInSyncReplicasStatus(ExtensionContext extensionContext) throws InterruptedException {
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -36,6 +36,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -283,6 +284,7 @@ public class TopicST extends AbstractST {
     }
 
     @ParallelTest
+    @Disabled("TopicOperator allows forbidden settings - https://github.com/strimzi/strimzi-kafka-operator/issues/6884")
     void testTopicModificationOfReplicationFactor(ExtensionContext extensionContext) {
         String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
 
@@ -387,6 +389,7 @@ public class TopicST extends AbstractST {
     }
 
     @ParallelTest
+    @Disabled("TopicOperator allows forbidden settings - https://github.com/strimzi/strimzi-kafka-operator/issues/6884")
     void testCreateTopicAfterUnsupportedOperation(ExtensionContext extensionContext) {
         String topicName = "topic-with-replication-to-change";
         String newTopicName = "another-topic";


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Disable tests

### Description

Because of #6884 some of our tests are failing, because `KafkaTopic` is not moved to `NotReady` state after applying some forbidden configuration.

This PR disables those tests, making our pipelines to work again.

After the issue will be fixed, the tests will be enabled again.

### Checklist

- [x] Make sure all tests pass