### PR TITLE
Do not install weak dependencies when installing OpenJDK

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 USER root
 
 RUN microdnf update \
-    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-11


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When installing OpenJDK, it also pulls a bunch of Python dependencies. One of them is the `platform-python-pip` package, which contains several vulnerabilities:

![Screenshot 2022-07-11 at 22 03 39](https://user-images.githubusercontent.com/5658439/178348574-2424db69-d9e2-455d-abdb-af9715f90014.png)

This PR adds the flag `--setopt=install_weak_deps=0` to not install the _weak_ dependencies. That seems to cause that the `platform-python-pip` is not installed anymore and the CVE scan is clean:

![Screenshot 2022-07-11 at 22 04 51](https://user-images.githubusercontent.com/5658439/178348762-40aef42a-e1a9-40f3-89d2-4a376c7f2cf6.png)

While this package is not really used by Strimzi and the CVEs should not impact it, having a clean scan is always nice.

This PR also sets the flag to not install any docs.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally