### PR TITLE
Fix NPE in `StrimziPodSetOperator.isReady`

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StrimziPodSetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StrimziPodSetOperator.java
@@ -70,10 +70,14 @@ public class StrimziPodSetOperator extends CrdOperator<KubernetesClient, Strimzi
     public boolean isReady(String namespace, String name) {
         StrimziPodSet podSet = operation().inNamespace(namespace).withName(name).get();
 
-        int replicas = podSet.getSpec().getPods().size();
+        if (podSet != null) {
+            int replicas = podSet.getSpec().getPods().size();
 
-        return podSet.getStatus() != null
-                && replicas == podSet.getStatus().getPods()
-                && replicas == podSet.getStatus().getReadyPods();
+            return podSet.getStatus() != null
+                    && replicas == podSet.getStatus().getPods()
+                    && replicas == podSet.getStatus().getReadyPods();
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `isReady` method should check if StrimziPodSet is ready or not. But it does not check if the PodSet actually exists (isn't null). That can result in a long string of NPE exceptions printed in the log since the `isReady` method is used to wait for readiness where it is called repeatedly until it succeeds or timeouts.