### PR TITLE
Disable the ZooKeeper Admin REST API by default

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -26,11 +26,12 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES);
         FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(ZookeeperClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
-        Map<String, String> config = new HashMap<>(4);
+        Map<String, String> config = new HashMap<>(5);
         config.put("tickTime", "2000");
         config.put("initLimit", "5");
         config.put("syncLimit", "2");
         config.put("autopurge.purgeInterval", "1");
+        config.put("admin.enableServer", "false");
         DEFAULTS = Collections.unmodifiableMap(config);
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Since ZooKeeper 3.5, it now has an Admin REST server started by default on port 8080 which can be used for the _4-letter commands_. We do not use it or expose it, but since it is enabled by default, it is running and consumes resources. This PR disables it by default.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally