### PR TITLE
Reconcile Image Pull Secrets in Service Accounts

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -34,6 +34,10 @@ public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesC
             desired.setSecrets(current.getSecrets());
         }
 
+        if (desired.getImagePullSecrets() == null || desired.getImagePullSecrets().isEmpty())    {
+            desired.setImagePullSecrets(current.getImagePullSecrets());
+        }
+
         return super.internalPatch(reconciliation, namespace, name, current, desired);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -5,6 +5,8 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
@@ -128,12 +130,18 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
                 new ObjectReferenceBuilder().withName("secretName2").build()
         );
 
+        List<LocalObjectReference> imagePullSecrets = List.of(
+                new LocalObjectReferenceBuilder().withName("pullSecretName1").build(),
+                new LocalObjectReferenceBuilder().withName("pullSecretName2").build()
+        );
+
         ServiceAccount current = new ServiceAccountBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
                     .withName(RESOURCE_NAME)
                 .endMetadata()
                 .withSecrets(secrets)
+                .withImagePullSecrets(imagePullSecrets)
                 .build();
 
         ServiceAccount desired = new ServiceAccountBuilder()
@@ -170,6 +178,8 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
                     assertThat(saCaptor.getValue(), is(notNullValue()));
                     assertThat(saCaptor.getValue().getSecrets().size(), is(2));
                     assertThat(saCaptor.getValue().getSecrets(), is(secrets));
+                    assertThat(saCaptor.getValue().getImagePullSecrets().size(), is(2));
+                    assertThat(saCaptor.getValue().getImagePullSecrets(), is(imagePullSecrets));
                     assertThat(saCaptor.getValue().getMetadata().getLabels().get("lKey"), is("lValue"));
                     assertThat(saCaptor.getValue().getMetadata().getAnnotations().get("aKey"), is("aValue"));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When patching the Service Acocunts, we have a special patch procedure in place to not remove the secrets assigned to the service account. The secrets are assigned by Kubernetes and if we remove it, Kube will have to patch the service account again to add them back.

This PR adds the same procedure also for the image pull secrets used for example on OpenShift. Not patching them internally is causing the same issue of constant updates of the Service Accounts in every reconciliation.

If we do RC2 of 0.30.0 for some reason, it should be backported there as well. But this is not a bug which would be new in 0.30. It was already in the previous versions.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally