### PR TITLE
Set `zookeeper.electionPortBindRetry` to infinite retry

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -74,6 +74,8 @@ fi
 
 # We need to disable the native ZK authorisation (we secure ZK through the TLS-Sidecars) to allow use of the reconfiguration options.
 KAFKA_OPTS="$KAFKA_OPTS -Dzookeeper.skipACL=yes"
+# We set the electionPortBindRetry zo 0 to retry forever - the recommended option for Kubernetes
+KAFKA_OPTS="$KAFKA_OPTS -Dzookeeper.electionPortBindRetry=0"
 export KAFKA_OPTS
 
 set -x


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Sometimes, when a new cluster is being deployed, the ZooKeeper pods first roll few times before they find each other. This PR adds new option `zookeeper.electionPortBindRetry` and sets it to `0` which means infinite retry. This should help the ZooKeeper nodes to find each other without unnecessary restarts (and based on my observations it does help to avoid the restarts).

This option is available only as a system property, so it is set directly in the `zookeeper_run.sh` script.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally