### PR TITLE
Update Jaeger client to 1.8.1 to address Gson and OkHttp CVEs

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -26,7 +26,7 @@
         <jmx-prometheus-javaagent.version>0.17.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
-        <jaeger-client.version>1.6.0</jaeger-client.version>
+        <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
     </properties>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -26,7 +26,7 @@
         <jmx-prometheus-javaagent.version>0.17.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
-        <jaeger-client.version>1.6.0</jaeger-client.version>
+        <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
     </properties>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR bumps the version of the Jaeger client to 1.8.1. This version addresses the GSON and OkHttp CVEs.

This should close #6934.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging