### PR TITLE
docs: adds a description of cc modes to the overview

### DIFF
--- a/documentation/modules/overview/con-metrics-overview-tools.adoc
+++ b/documentation/modules/overview/con-metrics-overview-tools.adoc
@@ -60,10 +60,10 @@ Based on _optimization goals_ that have been defined, Cruise Control generates _
 When an _optimization proposal_ is approved, Cruise Control applies the rebalancing outlined in the proposal.
 
 You can generate optimization proposals in specific modes. 
-A `full` mode rebalance across all brokers is used by default.
+The `full` mode rebalances across all brokers and is used by default.
 Other modes accommodate changes when scaling a cluster up or down.
-Generate an optimization proposal in `add-brokers` mode to include any newly added brokers in the rebalance.
-Generate an optimization proposal in `remove-brokers` mode to exclude any brokers from the rebalance that are set to be removed.  
+Generate an optimization proposal in `add-brokers` mode to move data from existing brokers to newly added ones.
+Generate an optimization proposal in `remove-brokers` mode to move all data off brokers to be removed, before scaling down.
 
 Prometheus can extract Cruise Control metrics data, including data related to optimization proposals and rebalancing operations.
 A sample configuration file and Grafana dashboard for Cruise Control are provided with Strimzi.

--- a/documentation/modules/overview/con-metrics-overview-tools.adoc
+++ b/documentation/modules/overview/con-metrics-overview-tools.adoc
@@ -59,5 +59,11 @@ Cruise Control collects resource utilization information to model and analyze th
 Based on _optimization goals_ that have been defined, Cruise Control generates _optimization proposals_ outlining how the cluster can be effectively rebalanced.
 When an _optimization proposal_ is approved, Cruise Control applies the rebalancing outlined in the proposal.
 
+You can generate optimization proposals in specific modes. 
+A `full` mode rebalance across all brokers is used by default.
+Other modes accommodate changes when scaling a cluster up or down.
+Generate an optimization proposal in `add-brokers` mode to include any newly added brokers in the rebalance.
+Generate an optimization proposal in `remove-brokers` mode to exclude any brokers from the rebalance that are set to be removed.  
+
 Prometheus can extract Cruise Control metrics data, including data related to optimization proposals and rebalancing operations.
 A sample configuration file and Grafana dashboard for Cruise Control are provided with Strimzi.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation change**
Updates the Cruise Control summary in the [Strimzi Overview guide](https://strimzi.io/docs/operators/in-development/overview.html) to describe the new modes that can be used when scaling up/down. 

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

