### PR TITLE
Make the Kafka Admin client in the User Operator configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Use CustomResource existing spec and status to fix Quarkus native build's serialization
 * Update JMX Exporter to version 0.17.0
 * Operator emits Kafka events to explain why it restarted a Kafka broker
+* Better configurability of the Kafka Admin client in the User Operator
 
 ## 0.29.0
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -113,6 +113,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
@@ -581,6 +582,11 @@ public class ResourceUtils {
         return new AdminClientProvider() {
             @Override
             public Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName) {
+                return createAdminClient(bootstrapHostnames, clusterCaCertSecret, keyCertSecret, keyCertName, new Properties());
+            }
+
+            @Override
+            public Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName, Properties config) {
                 Admin mock = mock(AdminClient.class);
                 DescribeClusterResult dcr;
                 try {

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -84,6 +84,10 @@ spec:
               value: "true"
             - name: STRIMZI_MAINTENANCE_TIME_WINDOWS <15>
               value: '* * 8-10 * * ?;* * 14-15 * * ?'
+            - name: STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION <16>
+              value: |
+                default.api.timeout.ms=60000
+                request.timeout.ms=120000
 ----
 <1> The Kubernetes namespace for the User Operator to watch for `KafkaUser` resources. Only one namespace can be specified.
 <2>  The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
@@ -113,6 +117,7 @@ When set to `false`, the User Operator will reject all resources with `simple` a
 This helps to avoid unnecessary exceptions in the Kafka cluster logs.
 The default is `true`.
 <15> (Optional) Semi-colon separated list of Cron Expressions defining the maintenance time windows during which the expiring user certificates will be renewed.
+<16> (Optional) Configuration options for configuring the Kafka Admin client used by the User Operator in the properties format.
 
 . If you are using TLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.
 Otherwise, go to the next step.

--- a/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
@@ -7,6 +7,8 @@ package io.strimzi.operator.common;
 import io.fabric8.kubernetes.api.model.Secret;
 import org.apache.kafka.clients.admin.Admin;
 
+import java.util.Properties;
+
 /**
  * Interface to be implemented for returning an instance of Kafka Admin interface
  */
@@ -22,4 +24,17 @@ public interface AdminClientProvider {
      * @return Instance of Kafka Admin interface
      */
     Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName);
+
+    /**
+     * Create a Kafka Admin interface instance
+     *
+     * @param bootstrapHostnames Kafka hostname to connect to for administration operations
+     * @param clusterCaCertSecret Secret containing the cluster CA certificate for TLS encryption
+     * @param keyCertSecret Secret containing keystore for TLS client authentication
+     * @param keyCertName Key inside the keyCertSecret for getting the keystore and the corresponding password
+     * @param config Additional configuration for the Kafka Admin Client
+     *
+     * @return Instance of Kafka Admin interface
+     */
+    Admin createAdminClient(String bootstrapHostnames, Secret clusterCaCertSecret, Secret keyCertSecret, String keyCertName, Properties config);
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -124,8 +124,14 @@ public class Main {
         CompositeFuture.join(clusterCaCertSecretFuture, euoKeySecretFuture)
                 .onComplete(ar -> {
                     if (ar.succeeded()) {
-                        Admin adminClient = adminClientProvider.createAdminClient(config.getKafkaBootstrapServers(),
-                                clusterCaCertSecretFuture.result(), euoKeySecretFuture.result(), euoKeySecretFuture.result() != null ? "entity-operator" : null);
+                        Admin adminClient = adminClientProvider
+                                .createAdminClient(
+                                        config.getKafkaBootstrapServers(),
+                                        clusterCaCertSecretFuture.result(),
+                                        euoKeySecretFuture.result(),
+                                        euoKeySecretFuture.result() != null ? "entity-operator" : null,
+                                        config.getKafkaAdminClientConfiguration()
+                                );
                         promise.complete(adminClient);
                     } else {
                         promise.fail(ar.cause());

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -181,5 +182,19 @@ public class UserOperatorConfigTest {
         assertThat(UserOperatorConfig.parseMaintenanceTimeWindows("* * 8-10 * * ?"), is(List.of("* * 8-10 * * ?")));
         assertThat(UserOperatorConfig.parseMaintenanceTimeWindows(null), is(nullValue()));
         assertThat(UserOperatorConfig.parseMaintenanceTimeWindows(""), is(nullValue()));
+    }
+
+    @Test
+    public void testParseKafkaAdminClientConfiguration()    {
+        Properties config = UserOperatorConfig.parseKafkaAdminClientConfiguration("default.api.timeout.ms=13000\n" +
+                "request.timeout.ms=130000");
+        assertThat(config.get("default.api.timeout.ms"), is("13000"));
+        assertThat(config.get("request.timeout.ms"), is("130000"));
+    }
+
+    @Test
+    public void testParseNullKafkaAdminClientConfiguration()    {
+        Properties config = UserOperatorConfig.parseKafkaAdminClientConfiguration(null);
+        assertThat(config.isEmpty(), is(true));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, all configuration of the Kafka Admin Client used by the User Operator is hardcoded inside the code. That means that:
* In case some tuning of the configuration is needed, there is no way to do it without code changes and rebuilding the User Operator
* Users who want to use the User Operator with any non-Strimzi Kafka server which does not use TLS client authentication have no way how to configure it (see for example #6998)

This PR adds a new environment variable `STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION` which can be used to pass additional configuration to the Admin client in the User operator. It can be used for things such as SASL configuration, but also tuning the timeouts etc.

The options passed through this environment variable do not have any validation or filtering. This is expected to be an _expert_ option, so it offers wide configurability with the risk of breaking the functionality, which I think is acceptable here.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md