### PR TITLE
Add default value for kubernetes-client backwards compatibility

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -411,6 +411,24 @@ public class ClusterOperatorConfig {
     }
 
     /**
+     * Retrieve kubernetes-client backwards compatibility configuration.
+     *
+     * @param env true to get the environment rather than system configuration
+     *
+     * @return backwards compatibility configuration
+     */
+    public static String[] getKubeClientBackwardsCompatibilityConfig(boolean env) {
+        String[] config = {
+            env ? "KUBERNETES_BACKWARDSCOMPATIBILITYINTERCEPTOR_DISABLE"
+                    : "kubernetes.backwardsCompatibilityInterceptor.disable",
+                System.getenv().getOrDefault(
+                        "KUBERNETES_BACKWARDSCOMPATIBILITYINTERCEPTOR_DISABLE",
+                        "false")
+        };
+        return config;
+    }
+
+    /**
      * @return  namespaces in which the operator runs and creates resources
      */
     public Set<String> getNamespaces() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -76,7 +76,11 @@ public class Main {
         // Verticle.stop() methods are not executed if you don't call Vertx.close()
         // Vertx registers a shutdown hook for that, but only if you use its Launcher as main class
         Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx)));
-        
+
+        // setting kubernetes-client backwards compatibility
+        String[] backCompConfig = ClusterOperatorConfig.getKubeClientBackwardsCompatibilityConfig(false);
+        System.getProperties().setProperty(backCompConfig[0], backCompConfig[1]);
+
         KubernetesClient client = new DefaultKubernetesClient();
 
         maybeCreateClusterRoles(vertx, config, client).onComplete(crs -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -165,7 +165,11 @@ public abstract class AbstractModel {
      */
     protected static final List<EnvVar> STATIC_ENV_VARS;
     static {
-        List<EnvVar> envVars = new ArrayList<>(3);
+        List<EnvVar> envVars = new ArrayList<>(4);
+
+        // setting kubernetes-client backwards compatibility
+        String[] backCompConfig = ClusterOperatorConfig.getKubeClientBackwardsCompatibilityConfig(true);
+        envVars.add(buildEnvVar(backCompConfig[0], backCompConfig[1]));
 
         if (System.getenv(ClusterOperatorConfig.HTTP_PROXY) != null)    {
             envVars.add(buildEnvVar(ClusterOperatorConfig.HTTP_PROXY, System.getenv(ClusterOperatorConfig.HTTP_PROXY)));
@@ -183,11 +187,7 @@ public abstract class AbstractModel {
             envVars.add(buildEnvVar(ClusterOperatorConfig.FIPS_MODE, System.getenv(ClusterOperatorConfig.FIPS_MODE)));
         }
 
-        if (envVars.size() > 0) {
-            STATIC_ENV_VARS = Collections.unmodifiableList(envVars);
-        } else {
-            STATIC_ENV_VARS = Collections.emptyList();
-        }
+        STATIC_ENV_VARS = Collections.unmodifiableList(envVars);
     }
 
     protected final Reconciliation reconciliation;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -67,6 +67,10 @@ public class ClusterOperatorConfigTest {
         assertThat(config.isCreateClusterRoles(), is(false));
         assertThat(config.isNetworkPolicyGeneration(), is(true));
         assertThat(config.isPodSetReconciliationOnly(), is(false));
+        assertThat(ClusterOperatorConfig.getKubeClientBackwardsCompatibilityConfig(true),
+                is(new String[]{"KUBERNETES_BACKWARDSCOMPATIBILITYINTERCEPTOR_DISABLE", "false"}));
+        assertThat(ClusterOperatorConfig.getKubeClientBackwardsCompatibilityConfig(false),
+                is(new String[]{"kubernetes.backwardsCompatibilityInterceptor.disable", "false"}));
     }
 
     @Test


### PR DESCRIPTION
The default value of kubernetes-client backwards compatibility has recently been changed:
https://github.com/fabric8io/kubernetes-client/blob/a5285fbefb1781c290052b35670a796e06110174/doc/MIGRATION-v6.md#backwards-compatibility-interceptor

This commit enables kubernetes-client backwards compatibility by default to avoid a change in behavior when switching to 6.x.
The kubernetes-client specific configuration is set as CO system property and passed as environment variable to all operands.

We use the value of KUBERNETES_BACKWARDSCOMPATIBILITYINTERCEPTOR_DISABLE enviroment variable if valid and present in CO deployment at install time.