### PR TITLE
docs: operators and clusters to watch

### DIFF
--- a/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
+++ b/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
@@ -15,24 +15,13 @@ The Entity Operator comprises the:
 
 Through `Kafka` resource configuration, the Cluster Operator can deploy the Entity Operator, including one or both operators, when deploying a Kafka cluster.
 
+The operators are automatically configured to manage the topics and users of the Kafka cluster.
+The Topic Operator and User Operator can only watch a single namespace.
+For more information, see xref:con-operators-namespaces-{context}[].
+
 NOTE: When deployed, the Entity Operator contains the operators according to the deployment configuration.
 
-The operators are automatically configured to manage the topics and users of the Kafka cluster.
-
-.Specifying a Kafka cluster to watch
-
-The Topic Operator and User Operator watch for topics and users in the namespace of a Kafka cluster deployment.
-
-If you deploy the operators using the Cluster Operator, they watch the Kafka cluster deployed by the Cluster Operator by default.
-You can also specify a namespace using `watchedNamespace` in the operator configuration.
-
-For a standalone deployment of each operator, you specify a namespace and connection to the Kafka cluster to watch in the configuration.
-
-The operators can only watch a single Kafka cluster in a namespace.
-If you want to use the operators with more than one Kafka cluster, install the clusters to separate namespaces.
-
 include::../../modules/configuring/ref-kafka-entity-operator.adoc[leveloffset=+1]
-
 //topic operator config
 include::../../modules/configuring/con-configuring-topic-operator.adoc[leveloffset=+1]
 //user operator config

--- a/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
+++ b/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
@@ -19,7 +19,7 @@ The operators are automatically configured to manage the topics and users of the
 The Topic Operator and User Operator can only watch a single namespace.
 For more information, see xref:con-operators-namespaces-{context}[].
 
-NOTE: When deployed, the Entity Operator contains the operators according to the deployment configuration.
+NOTE: When deployed, the Entity Operator pod contains the operators according to the deployment configuration.
 
 include::../../modules/configuring/ref-kafka-entity-operator.adoc[leveloffset=+1]
 //topic operator config

--- a/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
+++ b/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
@@ -19,6 +19,18 @@ NOTE: When deployed, the Entity Operator contains the operators according to the
 
 The operators are automatically configured to manage the topics and users of the Kafka cluster.
 
+.Specifying a Kafka cluster to watch
+
+The Topic Operator and User Operator watch for topics and users in the namespace of a Kafka cluster deployment.
+
+If you deploy the operators using the Cluster Operator, they watch the Kafka cluster deployed by the Cluster Operator by default.
+You can also specify a namespace using `watchedNamespace` in the operator configuration.
+
+For a standalone deployment of each operator, you specify a namespace and connection to the Kafka cluster to watch in the configuration.
+
+The operators can only watch a single Kafka cluster in a namespace.
+If you want to use the operators with more than one Kafka cluster, install the clusters to separate namespaces.
+
 include::../../modules/configuring/ref-kafka-entity-operator.adoc[leveloffset=+1]
 
 //topic operator config

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -15,7 +15,7 @@ This applies, for example, to a Kafka cluster running outside of Kubernetes.
 But you can deploy and use the Topic Operator and User Operator as standalone components.
 
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
-The Topic Operator and User Operator watch for `KafkaTopics` and `KafkaUsers` in the single namespace of the Kafka cluster deployment.
+The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in the single namespace of a Kafka cluster deployment.
 
 == Deploying a Kafka cluster with the Topic Operator and User Operator
 

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -15,7 +15,7 @@ This applies, for example, to a Kafka cluster running outside of Kubernetes.
 But you can deploy and use the Topic Operator and User Operator as standalone components.
 
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
-The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in a single namespace.
+The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in a single namespace. For more information, see link:{BookURLDeploying}#con-operators-namespaces-str[Watching namespaces with Strimzi operators^].
 
 == Deploying a Kafka cluster with the Topic Operator and User Operator
 

--- a/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-create-cluster.adoc
@@ -15,7 +15,7 @@ This applies, for example, to a Kafka cluster running outside of Kubernetes.
 But you can deploy and use the Topic Operator and User Operator as standalone components.
 
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
-The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in the single namespace of a Kafka cluster deployment.
+The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in a single namespace.
 
 == Deploying a Kafka cluster with the Topic Operator and User Operator
 

--- a/documentation/assemblies/operators/assembly-operators.adoc
+++ b/documentation/assemblies/operators/assembly-operators.adoc
@@ -8,6 +8,7 @@
 
 Use the Strimzi operators to manage your Kafka cluster, and Kafka topics and users.
 
+include::../../modules/operators/con-operators-namespaces.adoc[leveloffset=+1]
 include::assembly-using-the-cluster-operator.adoc[leveloffset=+1]
 include::assembly-using-the-topic-operator.adoc[leveloffset=+1]
 include::assembly-using-the-user-operator.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-configuring-topic-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-topic-operator.adoc
@@ -9,7 +9,7 @@ Topic Operator deployment can be configured using additional options inside the 
 The following properties are supported:
 
 `watchedNamespace`::
-The Kubernetes namespace in which the topic operator watches for `KafkaTopics`.
+The Kubernetes namespace in which the Topic Operator watches for `KafkaTopic` resources.
 Default is the namespace where the Kafka cluster is deployed.
 
 `reconciliationIntervalSeconds`::

