### PR TITLE
Future-proof Cruise Control integration for Strimzi PodSet migration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -204,7 +204,7 @@ public class CruiseControl extends AbstractModel {
 
             // To avoid illegal storage configurations provided by the user,
             // we rely on the storage configuration provided by the KafkaAssemblyOperator
-            cruiseControl.capacity = new Capacity(kafkaCr.getSpec(), storage);
+            cruiseControl.capacity = new Capacity(reconciliation, kafkaCr.getSpec(), storage);
 
             // Parse different types of metrics configurations
             ModelUtils.parseMetrics(cruiseControl, ccSpec);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -392,7 +392,7 @@ public class KafkaRoller {
         return false;
     }
 
-    private int idOfPod(String podName)  {
+    public static int idOfPod(String podName)  {
         return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -225,7 +225,7 @@ public class CruiseControlTest {
 
         Kafka resource = createKafka(cruiseControlSpec);
 
-        Capacity capacity = new Capacity(resource.getSpec(), kafkaStorage);
+        Capacity capacity = new Capacity(Reconciliation.DUMMY_RECONCILIATION, resource.getSpec(), kafkaStorage);
 
         assertThat(getCapacityConfigurationFromEnvVar(resource, ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION), is(capacity.toString()));
 
@@ -250,7 +250,7 @@ public class CruiseControlTest {
             .endSpec()
             .build();
         
-        capacity = new Capacity(resource.getSpec(), jbodStorage);
+        capacity = new Capacity(Reconciliation.DUMMY_RECONCILIATION, resource.getSpec(), jbodStorage);
         String cpuCapacity = new CpuCapacity(userDefinedCpuCapacity).toString();
 
         JsonArray brokerEntries = capacity.generateCapacityConfig().getJsonArray(Capacity.CAPACITIES_KEY);
@@ -295,7 +295,7 @@ public class CruiseControlTest {
             .build();
 
         resource = createKafka(cruiseControlSpec);
-        capacity = new Capacity(resource.getSpec(), kafkaStorage);
+        capacity = new Capacity(Reconciliation.DUMMY_RECONCILIATION, resource.getSpec(), kafkaStorage);
 
         brokerEntries = capacity.generateCapacityConfig().getJsonArray(Capacity.CAPACITIES_KEY);
         for (Object brokerEntry : brokerEntries) {
@@ -338,7 +338,7 @@ public class CruiseControlTest {
             .endSpec()
             .build();
 
-        capacity = new Capacity(resource.getSpec(), kafkaStorage);
+        capacity = new Capacity(Reconciliation.DUMMY_RECONCILIATION, resource.getSpec(), kafkaStorage);
         cpuCapacity = new CpuCapacity(userDefinedCpuCapacity).toString();
 
         brokerEntries = capacity.generateCapacityConfig().getJsonArray(Capacity.CAPACITIES_KEY);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Future-proofing Cruise Control integration for Strimzi PodSet migration. The Cruise Control capacity configuration generated for a cluster with a JBOD configuration requires a distinct broker capacity entry for every broker because the Kafka volume paths are not homogeneous across brokers and include the broker pod index in their names. The changes in this PR ensure that the proper broker indexes will be used even if/when we switch to using non-sequential broker ids as part of the PodSet migration.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

