### PR TITLE
[ST] Extend existing JMX systemtest to check JmxTrans logging functionality

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/JmxIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/JmxIsolatedST.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPassword;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.template.JmxTransOutputDefinitionTemplateBuilder;
-import io.strimzi.api.kafka.model.template.JmxTransQueryTemplate;
 import io.strimzi.api.kafka.model.template.JmxTransQueryTemplateBuilder;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.BeforeAllOnce;
@@ -75,8 +74,8 @@ public class JmxIsolatedST extends AbstractST {
                             .withName("standardOut")
                             .withOutputType("com.googlecode.jmxtrans.model.output.StdOutWriter")
                             .build())
-                    .withKafkaQueries( new JmxTransQueryTemplateBuilder()
-                            .withTargetMBean("kafka.server:type=" + jmxTransMetricTypeName + ",name=" +jmxTransMetricName )
+                    .withKafkaQueries(new JmxTransQueryTemplateBuilder()
+                            .withTargetMBean("kafka.server:type=" + jmxTransMetricTypeName + ",name=" + jmxTransMetricName)
                             .withAttributes("Count")
                             .withOutputs("standardOut")
                             .build())
@@ -122,7 +121,7 @@ public class JmxIsolatedST extends AbstractST {
         // Check Jmx Trans log result
         String jmxTransPodName = kubeClient().listPodsByPrefixInName(jmxTransName).get(0).getMetadata().getName();
         String jmxTransResult = kubeClient().logs(jmxTransPodName);
-        String expectedJmxTransContainString = "typeName=type="+ jmxTransMetricTypeName + ",name=" + jmxTransMetricName;
+        String expectedJmxTransContainString = "typeName=type=" + jmxTransMetricTypeName + ",name=" + jmxTransMetricName;
         assertThat("Result from Kafka JmxTrans doesn't contain correct logs, result: " + jmxTransResult, jmxTransResult, containsString(expectedJmxTransContainString));
 
         if (!Environment.isKRaftModeEnabled()) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature


### Description

This PR contains basic systemtest for JMX Trans. Test was simply modified to deploy JMX Trans with standard output, so that pod logs can be collected. Results of these logs are JMX metrics, which are asserted. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

