### PR TITLE
Try to fix the system tests logs backup

### DIFF
--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -7,8 +7,8 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highli
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug-${env:BUILD_ID:-0}.log
-appender.rolling.filePattern = ${env:TEST_LOG_DIR:-systemtest/target/logs}/strimzi-debug-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
+appender.rolling.fileName = ${env:TEST_LOG_DIR:-target/logs}/strimzi-debug-${env:BUILD_ID:-0}.log
+appender.rolling.filePattern = ${env:TEST_LOG_DIR:-target/logs}/strimzi-debug-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
 appender.rolling.policies.type = Policies
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size=100MB


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The system tests do now run in forked JVM. That means that the path configuration for logs is incorrectly configured and they are not backed-ip in Azure system test runs. The logs are now created in `systemtest/systemtest/target/logs` instead of `systemtest/target/logs`. This PR tries to fix the path. It also makes it easier to run the tests locally from IDE since now the logs will be created correctly there as well.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally