### PR TITLE
Fix loggers in the resource operators

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableStatusedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableStatusedResourceOperator.java
@@ -27,9 +27,6 @@ public abstract class AbstractWatchableStatusedResourceOperator<
         L extends KubernetesResourceList<T>,
         R extends Resource<T>>
         extends AbstractWatchableResourceOperator<C, T, L, R> {
-
-    public final static String ANY_NAMESPACE = "*";
-
     /**
      * Constructor.
      *

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 
 public class ResourceSupport {
     public static final long DEFAULT_TIMEOUT_MS = 300_000;
-    protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ResourceSupport.class);
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ResourceSupport.class);
 
     private final Vertx vertx;
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StrimziPodSetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StrimziPodSetOperator.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.StrimziPodSetList;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.ReconciliationLogger;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -16,8 +15,6 @@ import io.vertx.core.Vertx;
  * Operator for {@code StrimziPodSet}s
  */
 public class StrimziPodSetOperator extends CrdOperator<KubernetesClient, StrimziPodSet, StrimziPodSetList> {
-    protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StrimziPodSetOperator.class.getName());
-
     protected final long operationTimeoutMs;
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR should make sure that the resource operators use the right loggers in order to properly log the lines with the right class name / line number. This means that they should not inherit the loggers in the hierarchy but have its own logger in each class whihc does some logging. To help achieve this and make sure it stays that way, this PR sets the LOGGER fields as private to ensure it is not used in the inheriting classes.

This should close #3658 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging