### PR TITLE
Fix Jaeger version in the main pom.xml to be in sync with the Kafka 3rd-party libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
         <slf4j.version>1.7.36</slf4j.version>
         <quartz.version>2.3.2</quartz.version>
-        <jaeger.version>1.6.0</jaeger.version>
+        <jaeger.version>1.8.1</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #7009 I updated the Jaeger dependency to 1.8.1 to address some CVEs. I forgot to update it in the main `pom.xml` which kept using 1.6.0. While it is provided there and was not actually used anywhere, it might trigger false alarms in some CVE scanners. This PR updates it in the main pom.xml as well.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally