### PR TITLE
docs(mm2): Describes adding tasks for consumer group offset sync

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -13,7 +13,12 @@ MirrorMaker 2.0 uses:
 * Target cluster configuration to output data to the target cluster
 
 MirrorMaker 2.0 is based on the Kafka Connect framework, _connectors_ managing the transfer of data between clusters.
-A MirrorMaker 2.0 `MirrorSourceConnector` replicates topics from a source cluster to a target cluster.
+
+MirrorMaker 2.0 uses the following connectors:
+
+`MirrorSourceConnector`:: The source connector replicates topics from a source cluster to a target cluster.
+`MirrorCheckpointConnector`:: The checkpoint connector periodically tracks offsets. If enabled, it also synchronizes consumer group offsets between the source and target cluster.
+`MirrorHeartbeatConnector`:: The heartbeat connector periodically checks connectivity between the source and target cluster.
 
 The process of _mirroring_ data from one cluster to another cluster is asynchronous.
 The recommended pattern is for messages to be produced locally alongside the source Kafka cluster, then consumed remotely close to the target Kafka cluster.
@@ -76,15 +81,14 @@ MirrorMaker 2.0 monitors source topics and propagates any configuration changes 
 Only MirrorMaker 2.0 can write to remote topics.
 
 == Offset tracking
-MirrorMaker 2.0 tracks offsets for consumer groups using _internal topics_.
+MirrorMaker 2.0 tracks offsets for consumer groups using internal topics.
 
 * The `offset-syncs` topic maps the source and target offsets for replicated topic partitions from record metadata
 * The `checkpoints` topic maps the last committed offset in the source and target cluster for replicated topic partitions in each consumer group
 
+`MirrorCheckpointConnector` emits _checkpoints_ for offset tracking.
 Offsets for the `checkpoints` topic are tracked at predetermined intervals through configuration.
 Both topics enable replication to be fully restored from the correct offset position on failover.
-
-MirrorMaker 2.0 uses its `MirrorCheckpointConnector` to emit _checkpoints_ for offset tracking.
 
 The location of the `offset-syncs` topic is the `source` cluster by default.
 You can use the `offset-syncs.topic.location` connector configuration to change this to the `target` cluster.
@@ -118,13 +122,11 @@ Because the synchronization is time-based, any switchover by consumers to a pass
 
 == Connectivity checks
 
-A _heartbeat_ internal topic checks connectivity between clusters.
+`MirrorHeartbeatConnector` emits _heartbeats_ to check connectivity between clusters.
 
-The _heartbeat_ topic is replicated from the source cluster.
-
-Target clusters use the topic to check:
+An internal `heartbeat` topic is replicated from the source cluster.
+Target clusters use the `heartbeat` topic to check the following:
 
 * The connector managing connectivity between clusters is running
 * The source cluster is available
 
-MirrorMaker 2.0 uses its `MirrorHeartbeatConnector` to emit _heartbeats_ that perform these checks.

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -8,6 +8,7 @@
 [role="_abstract"]
 Connectors create the tasks that are responsible for moving data in and out of Kafka.
 Each connector comprises one or more tasks that are distributed across a group of worker pods that run the tasks.
+Increasing the number of tasks can help with performance issues when replicating a large number of partitions or synchronizing the offsets of a large number of consumer groups. 
 
 Tasks run in parallel.
 Workers are assigned one or more tasks.
@@ -16,9 +17,19 @@ If there are more tasks than workers, workers handle multiple tasks.
 
 You can specify the maximum number of connector tasks in your MirrorMaker configuration using the `tasksMax` property.
 Without specifying a maximum number of tasks, the default setting is a single task.
-If the infrastructure supports the processing overhead, increasing the number of tasks can improve throughput.
 
-.tasksMax configuration for a MirrorMaker connector
+The heartbeat connector always uses a single task.
+
+The number of tasks that are started for the source and checkpoint connectors is the lower value between the maximum number of possible tasks and the value for `tasksMax`.
+For the source connector, the maximum number of tasks possible is one for each partition being replicated from the source cluster.
+For the checkpoint connector, the maximum number of tasks possible is one for each consumer group being replicated from the source cluster.
+
+If the infrastructure supports the processing overhead, increasing the number of tasks can improve throughput and latency.
+For example, adding more tasks reduces the time taken to poll the source cluster when there is a high number of partitions or consumer groups.  
+
+Increasing the number of tasks for the checkpoint connector is useful when you have a large number of partitions.
+
+.Increasing the number of tasks for the source connector
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}
@@ -35,8 +46,35 @@ spec:
   # ...
 ----
 
-For the source connector, the maximum number of tasks possible is one for each partition being replicated from the source cluster.
-For the checkpoint connector, the maximum number of tasks possible is one for each group being replicated from the source cluster.
-The number of tasks that are started for these connectors is the lower value between the maximum number of possible tasks and the value for `tasksMax`.
+Increasing the number of tasks for the checkpoint connector is useful when you have a large number of consumer groups.
 
-The heartbeat connector always uses a single task.
+.Increasing the number of tasks for the checkpoint connector
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: {KafkaMirrorMaker2ApiVersion}
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mirror-maker2
+spec:
+  # ...
+  mirrors:
+  - sourceCluster: "my-cluster-source"
+    targetCluster: "my-cluster-target"
+    checkpointConnector:
+      tasksMax: 10
+  # ...
+----
+
+== Checking connector task operations
+
+If you are using Prometheus and Grafana to monitor your deployment, you can check MirrorMaker 2.0 performance.
+The example MirrorMaker 2.0 Grafana dashboard provided with Strimzi shows the following metrics related to tasks and latency.
+
+* The number of tasks
+* Replication latency
+* Offset synchronization latency
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:{BookURLDeploying}#assembly-metrics-setup-{context}[Grafana dashboards^]

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 Connectors create the tasks that are responsible for moving data in and out of Kafka.
 Each connector comprises one or more tasks that are distributed across a group of worker pods that run the tasks.
-Increasing the number of tasks can help with performance issues when replicating a large number of partitions or synchronizing the offsets of a large number of consumer groups. 
+Increasing the number of tasks can help with performance issues when replicating a large number of partitions or synchronizing the offsets of a large number of consumer groups.   
 
 Tasks run in parallel.
 Workers are assigned one or more tasks.
@@ -65,6 +65,11 @@ spec:
       tasksMax: 10
   # ...
 ----
+
+By default, MirrorMaker 2.0 checks for new consumer groups every 10 minutes. 
+You can adjust the `refresh.groups.interval.seconds` configuration to change the frequency.
+Take care when adjusting lower.
+More frequent checks can have a negative impact on performance.   
 
 == Checking connector task operations
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -23,6 +23,7 @@ The heartbeat connector always uses a single task.
 The number of tasks that are started for the source and checkpoint connectors is the lower value between the maximum number of possible tasks and the value for `tasksMax`.
 For the source connector, the maximum number of tasks possible is one for each partition being replicated from the source cluster.
 For the checkpoint connector, the maximum number of tasks possible is one for each consumer group being replicated from the source cluster.
+When setting a maximum number of tasks, consider the number of partitions and the hardware resources that support the process.
 
 If the infrastructure supports the processing overhead, increasing the number of tasks can improve throughput and latency.
 For example, adding more tasks reduces the time taken to poll the source cluster when there is a high number of partitions or consumer groups.  


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Updates MM2 section [Specifying a maximum number of tasks](https://strimzi.io/docs/operators/in-development/configuring.html#con-mirrormaker-tasks-max-str) to describe how to add more tasks for checkpoint connector and why you might want to. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

