### PR TITLE
Remove the Vert.x dependency from the `api` module

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -65,10 +65,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <scope>test</scope>

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 @Buildable(
@@ -48,7 +47,7 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     private Rack rack;
 
     @Description("The number of pods in the Kafka Connect group.")
-    @DefaultValue("3")
+    @JsonProperty(defaultValue = "3")
     public Integer getReplicas() {
         return replicas;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
@@ -50,7 +49,7 @@ public class AclRule implements UnknownPropertyPreserving, Serializable {
             "Currently the only supported type is `allow`. " +
             "ACL rules with type `allow` are used to allow user to execute the specified operations. " +
             "Default value is `allow`.")
-    @DefaultValue("allow")
+    @JsonProperty(defaultValue = "allow")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public AclRuleType getType() {
         return type;
@@ -71,7 +70,7 @@ public class AclRule implements UnknownPropertyPreserving, Serializable {
     }
 
     @Description("The host from which the action described in the ACL rule is allowed or denied.")
-    @DefaultValue("*")
+    @JsonProperty(defaultValue = "*")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public String getHost() {
         return host;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleGroupResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleGroupResource.java
@@ -5,10 +5,10 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -41,7 +41,7 @@ public class AclRuleGroupResource extends AclRuleResource {
             "With `literal` pattern type, the resource field will be used as a definition of a full topic name. " +
             "With `prefix` pattern type, the resource name will be used only as a prefix. " +
             "Default value is `literal`.")
-    @DefaultValue("literal")
+    @JsonProperty(defaultValue = "literal")
     @JsonInclude(value = JsonInclude.Include.NON_DEFAULT)
     public AclResourcePatternType getPatternType() {
         return patternType;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTopicResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTopicResource.java
@@ -5,10 +5,10 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -41,7 +41,7 @@ public class AclRuleTopicResource extends AclRuleResource {
             "With `literal` pattern type, the resource field will be used as a definition of a full topic name. " +
             "With `prefix` pattern type, the resource name will be used only as a prefix. " +
             "Default value is `literal`.")
-    @DefaultValue("literal")
+    @JsonProperty(defaultValue = "literal")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public AclResourcePatternType getPatternType() {
         return patternType;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTransactionalIdResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleTransactionalIdResource.java
@@ -5,10 +5,10 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -52,7 +52,7 @@ public class AclRuleTransactionalIdResource extends AclRuleResource {
             "With `literal` pattern type, the resource field will be used as a definition of a full name. " +
             "With `prefix` pattern type, the resource name will be used only as a prefix. " +
             "Default value is `literal`.")
-    @DefaultValue("literal")
+    @JsonProperty(defaultValue = "literal")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public AclResourcePatternType getPatternType() {
         return patternType;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -5,12 +5,12 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
@@ -114,7 +114,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
 
     @Description("The time between two consecutive grants refresh runs in seconds. The default value is 60.")
     @Minimum(0)
-    @DefaultValue("60")
+    @JsonProperty(defaultValue = "60")
     public Integer getGrantsRefreshPeriodSeconds() {
         return grantsRefreshPeriodSeconds;
     }
@@ -126,7 +126,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     @Description("The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism," +
             " so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.")
     @Minimum(1)
-    @DefaultValue("5")
+    @JsonProperty(defaultValue = "5")
     public Integer getGrantsRefreshPoolSize() {
         return grantsRefreshPoolSize;
     }
@@ -149,7 +149,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
 
     @Description("The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.")
     @Minimum(1)
-    @DefaultValue("60")
+    @JsonProperty(defaultValue = "60")
     public Integer getConnectTimeoutSeconds() {
         return connectTimeoutSeconds;
     }
@@ -160,7 +160,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
 
     @Description("The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.")
     @Minimum(1)
-    @DefaultValue("60")
+    @JsonProperty(defaultValue = "60")
     public Integer getReadTimeoutSeconds() {
         return readTimeoutSeconds;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeHttpConfig.java
@@ -5,12 +5,12 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
@@ -46,7 +46,7 @@ public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving, Seriali
     }
 
     @Description("The port which is the server listening on.")
-    @DefaultValue("8080")
+    @JsonProperty(defaultValue = "8080")
     @Minimum(1023)
     public int getPort() {
         return port;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -16,7 +16,6 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 @DescriptionFile
@@ -55,7 +54,7 @@ public class KafkaBridgeSpec extends Spec {
 
     @Description("The number of pods in the `Deployment`.")
     @Minimum(0)
-    @DefaultValue("1")
+    @JsonProperty(defaultValue = "1")
     public int getReplicas() {
         return replicas;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Probe.java
@@ -5,10 +5,10 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
@@ -45,7 +45,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
 
     @Description("The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.")
     @Minimum(0)
-    @DefaultValue("15")
+    @JsonProperty(defaultValue = "15")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getInitialDelaySeconds() {
         return initialDelaySeconds;
@@ -57,7 +57,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
 
     @Description("The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.")
     @Minimum(1)
-    @DefaultValue("5")
+    @JsonProperty(defaultValue = "5")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public int getTimeoutSeconds() {
         return timeoutSeconds;
@@ -69,7 +69,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
 
     @Description("How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.")
     @Minimum(1)
-    @DefaultValue("10")
+    @JsonProperty(defaultValue = "10")
     public Integer getPeriodSeconds() {
         return periodSeconds;
     }
@@ -80,7 +80,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
 
     @Description("Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.")
     @Minimum(1)
-    @DefaultValue("1")
+    @JsonProperty(defaultValue = "1")
     public Integer getSuccessThreshold() {
         return successThreshold;
     }
@@ -91,7 +91,7 @@ public class Probe implements UnknownPropertyPreserving, Serializable {
 
     @Description("Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.")
     @Minimum(1)
-    @DefaultValue("3")
+    @JsonProperty(defaultValue = "3")
     public Integer getFailureThreshold() {
         return failureThreshold;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TlsSidecar.java
@@ -5,10 +5,10 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.util.HashMap;
@@ -37,7 +37,7 @@ public class TlsSidecar extends Sidecar {
 
     @Description("The log level for the TLS sidecar. " +
             "Default value is `notice`.")
-    @DefaultValue("notice")
+    @JsonProperty(defaultValue = "notice")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public TlsSidecarLogLevel getLogLevel() {
         return logLevel;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
@@ -5,11 +5,11 @@
 package io.strimzi.api.kafka.model.connect.build;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -66,7 +66,7 @@ public class MavenArtifact extends Artifact {
     }
 
     @Description("Maven repository to download the artifact from. Applicable to the `maven` artifact type only.")
-    @DefaultValue("https://repo1.maven.org/maven2/")
+    @JsonProperty(defaultValue = "https://repo1.maven.org/maven2/")
     public String getRepository() {
         return repository;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/KafkaListenerAuthenticationOAuth.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.CertSecretSource;
 import io.strimzi.api.kafka.model.Constants;
@@ -13,7 +14,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
@@ -194,7 +194,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
             "The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. " +
             "Defaults to 300 seconds.")
     @Minimum(1)
-    @DefaultValue("300")
+    @JsonProperty(defaultValue = "300")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Integer getJwksRefreshSeconds() {
         return jwksRefreshSeconds;
@@ -206,7 +206,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     @Description("The minimum pause between two consecutive refreshes. When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Defaults to 1 second.")
     @Minimum(0)
-    @DefaultValue("1")
+    @JsonProperty(defaultValue = "1")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Integer getJwksMinRefreshPauseSeconds() {
         return jwksMinRefreshPauseSeconds;
@@ -220,7 +220,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
             "The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. " +
             "Defaults to 360 seconds.")
     @Minimum(1)
-    @DefaultValue("360")
+    @JsonProperty(defaultValue = "360")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Integer getJwksExpirySeconds() {
         return jwksExpirySeconds;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodDisruptionBudgetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodDisruptionBudgetTemplate.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.template;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
@@ -12,7 +13,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
@@ -52,7 +52,7 @@ public class PodDisruptionBudgetTemplate implements Serializable, UnknownPropert
             "Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. " +
             "Defaults to 1.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @DefaultValue("1")
+    @JsonProperty(defaultValue = "1")
     @Minimum(0)
     public int getMaxUnavailable() {
         return maxUnavailable;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.template;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.HostAlias;
@@ -20,7 +21,6 @@ import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
-import io.vertx.core.cli.annotations.DefaultValue;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
@@ -97,7 +97,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
             "You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. " +
             "Defaults to 30 seconds.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    @DefaultValue("30")
+    @JsonProperty(defaultValue = "30")
     @Minimum(0)
     public int getTerminationGracePeriodSeconds() {
         return terminationGracePeriodSeconds;
@@ -185,7 +185,7 @@ public class PodTemplate implements Serializable, UnknownPropertyPreserving {
     }
 
     @Pattern(Constants.MEMORY_REGEX)
-    @DefaultValue("5Mi")
+    @JsonProperty(defaultValue = "5Mi")
     @Description("Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). " +
             "Default value is `5Mi`.")
     public String getTmpDirSizeLimit() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `api` module has currently Vert.x `core` as dependency. The only reason for that is the `DefaultValue` annotation which is not even used for anything. This PR removes the use of this annotation and removes the Vert.x dependency from the `api` module. While Strimzi operators use Vert.x anyway, the `api` module can be used also by other projects and having Vert.x as dependency is completely unnecessary.

In case we decide to use the default value annotation i the future, I replaced the Vert.x `@DefaultValue` annotation with Jackson `@JsonProperty(defaultValue = ...)` annotation. So the information is not lost and can be still used in the future. (and for the record, the `@JsonProperty(defaultValue = ...)` annotation was already used in some places anyway).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally