### PR TITLE
docs: adds section that describes the MM2 producers and consumers

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
@@ -30,6 +30,9 @@ include::../../modules/configuring/con-config-mirrormaker2-replication.adoc[leve
 //Config for mirrormmaker connectors
 include::../../modules/configuring/con-config-mirrormaker2-connectors.adoc[leveloffset=+1]
 
+//Configuring MM2 producers and consumers
+include::../../modules/configuring/con-config-mirrormaker2-producers-consumers.adoc[leveloffset=+1]
+
 //Increasing the number of tasks
 include::../../modules/configuring/con-config-mirrormaker2-tasks-max.adoc[leveloffset=+1]
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
@@ -54,7 +54,7 @@ The following tables describe the producers and consumers for each of the connec
 
 |===
 
-IMPORTANT: The consumer configuration changes depending on the location of the `offset-syncs` topic. The default location is the source Kafka cluster. You can set `offset-syncs.topic.location` to `target` to use the target Kafka cluster. If you use the target Kafka cluster, use `mirrors.checkpointConnector.config: target.consumer.*` for the consumer configuration. 
+NOTE: You can set `offset-syncs.topic.location` to `target` to use the target Kafka cluster as the location of the `offset-syncs` topic. 
 
 .Heartbeat connector producer
 [cols="1,1a,3m",options="header"]
@@ -69,6 +69,8 @@ IMPORTANT: The consumer configuration changes depending on the location of the `
 |mirrors.heartbeatConnector.config: producer.override.*
 
 |===
+
+The following example shows how you configure the producers and consumers. 
 
 .Example configuration for connector producers and consumers
 [source,yaml,subs="+quotes,attributes"]
@@ -87,18 +89,18 @@ spec:
       tasksMax: 5
       config:
         producer.override.batch.size: 327680
-        producer.override.linger.ms: 5
-        producer.request.timeout.ms: 40000
-        consumer.fetch.max.bytes: 73400320
+        producer.override.linger.ms: 100
+        producer.request.timeout.ms: 30000
+        consumer.fetch.max.bytes: 52428800
         # ...
     checkpointConnector:
       config:
-        producer.override.request.timeout.ms: 40000
-        consumer.max.poll.interval.ms: 180000
+        producer.override.request.timeout.ms: 30000
+        consumer.max.poll.interval.ms: 300000
         # ...
     heartbeatConnector:
       config:
-        producer.override.request.timeout.ms: 40000
+        producer.override.request.timeout.ms: 30000
         # ...      
 ----
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
@@ -6,7 +6,7 @@
 = Connector producer and consumer configuration
 
 [role="_abstract"]
-MirrorMaker 2.0 connectors uses internal producers and consumers.
+MirrorMaker 2.0 connectors use internal producers and consumers.
 If needed, you can configure these producers and consumers to override the default settings. 
 
 For example, you can increase the `batch.size` for the source producer that sends topics to the target Kafka cluster to better accommodate large volumes of messages.

--- a/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// assembly-config-mirrormaker2.adoc
+
+[id='con-mirrormaker-producers-consumers-{context}']
+= Connector producer and consumer configuration
+
+[role="_abstract"]
+MirrorMaker 2.0 connectors uses internal producers and consumers.
+If needed, you can configure these producers and consumers to override the default settings. 
+
+For example, you can increase the `batch.size` for the source producer that sends topics to the target Kafka cluster to better accommodate large volumes of messages.
+
+IMPORTANT: Producer and consumer configuration options depend on the MirrorMaker 2.0 implementation, and may be subject to change.  
+
+The following tables describe the producers and consumers for each of the connectors and where you can add configuration. 
+
+.Source connector producers and consumers
+[cols="1,1a,3m",options="header"]
+|===
+
+|Type
+|Description
+|Configuration
+
+|Producer
+|Sends topic messages to the target Kafka cluster. Consider tuning the configuration of this producer when it is handling large volumes of data. 
+|mirrors.sourceConnector.config: producer.override.*
+
+|Producer
+|Writes to the `offset-syncs` topic, which maps the source and target offsets for replicated topic partitions. 
+|mirrors.sourceConnector.config: producer.*
+
+|Consumer
+|Retrieves topic messages from the source Kafka cluster.
+|mirrors.sourceConnector.config: consumer.* 
+|===
+
+.Checkpoint connector producers and consumers
+[cols="1,1a,3m",options="header"]
+|===
+
+|Type
+|Description
+|Configuration
+
+|Producer
+|Emits consumer offset checkpoints.
+|mirrors.checkpointConnector.config: producer.override.* 
+
+|Consumer
+|Loads the `offset-syncs` topic.
+|mirrors.checkpointConnector.config: consumer.*
+
+|===
+
+.Heartbeat connector producer
+[cols="1,1a,3m",options="header"]
+|===
+
+|Type
+|Description
+|Configuration
+
+|Producer
+|Emits heartbeats.
+|mirrors.heartbeatConnector.config: producer.override.*
+
+|===
+
+.Example configuration for connector producers and consumers
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaMirrorMaker2ApiVersion}
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker2
+spec:
+  version: {DefaultKafkaVersion}
+  # ...
+  mirrors:
+  - sourceCluster: "my-cluster-source"
+    targetCluster: "my-cluster-target"
+    sourceConnector:
+      tasksMax: 5
+      config:
+        producer.override.batch.size: 327680
+        producer.override.linger.ms: 5
+        producer.request.timeout.ms: 40000
+        consumer.fetch.max.bytes: 73400320
+        # ...
+    checkpointConnector:
+      config:
+        producer.override.request.timeout.ms: 40000
+        consumer.max.poll.interval.ms: 180000
+        # ...
+    heartbeatConnector:
+      config:
+        producer.override.request.timeout.ms: 40000
+        # ...      
+----
+
+NOTE: You can configure producers and consumers at the cluster level using `spec.clusters.config.producer.\*` or `spec.clusters.config.consumer.*` properties. 
+If you do this, the changes might impact all internal producers and consumers. 
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:type-KafkaMirrorMaker2ConnectorSpec-reference[]
+* xref:type-KafkaMirrorMaker2MirrorSpec-reference[]

--- a/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
@@ -54,6 +54,8 @@ The following tables describe the producers and consumers for each of the connec
 
 |===
 
+IMPORTANT: The consumer configuration changes depending on the location of the `offset-syncs` topic. The default location is the source Kafka cluster. You can set `offset-syncs.topic.location` to `target` to use the target Kafka cluster. If you use the target Kafka cluster, use `mirrors.checkpointConnector.config: target.consumer.*` for the consumer configuration. 
+
 .Heartbeat connector producer
 [cols="1,1a,3m",options="header"]
 |===
@@ -99,9 +101,6 @@ spec:
         producer.override.request.timeout.ms: 40000
         # ...      
 ----
-
-NOTE: You can configure producers and consumers at the cluster level using `spec.clusters.config.producer.\*` or `spec.clusters.config.consumer.*` properties. 
-If you do this, the changes might impact all internal producers and consumers. 
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds a new section to the [Kafka MirrorMaker cluster configuration](https://strimzi.io/docs/operators/in-development/configuring.html#assembly-deployment-configuration-kafka-mirror-maker-str) section of the _Configuring_ guide

- Describes the MM2 producers and consumers for each of the MM2 connectors
- Shows where you configure the producers in the MM2 resource
- Provides an example showing possible configurations

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

