### PR TITLE
Change registry variables in SCRAPER_IMAGE_DEFAULT initialization

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -206,7 +206,7 @@ public class Environment {
     public static final String TEST_HTTP_PRODUCER_IMAGE = getOrDefault(TEST_HTTP_PRODUCER_IMAGE_ENV, TEST_HTTP_PRODUCER_IMAGE_DEFAULT);
     public static final String TEST_HTTP_CONSUMER_IMAGE = getOrDefault(TEST_HTTP_CONSUMER_IMAGE_ENV, TEST_HTTP_CONSUMER_IMAGE_DEFAULT);
 
-    private static final String SCRAPER_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
+    private static final String SCRAPER_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/kafka:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
     public static final String SCRAPER_IMAGE = getOrDefault(SCRAPER_IMAGE_ENV, SCRAPER_IMAGE_DEFAULT);
 
     // variables for kafka bridge image


### PR DESCRIPTION
Signed-off-by: Kun-Lu <kun.lu@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

PR #6839  changed image of `Scraper` pod, but the following line could contain a potential bug:
 
https://github.com/strimzi/strimzi-kafka-operator/blob/c92bcb6e33a1804cab77e9a75088dd8858c98bc3/systemtest/src/main/java/io/strimzi/systemtest/Environment.java#L209

The above code uses `STRIMZI_REGISTRY_DEFAULT` and `STRIMZI_ORG_DEFAULT` as docker registry while using `STRIMZI_TAG` for image tag. This will cause inconsistency when building the project in a local/CI environment with customized STRIMZI_TAG for system testing, because the value of `SCRAPER_IMAGE` could not point to the locally built strimzi kafka image.

This small code change would replace `STRIMZI_REGISTRY_DEFAULT` and `STRIMZI_ORG_DEFAULT` with `STRIMZI_REGISTRY` and `STRIMZI_ORG` respectively to use the locally built kafka image as `SCRAPER_IMAGE`, so that system tests such as TracingST would not fail in a local/CI environment due to missing `SCRAPER_IMAGE`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

