### PR TITLE
Clean the `/tmp` directory when the container restarts

### DIFF
--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+set -e
+
+# Clean-up /tmp directory from files which might have remained from previous container restart
+rm -rfv /tmp/*
+
 export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.operator.cluster.Main
 

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Clean-up /tmp directory from files which might have remained from previous container restart
+rm -rfv /tmp/*
+
 if [ -f /opt/topic-operator/custom-config/log4j2.properties ];
 then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/topic-operator/custom-config/log4j2.properties"

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Clean-up /tmp directory from files which might have remained from previous container restart
+rm -rfv /tmp/*
+
 if [ -f /opt/user-operator/custom-config/log4j2.properties ];
 then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/user-operator/custom-config/log4j2.properties"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the container restarts, the `/tmp` storage is kept from the previous run. Over time and many restarts, it can mean that the files there left by previous runs cause it to run out of storage => this includes for example the files such as the Vert.x cache files which are created with every run with a unique name.

This PR adds to the beginning a cleanup of the `/tmp` dir which deletes all files. Since we do not expect any files to be carried over in these situations, it should help to deal with running out of disk because of the restarts without causing any issues.

This should resolve #6919.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging