### PR TITLE
Fix typo in the CHANGELOG.md (Kafka versus Kubernetes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Add CPU capacity overrides for Cruise Control capacity config
 * Use CustomResource existing spec and status to fix Quarkus native build's serialization
 * Update JMX Exporter to version 0.17.0
-* Operator emits Kafka events to explain why it restarted a Kafka broker
+* Operator emits Kubernetes Events to explain why it restarted a Kafka broker
 * Better configurability of the Kafka Admin client in the User Operator
 * Update Strimzi Kafka Bridge to 0.21.6
 


### PR DESCRIPTION
### Type of change

- Bugfix
There is a typo in the CHANGELOG.md where it says that the operator publishes _Kafka events_ about rolling restarts. This Pr fixes it and changes it to _Kubernetes Events_ (with capital E to make it more clear it is a Kubernetes resource).