### PR TITLE
Bump the `net.java.dev.jna:jna` library for better support of different platforms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,14 @@
                 <version>${strimzi-test-container.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- Required to be able to use the Test Container on different platforms such as Arm based Macs -->
+            <!-- Can be removed once the Strimzi Test Container is using new Test Container version -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.8.0</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Strimzi Test Container is currently using to old versions of some libraries which do not allow it to run onsome platforms such as Arm based Macs. This PR bumps the version of `net.java.dev.jna:jna` to make it possible. With the next Strimzi test Container release, which pulls already a newer version of the dependency, this override can be removed.