### PR TITLE
Fix NPE when user specifies incorrect TLS secret or key inside that Secret

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -643,45 +643,61 @@ public class Util {
         }
     }
 
+    /**
+     * Utility method which gets the secret and validates that the required fields are present in it
+     *
+     * @param secretOperator    Secret operator to get the secret from the Kubernetes API
+     * @param namespace         Namespace where the Secret exist
+     * @param name              Name of the Secret
+     * @param items             List of items which should be present in the Secret
+     *
+     * @return      Future with the Secret if is exits and has the required items. Failed future with an error message otherwise.
+     */
+    /* test */ static Future<Secret> getValidatedSecret(SecretOperator secretOperator, String namespace, String name, String... items)  {
+        return secretOperator.getAsync(namespace, name)
+                .compose(secret -> {
+                    if (secret == null) {
+                        return Future.failedFuture(new InvalidConfigurationException("Secret " + name + " not found"));
+                    } else {
+                        List<String> errors = new ArrayList<>(0);
+
+                        for (String item : items)   {
+                            if (!secret.getData().containsKey(item))    {
+                                // Item not found => error will be raised
+                                errors.add(item);
+                            }
+                        }
+
+                        if (errors.isEmpty()) {
+                            return Future.succeededFuture(secret);
+                        } else {
+                            return Future.failedFuture(new InvalidConfigurationException(String.format("Items with key(s) %s are missing in Secret %s", errors, name)));
+                        }
+                    }
+                });
+    }
+
     private static Future<String> getCertificateAsync(SecretOperator secretOperator, String namespace, CertSecretSource certSecretSource) {
-        return secretOperator.getAsync(namespace, certSecretSource.getSecretName())
-                .compose(secret -> secret == null ? Future.failedFuture("Secret " + certSecretSource.getSecretName() + " not found") : Future.succeededFuture(secret.getData().get(certSecretSource.getCertificate())));
+        return getValidatedSecret(secretOperator, namespace, certSecretSource.getSecretName(), certSecretSource.getCertificate())
+                .compose(secret -> Future.succeededFuture(secret.getData().get(certSecretSource.getCertificate())));
     }
 
     private static Future<CertAndKey> getCertificateAndKeyAsync(SecretOperator secretOperator, String namespace, KafkaClientAuthenticationTls auth) {
-        return secretOperator.getAsync(namespace, auth.getCertificateAndKey().getSecretName())
-                .compose(secret -> secret == null ? Future.failedFuture("Secret " + auth.getCertificateAndKey().getSecretName() + " not found") :
-                        Future.succeededFuture(new CertAndKey(secret.getData().get(auth.getCertificateAndKey().getKey()).getBytes(StandardCharsets.UTF_8), secret.getData().get(auth.getCertificateAndKey().getCertificate()).getBytes(StandardCharsets.UTF_8))));
+        return getValidatedSecret(secretOperator, namespace, auth.getCertificateAndKey().getSecretName(), auth.getCertificateAndKey().getCertificate(), auth.getCertificateAndKey().getKey())
+                .compose(secret -> Future.succeededFuture(new CertAndKey(secret.getData().get(auth.getCertificateAndKey().getKey()).getBytes(StandardCharsets.UTF_8), secret.getData().get(auth.getCertificateAndKey().getCertificate()).getBytes(StandardCharsets.UTF_8))));
     }
 
     private static Future<String> getPasswordAsync(SecretOperator secretOperator, String namespace, KafkaClientAuthentication auth) {
         if (auth instanceof KafkaClientAuthenticationPlain) {
-            return secretOperator.getAsync(namespace, ((KafkaClientAuthenticationPlain) auth).getPasswordSecret().getSecretName())
-            .compose(secret -> {
-                if (secret == null) {
-                    return Future.failedFuture("Secret " + ((KafkaClientAuthenticationPlain) auth).getPasswordSecret().getSecretName() + " not found");
-                } else {
-                    String passwordKey = ((KafkaClientAuthenticationPlain) auth).getPasswordSecret().getPassword();
-                    if (!secret.getData().containsKey(passwordKey)) {
-                        return Future.failedFuture(String.format("Secret %s does not contain key %s", ((KafkaClientAuthenticationPlain) auth).getPasswordSecret().getSecretName(), passwordKey));
-                    }
-                    return Future.succeededFuture(secret.getData().get(passwordKey));
-                }   
-            });
-        }
-        if (auth instanceof KafkaClientAuthenticationScram) {
-            return secretOperator.getAsync(namespace, ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getSecretName())
-            .compose(secret -> {
-                if (secret == null) {
-                    return Future.failedFuture("Secret " + ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getSecretName() + " not found");
-                } else {
-                    String passwordKey = ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getPassword();
-                    if (!secret.getData().containsKey(passwordKey)) {
-                        return Future.failedFuture(String.format("Secret %s does not contain key %s", ((KafkaClientAuthenticationScram) auth).getPasswordSecret().getSecretName(), passwordKey));
-                    }
-                    return Future.succeededFuture(secret.getData().get(passwordKey));
-                }
-            });                    
+            KafkaClientAuthenticationPlain plainAuth = (KafkaClientAuthenticationPlain) auth;
+
+            return getValidatedSecret(secretOperator, namespace, plainAuth.getPasswordSecret().getSecretName(), plainAuth.getPasswordSecret().getPassword())
+                    .compose(secret -> Future.succeededFuture(secret.getData().get(plainAuth.getPasswordSecret().getPassword())));
+        } else if (auth instanceof KafkaClientAuthenticationScram) {
+            KafkaClientAuthenticationScram scramAuth = (KafkaClientAuthenticationScram) auth;
+
+            return getValidatedSecret(secretOperator, namespace, scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword())
+                    .compose(secret -> Future.succeededFuture(secret.getData().get(scramAuth.getPasswordSecret().getPassword())));
         } else {
             return Future.failedFuture("Auth type " + auth.getType() + " does not have a password property");
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As discussed in #6898, when the user specifies badly the TLS or the TLS authentication secret, an ugly NPE exception is thrown currently. This PR tries to improve this and add a proper validation. The new error message is much more friendly:

```
2022-06-08 12:13:48 ERROR AbstractOperator:247 - Reconciliation #15(watch) KafkaConnect(myproject/my-connect): createOrUpdate failed
io.strimzi.operator.common.InvalidConfigurationException: Items with key(s) [user.crt, user.key] are missing in Secret my-connect
	at io.strimzi.operator.common.Util.lambda$getValidatedSecret$22(Util.java:674) ~[io.strimzi.operator-common-0.30.0-SNAPSHOT.jar:0.30.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.2.4.jar:4.2.4]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[io.netty.netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[io.netty.netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty.netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503) ~[io.netty.netty-transport-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995) ~[io.netty.netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.77.Final.jar:4.1.77.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

This PR does it by creating a new method which can get the secret and validate whether it contains the selected items. This is then called from the different methods getting the various secrets to unify the way we get and validate the secrets instead of having it separately in each `if` branch. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging