### PR TITLE
Remove the unused ZooKeeper image configuration from the Helm Chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -112,10 +112,6 @@ the documentation for more details.
 | `priorityClassName`                  | Cluster Operator pod's priority class name | `nil`                                               |
 | `securityContext`                    | Cluster Operator container's security context |  `nil`                                           |
 | `extraEnvs`                          | Extra environment variables for the Cluster operator container | `[]`                            |
-| `zookeeper.image.registry  `         | Override default ZooKeeper image registry | `nil`                                                |
-| `zookeeper.image.repository`         | Override default ZooKeeper image repository | `nil`                                              |
-| `zookeeper.image.name`               | ZooKeeper image name                      | `kafka`                                              |
-| `zookeeper.image.tag`                | Override default ZooKeeper tag registry   | `nil`                                                |
 | `jmxtrans.image.registry`            | Override default JmxTrans image registry                   | `nil`                               |
 | `jmxtrans.image.repository`          | Override default JmxTrans image repository                 | `nil`                               |
 | `jmxtrans.image.name`                | JmxTrans image name                       | `jmxtrans`                                           |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -41,15 +41,9 @@ priorityClassName: ""
 podSecurityContext: {}
 securityContext: {}
 
-# Docker images that operator uses to provision various components of Strimzi.  To use your own registry prefix the
+# Docker images that operator uses to provision various components of Strimzi. To use your own registry prefix the
 # repository name with your registry URL.
-# Ex) repository: registry.xyzcorp.com/strimzi/zookeeper
-zookeeper:
-  image:
-    registry: ""
-    repository: ""
-    name: kafka
-    tagPrefix: ""
+# Ex) repository: registry.xyzcorp.com/strimzi/kafka
 kafka:
   image:
     registry: ""

--- a/packaging/helm-charts/kafka-version-tpl.sh
+++ b/packaging/helm-charts/kafka-version-tpl.sh
@@ -20,7 +20,6 @@ kafka_exporter_version="{{ default .Values.defaultImageRegistry .Values.kafkaExp
 
 for version in "${versions[@]}"
 do
-    zookeeper_version="{{ default .Values.defaultImageRegistry .Values.zookeeper.image.registry }}/{{ default .Values.defaultImageRepository .Values.zookeeper.image.repository }}/{{ .Values.zookeeper.image.name }}:{{ default .Values.defaultImageTag .Values.zookeeper.image.tagPrefix }}-kafka-${version}"
     entity_operator_tls_sidecar_version="{{ default .Values.defaultImageRegistry .Values.tlsSidecarEntityOperator.image.registry }}/{{ default .Values.defaultImageRepository .Values.tlsSidecarEntityOperator.image.repository }}/{{ .Values.tlsSidecarEntityOperator.image.name }}:{{ default .Values.defaultImageTag .Values.tlsSidecarEntityOperator.image.tagPrefix }}-kafka-${version}"
     kafka_exporter_version="{{ default .Values.defaultImageRegistry .Values.kafkaExporter.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaExporter.image.repository }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaExporter.image.tagPrefix }}-kafka-${version}"
     cruise_control_version="{{ default .Values.defaultImageRegistry .Values.cruiseControl.image.registry }}/{{ default .Values.defaultImageRepository .Values.cruiseControl.image.repository }}/{{ .Values.cruiseControl.image.name }}:{{ default .Values.defaultImageTag .Values.cruiseControl.image.tagPrefix }}-kafka-${version}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Already for a long time we do not have a separate configuration of ZooKeeper container images in the Cluster OPerator deployment. The ZooKeeper image is the same as Kafka image or can be changed in `.spec.zookeeper.image`. This PR removes the old unused options from the Helm Chart files and from the README file.

This is related to #6981 