### PR TITLE
Use the suffix flag properly in the release pipeline

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -38,7 +38,7 @@ stages:
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn:
       - prepare_release_artifacts
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'), eq('${{ parameters.useSuffix }}', 'true'))
     jobs:
       - template: 'templates/jobs/build/push_containers.yaml'
         parameters:
@@ -53,7 +53,7 @@ stages:
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
       - containers_publish_with_suffix
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    condition: and(in(dependencies.containers_publish_with_suffix.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/build/push_containers.yaml'
         parameters:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The release pipeline in Azure normally produces 2 sets of images:
* One with the tag based on the regular version (e.g. 0.29.0)
* One with the suffixed version (e.g. 0.29.0-1)

The suffixed version is important for any respins of the images because of CVEs in the base image -> where after the CVE re-spin, the suffixed version will not be overwritten with the change. But the version without the suffix will be overwritten with the new image which fixes the CVE.

This is however not needed for release candidates, since we would never respin them for CVEs. That is why the Azure release pipeline has a flag for skipping the suffixed images. However, this flag was till now not used. This PR changes it and makes use of this flag.