### PR TITLE
[systemtest] Use different pod than Kafka for executing all Kafka scripts

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/cli/KafkaCmdClient.java
@@ -17,13 +17,13 @@ import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
 public class KafkaCmdClient {
 
-    public static List<String> listTopicsUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer) {
-        return Arrays.asList(cmdKubeClient(namespaceName).execInPod(scraperPodName, "/bin/bash", "-c",
+    public static List<String> listTopicsUsingPodCli(String namespaceName, String podName, String bootstrapServer) {
+        return Arrays.asList(cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c",
             "bin/kafka-topics.sh --list --bootstrap-server " + bootstrapServer).out().split("\\s+"));
     }
 
-    public static String createTopicUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, String topic, int replicationFactor, int partitions) {
-        String response = cmdKubeClient(namespaceName).execInPod(scraperPodName, "/bin/bash", "-c",
+    public static String createTopicUsingPodCli(String namespaceName, String podName, String bootstrapServer, String topic, int replicationFactor, int partitions) {
+        String response = cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c",
             "bin/kafka-topics.sh --bootstrap-server " + bootstrapServer + " --create " + " --topic " + topic +
                 " --replication-factor " + replicationFactor + " --partitions " + partitions).out();
 
@@ -32,23 +32,23 @@ public class KafkaCmdClient {
         return response;
     }
 
-    public static String deleteTopicUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, String topic) {
-        return cmdKubeClient(namespaceName).execInPod(scraperPodName, "/bin/bash", "-c",
+    public static String deleteTopicUsingPodCli(String namespaceName, String podName, String bootstrapServer, String topic) {
+        return cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c",
             "bin/kafka-topics.sh --bootstrap-server " + bootstrapServer + " --delete --topic " + topic).out();
     }
 
-    public static String updateTopicPartitionsCountUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, String topic, int partitions) {
-        return cmdKubeClient(namespaceName).execInPod(scraperPodName, "/bin/bash", "-c",
+    public static String updateTopicPartitionsCountUsingPodCli(String namespaceName, String podName, String bootstrapServer, String topic, int partitions) {
+        return cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c",
             "bin/kafka-topics.sh --bootstrap-server " + bootstrapServer + " --alter --topic " + topic + " --partitions " + partitions).out();
     }
 
-    public static String listTopicsUsingPodCliWithConfigProperties(String namespaceName, String scraperPodName, String bootstrapServer, String properties) {
+    public static String listTopicsUsingPodCliWithConfigProperties(String namespaceName, String podName, String bootstrapServer, String properties) {
         cmdKubeClient().namespace(namespaceName).execInPod(Level.TRACE,
-            scraperPodName,
+            podName,
             "/bin/bash", "-c", "echo \"" + properties + "\" | tee /tmp/config.properties"
         );
 
-        return cmdKubeClient().namespace(namespaceName).execInPod(Level.DEBUG, scraperPodName, "/opt/kafka/bin/kafka-topics.sh",
+        return cmdKubeClient().namespace(namespaceName).execInPod(Level.DEBUG, podName, "/opt/kafka/bin/kafka-topics.sh",
                 "--list",
                 "--bootstrap-server",
                 bootstrapServer,
@@ -57,8 +57,8 @@ public class KafkaCmdClient {
             .out();
     }
 
-    public static String describeTopicUsingPodCli(final String namespaceName, String scraperPodName, String bootstrapServer, String topicName) {
-        return cmdKubeClient().namespace(namespaceName).execInPod(scraperPodName, "/opt/kafka/bin/kafka-topics.sh",
+    public static String describeTopicUsingPodCli(final String namespaceName, String podName, String bootstrapServer, String topicName) {
+        return cmdKubeClient().namespace(namespaceName).execInPod(podName, "/opt/kafka/bin/kafka-topics.sh",
                 "--topic",
                 topicName,
                 "--describe",
@@ -67,32 +67,25 @@ public class KafkaCmdClient {
             .out();
     }
 
-    public static String describeUserUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, String userName) {
-        return describeKafkaEntityUsingPodCli(namespaceName, scraperPodName, bootstrapServer, "user", userName);
+    public static String describeUserUsingPodCli(String namespaceName, String podName, String bootstrapServer, String userName) {
+        return describeKafkaEntityUsingPodCli(namespaceName, podName, bootstrapServer, "users", userName);
     }
 
-    public static String describeKafkaBrokerLoggersUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, int podNum) {
-        return describeKafkaEntityUsingPodCli(namespaceName, scraperPodName, bootstrapServer, "brokers-loggers", String.valueOf(podNum));
+    public static String describeKafkaBrokerLoggersUsingPodCli(String namespaceName, String podName, String bootstrapServer, int podNum) {
+        return describeKafkaEntityUsingPodCli(namespaceName, podName, bootstrapServer, "broker-loggers", String.valueOf(podNum));
     }
 
-    public static String describeKafkaBrokerUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, int podNum) {
-        return describeKafkaEntityUsingPodCli(namespaceName, scraperPodName, bootstrapServer, "brokers", String.valueOf(podNum));
+    public static String describeKafkaBrokerUsingPodCli(String namespaceName, String podName, String bootstrapServer, int podNum) {
+        return describeKafkaEntityUsingPodCli(namespaceName, podName, bootstrapServer, "brokers", String.valueOf(podNum));
     }
 
-    public static String describeKafkaEntityUsingPodCli(String namespaceName, String scraperPodName, String bootstrapServer, String entityType, String entityName) {
-        return cmdKubeClient().namespace(namespaceName).execInPod(Level.DEBUG, scraperPodName, "/bin/bash", "-c", "bin/kafka-configs.sh",
-                "--bootstrap-server",
-                bootstrapServer,
-                "--entity-type",
-                entityType,
-                "--entity-name",
-                entityName,
-                "--describe")
-            .out();
+    public static String describeKafkaEntityUsingPodCli(String namespaceName, String podName, String bootstrapServer, String entityType, String entityName) {
+        return cmdKubeClient().namespace(namespaceName).execInPod(Level.DEBUG, podName, "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server "
+                    + bootstrapServer + " --entity-type " + entityType + " --entity-name " + entityName + " --describe").out();
     }
 
-    public static int getCurrentOffsets(String namespaceName, String scraperPodName, String bootstrapServer, String topicName, String consumerGroup) {
-        String offsetOutput = cmdKubeClient().namespace(namespaceName).execInPod(scraperPodName, "/opt/kafka/bin/kafka-consumer-groups.sh",
+    public static int getCurrentOffsets(String namespaceName, String podName, String bootstrapServer, String topicName, String consumerGroup) {
+        String offsetOutput = cmdKubeClient().namespace(namespaceName).execInPod(podName, "/opt/kafka/bin/kafka-consumer-groups.sh",
                 "--describe",
                 "--bootstrap-server",
                 bootstrapServer,

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
@@ -116,6 +116,10 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
             .createInstallation()
             .runInstallation();
 
+        resourceManager.createResource(context, ScraperTemplates.scraperPod(clusterOperator.getDeploymentNamespace(), scraperName).build());
+
+        scraperPodName = kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), scraperName).get(0).getMetadata().getName();
+
         // restore command
         LOGGER.info("Running restore procedure for {}/{}", clusterOperator.getDeploymentNamespace(), clusterName);
         String[] restoreCommand = new String[] {

--- a/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/backup/ColdBackupScriptIsolatedST.java
@@ -7,16 +7,19 @@ package io.strimzi.systemtest.backup;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.TestUtils.USER_PATH;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.test.annotations.IsolatedTest;
@@ -51,6 +54,8 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
     @KRaftNotSupported("Debug needed - https://github.com/strimzi/strimzi-kafka-operator/issues/6863")
     void backupAndRestore(ExtensionContext context) {
         String clusterName = mapWithClusterNames.get(context.getDisplayName());
+        String scraperName = mapWithScraperNames.get(context.getDisplayName());
+
         String groupId = "my-group", newGroupId = "new-group";
 
         String topicName = mapWithTestTopics.get(context.getDisplayName());
@@ -60,11 +65,16 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
         int firstBatchSize = 100, secondBatchSize = 10;
         String backupFilePath = USER_PATH + "/target/" + clusterName + ".tgz";
 
-        resourceManager.createResource(context, KafkaTemplates.kafkaPersistent(clusterName, 1, 1)
-            .editMetadata()
-                .withNamespace(clusterOperator.getDeploymentNamespace())
-            .endMetadata()
-            .build());
+        resourceManager.createResource(context,
+            KafkaTemplates.kafkaPersistent(clusterName, 1, 1)
+                .editMetadata()
+                    .withNamespace(clusterOperator.getDeploymentNamespace())
+                .endMetadata()
+                .build(),
+            ScraperTemplates.scraperPod(clusterOperator.getDeploymentNamespace(), scraperName).build()
+        );
+
+        String scraperPodName = kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), scraperName).get(0).getMetadata().getName();
 
         KafkaClients clients = new KafkaClientsBuilder()
             .withProducerName(producerName)
@@ -81,7 +91,7 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
         ClientUtils.waitForClientsSuccess(producerName, consumerName, clusterOperator.getDeploymentNamespace(), firstBatchSize);
 
         // save consumer group offsets
-        int offsetsBeforeBackup = KafkaUtils.getCurrentOffsets(KafkaResources.kafkaPodName(clusterName, 0), topicName, groupId);
+        int offsetsBeforeBackup = KafkaCmdClient.getCurrentOffsets(clusterOperator.getDeploymentNamespace(), scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName, groupId);
         assertThat("No offsets map before backup", offsetsBeforeBackup > 0);
 
         // send additional messages
@@ -120,7 +130,7 @@ public class ColdBackupScriptIsolatedST extends AbstractST {
             .withMessageCount(secondBatchSize)
             .build();
 
-        int offsetsAfterRestore = KafkaUtils.getCurrentOffsets(KafkaResources.kafkaPodName(clusterName, 0), topicName, groupId);
+        int offsetsAfterRestore = KafkaCmdClient.getCurrentOffsets(clusterOperator.getDeploymentNamespace(), scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName, groupId);
         assertThat("Current consumer group offsets are not the same as before the backup", offsetsAfterRestore, is(offsetsBeforeBackup));
 
         // check consumer group recovery

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -47,6 +47,7 @@ import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
@@ -587,9 +588,14 @@ class KafkaST extends AbstractST {
     void testForTopicOperator(ExtensionContext extensionContext) throws InterruptedException {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaEphemeral(clusterName, 3).build(),
+            ScraperTemplates.scraperPod(namespaceName, scraperName).build()
+        );
 
+        final String scraperPodName =  kubeClient().listPodsByPrefixInName(namespaceName, scraperName).get(0).getMetadata().getName();
         final String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
         final String cliTopicName = "topic-from-cli";
 
@@ -599,19 +605,19 @@ class KafkaST extends AbstractST {
         KafkaTopicUtils.waitForKafkaTopicReady(namespaceName, topicName);
 
         assertThat(KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get().getMetadata().getName(), is(topicName));
-        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, clusterName, 0), hasItem(topicName));
+        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName)), hasItem(topicName));
 
-        KafkaCmdClient.createTopicUsingPodCli(namespaceName, clusterName, 0, cliTopicName, 1, 1);
-        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, clusterName, 0), hasItems(topicName, cliTopicName));
+        KafkaCmdClient.createTopicUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), cliTopicName, 1, 1);
+        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName)), hasItems(topicName, cliTopicName));
         assertThat(cmdKubeClient(namespaceName).list(KafkaTopic.RESOURCE_KIND), hasItems(cliTopicName, topicName));
 
         //Updating first topic using pod CLI
-        KafkaCmdClient.updateTopicPartitionsCountUsingPodCli(namespaceName, clusterName, 0, topicName, 2);
+        KafkaCmdClient.updateTopicPartitionsCountUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName, 2);
 
         KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
 
-        assertThat(KafkaCmdClient.describeTopicUsingPodCli(namespaceName, clusterName, 0, topicName),
-                hasItems("PartitionCount:2"));
+        assertThat(KafkaCmdClient.describeTopicUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName),
+                containsString("PartitionCount:2"));
         KafkaTopic testTopic = fromYamlString(cmdKubeClient(namespaceName).get(KafkaTopic.RESOURCE_KIND, topicName), KafkaTopic.class);
         assertThat(testTopic, is(CoreMatchers.notNullValue()));
         assertThat(testTopic.getSpec(), is(CoreMatchers.notNullValue()));
@@ -622,8 +628,8 @@ class KafkaST extends AbstractST {
 
         KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
 
-        assertThat(KafkaCmdClient.describeTopicUsingPodCli(namespaceName, clusterName, 0, cliTopicName),
-                hasItems("PartitionCount:2"));
+        assertThat(KafkaCmdClient.describeTopicUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), cliTopicName),
+            containsString("PartitionCount:2"));
         testTopic = fromYamlString(cmdKubeClient(namespaceName).get(KafkaTopic.RESOURCE_KIND, cliTopicName), KafkaTopic.class);
         assertThat(testTopic, is(CoreMatchers.notNullValue()));
         assertThat(testTopic.getSpec(), is(CoreMatchers.notNullValue()));
@@ -633,12 +639,12 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName(KafkaTopic.RESOURCE_KIND, cliTopicName);
 
         //Deleting another topic using pod CLI
-        KafkaCmdClient.deleteTopicUsingPodCli(namespaceName, clusterName, 0, topicName);
+        KafkaCmdClient.deleteTopicUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName);
         KafkaTopicUtils.waitForKafkaTopicDeletion(namespaceName, topicName);
 
         //Checking all topics were deleted
         Thread.sleep(Constants.TIMEOUT_TEARDOWN);
-        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(namespaceName, clusterName, 0);
+        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName));
         assertThat(topics, not(hasItems(topicName)));
         assertThat(topics, not(hasItems(cliTopicName)));
     }
@@ -859,6 +865,7 @@ class KafkaST extends AbstractST {
     void testTopicWithoutLabels(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
 
         // Negative scenario: creating topic without any labels and make sure that TO can't handle this topic
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3).build());
@@ -868,12 +875,16 @@ class KafkaST extends AbstractST {
             .editMetadata()
                 .withLabels(null)
             .endMetadata()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(namespaceName, scraperName).build()
+        );
+
+        final String scraperPodName =  kubeClient().listPodsByPrefixInName(namespaceName, scraperName).get(0).getMetadata().getName();
 
         // Checking that resource was created
         assertThat(cmdKubeClient(namespaceName).list("kafkatopic"), hasItems("topic-without-labels"));
         // Checking that TO didn't handle new topic and zk pods don't contain new topic
-        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, clusterName, 0), not(hasItems("topic-without-labels")));
+        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName)), not(hasItems("topic-without-labels")));
 
         // Checking TO logs
         String tOPodName = cmdKubeClient(namespaceName).listResourcesByLabel("pod", Labels.STRIMZI_NAME_LABEL + "=" + clusterName + "-entity-operator").get(0);
@@ -885,7 +896,7 @@ class KafkaST extends AbstractST {
         KafkaTopicUtils.waitForKafkaTopicDeletion(namespaceName,  "topic-without-labels");
 
         //Checking all topics were deleted
-        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(namespaceName, clusterName, 0);
+        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName));
         assertThat(topics, not(hasItems("topic-without-labels")));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfST.java
@@ -14,11 +14,13 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
+import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.externalClients.ExternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
@@ -41,7 +43,6 @@ import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.ROLLING_UPDATE;
-import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -68,6 +69,8 @@ public class DynamicConfST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testSimpleDynamicConfiguration(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
+
         Map<String, Object> deepCopyOfShardKafkaConfig = kafkaConfig.entrySet().stream()
             .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 
@@ -80,7 +83,11 @@ public class DynamicConfST extends AbstractST {
                     .withConfig(deepCopyOfShardKafkaConfig)
                 .endKafka()
             .endSpec()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(namespace, scraperName).build()
+        );
+
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, KAFKA_REPLICAS)) {
             String kafkaConfiguration = kubeClient().getConfigMap(namespace, cmName).getData().get("server.config");
@@ -89,14 +96,14 @@ public class DynamicConfST extends AbstractST {
             assertThat(kafkaConfiguration, containsString("log.message.format.version=" + TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).messageVersion()));
         }
 
-        String kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        String kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("Dynamic configs for broker 0 are:\n"));
 
         deepCopyOfShardKafkaConfig.put("unclean.leader.election.enable", true);
 
         updateAndVerifyDynConf(namespace, clusterName, deepCopyOfShardKafkaConfig);
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("unclean.leader.election.enable=" + true));
 
         LOGGER.info("Verify values after update");
@@ -115,6 +122,8 @@ public class DynamicConfST extends AbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testUpdateToExternalListenerCausesRollingRestart(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
+
         Map<String, Object> deepCopyOfShardKafkaConfig = kafkaConfig.entrySet().stream()
             .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
         LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
@@ -146,16 +155,20 @@ public class DynamicConfST extends AbstractST {
                     .withConfig(deepCopyOfShardKafkaConfig)
                 .endKafka()
             .endSpec()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(namespace, scraperName).build()
+        );
 
-        String kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
+        String kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
+
         assertThat(kafkaConfigurationFromPod, containsString("Dynamic configs for broker 0 are:\n"));
 
         deepCopyOfShardKafkaConfig.put("unclean.leader.election.enable", true);
 
         updateAndVerifyDynConf(namespace, clusterName, deepCopyOfShardKafkaConfig);
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("unclean.leader.election.enable=" + true));
 
         // Edit listeners - this should cause RU (because of new crts)
@@ -188,24 +201,24 @@ public class DynamicConfST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(namespace, kafkaSelector, KAFKA_REPLICAS, kafkaPods);
         assertThat(RollingUpdateUtils.componentHasRolled(namespace, kafkaSelector, kafkaPods), is(true));
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("Dynamic configs for broker 0 are:\n"));
 
         deepCopyOfShardKafkaConfig.put("compression.type", "snappy");
 
         updateAndVerifyDynConf(namespace, clusterName, deepCopyOfShardKafkaConfig);
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("compression.type=snappy"));
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("Dynamic configs for broker 0 are:\n"));
 
         deepCopyOfShardKafkaConfig.put("unclean.leader.election.enable", true);
 
         updateAndVerifyDynConf(namespace, clusterName, deepCopyOfShardKafkaConfig);
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("unclean.leader.election.enable=" + true));
 
         // Remove external listeners (node port) - this should cause RU (we need to update advertised.listeners)
@@ -233,14 +246,14 @@ public class DynamicConfST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(namespace, kafkaSelector, KAFKA_REPLICAS, kafkaPods);
         assertThat(RollingUpdateUtils.componentHasRolled(namespace, kafkaSelector, kafkaPods), is(true));
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("Dynamic configs for broker 0 are:\n"));
 
         deepCopyOfShardKafkaConfig.put("unclean.leader.election.enable", false);
 
         updateAndVerifyDynConf(namespace, clusterName, deepCopyOfShardKafkaConfig);
 
-        kafkaConfigurationFromPod = cmdKubeClient().namespace(namespace).execInPod(KafkaResources.kafkaPodName(clusterName, 0), "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --describe").out();
+        kafkaConfigurationFromPod = KafkaCmdClient.describeKafkaBrokerUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0);
         assertThat(kafkaConfigurationFromPod, containsString("unclean.leader.election.enable=" + false));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -821,7 +821,7 @@ class LoggingChangeST extends AbstractST {
             ScraperTemplates.scraperPod(namespaceName, scraperName).build()
         );
 
-        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespaceName, scraperName).get(0).getMetadata().getName();
         Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         TestUtils.waitFor("log to not be empty", Duration.ofMillis(100).toMillis(), Constants.SAFETY_RECONCILIATION_INTERVAL,
@@ -845,7 +845,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Waiting for dynamic change in the kafka pod");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("root=DEBUG"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("root=DEBUG"));
 
         TestUtils.waitFor("log to not be empty", Duration.ofMillis(100).toMillis(), Constants.SAFETY_RECONCILIATION_INTERVAL,
             () -> {
@@ -903,7 +903,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Waiting for dynamic change in the kafka pod");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("root=INFO"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("root=INFO"));
 
         TestUtils.waitFor("log to not be empty", Duration.ofMillis(100).toMillis(), Constants.SAFETY_RECONCILIATION_INTERVAL,
             () -> {
@@ -933,7 +933,7 @@ class LoggingChangeST extends AbstractST {
             ScraperTemplates.scraperPod(namespaceName, scraperName).build()
         );
 
-        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespaceName, scraperName).get(0).getMetadata().getName();
         Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         InlineLogging il = new InlineLogging();
@@ -945,7 +945,7 @@ class LoggingChangeST extends AbstractST {
 
         RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("paprika=INFO"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("paprika=INFO"));
     }
 
     @ParallelNamespaceTest
@@ -1024,7 +1024,7 @@ class LoggingChangeST extends AbstractST {
             ScraperTemplates.scraperPod(namespaceName, scraperName).build()
         );
 
-        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespaceName, scraperName).get(0).getMetadata().getName();
         Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         configMap = new ConfigMapBuilder()
@@ -1056,7 +1056,7 @@ class LoggingChangeST extends AbstractST {
         RollingUpdateUtils.waitForNoRollingUpdate(namespaceName, kafkaSelector, kafkaPods);
         assertThat("Kafka pod should not roll", RollingUpdateUtils.componentHasRolled(namespaceName, kafkaSelector, kafkaPods), is(false));
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("kafka.authorizer.logger=ERROR"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("kafka.authorizer.logger=ERROR"));
 
         // log4j.appender.CONSOLE.layout.ConversionPattern is changed and thus we need RU
         configMap = new ConfigMapBuilder()
@@ -1088,7 +1088,7 @@ class LoggingChangeST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
 
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("kafka.authorizer.logger=DEBUG"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("kafka.authorizer.logger=DEBUG"));
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -26,6 +26,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -787,6 +788,7 @@ class LoggingChangeST extends AbstractST {
     void testDynamicallySetKafkaLoggingLevels(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
         String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
         final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, kafkaName);
 
@@ -815,8 +817,11 @@ class LoggingChangeST extends AbstractST {
                         .withInlineLogging(ilOff)
                     .endKafka()
                 .endSpec()
-                .build());
+                .build(),
+            ScraperTemplates.scraperPod(namespaceName, scraperName).build()
+        );
 
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
         Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         TestUtils.waitFor("log to not be empty", Duration.ofMillis(100).toMillis(), Constants.SAFETY_RECONCILIATION_INTERVAL,
@@ -840,9 +845,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Waiting for dynamic change in the kafka pod");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPodContainer(Level.TRACE, KafkaResources.kafkaPodName(clusterName, 0),
-                "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out()
-                .contains("root=DEBUG"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("root=DEBUG"));
 
         TestUtils.waitFor("log to not be empty", Duration.ofMillis(100).toMillis(), Constants.SAFETY_RECONCILIATION_INTERVAL,
             () -> {
@@ -900,9 +903,7 @@ class LoggingChangeST extends AbstractST {
 
         LOGGER.info("Waiting for dynamic change in the kafka pod");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPodContainer(Level.TRACE, KafkaResources.kafkaPodName(clusterName, 0),
-                "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out()
-                .contains("root=INFO"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("root=INFO"));
 
         TestUtils.waitFor("log to not be empty", Duration.ofMillis(100).toMillis(), Constants.SAFETY_RECONCILIATION_INTERVAL,
             () -> {
@@ -923,10 +924,16 @@ class LoggingChangeST extends AbstractST {
     void testDynamicallySetUnknownKafkaLogger(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
 
         final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 1).build());
+        resourceManager.createResource(extensionContext,
+            KafkaTemplates.kafkaPersistent(clusterName, 3, 1).build(),
+            ScraperTemplates.scraperPod(namespaceName, scraperName).build()
+        );
+
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
         Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         InlineLogging il = new InlineLogging();
@@ -938,9 +945,7 @@ class LoggingChangeST extends AbstractST {
 
         RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPodContainer(Level.TRACE, KafkaResources.kafkaPodName(clusterName, 0),
-                        "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out()
-                        .contains("paprika=INFO"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("paprika=INFO"));
     }
 
     @ParallelNamespaceTest
@@ -968,6 +973,7 @@ class LoggingChangeST extends AbstractST {
     void testDynamicallySetKafkaExternalLogging(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        final String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
         final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
 
         // this test changes dynamically unchangeable logging config and thus RU is expected
@@ -1014,9 +1020,11 @@ class LoggingChangeST extends AbstractST {
                     .withExternalLogging(el)
                 .endKafka()
             .endSpec()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(namespaceName, scraperName).build()
+        );
 
-        String kafkaName = KafkaResources.kafkaStatefulSetName(clusterName);
+        String scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
         Map<String, String> kafkaPods = PodUtils.podSnapshot(namespaceName, kafkaSelector);
 
         configMap = new ConfigMapBuilder()
@@ -1048,9 +1056,7 @@ class LoggingChangeST extends AbstractST {
         RollingUpdateUtils.waitForNoRollingUpdate(namespaceName, kafkaSelector, kafkaPods);
         assertThat("Kafka pod should not roll", RollingUpdateUtils.componentHasRolled(namespaceName, kafkaSelector, kafkaPods), is(false));
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPodContainer(Level.TRACE, KafkaResources.kafkaPodName(clusterName, 0),
-                "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out()
-                .contains("kafka.authorizer.logger=ERROR"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("kafka.authorizer.logger=ERROR"));
 
         // log4j.appender.CONSOLE.layout.ConversionPattern is changed and thus we need RU
         configMap = new ConfigMapBuilder()
@@ -1082,9 +1088,7 @@ class LoggingChangeST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
 
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().namespace(namespaceName).execInPodContainer(Level.TRACE, KafkaResources.kafkaPodName(clusterName, 0),
-                "kafka", "/bin/bash", "-c", "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type broker-loggers --entity-name 0").out()
-                .contains("kafka.authorizer.logger=DEBUG"));
+            () -> KafkaCmdClient.describeKafkaBrokerLoggersUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), 0).contains("kafka.authorizer.logger=DEBUG"));
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -639,8 +639,8 @@ class MirrorMaker2IsolatedST extends AbstractST {
             assertNotNull(kafkaTopics.stream().filter(kafkaTopic -> kafkaTopic.equals(testStorage.getTopicName())).findAny());
 
             String kafkaTopicSpec = KafkaCmdClient.describeTopicUsingPodCli(testStorage.getNamespaceName(), scraperPodName, KafkaResources.plainBootstrapAddress(kafkaClusterTargetName), testStorage.getTopicName());
-            assertThat(kafkaTopicSpec, containsString("Topic:" + testStorage.getTopicName()));
-            assertThat(kafkaTopicSpec, containsString("PartitionCount:3"));
+            assertThat(kafkaTopicSpec, containsString("Topic: " + testStorage.getTopicName()));
+            assertThat(kafkaTopicSpec, containsString("PartitionCount: 3"));
         }
     }
 
@@ -709,8 +709,8 @@ class MirrorMaker2IsolatedST extends AbstractST {
             assertNotNull(kafkaTopics.stream().filter(kafkaTopic -> kafkaTopic.equals(testStorage.getTopicName())).findAny());
 
             String kafkaTopicSpec = KafkaCmdClient.describeTopicUsingPodCli(testStorage.getNamespaceName(), scraperPodName, KafkaResources.plainBootstrapAddress(kafkaClusterTargetName), testStorage.getTopicName());
-            assertThat(kafkaTopicSpec, containsString("Topic:" + testStorage.getTopicName()));
-            assertThat(kafkaTopicSpec, containsString("PartitionCount:3"));
+            assertThat(kafkaTopicSpec, containsString("Topic: " + testStorage.getTopicName()));
+            assertThat(kafkaTopicSpec, containsString("PartitionCount: 3"));
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -454,8 +454,8 @@ public class TopicST extends AbstractST {
                     String topicInfo =  KafkaCmdClient.describeTopicUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName);
                     LOGGER.info("Checking topic {} in Kafka {}", topicName, clusterName);
                     LOGGER.debug("Topic {} info: {}", topicName, topicInfo);
-                    assertThat(topicInfo, containsString("Topic:" + topicName));
-                    assertThat(topicInfo, containsString("PartitionCount:" + topicPartitions));
+                    assertThat(topicInfo, containsString("Topic: " + topicName));
+                    assertThat(topicInfo, containsString("PartitionCount: " + topicPartitions));
                     return true;
                 } catch (KubeClusterException e) {
                     LOGGER.info("Describing topic using pod cli occurred following error:{}", e.getMessage());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -25,6 +25,7 @@ import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
@@ -41,7 +42,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -53,8 +53,8 @@ import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
@@ -71,8 +71,10 @@ public class TopicST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicST.class);
     private static final String TOPIC_CLUSTER_NAME = "topic-cluster-name";
+    private static final String SCRAPER_NAME = TOPIC_CLUSTER_NAME + "-" + Constants.SCRAPER_NAME;
 
     private final String namespace = testSuiteNamespaceManager.getMapOfAdditionalNamespaces().get(TopicST.class.getSimpleName()).stream().findFirst().get();
+    private String scraperPodName;
 
     @ParallelTest
     void testMoreReplicasThanAvailableBrokers(ExtensionContext extensionContext) {
@@ -118,7 +120,7 @@ public class TopicST extends AbstractST {
         int topicPartitions = 3;
 
         LOGGER.debug("Creating topic {} with {} replicas and {} partitions", topicName, 3, topicPartitions);
-        KafkaCmdClient.createTopicUsingPodCli(namespace, TOPIC_CLUSTER_NAME, 0, topicName, 3, topicPartitions);
+        KafkaCmdClient.createTopicUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(TOPIC_CLUSTER_NAME), topicName, 3, topicPartitions);
 
         KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(namespace).withName(topicName).get();
 
@@ -127,7 +129,7 @@ public class TopicST extends AbstractST {
         topicPartitions = 5;
         LOGGER.info("Editing topic via Kafka, settings to partitions {}", topicPartitions);
 
-        KafkaCmdClient.updateTopicPartitionsCountUsingPodCli(namespace, TOPIC_CLUSTER_NAME, 0, topicName, topicPartitions);
+        KafkaCmdClient.updateTopicPartitionsCountUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(TOPIC_CLUSTER_NAME), topicName, topicPartitions);
         LOGGER.debug("Topic {} updated from {} to {} partitions", topicName, 3, topicPartitions);
 
         KafkaTopicUtils.waitForKafkaTopicPartitionChange(namespace, topicName, topicPartitions);
@@ -437,7 +439,7 @@ public class TopicST extends AbstractST {
 
     boolean hasTopicInKafka(String topicName, String clusterName) {
         LOGGER.info("Checking topic {} in Kafka", topicName);
-        return KafkaCmdClient.listTopicsUsingPodCli(namespace, clusterName, 0).contains(topicName);
+        return KafkaCmdClient.listTopicsUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName)).contains(topicName);
     }
 
     boolean hasTopicInCRK8s(KafkaTopic kafkaTopic, String topicName) {
@@ -449,10 +451,11 @@ public class TopicST extends AbstractST {
         TestUtils.waitFor("Describing topic " + topicName + " using pod CLI", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, Constants.GLOBAL_TIMEOUT,
             () -> {
                 try {
-                    List<String> topicInfo =  KafkaCmdClient.describeTopicUsingPodCli(namespaceName, clusterName, 0, topicName);
+                    String topicInfo =  KafkaCmdClient.describeTopicUsingPodCli(namespaceName, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName), topicName);
                     LOGGER.info("Checking topic {} in Kafka {}", topicName, clusterName);
                     LOGGER.debug("Topic {} info: {}", topicName, topicInfo);
-                    assertThat(topicInfo, hasItems("Topic:" + topicName, "PartitionCount:" + topicPartitions));
+                    assertThat(topicInfo, containsString("Topic:" + topicName));
+                    assertThat(topicInfo, containsString("PartitionCount:" + topicPartitions));
                     return true;
                 } catch (KubeClusterException e) {
                     LOGGER.info("Describing topic using pod cli occurred following error:{}", e.getMessage());
@@ -464,7 +467,7 @@ public class TopicST extends AbstractST {
     void verifyTopicViaKafkaTopicCRK8s(KafkaTopic kafkaTopic, String topicName, int topicPartitions, String clusterName) {
         LOGGER.info("Checking in KafkaTopic CR that topic {} was created with expected settings", topicName);
         assertThat(kafkaTopic, is(notNullValue()));
-        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespace, clusterName, 0), hasItem(topicName));
+        assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(clusterName)), hasItem(topicName));
         assertThat(kafkaTopic.getMetadata().getName(), is(topicName));
         assertThat(kafkaTopic.getSpec().getPartitions(), is(topicPartitions));
     }
@@ -472,10 +475,15 @@ public class TopicST extends AbstractST {
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         LOGGER.info("Deploying shared Kafka across all test cases in {} namespace", namespace);
+
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(TOPIC_CLUSTER_NAME, 3, 1)
             .editMetadata()
                 .withNamespace(namespace)
             .endMetadata()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(namespace, SCRAPER_NAME).build()
+        );
+
+        scraperPodName = kubeClient().listPodsByPrefixInName(namespace, SCRAPER_NAME).get(0).getMetadata().getName();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -68,6 +68,8 @@ class UserST extends AbstractST {
 
     private final String userClusterName = "user-cluster-name";
     private final String namespace = testSuiteNamespaceManager.getMapOfAdditionalNamespaces().get(UserST.class.getSimpleName()).stream().findFirst().get();
+
+    private final String scraperName = userClusterName + "-" + Constants.SCRAPER_NAME;
     private String scraperPodName = "";
 
     @ParallelTest
@@ -540,8 +542,6 @@ class UserST extends AbstractST {
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
-        String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
-
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
             .editMetadata()
                 .withNamespace(namespace)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -24,6 +24,7 @@ import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.crd.KafkaUserResource;
@@ -31,12 +32,12 @@ import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.executor.ExecResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,7 +50,6 @@ import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SCALABILITY;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
-import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -68,6 +68,7 @@ class UserST extends AbstractST {
 
     private final String userClusterName = "user-cluster-name";
     private final String namespace = testSuiteNamespaceManager.getMapOfAdditionalNamespaces().get(UserST.class.getSimpleName()).stream().findFirst().get();
+    private String scraperPodName = "";
 
     @ParallelTest
     @KRaftNotSupported("Scram-sha is not supported by KRaft mode and is used in this test case")
@@ -279,19 +280,14 @@ class UserST extends AbstractST {
 
         final String userName = KafkaUserResource.kafkaUserClient().inNamespace(namespace).withName(user.getMetadata().getName()).get().getStatus().getUsername();
 
-        String command = "bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --user " + userName;
-        LOGGER.debug("Command for kafka-configs.sh {}", command);
-
         TestUtils.waitFor("all KafkaUser " + userName + " attributes are present", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> {
-                ExecResult result = cmdKubeClient(namespace).execInPod(KafkaResources.kafkaPodName(userClusterName, 0), "/bin/bash", "-c", command);
-                boolean res = result.out().contains("Quota configs for user-principal '" + userName + "' are");
-                res = res && result.out().contains("request_percentage=" + reqPerc);
-                res = res && result.out().contains("producer_byte_rate=" + prodRate);
-                res = res && result.out().contains("consumer_byte_rate=" + consRate);
-                res = res && result.out().contains("controller_mutation_rate=" + mutRate);
-
-                return res;
+                String result = KafkaCmdClient.describeUserUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(userClusterName), userName);
+                return result.contains("Quota configs for user-principal '" + userName + "' are") &&
+                    result.contains("request_percentage=" + reqPerc) &&
+                    result.contains("producer_byte_rate=" + prodRate) &&
+                    result.contains("consumer_byte_rate=" + consRate) &&
+                    result.contains("controller_mutation_rate=" + mutRate);
             });
 
         // delete user
@@ -300,14 +296,14 @@ class UserST extends AbstractST {
 
         TestUtils.waitFor("all KafkaUser " + userName + " attributes will be cleaned", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> {
-                ExecResult resultAfterDelete = cmdKubeClient(namespace).execInPod(KafkaResources.kafkaPodName(userClusterName, 0), "/bin/bash", "-c", command);
+                String resultAfterDelete = KafkaCmdClient.describeUserUsingPodCli(namespace, scraperPodName, KafkaResources.plainBootstrapAddress(userClusterName), userName);
 
                 return
-                    !resultAfterDelete.out().contains(userName) &&
-                    !resultAfterDelete.out().contains("request_percentage") &&
-                    !resultAfterDelete.out().contains("producer_byte_rate") &&
-                    !resultAfterDelete.out().contains("consumer_byte_rate") &&
-                    !resultAfterDelete.out().contains("controller_mutation_rate");
+                    !resultAfterDelete.contains(userName) &&
+                    !resultAfterDelete.contains("request_percentage") &&
+                    !resultAfterDelete.contains("producer_byte_rate") &&
+                    !resultAfterDelete.contains("consumer_byte_rate") &&
+                    !resultAfterDelete.contains("controller_mutation_rate");
             });
     }
 
@@ -544,10 +540,16 @@ class UserST extends AbstractST {
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
+        String scraperName = mapWithScraperNames.get(extensionContext.getDisplayName());
+
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
             .editMetadata()
                 .withNamespace(namespace)
             .endMetadata()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(namespace, scraperName).build()
+        );
+
+        scraperPodName = kubeClient().listPodsByPrefixInName(namespace, scraperName).get(0).getMetadata().getName();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -210,7 +210,7 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
 
         scraperPodName = kubeClient().listPodsByPrefixInName(THIRD_NAMESPACE, scraperName).get(0).getMetadata().getName();
 
-        cluster.setNamespace(THIRD_NAMESPACE);
+        cluster.setNamespace(SECOND_NAMESPACE);
         // Deploy Kafka in other namespace than CO
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(SECOND_CLUSTER_NAME, 1).build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -26,6 +26,7 @@ import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -56,6 +57,7 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
 
     private static final Logger LOGGER = LogManager.getLogger(AllNamespaceIsolatedST.class);
     private static final String THIRD_NAMESPACE = "third-namespace-test";
+    private String scraperPodName;
 
     /**
      * Test the case where the TO is configured to watch a different namespace that it is deployed in
@@ -67,7 +69,7 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
 
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
-        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(MAIN_NAMESPACE_CLUSTER_NAME, 0);
+        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(THIRD_NAMESPACE, scraperPodName, KafkaResources.plainBootstrapAddress(MAIN_NAMESPACE_CLUSTER_NAME));
         assertThat(topics, not(hasItems(TOPIC_NAME)));
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(MAIN_NAMESPACE_CLUSTER_NAME, topicName, SECOND_NAMESPACE).build());
@@ -180,6 +182,8 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
     private void deployTestSpecificResources(ExtensionContext extensionContext) {
         LOGGER.info("Creating resources before the test class");
 
+        final String scraperName = MAIN_NAMESPACE_CLUSTER_NAME + "-" + Constants.SCRAPER_NAME;
+
         clusterOperator.unInstall();
         clusterOperator = clusterOperator.defaultInstallation()
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
@@ -200,9 +204,13 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .build());
+            .build(),
+            ScraperTemplates.scraperPod(THIRD_NAMESPACE, scraperName).build()
+        );
 
-        cluster.setNamespace(SECOND_NAMESPACE);
+        scraperPodName = kubeClient().listPodsByPrefixInName(THIRD_NAMESPACE, scraperName).get(0).getMetadata().getName();
+
+        cluster.setNamespace(THIRD_NAMESPACE);
         // Deploy Kafka in other namespace than CO
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(SECOND_CLUSTER_NAME, 1).build());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceIsolatedST.java
@@ -51,7 +51,7 @@ class MultipleNamespaceIsolatedST extends AbstractNamespaceST {
 
         LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
         cluster.setNamespace(SECOND_NAMESPACE);
-        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(SECOND_NAMESPACE, scraperPodName, KafkaResources.bootstrapServiceName(MAIN_NAMESPACE_CLUSTER_NAME));
+        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(SECOND_NAMESPACE, scraperPodName, KafkaResources.plainBootstrapAddress(MAIN_NAMESPACE_CLUSTER_NAME));
         assertThat(topics, not(hasItems(topicName)));
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(MAIN_NAMESPACE_CLUSTER_NAME, topicName, clusterOperator.getDeploymentNamespace()).build());


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Refactoring

### Description

How was already multiple times mentioned, we should use different pod than Kafka/ZK pod for executing the Kafka scripts. In #6839 the `Scraper` deployment was edited to use our Kafka image, so the pod will contain all needed scripts, which we can use in our tests.

In this PR I'm refactoring our utils classes and tests to use `Scraper` pod for all Kafka scripts execution and also bringing all the commands from utils classes to one place - `KafkaCmdClient`.

Closes #6689 

### Checklist

- [ ] Make sure all tests pass


