### PR TITLE
docs: verify kafka user is ready

### DIFF
--- a/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
@@ -27,9 +27,5 @@ To deploy the standalone User Operator, you need to set environment variables to
 These environment variables do not need to be set if you are deploying the User Operator using the Cluster Operator as they will be set by the Cluster Operator.
 ====
 
-.Authenticating and authorizing access to Kafka
-Use `KafkaUser` to enable the authentication and authorization mechanisms that a specific client uses to access Kafka.
-
-For more information on using `KafkUser` to manage users and secure access to Kafka brokers, see xref:assembly-securing-kafka-{context}[Securing access to Kafka brokers].
-
+include::../../modules/operators/proc-configuring-kafka-user.adoc[leveloffset=+1]
 include::../../modules/operators/proc-user-operator-with-resource-requests-limits.adoc[leveloffset=+1]

--- a/documentation/assemblies/security/assembly-securing-kafka.adoc
+++ b/documentation/assemblies/security/assembly-securing-kafka.adoc
@@ -47,5 +47,5 @@ Refer to the schema reference for more information on access configuration prope
 
 //steps to secure the brokers
 include::modules/proc-securing-kafka.adoc[leveloffset=+1]
-include::modules/proc-configuring-kafka-user.adoc[leveloffset=+1]
+include::modules/proc-configuring-secure-kafka-user.adoc[leveloffset=+1]
 include::modules/proc-restricting-access-to-listeners-using-network-policies.adoc[leveloffset=+1]

--- a/documentation/modules/operators/proc-configuring-kafka-topic.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-topic.adoc
@@ -76,7 +76,7 @@ my-topic-3   my-cluster  10          3                  True
 +
 Topic creation is successful when the `READY` output shows `True`.
 
-. If the `READY` column stays blank, get more details on the status from the resource YAML.
+. If the `READY` column stays blank, get more details on the status from the resource YAML or from the Topic Operator logs.
 +
 Messages provide details on the reason for the current status.
 +

--- a/documentation/modules/operators/proc-configuring-kafka-topic.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-topic.adoc
@@ -21,11 +21,11 @@ This procedure shows how to create a topic with 10 partitions and 2 replicas.
 
 It is important that you consider the following before making your changes:
 
-* Kafka *does not* support making the following changes through the `KafkaTopic` resource:
-** Changing topic names using `spec.topicName`
-** Decreasing partition size using `spec.partitions`
-* You cannot use `spec.replicas` to change the number of replicas that were initially specified.
+* Kafka does not support decreasing the number of partitions.
 * Increasing `spec.partitions` for topics with keys will change how records are partitioned, which can be particularly problematic when the topic uses _semantic partitioning_.
+* Strimzi does not support making the following changes through the `KafkaTopic` resource:
+** Using `spec.replicas` to change the number of replicas that were initially specified
+** Changing topic names using `spec.topicName`
 
 .Prerequisites
 

--- a/documentation/modules/operators/proc-configuring-kafka-topic.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-topic.adoc
@@ -3,16 +3,17 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='proc-configuring-kafka-topic-{context}']
-= Configuring a Kafka topic
+= Configuring Kafka topics
 
-Use the properties of the `KafkaTopic` resource to configure a Kafka topic.
+[role="_abstract"]
+Use the properties of the `KafkaTopic` resource to configure Kafka topics.
 
 You can use `kubectl apply` to create or modify topics, and `kubectl delete` to delete existing topics.
 
 For example:
 
-* `kubectl apply -f <topic-config-file>`
-* `kubectl delete KafkaTopic <topic-name>`
+* `kubectl apply -f _<topic_config_file>_`
+* `kubectl delete KafkaTopic _<topic_name>_`
 
 This procedure shows how to create a topic with 10 partitions and 2 replicas.
 
@@ -20,7 +21,7 @@ This procedure shows how to create a topic with 10 partitions and 2 replicas.
 
 It is important that you consider the following before making your changes:
 
-* Kafka does _not_ support making the following changes through the `KafkaTopic` resource:
+* Kafka *does not* support making the following changes through the `KafkaTopic` resource:
 ** Changing topic names using `spec.topicName`
 ** Decreasing partition size using `spec.partitions`
 * You cannot use `spec.replicas` to change the number of replicas that were initially specified.
@@ -34,9 +35,9 @@ It is important that you consider the following before making your changes:
 
 .Procedure
 
-. Prepare a file containing the `KafkaTopic` to be created.
+. Configure the `KafkaTopic` resource.
 +
-.An example `KafkaTopic`
+.Example Kafka topic configuration
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaTopicApiVersion}
@@ -55,4 +56,79 @@ TIP: When modifying a topic, you can get the current version of the resource usi
 . Create the `KafkaTopic` resource in Kubernetes.
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _TOPIC-CONFIG-FILE_
+kubectl apply -f _<topic_config_file>_
+
+. Wait for the ready status of the topic to change to `True`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkatopics -o wide -w -n _<namespace>_
+----
++
+.Kafka topic status
+[source,shell,subs="+quotes"]
+----
+NAME         CLUSTER     PARTITIONS  REPLICATION FACTOR READY
+my-topic-1   my-cluster  10          3                  True
+my-topic-2   my-cluster  10          3
+my-topic-3   my-cluster  10          3                  True
+----
++
+Topic creation is successful when the `READY` output shows `True`.
+
+. If the `READY` column stays blank, get more details on the status from the resource YAML.
++
+Messages provide details on the reason for the current status.
++
+[source,shell,subs="+quotes"]
+----
+oc get kafkatopics my-topic-2 -o yaml
+----
++
+.Details on a topic with a `NotReady` status
+[source,shell,subs="+quotes"]
+----
+# ...
+status:
+  conditions:
+  - lastTransitionTime: "2022-06-13T10:14:43.351550Z"
+    message: Number of partitions cannot be decreased
+    reason: PartitionDecreaseException
+    status: "True"
+    type: NotReady
+----
++
+In this example, the reason the topic is not ready is because the original number of partitions was reduced in the `KafkaTopic` configuration.
+Kafka does not support this.
++
+After resetting the topic configuration, the status shows the topic is ready.
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkatopics my-topic-2 -o wide -w -n _<namespace>_
+----
++
+.Status update of the topic
+[source,shell,subs="+quotes"]
+----
+NAME         CLUSTER     PARTITIONS  REPLICATION FACTOR READY
+my-topic-2   my-cluster  10          3                  True
+----
++
+Fetching the details shows no messages
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkatopics my-topic-2 -o yaml
+----
++
+.Details on a topic with a `READY` status
+[source,shell,subs="+quotes"]
+----
+# ...
+status:
+  conditions:
+  - lastTransitionTime: '2022-06-13T10:15:03.761084Z'
+    status: 'True'
+    type: Ready
+----

--- a/documentation/modules/operators/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-user.adoc
@@ -1,0 +1,181 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-user-operator.adoc
+
+[id='proc-configuring-kafka-user-{context}']
+= Configuring Kafka users
+
+[role="_abstract"]
+Use the properties of the `KafkaUser` resource to configure Kafka users.
+
+You can use `kubectl apply` to create or modify users, and `kubectl delete` to delete existing users.
+
+For example:
+
+* `kubectl apply -f _<user_config_file>_`
+* `kubectl delete KafkaUser _<user_name>_`
+
+Users represent Kafka clients.
+When you configure Kafka users, you enable the user authentication and authorization mechanisms required by clients to access Kafka.
+The mechanism used must match the equivalent `Kafka` configuration.
+For more information on using `Kafka` and `KafkUser` resources to secure access to Kafka brokers, see xref:assembly-securing-kafka-{context}[Securing access to Kafka brokers].
+
+.Prerequisites
+
+* A running Kafka cluster xref:con-securing-kafka-authentication-{context}[configured with a Kafka broker listener using TLS authentication and encryption].
+* A running User Operator (typically xref:assembly-kafka-entity-operator-str[deployed with the Entity Operator]).
+
+.Procedure
+
+. Configure the `KafkaUser` resource.
++
+This example specifies TLS authentication and simple authorization using ACLs.
++
+.Example Kafka user configuration
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaUserApiVersion}
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Example consumer Acls for topic my-topic using consumer group my-group
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: group
+          name: my-group
+          patternType: literal
+        operation: Read
+        host: "*"
+      # Example Producer Acls for topic my-topic
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"
+----
+
+. Create the `KafkaUser` resource in Kubernetes.
++
+[source,shell,subs=+quotes]
+kubectl apply -f _<user_config_file>_
+
+. Wait for the ready status of the user to change to `True`:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkausers -o wide -w -n _<namespace>_
+----
++
+.Kafka user status
+[source,shell,subs="+quotes"]
+----
+NAME       CLUSTER     AUTHENTICATION  AUTHORIZATION READY
+my-user-1  my-cluster  tls             simple        True
+my-user-2  my-cluster  tls             simple
+my-user-3  my-cluster  tls             simple        True
+----
++
+User creation is successful when the `READY` output shows `True`.
+
+. If the `READY` column stays blank, get more details on the status from the resource YAML.
++
+Messages provide details on the reason for the current status.
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkausers my-user-2 -o yaml
+----
++
+.Details on a user with a `NotReady` status
+[source,shell,subs="+quotes"]
+----
+# ...
+status:
+  conditions:
+  - lastTransitionTime: "2022-06-10T10:07:37.238065Z"
+    message: Simple authorization ACL rules are configured but not supported in the
+      Kafka cluster configuration.
+    reason: InvalidResourceException
+    status: "True"
+    type: NotReady
+----
++
+In this example, the reason the user is not ready is because simple authorization is missing in the `Kafka` configuration.
++
+.Kafka configuration for simple authorization
+[source,yaml,subs="attributes+"]
+----
+  apiVersion: {KafkaApiVersion}
+  kind: Kafka
+  metadata:
+    name: my-cluster
+  spec:
+    kafka:
+      # ...
+      authorization:
+        type: simple
+----
++
+After updating the Kafka configuration, the status shows the user is ready.
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkausers my-user-2 -o wide -w -n _<namespace>_
+----
++
+.Status update of the user
+[source,shell,subs="+quotes"]
+----
+NAME       CLUSTER     AUTHENTICATION  AUTHORIZATION READY
+my-user-2  my-cluster  tls             simple        True
+----
++
+Fetching the details shows no messages.
++
+[source,shell,subs="+quotes"]
+----
+kubectl get kafkausers my-user-2 -o yaml
+----
++
+.Details on a user with a `READY` status
+[source,shell,subs="+quotes"]
+----
+# ...
+status:
+  conditions:
+  - lastTransitionTime: "2022-06-10T10:33:40.166846Z"
+    status: "True"
+    type: Ready
+----

--- a/documentation/modules/operators/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-user.adoc
@@ -109,7 +109,7 @@ my-user-3  my-cluster  tls             simple        True
 +
 User creation is successful when the `READY` output shows `True`.
 
-. If the `READY` column stays blank, get more details on the status from the resource YAML.
+. If the `READY` column stays blank, get more details on the status from the resource YAML or User Operator logs.
 +
 Messages provide details on the reason for the current status.
 +

--- a/documentation/modules/operators/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-user.adoc
@@ -132,7 +132,7 @@ status:
     type: NotReady
 ----
 +
-In this example, the reason the user is not ready is because simple authorization is missing in the `Kafka` configuration.
+In this example, the reason the user is not ready is because simple authorization is not enabled in the `Kafka` configuration.
 +
 .Kafka configuration for simple authorization
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/operators/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-user.adoc
@@ -18,7 +18,7 @@ For example:
 Users represent Kafka clients.
 When you configure Kafka users, you enable the user authentication and authorization mechanisms required by clients to access Kafka.
 The mechanism used must match the equivalent `Kafka` configuration.
-For more information on using `Kafka` and `KafkUser` resources to secure access to Kafka brokers, see xref:assembly-securing-kafka-{context}[Securing access to Kafka brokers].
+For more information on using `Kafka` and `KafkaUser` resources to secure access to Kafka brokers, see xref:assembly-securing-kafka-{context}[Securing access to Kafka brokers].
 
 .Prerequisites
 

--- a/documentation/modules/security/proc-configuring-secure-kafka-user.adoc
+++ b/documentation/modules/security/proc-configuring-secure-kafka-user.adoc
@@ -2,17 +2,11 @@
 //
 // assembly-using-the-user-operator.adoc
 
-[id='proc-configuring-kafka-user-{context}']
+[id='proc-configuring-secure-kafka-user-{context}']
 = Securing user access to Kafka
 
-Use the properties of the `KafkaUser` resource to configure a Kafka user.
-
-You can use `kubectl apply` to create or modify users, and `kubectl delete` to delete existing users.
-
-For example:
-
-* `kubectl apply -f _USER-CONFIG-FILE_`
-* `kubectl delete KafkaUser _USER-NAME_`
+[role="_abstract"]
+Create or modify a `KafkaUser` to represent a client that requires secure access to the Kafka cluster.
 
 When you configure the `KafkaUser` authentication and authorization mechanisms, ensure they match the equivalent `Kafka` configuration:
 
@@ -76,9 +70,9 @@ spec:
 . Create or update the `KafkaUser` resource.
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _USER-CONFIG-FILE_
+kubectl apply -f _<user_config_file>_
 +
 The user is created, as well as a Secret with the same name as the `KafkaUser` resource.
 The Secret contains a private and public key for TLS client authentication.
 
-For information on configuring a Kafka client with properties for secure connection to Kafka brokers, see link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^] in the _Deploying and Upgrading Strimzi_ guide.
+For information on configuring a Kafka client with properties for secure connection to Kafka brokers, see link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^].


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

- Introduces a _Configuring Kafka Users_ procedure to the _Configuring_ guide. The new procedure helps to explain how to verify that a Kafka user is READY. And how to check when a user is NOT READY.
- For consistency, the equivalent _Creating Kafka topics_ operator-related procedure has been given the same verification steps.
- The _Securing user access to Kafka_ procedure has been streamlined to retain only the content related to that procedure. General user admin content moves to the new procedure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

