### PR TITLE
Regenerate the docs snippet with Kafka versions

### DIFF
--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -5,7 +5,7 @@
 // DO NOT EDIT BY HAND
 [options="header"]
 |=================
-|Kafka version |Interbroker protocol version |Log message format version| ZooKeeper version
+|Kafka version |Inter-broker protocol version |Log message format version| ZooKeeper version
 | 3.1.0 | 3.1 | 3.1 | 3.6.3
 | 3.1.1 | 3.1 | 3.1 | 3.6.3
 | 3.2.0 | 3.2 | 3.2 | 3.6.3


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#6879 changed the `documentation/snip-kafka-versions.sh` script to do some changes to the generated file with Kafka versions. However, it did not update the snippet file it self. So it is no poping as uncommitted change after running the build locally. This Pr adds the updated version of the generated file to fix this.

### Checklist

- [x] Update documentation