### PR TITLE
[systemtest] Update version of `test-clients` and client's Kafka version

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -170,8 +170,8 @@ public class Environment {
     private static final String RESOURCE_ALLOCATION_STRATEGY_DEFAULT = "SHARE_MEMORY_FOR_ALL_COMPONENTS";
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
-    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.1.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.2.0";
+    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.2.0";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.3.0";
 
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     /**

--- a/systemtest/src/test/resources/oauth2/create_realm_authorization.sh
+++ b/systemtest/src/test/resources/oauth2/create_realm_authorization.sh
@@ -362,6 +362,25 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
             ]
           },
           {
+            "name": "kafka-cluster:cluster2,Group:b_*",
+            "type": "Group",
+            "ownerManagedAccess": false,
+            "displayName": "Consumer groups on cluster cluster2 that start with b_",
+            "attributes": {},
+            "uris": [],
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
             "name": "kafka-cluster:cluster2,Cluster:*",
             "type": "Cluster",
             "ownerManagedAccess": false,
@@ -377,6 +396,9 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
               },
               {
                 "name": "ClusterAction"
+              },
+              {
+                "name": "IdempotentWrite"
               }
             ]
           },
@@ -447,7 +469,21 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
             "type" : "Cluster",
             "ownerManagedAccess" : false,
             "attributes" : { },
-            "uris" : [ ]
+            "uris" : [ ],
+            "scopes": [
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              },
+              {
+                "name": "ClusterAction"
+              },
+              {
+                "name": "IdempotentWrite"
+              }
+            ]
           }
         ],
         "policies": [
@@ -517,12 +553,34 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
             }
           },
           {
+             "name": "Dev Team A can do IdempotentWrites on cluster cluster2",
+             "config": {
+                 "applyPolicies": "[\"Dev Team A\"]",
+                 "resources": "[\"kafka-cluster:cluster2,Cluster:*\"]",
+                 "scopes": "[\"IdempotentWrite\"]"
+             },
+             "decisionStrategy": "UNANIMOUS",
+             "logic": "POSITIVE",
+             "type": "scope"
+          },
+          {
             "name": "Dev Team B owns topics that start with b- on cluster cluster2",
             "type": "resource",
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
               "resources": "[\"Topic:b-*\"]",
+              "applyPolicies": "[\"Dev Team B\"]"
+            }
+          },
+          {
+            "name": "Dev Team B can do IdempotentWrites on cluster cluster2",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"kafka-cluster:cluster2,Cluster:*\"]",
+              "scopes": "[\"IdempotentWrite\"]",
               "applyPolicies": "[\"Dev Team B\"]"
             }
           },
@@ -614,7 +672,47 @@ RESULT=$(curl -v --insecure "https://$URL/auth/admin/realms" \
               "resources" : "[\"Cluster:*\"]",
               "applyPolicies" : "[\"ClusterManager Group\"]"
             }
-          }
+          },
+          {
+            "name": "Team A Client",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"team-a-client\"]"
+            }
+         },
+         {
+           "name": "Team A Client has IdempotentWrite permission on cluster",
+           "type": "scope",
+           "logic": "POSITIVE",
+           "decisionStrategy": "UNANIMOUS",
+           "config": {
+             "resources": "[\"Cluster:*\"]",
+             "scopes": "[\"IdempotentWrite\"]",
+             "applyPolicies": "[\"Team A Client\"]"
+           }
+         },
+         {
+           "name": "Team B Client",
+           "type": "client",
+           "logic": "POSITIVE",
+           "decisionStrategy": "UNANIMOUS",
+           "config": {
+             "clients": "[\"team-b-client\"]"
+           }
+         },
+         {
+           "name": "Team B Client has IdempotentWrite permission on cluster",
+           "type": "scope",
+           "logic": "POSITIVE",
+           "decisionStrategy": "UNANIMOUS",
+           "config": {
+             "resources": "[\"Cluster:*\"]",
+             "scopes": "[\"IdempotentWrite\"]",
+             "applyPolicies": "[\"Team B Client\"]"
+           }
+         }
         ],
         "scopes": [
           {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bump versions

### Description

Because new version of test-clients was released, we should bump version in the `Environment.java` to use it in our STs. Also I'm updating the Kafka version used in clients to `3.2.0`

When using Oauth and Keycloak with Kafka 3.2.0, the `IdempotentWrite` policies needs to be set to let producers working again. That's why I'm adding those policies into our `create_realm_authorization.sh`.

### Checklist

- [ ] Make sure all tests pass
