### PR TITLE
Handled `AnnotatedRouteNoHostException` causing the `KafkaRebalance` to get into `NotReady` state when CC is enabled form Disabled state

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1365,7 +1365,7 @@ public class KafkaRebalanceAssemblyOperator
         // We check for `CruiseControlRetriableConnectionException` if request are made when CC was not active since not handling this case will move the KafkaRebalance to `NotReady`
         // and it will stay in `NotReady` state until we apply `refresh`
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh
-                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "CruiseControlRetriableConnectException".equals(condition.getReason()))) {
+                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "CruiseControlRetriableConnectionException".equals(condition.getReason()))) {
             return true;
         } else {
             return CruiseControlIssues.checkForMatch(kafkaRebalance.getStatus().getConditions());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1364,7 +1364,7 @@ public class KafkaRebalanceAssemblyOperator
         // check if refresh annotation applied or request are made when CC is not active
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh
                 || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "ConnectException".equals(condition.getReason()))
-                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "AnnotatedNoRouteToHostException".equals(condition.getReason()))) {
+                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "NoRouteToHostException".equals(condition.getReason()))) {
             return true;
         } else {
             return CruiseControlIssues.checkForMatch(kafkaRebalance.getStatus().getConditions());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1362,7 +1362,9 @@ public class KafkaRebalanceAssemblyOperator
 
     private boolean shouldRenewRebalance(KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation) {
         // check if refresh annotation applied or request are made when CC is not active
-        if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "ConnectException".equals(condition.getReason()))) {
+        if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh
+                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "ConnectException".equals(condition.getReason()))
+                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "AnnotatedNoRouteToHostException".equals(condition.getReason()))) {
             return true;
         } else {
             return CruiseControlIssues.checkForMatch(kafkaRebalance.getStatus().getConditions());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1362,7 +1362,7 @@ public class KafkaRebalanceAssemblyOperator
 
     private boolean shouldRenewRebalance(KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation) {
         // check if refresh annotation applied or request are made when CC is not active
-        // We check for `CruiseControlRetriableConnectException` if request are made when CC was not active since not handling this case will move the KafkaRebalance to `NotReady`
+        // We check for `CruiseControlRetriableConnectionException` if request are made when CC was not active since not handling this case will move the KafkaRebalance to `NotReady`
         // and it will stay in `NotReady` state until we apply `refresh`
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh
                 || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "CruiseControlRetriableConnectException".equals(condition.getReason()))) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1362,9 +1362,10 @@ public class KafkaRebalanceAssemblyOperator
 
     private boolean shouldRenewRebalance(KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation) {
         // check if refresh annotation applied or request are made when CC is not active
+        // We check for `CruiseControlRetriableConnectException` if request are made when CC was not active since not handling this case will move the KafkaRebalance to `NotReady`
+        // and it will stay in `NotReady` state until we apply `refresh`
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh
-                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "ConnectException".equals(condition.getReason()))
-                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "NoRouteToHostException".equals(condition.getReason()))) {
+                || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "CruiseControlRetriableConnectException".equals(condition.getReason()))) {
             return true;
         } else {
             return CruiseControlIssues.checkForMatch(kafkaRebalance.getStatus().getConditions());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1361,9 +1361,9 @@ public class KafkaRebalanceAssemblyOperator
     }
 
     private boolean shouldRenewRebalance(KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation) {
-        // check if refresh annotation applied or request are made when CC is not active
-        // We check for `CruiseControlRetriableConnectionException` if request are made when CC was not active since not handling this case will move the KafkaRebalance to `NotReady`
-        // and it will stay in `NotReady` state until we apply `refresh`
+        // Checks if `refresh` annotation applied or request are made when CC is not active
+        // We check for `CruiseControlRetriableConnectionException` which is thrown if requests are made when CC was not active. Not handling this case will move the KafkaRebalance to `NotReady` state
+        // and it will stay in `NotReady` state until we apply `refresh` annotation
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh
                 || kafkaRebalance.getStatus().getConditions().stream().anyMatch(condition -> "CruiseControlRetriableConnectionException".equals(condition.getReason()))) {
             return true;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -437,7 +437,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             // so we catch and raise a TimeoutException instead
             result.fail(new TimeoutException(t.getMessage()));
         } else if (t instanceof NoRouteToHostException) {
-            // Netty throws a AnnotatedNoRouteToHostException when the request times out
+            // Netty throws a AnnotatedNoRouteToHostException when it cannot resolve the host
             //so we catch and raise a NoRouteToHostException instead
             result.fail(new NoRouteToHostException(t.getMessage()));
         } else if (t instanceof ConnectException) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -439,7 +439,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         } else if (t instanceof NoRouteToHostException || t instanceof ConnectException) {
             // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) and  when it cannot resolve the host
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
-            // so we catch and raise a CruiseControlRestException instead since
+            // so we catch and raise a CruiseControlRetriableConnectException instead since
             result.fail(new CruiseControlRetriableConnectException(t.getMessage()));
         }  else {
             result.fail(t);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -437,9 +437,9 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             // so we catch and raise a TimeoutException instead
             result.fail(new TimeoutException(t.getMessage()));
         } else if (t instanceof NoRouteToHostException || t instanceof ConnectException) {
-            // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) and  when it cannot resolve the host
+            // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) when it cannot resolve the host
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
-            // so we catch and raise a CruiseControlRetriableConnectionException instead since
+            // so we catch and raise a CruiseControlRetriableConnectionException instead
             result.fail(new CruiseControlRetriableConnectionException(t));
         }  else {
             result.fail(t);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -22,6 +22,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.PemTrustOptions;
 
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeoutException;
 
@@ -435,6 +436,10 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             // Vert.x throws a NoStackTraceTimeoutException (inherits from TimeoutException) when the request times out
             // so we catch and raise a TimeoutException instead
             result.fail(new TimeoutException(t.getMessage()));
+        } else if (t instanceof NoRouteToHostException) {
+            // Netty throws a AnnotatedNoRouteToHostException when the request times out
+            //so we catch and raise a NoRouteToHostException instead
+            result.fail(new NoRouteToHostException(t.getMessage()));
         } else if (t instanceof ConnectException) {
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
             // so we catch and raise a ConnectException instead

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -436,15 +436,12 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             // Vert.x throws a NoStackTraceTimeoutException (inherits from TimeoutException) when the request times out
             // so we catch and raise a TimeoutException instead
             result.fail(new TimeoutException(t.getMessage()));
-        } else if (t instanceof NoRouteToHostException) {
-            // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) when it cannot resolve the host
-            //so we catch and raise a NoRouteToHostException instead
-            result.fail(new NoRouteToHostException(t.getMessage()));
-        } else if (t instanceof ConnectException) {
+        } else if (t instanceof NoRouteToHostException || t instanceof ConnectException) {
+            // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) and  when it cannot resolve the host
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
-            // so we catch and raise a ConnectException instead
-            result.fail(new ConnectException(t.getMessage()));
-        } else {
+            // so we catch and raise a CruiseControlRestException instead since
+            result.fail(new CruiseControlRetriableConnectException(t.getMessage()));
+        }  else {
             result.fail(t);
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -439,8 +439,8 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         } else if (t instanceof NoRouteToHostException || t instanceof ConnectException) {
             // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) and  when it cannot resolve the host
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
-            // so we catch and raise a CruiseControlRetriableConnectException instead since
-            result.fail(new CruiseControlRetriableConnectException(t.getMessage()));
+            // so we catch and raise a CruiseControlRetriableConnectionException instead since
+            result.fail(new CruiseControlRetriableConnectionException(t));
         }  else {
             result.fail(t);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -437,7 +437,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             // so we catch and raise a TimeoutException instead
             result.fail(new TimeoutException(t.getMessage()));
         } else if (t instanceof NoRouteToHostException) {
-            // Netty throws a AnnotatedNoRouteToHostException when it cannot resolve the host
+            // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) when it cannot resolve the host
             //so we catch and raise a NoRouteToHostException instead
             result.fail(new NoRouteToHostException(t.getMessage()));
         } else if (t instanceof ConnectException) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -441,7 +441,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
             // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
             // so we catch and raise a CruiseControlRetriableConnectionException instead
             result.fail(new CruiseControlRetriableConnectionException(t));
