### PR TITLE
Configure JMX only once

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/set_kafka_jmx_options.sh
+++ b/docker-images/kafka-based/kafka/scripts/set_kafka_jmx_options.sh
@@ -6,7 +6,7 @@ JMX_USERNAME="$2"
 JMX_PASSWORD="$3"
 
 if [ "$JMX_ENABLED" = "true" ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
 
   if [ -n "$JMX_USERNAME" ]; then
     mkdir -p /tmp/jmx/
@@ -26,13 +26,11 @@ ${JMX_USERNAME} ${JMX_PASSWORD}
 EOF
     chmod 400 "${JMX_PASSWORD_FILE}"
     KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.access.file=${JMX_ACCESS_FILE} -Dcom.sun.management.jmxremote.password.file=${JMX_PASSWORD_FILE}  -Dcom.sun.management.jmxremote.authenticate=true"
-
-    KAFKA_OPTS="${KAFKA_OPTS} ${KAFKA_JMX_OPTS}"
-    export KAFKA_OPTS
   else
     # expose the port insecurely
     KAFKA_JMX_OPTS="${KAFKA_JMX_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
-    KAFKA_OPTS="${KAFKA_OPTS} ${KAFKA_JMX_OPTS}"
-    export KAFKA_OPTS
   fi
+
+  echo "Enabling JMX access ${KAFKA_JMX_OPTS}"
+  export KAFKA_JMX_OPTS
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The script for configuring JMX in Kafka operands is setting the environment variables into `KAFKA_OPTS`. This means that `KAFKA_JMX_OPTS` will be empty and therefore `kafka-run-class.sh` will set some of the JMX options again and they will be set twice which is confusing.

This Pr changes the script which sets the JMX options to export the `KAFKA_JMX_OPTS` environment variable whihc will be just re-used in `kafka-run-class.sh` and everything will be set only once.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally