### PR TITLE
Update Vert.x to 4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
         <fabric8.openshift-client.version>5.12.2</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>5.12.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <vertx.version>4.2.4</vertx.version>
-        <vertx-junit5.version>4.2.4</vertx-junit5.version>
+        <vertx.version>4.3.1</vertx.version>
+        <vertx-junit5.version>4.3.1</vertx-junit5.version>
         <log4j.version>2.17.2</log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <valid4j.version>1.1</valid4j.version>

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/SessionStartupDoesNotBlockMainThreadTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/SessionStartupDoesNotBlockMainThreadTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -44,9 +43,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-// Disabled because they were flaky in some environments.
-// Should be re-enabled after Vert.x 4.3.0 upgrade => https://github.com/strimzi/strimzi-kafka-operator/issues/6741
-@Disabled
 public class SessionStartupDoesNotBlockMainThreadTest {
 
     @Mock


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Vert.x library to 4.3.1. This also re-enabled the tests previously disabled and waiting for fixes in Vert.x 4.3.1: 
* This should close #6741.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging