### PR TITLE
Disable `CruiseControlST.testCruiseControlDuringBrokerScaleUpAndDown` test in KRaft mode

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -359,6 +359,7 @@ public class CruiseControlST extends AbstractST {
     }
 
     @IsolatedTest
+    @KRaftNotSupported("Scale-up / scale-down not working in KRaft mode - https://github.com/strimzi/strimzi-kafka-operator/issues/6862")
     void testCruiseControlDuringBrokerScaleUpAndDown(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, namespace);
         final int initialReplicas = 3;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Scaling of Kafka cluster does not work in KRaft mode due to #6882. This test is currently failing in KRaft mode and should be disabled there.