-        }  else {
+        } else {
             result.fail(t);
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectException.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
+
+public class CruiseControlRetriableConnectException extends RuntimeException {
+
+    public CruiseControlRetriableConnectException(String message) {
+        super(message);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectionException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectionException.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 public class CruiseControlRetriableConnectionException extends RuntimeException {
 
-    public CruiseControlRetriableConnectionException(Throwable message) {
-        super(message);
+    public CruiseControlRetriableConnectionException(Throwable cause) {
+        super(cause);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectionException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectionException.java
@@ -4,9 +4,9 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
-public class CruiseControlRetriableConnectException extends RuntimeException {
+public class CruiseControlRetriableConnectionException extends RuntimeException {
 
-    public CruiseControlRetriableConnectException(String message) {
+    public CruiseControlRetriableConnectionException(Throwable message) {
         super(message);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -29,12 +29,13 @@ import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApi;
-import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRestException;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.MockCruiseControl;
-import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRetriableConnectException;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -59,7 +60,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.integration.ClientAndServer;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Optional;
@@ -1533,7 +1533,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 }
                 // the resource moved from 'New' to 'NotReady' (mocked Cruise Control not reachable)
                 assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,
-                        KafkaRebalanceState.NotReady, ConnectException.class,
+                        KafkaRebalanceState.NotReady, CruiseControlRetriableConnectException.class,
                         "Connection refused");
                 checkpoint.flag();
             }));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -34,7 +34,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRestException;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.MockCruiseControl;
-import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRetriableConnectException;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlRetriableConnectionException;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -1533,7 +1533,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 }
                 // the resource moved from 'New' to 'NotReady' (mocked Cruise Control not reachable)
                 assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,
-                        KafkaRebalanceState.NotReady, CruiseControlRetriableConnectException.class,
+                        KafkaRebalanceState.NotReady, CruiseControlRetriableConnectionException.class,
                         "Connection refused");
                 checkpoint.flag();
             }));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -60,7 +60,7 @@ public class KafkaRebalanceStateMachineTest {
     private static final String RESOURCE_NAME = "my-rebalance";
     private static final String CLUSTER_NAMESPACE = "cruise-control-namespace";
     private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
-    private static final String EXCEPTION_STRING = "CruiseControlRetriableConnectException";
+    private static final String REASON = "CruiseControlRetriableConnectException";
     private static final KafkaRebalanceSpec EMPTY_KAFKA_REBALANCE_SPEC = new KafkaRebalanceSpecBuilder().build();
     private static final KafkaRebalanceSpec ADD_BROKER_KAFKA_REBALANCE_SPEC =
             new KafkaRebalanceSpecBuilder()
@@ -97,13 +97,13 @@ public class KafkaRebalanceStateMachineTest {
      * @param currentStatusSessionID The user task ID attached to the current KafkaRebalance resource. Can be null.
      * @param userAnnotation An annotation to be applied after the reconcile has started, for example "approve" or "stop".
      * @param rebalanceSpec A custom rebalance specification. If null a blank spec will be used.
-     * @param exceptionString
      * @return A KafkaRebalance instance configured with the supplied parameters.
+     * @return Reason for the condition
      */
     private KafkaRebalance createKafkaRebalance(KafkaRebalanceState currentState,
                                                 String currentStatusSessionID,
                                                 String userAnnotation,
-                                                KafkaRebalanceSpec rebalanceSpec, String exceptionString) {
+                                                KafkaRebalanceSpec rebalanceSpec, String reason) {
 
         KafkaRebalanceBuilder kafkaRebalanceBuilder =
                 new KafkaRebalanceBuilder()
@@ -120,8 +120,8 @@ public class KafkaRebalanceStateMachineTest {
             Condition currentRebalanceCondition = new Condition();
             currentRebalanceCondition.setType(currentState.toString());
             currentRebalanceCondition.setStatus("True");
-            if (exceptionString != null) {
-                currentRebalanceCondition.setReason(exceptionString);
+            if (reason != null) {
+                currentRebalanceCondition.setReason(reason);
             }
             KafkaRebalanceStatus currentStatus = new KafkaRebalanceStatus();
             currentStatus.setConditions(Collections.singletonList(currentRebalanceCondition));
@@ -879,25 +879,25 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testReadyAfterNoRouteToHostException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, REASON);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, REASON);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, REASON);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
     }
 
     @Test
     public void testReadyAfterConnectException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, REASON);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, REASON);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, REASON);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -96,12 +96,13 @@ public class KafkaRebalanceStateMachineTest {
      * @param currentStatusSessionID The user task ID attached to the current KafkaRebalance resource. Can be null.
      * @param userAnnotation An annotation to be applied after the reconcile has started, for example "approve" or "stop".
      * @param rebalanceSpec A custom rebalance specification. If null a blank spec will be used.
+     * @param exceptionString
      * @return A KafkaRebalance instance configured with the supplied parameters.
      */
     private KafkaRebalance createKafkaRebalance(KafkaRebalanceState currentState,
                                                 String currentStatusSessionID,
                                                 String userAnnotation,
-                                                KafkaRebalanceSpec rebalanceSpec) {
+                                                KafkaRebalanceSpec rebalanceSpec, String exceptionString) {
 
         KafkaRebalanceBuilder kafkaRebalanceBuilder =
                 new KafkaRebalanceBuilder()
@@ -118,7 +119,9 @@ public class KafkaRebalanceStateMachineTest {
             Condition currentRebalanceCondition = new Condition();
             currentRebalanceCondition.setType(currentState.toString());
             currentRebalanceCondition.setStatus("True");
-
+            if (exceptionString != null) {
+                currentRebalanceCondition.setReason(exceptionString);
+            }
             KafkaRebalanceStatus currentStatus = new KafkaRebalanceStatus();
             currentStatus.setConditions(Collections.singletonList(currentRebalanceCondition));
             currentStatus.setSessionId(currentStatusSessionID);
@@ -198,13 +201,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testNewToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krNewToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNewToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNewToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -219,13 +222,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testNewWithNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krNewWithNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNewWithNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNewWithNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -242,13 +245,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testNewToProposalPending(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krNewToProposalPending(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNewToProposalPending(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNewToProposalPending(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -269,7 +272,7 @@ public class KafkaRebalanceStateMachineTest {
         customGoals.add("Goal.three");
 
         KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder().addAllToGoals(customGoals).build();
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
         rebalanceSpec = new KafkaRebalanceSpecBuilder()
@@ -277,7 +280,7 @@ public class KafkaRebalanceStateMachineTest {
                 .withBrokers(3)
                 .addAllToGoals(customGoals)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
         rebalanceSpec = new KafkaRebalanceSpecBuilder()
@@ -285,7 +288,7 @@ public class KafkaRebalanceStateMachineTest {
                 .withBrokers(3)
                 .addAllToGoals(customGoals)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -317,7 +320,7 @@ public class KafkaRebalanceStateMachineTest {
         customGoals.add("Goal.three");
 
         KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder().addAllToGoals(customGoals).withSkipHardGoalCheck(true).build();
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null);
         this.krNewBadGoalsErrorWithSkipHGCheck(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
         rebalanceSpec = new KafkaRebalanceSpecBuilder()
@@ -326,7 +329,7 @@ public class KafkaRebalanceStateMachineTest {
                 .addAllToGoals(customGoals)
                 .withSkipHardGoalCheck(true)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
         rebalanceSpec = new KafkaRebalanceSpecBuilder()
@@ -335,7 +338,7 @@ public class KafkaRebalanceStateMachineTest {
                 .addAllToGoals(customGoals)
                 .withSkipHardGoalCheck(true)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -352,13 +355,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalPendingToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -373,13 +376,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalPendingToProposalReadyWithDelay(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToProposalReadyWithDelay(vertx, context, 3, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToProposalReadyWithDelay(vertx, context, 3, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToProposalReadyWithDelay(vertx, context, 3, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -394,13 +397,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalPendingToStopped(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToStopped(vertx, context, 3, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToStopped(vertx, context, 3, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalPendingToStopped(vertx, context, 3, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -415,13 +418,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyNoChange(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyNoChange(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyNoChange(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyNoChange(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -436,13 +439,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyToRebalancingWithNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancingWithNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancingWithNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancingWithNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -457,13 +460,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyToRebalancingWithPendingSummary(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -478,13 +481,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyToRebalancing(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -499,13 +502,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyRefreshNoChange(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshNoChange(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshNoChange(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshNoChange(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -520,13 +523,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -541,13 +544,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krProposalReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -562,13 +565,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testRebalancingCompleted(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingCompleted(vertx, context, 0, 0, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingCompleted(vertx, context, 0, 0, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingCompleted(vertx, context, 0, 0, kcRebalance);
     }
 
@@ -583,13 +586,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testRebalancingPendingThenExecution(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingPendingThenExecution(vertx, context, 1, 1, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingPendingThenExecution(vertx, context, 1, 1, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingPendingThenExecution(vertx, context, 1, 1, kcRebalance);
     }
 
@@ -607,13 +610,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testRebalancingToStopped(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingToStopped(vertx, context, 0, 0, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingToStopped(vertx, context, 0, 0, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingToStopped(vertx, context, 0, 0, kcRebalance);
     }
 
@@ -629,13 +632,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testRebalancingCompletedWithError(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingToStopped(vertx, context, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingToStopped(vertx, context, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krRebalancingToStopped(vertx, context, kcRebalance);
     }
 
@@ -650,13 +653,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testStoppedRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -671,13 +674,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testStoppedRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -692,13 +695,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testStoppedRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krStoppedRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -713,13 +716,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -734,13 +737,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -755,13 +758,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -776,13 +779,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -797,13 +800,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -818,13 +821,13 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testNotReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.krNotReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -839,25 +842,25 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testProposalReadyWithWrongAnnotation(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.ProposalReady,  KafkaRebalanceAnnotation.unknown);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.ProposalReady, KafkaRebalanceAnnotation.unknown);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.ProposalReady, KafkaRebalanceAnnotation.unknown);
     }
 
     @Test
     public void testReadyWithWrongAnnotation(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.Ready, KafkaRebalanceAnnotation.approve);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.Ready, KafkaRebalanceAnnotation.approve);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.Ready, KafkaRebalanceAnnotation.approve);
     }
 
@@ -869,6 +872,45 @@ public class KafkaRebalanceStateMachineTest {
 
         checkTransition(vertx, context,
                 kafkaRebalanceState, kafkaRebalanceState,
+                kafkaRebalanceAnnotation, kcRebalance)
+                .onComplete(result -> defaultStatusHandler(result, context));
+    }
+
+    @Test
+    public void testReadyAfterNoRouteToHostException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        String exceptionString = "NoRouteToHostException";
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, exceptionString);
+        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+    }
+
+    @Test
+    public void testReadyAfterConnectException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        String exceptionString = "ConnectException";
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, exceptionString);
+        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+    }
+
+
+    private void testStateWithException(Vertx vertx, VertxTestContext context,
+                                              int pendingCalls, CruiseControlEndpoints endpoint,
+                                              KafkaRebalance kcRebalance, KafkaRebalanceState kafkaRebalanceState,
+                                              KafkaRebalanceAnnotation kafkaRebalanceAnnotation) throws IOException, URISyntaxException {
+        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+
+        checkTransition(vertx, context,
+                kafkaRebalanceState, KafkaRebalanceState.ProposalReady,
                 kafkaRebalanceAnnotation, kcRebalance)
                 .onComplete(result -> defaultStatusHandler(result, context));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -60,6 +60,7 @@ public class KafkaRebalanceStateMachineTest {
     private static final String RESOURCE_NAME = "my-rebalance";
     private static final String CLUSTER_NAMESPACE = "cruise-control-namespace";
     private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
+    private static final String EXCEPTION_STRING = "CruiseControlRetriableConnectException";
     private static final KafkaRebalanceSpec EMPTY_KAFKA_REBALANCE_SPEC = new KafkaRebalanceSpecBuilder().build();
     private static final KafkaRebalanceSpec ADD_BROKER_KAFKA_REBALANCE_SPEC =
             new KafkaRebalanceSpecBuilder()
@@ -878,27 +879,25 @@ public class KafkaRebalanceStateMachineTest {
 
     @Test
     public void testReadyAfterNoRouteToHostException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        String exceptionString = "NoRouteToHostException";
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, exceptionString);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
     }
 
     @Test
     public void testReadyAfterConnectException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        String exceptionString = "ConnectException";
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, exceptionString);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, exceptionString);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, EXCEPTION_STRING);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -97,8 +97,8 @@ public class KafkaRebalanceStateMachineTest {
      * @param currentStatusSessionID The user task ID attached to the current KafkaRebalance resource. Can be null.
      * @param userAnnotation An annotation to be applied after the reconcile has started, for example "approve" or "stop".
      * @param rebalanceSpec A custom rebalance specification. If null a blank spec will be used.
+     * @param reason Reason for the condition
      * @return A KafkaRebalance instance configured with the supplied parameters.
-     * @return Reason for the condition
      */
     private KafkaRebalance createKafkaRebalance(KafkaRebalanceState currentState,
                                                 String currentStatusSessionID,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -60,7 +60,7 @@ public class KafkaRebalanceStateMachineTest {
     private static final String RESOURCE_NAME = "my-rebalance";
     private static final String CLUSTER_NAMESPACE = "cruise-control-namespace";
     private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
-    private static final String REASON = "CruiseControlRetriableConnectException";
+    private static final String REASON = "CruiseControlRetriableConnectionException";
     private static final KafkaRebalanceSpec EMPTY_KAFKA_REBALANCE_SPEC = new KafkaRebalanceSpecBuilder().build();
     private static final KafkaRebalanceSpec ADD_BROKER_KAFKA_REBALANCE_SPEC =
             new KafkaRebalanceSpecBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -60,7 +60,7 @@ public class KafkaRebalanceStateMachineTest {
     private static final String RESOURCE_NAME = "my-rebalance";
     private static final String CLUSTER_NAMESPACE = "cruise-control-namespace";
     private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
-    private static final String REASON = "CruiseControlRetriableConnectionException";
+    private static final String CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION = "CruiseControlRetriableConnectionException";
     private static final KafkaRebalanceSpec EMPTY_KAFKA_REBALANCE_SPEC = new KafkaRebalanceSpecBuilder().build();
     private static final KafkaRebalanceSpec ADD_BROKER_KAFKA_REBALANCE_SPEC =
             new KafkaRebalanceSpecBuilder()
@@ -878,26 +878,14 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     @Test
-    public void testReadyAfterNoRouteToHostException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, REASON);
+    public void testReadyAfterCruiseControlRetriableConnectionException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, REASON);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, REASON);
-        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
-    }
-
-    @Test
-    public void testReadyAfterConnectException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, REASON);
-        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, REASON);
-        this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, REASON);
+        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
     }
 


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

- Bugfix

### Description

This PR fixes the issue for `KafkaRebalance` going into `NotReady` state when CC is enabled from Disabled state due to the `AnnotatedRouteNoHostException`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

