### PR TITLE
docs: updates for MM2 handling large message volumes

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -6,16 +6,18 @@
 = Handling high volumes of messages
 
 [role="_abstract"]
-If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to support it. 
-The configuration can help manage throughput and issues with latency. 
+If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration configuration to help manage throughput and issues with latency. 
+Operations like tracking web activity can generate a high volume of messages. 
+But even a source cluster with moderate throughput can produce a high volume of messages if it has a lot of existing data. 
 
-MirrorMaker 2.0 uses an internal producer to replicate data from the source to the target Kafka cluster. 
-To control the streaming of high volumes of data, you can tune the producer batch size configuration for optimal throughput. 
+MirrorMaker 2.0 fetches data from the source cluster and hands it to the Kafka Connect runtime producers so that it's replicated to the target cluster.
+
+To control the streaming of high volumes of data, you can tune the configuration of the Kafka Connect runtime producers for optimal throughput.
 
 In certain circumstances, you might want to increase the size of the message batches sent in a single produce request.
-You increase the batch size using the `batch.size` producer configuration to reduce the number of outstanding messages ready to be sent.
+You increase the batch size using the `batch.size` producer configuration.
+A larger batch size reduces the number of outstanding messages ready to be sent and the size of the backlog in the message queue
 Messages being sent to the same partition are batched together.
-A larger batch size reduces the number of requests and the size of the backlog in the message queue.
 A produce request is sent to the target cluster when the batch size is reached.
 By increasing the batch size, produce requests are delayed and more messages are added to the batch and sent to brokers at the same time.  
 This can improve throughput when you have just a few topic partitions that handle large numbers of messages.  
@@ -23,7 +25,7 @@ This can improve throughput when you have just a few topic partitions that handl
 Consider the number and size of the records that the producer handles for a suitable producer batch size. 
 
 Use `linger.ms` to add a wait time in milliseconds to delay produce requests when producer load decreases. 
-What the delay means is that more records can be added to batches if they are under the maximum batch size.  
+The delay means that more records can be added to batches if they are under the maximum batch size.  
 
 Configure the `batch.size` and `linger.ms` values at the source connector level (`producer.override.*`), as they relate to the specific producer that sends topic messages to the target Kafka cluster.
 
@@ -35,12 +37,12 @@ The data replication pipeline to the target Kafka cluster is as follows:
 The producer sends messages in its buffer to topics in the target Kafka cluster.
 While this is happening, Kafka Connect tasks continue to poll topics in the source Kafka cluster to add messages to the source message queue.
 
-The size of the buffer is set using the `producer.buffer.memory` property. 
+The size of the producer buffer for the source connector is set using the `producer.override.buffer.memory` property.
 Tasks wait for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
 This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed. 
 The source task does not wait for the producer to empty the message queue before committing offsets, except during shutdown.
 
-If the producer is unable to keep up with the throughput of messages in the source message queue, buffering is blocked until there is space available in the buffer within a time period allocated by `max.block.ms`.
+If the producer is unable to keep up with the throughput of messages in the source message queue, buffering is blocked until there is space available in the buffer within a time period bounded by `max.block.ms`.
 Any unacknowledged messages still in the buffer are sent during this period.
 New messages are not added to the buffer until these messages are acknowledged and flushed.
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -38,11 +38,7 @@ While this is happening, Kafka Connect tasks continue to poll topics in the sour
 The size of the buffer is set using the `producer.buffer.memory` property. 
 Tasks wait for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
 This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed. 
-
-NOTE: Kafka 3.1.0 and newer versions do not wait for the producer to empty the message queue before committing offsets, except during shutdown.
-
-Try to avoid a situation where there are too many messages in the buffer, so they can't all be flushed before the offset flush timeout is reached.
-The offset flush timeout period needs to be sufficient for the size of the buffer.
+Kafka does not wait for the producer to empty the message queue before committing offsets, except during shutdown.
 
 If the producer is unable to keep up with the throughput of messages in the source message queue, buffering is blocked until there is space available in the buffer within a time period allocated by `max.block.ms`.
 Any unacknowledged messages still in the buffer are sent during this period.
@@ -84,7 +80,7 @@ spec:
       tasksMax: 2
       config:
         producer.override.batch.size: 327680
-        producer.override.linger.ms: 5
+        producer.override.linger.ms: 100
     # ...
   resources: 
     requests:

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -9,7 +9,7 @@
 If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to support it. 
 The configuration can help manage throughput and issues with latency. 
 
-MirrorMaker 2.0 uses an internal producer client to replicate data from the source to the target Kafka cluster. 
+MirrorMaker 2.0 uses an internal producer to replicate data from the source to the target Kafka cluster. 
 To control the streaming of high volumes of data, you can tune the producer batch size configuration for optimal throughput. 
 
 In certain circumstances, you might want to increase the size of the message batches sent in a single produce request.
@@ -20,16 +20,16 @@ A produce request is sent to the target cluster when the batch size is reached.
 By increasing the batch size, produce requests are delayed and more messages are added to the batch and sent to brokers at the same time.  
 This can improve throughput when you have just a few topic partitions that handle large numbers of messages.  
 
-Consider the number and size of records for a suitable producer batch size. 
-Use something like the following formula: `max.poll.records * record-size-avg * 1024`. 
-`max.poll.records` is the maximum number of messages to return in a poll. 
-`record-size-avg` is a metric that gives the average size of a records. 
+Consider the number and size of the records that the producer handles for a suitable producer batch size. 
 
-Use `producer.linger.ms` to add a wait time in milliseconds to delay produce requests when producer load decreases. 
-What the delay means is that more records can be added to batches if they are under the maximum batch size.       
+Use `linger.ms` to add a wait time in milliseconds to delay produce requests when producer load decreases. 
+What the delay means is that more records can be added to batches if they are under the maximum batch size.  
 
-The data replication pipeline is as follows:
+Configure the `batch.size` and `linger.ms` values at the source connector level (`producer.override.*`), as they relate to the specific producer that sends topic messages to the target Kafka cluster.
 
+The data replication pipeline to the target Kafka cluster is as follows:
+
+.Data replication pipeline
 *source topic -> (Kafka Connect tasks) source message queue -> producer buffer -> target topic*.
 
 The producer sends messages in its buffer to topics in the target Kafka cluster.
@@ -76,14 +76,15 @@ spec:
   - alias: "my-cluster-target"
     config:
       offset.flush.timeout.ms: 10000
-      producer.batch.size: 327680
-      producer.linger.ms: 5
     bootstrapServers: my-cluster-target-kafka-bootstrap:9092
   mirrors:
   - sourceCluster: "my-cluster-source"
     targetCluster: "my-cluster-target"
     sourceConnector:
       tasksMax: 2
+      config:
+        producer.override.batch.size: 327680
+        producer.override.linger.ms: 5
     # ...
   resources: 
     requests:

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -6,26 +6,53 @@
 = Handling high volumes of messages
 
 [role="_abstract"]
-If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to support it.
+If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to support it. The configuration can help manage throughput and issues with latency. 
 
-The flush pipeline for data replication is *source topic -> (Kafka Connect) source message queue -> producer buffer -> target topic*.
-An offset flush timeout period (`offset.flush.timeout.ms`) is the time to wait for the producer buffer (`producer.buffer.memory`) to flush and offset data to be committed.
-Try to avoid a situation where a large producer buffer and an insufficient offset flush timeout period causes a _failed to flush_ or _failed to commit offsets_ type of error.
+MirrorMaker 2.0 uses an internal producer client (`KafkaProducer`) to replicate data from the source to target Kafka cluster. 
+To control the streaming of high volumes of data, you can tune the following producer configuration for optimal throughput: 
 
-This type of error means that there are too many messages in the producer buffer, so they can't all be flushed before the offset flush timeout is reached.
+* Producer batch size 
+* Producer buffer size 
 
-If you are getting this type of error, try the following configuration changes:
+.Producer batch size
+In certain circumstances, you might want to increase the size of the message batches sent in a single produce request.
+You increase the batch size using the `batch.size` producer configuration to reduce the number of outstanding messages ready to be sent.
+A larger batch size reduces the number of requests and the backlog in the message queue.
+A produce request is sent to the target cluster when the batch size is reached.
+By increasing the batch size, produce requests are delayed and more messages are added to the batch and sent to brokers at the same time.  
+This can improve throughput when you have just a few topic partitions that handle large numbers of messages. 
+
+NOTE: To be able to increase the batch size, the `connector.client.config.override.policy` must be set to `All`. This is the default setting. The property enables connector client configurations.   
+
+.Producer buffer size
+The data replication pipeline is as follows:
+
+*source topic -> (Kafka Connect tasks) source message queue -> producer buffer -> target topic*.
+
+The producer sends messages in its buffer to topics in the target Kafka cluster.
+While this is happening, Kafka Connect tasks continue to poll topics in the source Kafka cluster to add messages to the source message queue.
+
+The size of the buffer is set using the `producer.buffer.memory` property. 
+The producer waits for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
+This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed.
+
+Try to avoid a situation where there are too many messages in the buffer, so they can't all be flushed before the offset flush timeout is reached.
+The offset flush timeout period needs to be sufficient for the size of the buffer.
+
+If the producer is unable to keep up with the throughput of messages in the source message queue, buffering is blocked until there is space available in the buffer within a time period allocated by `max.block.ms`.
+Any unacknowledged messages still in the buffer are sent during this period.
+New messages are not added to the buffer until these messages are acknowledged and flushed.
+
+You can try the following configuration changes to keep the underlying source message queue of outstanding messages at a manageable size:
 
 * Decreasing the default value in bytes of the `producer.buffer.memory`
 * Increasing the default value in milliseconds of the `offset.flush.timeout.ms`
+* Ensuring that there are enough xref:con-common-configuration-resources-reference[CPU and memory resources]
+* Increasing the number of tasks that run in parallel by doing the following:
+** xref:con-mirrormaker-tasks-max-{context}[Increasing the number of tasks] using the `tasksMax` property
+** Increasing the number of nodes for the workers that run tasks using the `replicas` property
 
-The changes should help to keep the underlying Kafka Connect queue of outstanding messages at a manageable size.
-You might need to adjust the values to have the desired effect.
-
-If these configuration changes don't resolve the error, you can try increasing the number of tasks that run in parallel by doing the following.
-
-* xref:con-mirrormaker-tasks-max-{context}[Increasing the number of tasks] using the `tasksMax` property
-* Increasing the number of nodes for the workers that run tasks using the `replicas` property
+You might need to keep adjusting the configuration values until they have the desired effect.
 
 .Example MirrorMaker 2.0 configuration for handling high volumes of messages
 [source,yaml,subs="+quotes,attributes"]
@@ -45,12 +72,21 @@ spec:
     config:
       offset.flush.timeout.ms: 10000
       producer.buffer.memory: 8388608
+      producer.batch.size: 327680
     bootstrapServers: my-cluster-target-kafka-bootstrap:9092
   mirrors:
   - sourceCluster: "my-cluster-source"
     targetCluster: "my-cluster-target"
     sourceConnector:
       tasksMax: 10
+    # ...
+  resources: 
+    requests:
+      cpu: "1"
+      memory: Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi      
 ----
 
 == Checking the message flow

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -14,10 +14,19 @@ To control the streaming of high volumes of data, you can tune the producer batc
 
 In certain circumstances, you might want to increase the size of the message batches sent in a single produce request.
 You increase the batch size using the `batch.size` producer configuration to reduce the number of outstanding messages ready to be sent.
-A larger batch size reduces the number of requests and the backlog in the message queue.
+Messages being sent to the same partition are batched together.
+A larger batch size reduces the number of requests and the size of the backlog in the message queue.
 A produce request is sent to the target cluster when the batch size is reached.
 By increasing the batch size, produce requests are delayed and more messages are added to the batch and sent to brokers at the same time.  
 This can improve throughput when you have just a few topic partitions that handle large numbers of messages.  
+
+Consider the number and size of records for a suitable producer batch size. 
+Use something like the following formula: `max.poll.records * record-size-avg * 1024`. 
+`max.poll.records` is the maximum number of messages to return in a poll. 
+`record-size-avg` is a metric that gives the average size of a records. 
+
+Use `producer.linger.ms` to add a wait time in milliseconds to delay produce requests when producer load decreases. 
+What the delay means is that more records can be added to batches if they are under the maximum batch size.       
 
 The data replication pipeline is as follows:
 
@@ -29,6 +38,8 @@ While this is happening, Kafka Connect tasks continue to poll topics in the sour
 The size of the buffer is set using the `producer.buffer.memory` property. 
 Tasks wait for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
 This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed. 
+
+NOTE: Kafka 3.1.0 and newer versions do not wait for the producer to empty the message queue before committing offsets, except during shutdown.
 
 Try to avoid a situation where there are too many messages in the buffer, so they can't all be flushed before the offset flush timeout is reached.
 The offset flush timeout period needs to be sufficient for the size of the buffer.
@@ -65,8 +76,8 @@ spec:
   - alias: "my-cluster-target"
     config:
       offset.flush.timeout.ms: 10000
-      producer.buffer.memory: 8388608
       producer.batch.size: 327680
+      producer.linger.ms: 5
     bootstrapServers: my-cluster-target-kafka-bootstrap:9092
   mirrors:
   - sourceCluster: "my-cluster-source"

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -6,7 +6,7 @@
 = Handling high volumes of messages
 
 [role="_abstract"]
-If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration configuration to help manage throughput and issues with latency. 
+If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to help manage throughput and issues with latency. 
 Operations like tracking web activity can generate a high volume of messages. 
 But even a source cluster with moderate throughput can produce a high volume of messages if it has a lot of existing data. 
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -6,13 +6,14 @@
 = Handling high volumes of messages
 
 [role="_abstract"]
-If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to support it. The configuration can help manage throughput and issues with latency. 
+If your MirrorMaker 2.0 deployment is going to be handling a high volume of messages, you might need to adjust its configuration to support it. 
+The configuration can help manage throughput and issues with latency. 
 
-MirrorMaker 2.0 uses an internal producer client (`KafkaProducer`) to replicate data from the source to target Kafka cluster. 
+MirrorMaker 2.0 uses an internal producer client to replicate data from the source to the target Kafka cluster. 
 To control the streaming of high volumes of data, you can tune the following producer configuration for optimal throughput: 
 
 * Producer batch size 
-* Producer buffer size 
+* Producer buffer memory 
 
 .Producer batch size
 In certain circumstances, you might want to increase the size of the message batches sent in a single produce request.
@@ -20,11 +21,9 @@ You increase the batch size using the `batch.size` producer configuration to red
 A larger batch size reduces the number of requests and the backlog in the message queue.
 A produce request is sent to the target cluster when the batch size is reached.
 By increasing the batch size, produce requests are delayed and more messages are added to the batch and sent to brokers at the same time.  
-This can improve throughput when you have just a few topic partitions that handle large numbers of messages. 
+This can improve throughput when you have just a few topic partitions that handle large numbers of messages.  
 
-NOTE: To be able to increase the batch size, the `connector.client.config.override.policy` must be set to `All`. This is the default setting. The property enables connector client configurations.   
-
-.Producer buffer size
+.Producer buffer memory
 The data replication pipeline is as follows:
 
 *source topic -> (Kafka Connect tasks) source message queue -> producer buffer -> target topic*.
@@ -33,7 +32,7 @@ The producer sends messages in its buffer to topics in the target Kafka cluster.
 While this is happening, Kafka Connect tasks continue to poll topics in the source Kafka cluster to add messages to the source message queue.
 
 The size of the buffer is set using the `producer.buffer.memory` property. 
-The producer waits for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
+Tasks wait for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
 This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed.
 
 Try to avoid a situation where there are too many messages in the buffer, so they can't all be flushed before the offset flush timeout is reached.
@@ -50,8 +49,9 @@ You can try the following configuration changes to keep the underlying source me
 * Ensuring that there are enough xref:con-common-configuration-resources-reference[CPU and memory resources]
 * Increasing the number of tasks that run in parallel by doing the following:
 ** xref:con-mirrormaker-tasks-max-{context}[Increasing the number of tasks] using the `tasksMax` property
-** Increasing the number of nodes for the workers that run tasks using the `replicas` property
+** Increasing the number of worker nodes that run tasks using the `replicas` property
 
+Consider the number of tasks that can run in parallel according to the available CPU and memory resources and number of worker nodes. 
 You might need to keep adjusting the configuration values until they have the desired effect.
 
 .Example MirrorMaker 2.0 configuration for handling high volumes of messages
@@ -78,7 +78,7 @@ spec:
   - sourceCluster: "my-cluster-source"
     targetCluster: "my-cluster-target"
     sourceConnector:
-      tasksMax: 10
+      tasksMax: 2
     # ...
   resources: 
     requests:

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -38,7 +38,7 @@ While this is happening, Kafka Connect tasks continue to poll topics in the sour
 The size of the buffer is set using the `producer.buffer.memory` property. 
 Tasks wait for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
 This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed. 
-Kafka does not wait for the producer to empty the message queue before committing offsets, except during shutdown.
+The source task does not wait for the producer to empty the message queue before committing offsets, except during shutdown.
 
 If the producer is unable to keep up with the throughput of messages in the source message queue, buffering is blocked until there is space available in the buffer within a time period allocated by `max.block.ms`.
 Any unacknowledged messages still in the buffer are sent during this period.

--- a/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-high-volume-messages.adoc
@@ -10,12 +10,8 @@ If your MirrorMaker 2.0 deployment is going to be handling a high volume of mess
 The configuration can help manage throughput and issues with latency. 
 
 MirrorMaker 2.0 uses an internal producer client to replicate data from the source to the target Kafka cluster. 
-To control the streaming of high volumes of data, you can tune the following producer configuration for optimal throughput: 
+To control the streaming of high volumes of data, you can tune the producer batch size configuration for optimal throughput. 
 
-* Producer batch size 
-* Producer buffer memory 
-
-.Producer batch size
 In certain circumstances, you might want to increase the size of the message batches sent in a single produce request.
 You increase the batch size using the `batch.size` producer configuration to reduce the number of outstanding messages ready to be sent.
 A larger batch size reduces the number of requests and the backlog in the message queue.
@@ -23,7 +19,6 @@ A produce request is sent to the target cluster when the batch size is reached.
 By increasing the batch size, produce requests are delayed and more messages are added to the batch and sent to brokers at the same time.  
 This can improve throughput when you have just a few topic partitions that handle large numbers of messages.  
 
-.Producer buffer memory
 The data replication pipeline is as follows:
 
 *source topic -> (Kafka Connect tasks) source message queue -> producer buffer -> target topic*.
@@ -33,7 +28,7 @@ While this is happening, Kafka Connect tasks continue to poll topics in the sour
 
 The size of the buffer is set using the `producer.buffer.memory` property. 
 Tasks wait for a specified timeout period (`offset.flush.timeout.ms`) before the buffer is flushed. 
-This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed.
+This should be enough time for the sent messages to be acknowledged by the brokers and offset data committed. 
 
 Try to avoid a situation where there are too many messages in the buffer, so they can't all be flushed before the offset flush timeout is reached.
 The offset flush timeout period needs to be sufficient for the size of the buffer.
@@ -44,7 +39,6 @@ New messages are not added to the buffer until these messages are acknowledged a
 
 You can try the following configuration changes to keep the underlying source message queue of outstanding messages at a manageable size:
 
-* Decreasing the default value in bytes of the `producer.buffer.memory`
 * Increasing the default value in milliseconds of the `offset.flush.timeout.ms`
 * Ensuring that there are enough xref:con-common-configuration-resources-reference[CPU and memory resources]
 * Increasing the number of tasks that run in parallel by doing the following:
@@ -63,7 +57,7 @@ metadata:
   name: my-mirror-maker2
 spec:
   version: {DefaultKafkaVersion}
-  replicas: 5
+  replicas: 1
   connectCluster: "my-cluster-target"
   clusters:
   - alias: "my-cluster-source"


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates [Handling high volumes of messages](https://strimzi.io/docs/operators/in-development/configuring.html#con-mirrormaker-high-volume-messages-str) in the _Configuring_ guide.

MirrorMaker2 used to fail when handling large volumes of messages because of a high producer buffer or low offset commit timeout. This caused a failed to flush error. The underlying issue has now been fixed.

The section has been updated to explain how you can tune the MM2 config to handle high volumes of messages, rather than workaround the error.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

