### PR TITLE
Update the Maven Builder container image to use openjdk-11:1.13

### DIFF
--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.13
 
 USER root
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR bumps the version of the OpenJDK 11 container image we use as the Maven Builder to 1.13. The new version seems to be approximately half the size of the older 1.11 image.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally