### PR TITLE
Extended `bootstrap.nodePort` to `LoadBalancer` type

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -340,6 +340,7 @@ public class ListenersValidator {
      */
     private static void validateBootstrapNodePort(Set<String> errors, GenericKafkaListener listener) {
         if (!KafkaListenerType.NODEPORT.equals(listener.getType())
+                && !KafkaListenerType.LOADBALANCER.equals(listener.getType())
                 && listener.getConfiguration().getBootstrap().getNodePort() != null)    {
             errors.add("listener " + listener.getName() + " cannot configure bootstrap.nodePort because it is not NodePort based listener");
         }
@@ -406,6 +407,7 @@ public class ListenersValidator {
      */
     private static void validateBrokerNodePort(Set<String> errors, GenericKafkaListener listener, GenericKafkaListenerConfigurationBroker broker) {
         if (!KafkaListenerType.NODEPORT.equals(listener.getType())
+                && !KafkaListenerType.LOADBALANCER.equals(listener.getType())
                 && broker.getNodePort() != null)    {
             errors.add("listener " + listener.getName() + " cannot configure brokers[].nodePort because it is not NodePort based listener");
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -330,12 +330,30 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
-                "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener",
-                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
+                "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
+    }
+
+    @ParallelTest
+    public void testLoadBalancerListenerWithNodePort() {
+        String name = "lb";
+
+        GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
+                .withName(name)
+                .withPort(9092)
+                .withType(KafkaListenerType.LOADBALANCER)
+                .withNewConfiguration()
+                .withNewBootstrap()
+                .withNodePort(32189)
+                .endBootstrap()
+                .endConfiguration()
+                .build();
+
+        List<GenericKafkaListener> listeners = asList(listener1);
+
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners);
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR resolves the issue mentioned in #6894. Now you can define a `kafka.spec.kafka.listeners.configuration.bootstrap.nodePorteven` with a `Loadbalancer` type listener.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