--- a/documentation/modules/configuring/con-configuring-user-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-user-operator.adoc
@@ -9,7 +9,7 @@ User Operator deployment can be configured using additional options inside the `
 The following properties are supported:
 
 `watchedNamespace`::
-The Kubernetes namespace in which the user operator watches for `KafkaUsers`.
+The Kubernetes namespace in which the User Operator watches for `KafkaUser` resources.
 Default is the namespace where the Kafka cluster is deployed.
 
 `reconciliationIntervalSeconds`::

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -18,8 +18,9 @@ Add or set the environment variables needed to make a connection to a Kafka clus
 The Topic Operator watches for `KafkaTopic` resources in a single namespace.
 You specify the namespace to watch, and the connection to the Kafka cluster, in the Topic Operator configuration.
 A single Topic Operator can watch a single namespace. 
-Use more than one Topic Operator to watch different namespaces. 
-In this way, you can use the Topic Operator with multiple Kafka clusters.  
+One namespace should be watched by only one Topic Operator.
+If you want to use more than one Topic Operator, configure each of them to watch different namespaces.
+In this way, you can use Topic Operators with multiple Kafka clusters.  
 
 .Prerequisites
 

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -15,10 +15,11 @@ Standalone deployment files are provided with Strimzi.
 Use the `05-Deployment-strimzi-topic-operator.yaml` deployment file to deploy the Topic Operator.
 Add or set the environment variables needed to make a connection to a Kafka cluster.
 
-The Topic Operator watches for `KafkaTopic` resources in the namespace of a Kafka cluster deployment.
-You specify a namespace and connection to the Kafka cluster to watch in the configuration.
-The Topic Operator can only watch a single Kafka cluster in a namespace.
-If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
+The Topic Operator watches for `KafkaTopic` resources in a single namespace.
+You specify the namespace to watch, and the connection to the Kafka cluster, in the Topic Operator configuration.
+A single Topic Operator can watch a single namespace. 
+Use more than one Topic Operator to watch different namespaces. 
+In this way, you can use the Topic Operator with multiple Kafka clusters.  
 
 .Prerequisites
 

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -15,6 +15,11 @@ Standalone deployment files are provided with Strimzi.
 Use the `05-Deployment-strimzi-topic-operator.yaml` deployment file to deploy the Topic Operator.
 Add or set the environment variables needed to make a connection to a Kafka cluster.
 
+The Topic Operator watches for `KafkaTopic` resources in the namespace of a Kafka cluster deployment.
+You specify a namespace and connection to the Kafka cluster to watch in the configuration.
+The Topic Operator can only watch a single Kafka cluster in a namespace.
+If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
+
 .Prerequisites
 
 * You are running a Kafka cluster for the Topic Operator to connect to.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
@@ -11,7 +11,10 @@ This procedure describes how to deploy the Topic Operator using the Cluster Oper
 You configure the `entityOperator` property of the `Kafka` resource to include the `topicOperator`.
 By default, the Topic Operator watches for `KafkaTopic` resources in the namespace of the Kafka cluster deployed by the Cluster Operator.
 You can also specify a namespace using `watchedNamespace` in the Topic Operator `spec`.
-A single Topic Operator can watch a single namespace. 
+A single Topic Operator can watch a single namespace.
+One namespace should be watched by only one Topic Operator.
+
+If you use Strimzi to deploy multiple Kafka clusters into the same namespace, enable the Topic Operator for only one Kafka cluster or use the `watchedNamespace` property to configure the Topic Operators to watch other namespaces.
 
 If you want to use the Topic Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-topic-operator-standalone-{context}[deploy the Topic Operator as a standalone component].

--- a/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
@@ -11,8 +11,7 @@ This procedure describes how to deploy the Topic Operator using the Cluster Oper
 You configure the `entityOperator` property of the `Kafka` resource to include the `topicOperator`.
 By default, the Topic Operator watches for `KafkaTopic` resources in the namespace of the Kafka cluster deployed by the Cluster Operator.
 You can also specify a namespace using `watchedNamespace` in the Topic Operator `spec`.
-The Topic Operator can only watch a single Kafka cluster in a namespace.
-If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
+A single Topic Operator can watch a single namespace. 
 
 If you want to use the Topic Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-topic-operator-standalone-{context}[deploy the Topic Operator as a standalone component].

--- a/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
@@ -9,7 +9,10 @@
 This procedure describes how to deploy the Topic Operator using the Cluster Operator.
 
 You configure the `entityOperator` property of the `Kafka` resource to include the `topicOperator`.
-By default, the Topic Operator watches for `KafkaTopics` in the namespace of the Kafka cluster deployment.
+By default, the Topic Operator watches for `KafkaTopic` resources in the namespace of the Kafka cluster deployed by the Cluster Operator.
+You can also specify a namespace using `watchedNamespace` in the Topic Operator `spec`.
+The Topic Operator can only watch a single Kafka cluster in a namespace.
+If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
 
 If you want to use the Topic Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-topic-operator-standalone-{context}[deploy the Topic Operator as a standalone component].
@@ -44,4 +47,24 @@ Use an empty object (`{}`) if you want all properties to use their default value
 +
 Use `kubectl apply`:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _<kafka_configuration_file>_
+
+. Check the status of the deployment:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get pods -n _<my_cluster_operator_namespace>_
+----
++
+.Output shows the pod name and readiness
+[source,shell,subs="+quotes"]
+----
+NAME                        READY   STATUS    RESTARTS
+my-cluster-entity-operator  3/3     Running   0
+# ...
+----
++
+`my-cluster` is the name of the Kafka cluster.
++
+`READY` shows the number of replicas that are ready/expected.
+The deployment is successful when the `STATUS` shows as `Running`.

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -17,8 +17,9 @@ Add or set the environment variables needed to make a connection to a Kafka clus
 
 The User Operator watches for `KafkaUser` resources in a single namespace.
 You specify the namespace to watch, and the connection to the Kafka cluster, in the User Operator configuration.
-A single User Operator can watch a single namespace. 
-Use more than one User Operator to watch different namespaces. 
+A single User Operator can watch a single namespace.    
+One namespace should be watched by only one User Operator.
+If you want to use more than one User Operator, configure each of them to watch different namespaces. 
 In this way, you can use the User Operator with multiple Kafka clusters.  
 
 .Prerequisites

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -15,10 +15,11 @@ Standalone deployment files are provided with Strimzi.
 Use the `05-Deployment-strimzi-user-operator.yaml` deployment file to deploy the User Operator.
 Add or set the environment variables needed to make a connection to a Kafka cluster.
 
-The User Operator watches for `KafkaUser` resources in the namespace of a Kafka cluster deployment.
-You specify a namespace and connection to the Kafka cluster to watch in the configuration.
-The User Operator can only watch a single Kafka cluster in a namespace.
-If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
+The User Operator watches for `KafkaUser` resources in a single namespace.
+You specify the namespace to watch, and the connection to the Kafka cluster, in the User Operator configuration.
+A single User Operator can watch a single namespace. 
+Use more than one User Operator to watch different namespaces. 
+In this way, you can use the User Operator with multiple Kafka clusters.  
 
 .Prerequisites
 

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -15,6 +15,11 @@ Standalone deployment files are provided with Strimzi.
 Use the `05-Deployment-strimzi-user-operator.yaml` deployment file to deploy the User Operator.
 Add or set the environment variables needed to make a connection to a Kafka cluster.
 
+The User Operator watches for `KafkaUser` resources in the namespace of a Kafka cluster deployment.
+You specify a namespace and connection to the Kafka cluster to watch in the configuration.
+The User Operator can only watch a single Kafka cluster in a namespace.
+If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
+
 .Prerequisites
 
 * You are running a Kafka cluster for the User Operator to connect to.

--- a/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
@@ -9,7 +9,10 @@
 This procedure describes how to deploy the User Operator using the Cluster Operator.
 
 You configure the `entityOperator` property of the `Kafka` resource to include the `userOperator`.
-By default, the User Operator watches for `KafkaUsers` in the namespace of the Kafka cluster deployment.
+By default, the User Operator watches for `KafkaUser` resources in the namespace of the Kafka cluster deployment.
+You can also specify a namespace using `watchedNamespace` in the User Operator `spec`.
+The User Operator can only watch a single Kafka cluster in a namespace.
+If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
 
 If you want to use the User Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-user-operator-standalone-{context}[deploy the User Operator as a standalone component].
@@ -41,4 +44,24 @@ spec:
 Use an empty object (`{}`) if you want all properties to use their default values.
 . Create or update the resource:
 [source,shell,subs=+quotes]
-kubectl apply -f _<your-file>_
+kubectl apply -f _<kafka_configuration_file>_
+
+. Check the status of the deployment:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get pods -n _<my_cluster_operator_namespace>_
+----
++
+.Output shows the pod name and readiness
+[source,shell,subs="+quotes"]
+----
+NAME                        READY   STATUS    RESTARTS
+my-cluster-entity-operator  3/3     Running   0
+# ...
+----
++
+`my-cluster` is the name of the Kafka cluster.
++
+`READY` shows the number of replicas that are ready/expected.
+The deployment is successful when the `STATUS` shows as `Running`.

--- a/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
@@ -11,8 +11,7 @@ This procedure describes how to deploy the User Operator using the Cluster Opera
 You configure the `entityOperator` property of the `Kafka` resource to include the `userOperator`.
 By default, the User Operator watches for `KafkaUser` resources in the namespace of the Kafka cluster deployment.
 You can also specify a namespace using `watchedNamespace` in the User Operator `spec`.
-The User Operator can only watch a single Kafka cluster in a namespace.
-If you want to use the operator with more than one Kafka cluster, install the clusters to separate namespaces.
+A single User Operator can watch a single namespace. 
 
 If you want to use the User Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-user-operator-standalone-{context}[deploy the User Operator as a standalone component].

--- a/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-with-cluster-operator.adoc
@@ -12,6 +12,7 @@ You configure the `entityOperator` property of the `Kafka` resource to include t
 By default, the User Operator watches for `KafkaUser` resources in the namespace of the Kafka cluster deployment.
 You can also specify a namespace using `watchedNamespace` in the User Operator `spec`.
 A single User Operator can watch a single namespace. 
+One namespace should be watched by only one User Operator.
 
 If you want to use the User Operator with a Kafka cluster that is not managed by Strimzi,
 you must xref:deploying-the-user-operator-standalone-{context}[deploy the User Operator as a standalone component].

--- a/documentation/modules/operators/con-operators-namespaces.adoc
+++ b/documentation/modules/operators/con-operators-namespaces.adoc
@@ -18,13 +18,13 @@ The Topic Operator and User Operator can watch a single namespace.
 The Topic Operator and the User Operator can only watch a single Kafka cluster in a namespace.
 And they can only be connected to a single Kafka cluster.  
 
-If a Topic Operator watches more than one namespace, name collisions and topic deletion can occur. This is because each Kafka cluster uses Kafka topics that have the same name (such as `__consumer_offsets`). 
+If multiple Topic Operators watch the same namespace, name collisions and topic deletion can occur. 
+This is because each Kafka cluster uses Kafka topics that have the same name (such as `__consumer_offsets`). 
+Make sure that only one Topic Operator watches a given namespace.
 
-By using a single User Operator with a single namespace, a user with a given username can exist in more than one Kafka cluster.    
+When using multiple User Operators with a single namespace, a user with a given username can exist in more than one Kafka cluster.    
 
 If you deploy the Topic Operator and User Operator using the Cluster Operator, they watch the Kafka cluster deployed by the Cluster Operator by default.
 You can also specify a namespace using `watchedNamespace` in the operator configuration.
 
 For a standalone deployment of each operator, you specify a namespace and connection to the Kafka cluster to watch in the configuration.
-
-If you want to use the operators with more than one Kafka cluster, install the clusters to separate namespaces and use a separate operator configured to watch each namespace.

--- a/documentation/modules/operators/con-operators-namespaces.adoc
+++ b/documentation/modules/operators/con-operators-namespaces.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// assembly-operators.adoc
+
+[id='con-operators-namespaces-{context}']
+
+= Watching namespaces with Strimzi operators
+
+[role="_abstract"]
+Operators watch and manage Strimzi resources in namespaces.
+The Cluster Operator can watch a single namespace, multiple namespaces, or all namespaces in a Kubernetes cluster.
+The Topic Operator and User Operator can watch a single namespace.
+
+* The Cluster Operator watches for `Kafka` resources
+* The Topic Operator watches for `KafkaTopic` resources
+* The User Operator watches for `KafkaUser` resources 
+
+The Topic Operator and the User Operator can only watch a single Kafka cluster in a namespace.
+And they can only be connected to a single Kafka cluster.  
+
+If a Topic Operator watches more than one namespace, name collisions and topic deletion can occur. This is because each Kafka cluster uses Kafka topics that have the same name (such as `__consumer_offsets`). 
+
+By using a single User Operator with a single namespace, a user with a given username can exist in more than one Kafka cluster.    
+
+If you deploy the Topic Operator and User Operator using the Cluster Operator, they watch the Kafka cluster deployed by the Cluster Operator by default.
+You can also specify a namespace using `watchedNamespace` in the operator configuration.
+
+For a standalone deployment of each operator, you specify a namespace and connection to the Kafka cluster to watch in the configuration.
+
+If you want to use the operators with more than one Kafka cluster, install the clusters to separate namespaces and use a separate operator configured to watch each namespace.

--- a/documentation/modules/operators/ref-operator-topic.adoc
+++ b/documentation/modules/operators/ref-operator-topic.adoc
@@ -11,7 +11,7 @@ The full schema for `KafkaTopic` is described in xref:type-KafkaTopic-reference[
 
 == Identifying a Kafka cluster for topic handling
 
-A `KafkaTopic` resource includes a label that defines the appropriate name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
+A `KafkaTopic` resource includes a label that specifies the name of the Kafka cluster (derived from the name of the `Kafka` resource) to which it belongs.
 
 For example:
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

- Adds some clarification on what the Topic Operator and User Operator will watch when deployed, in terms of namespace and Kafka cluster.  
    - Updates the procedures to deploy the operators with the Cluster Operator and the standalone procedures in the _Deploying_ guide. 
    - Adds _Specifying a Kafka cluster to watch_ to the configuring the Entity Operator section in the _Configuring_ guide  
- Adds a verification step to the procedures for deploying the operators with the Cluster Operator. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

