### PR TITLE
Fix flaky `ServiceAccountOperatorIT` test

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
@@ -18,9 +17,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
@@ -66,15 +62,12 @@ public class ServiceAccountOperatorIT extends AbstractResourceOperatorIT<Kuberne
         ServiceAccount newResource = getOriginal();
         ServiceAccount modResource = getModified();
 
-        List<ObjectReference> secrets = new ArrayList<>();
-
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, newResource)
                 .onComplete(context.succeeding(rrCreated -> {
                     ServiceAccount created = op.get(namespace, resourceName);
 
                     context.verify(() -> assertThat(created, Matchers.is(notNullValue())));
                     assertResources(context, newResource, created);
-                    secrets.addAll(created.getSecrets());
                 }))
                 .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, modResource))
                 .onComplete(context.succeeding(rrModified -> {
@@ -82,7 +75,6 @@ public class ServiceAccountOperatorIT extends AbstractResourceOperatorIT<Kuberne
 
                     context.verify(() -> assertThat(modified, Matchers.is(notNullValue())));
                     assertResources(context, modResource, modified);
-                    context.verify(() -> assertThat(modified.getSecrets(), is(secrets)));
                 }))
                 .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null))
                 .onComplete(context.succeeding(rrDeleted -> {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `ServiceAccountOperatorIT` test seems to be flaky after we added the code for special handling of the `imagePullSecrets` field when patching the Service Account (see #7056). It seems that the additional code breaks the timing between the creation of the SA and Kubernetes assigning the token secrets to it which causes it to fail due to a race condition:

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR] io.strimzi.operator.common.operator.resource.ServiceAccountOperatorIT.testCreateModifyDelete(VertxTestContext)
[ERROR]   Run 1: ServiceAccountOperatorIT.testCreateModifyDelete(VertxTestContext) java.lang.AssertionError: 
Expected: is <[]>
     but: was <[ObjectReference(apiVersion=null, fieldPath=null, kind=null, name=my-test-resource-275219404-token-l6fk8, namespace=null, resourceVersion=null, uid=null, additionalProperties={})]>
[ERROR]   Run 2: ServiceAccountOperatorIT.testCreateModifyDelete(VertxTestContext) java.lang.AssertionError: 
Expected: is <[]>
     but: was <[ObjectReference(apiVersion=null, fieldPath=null, kind=null, name=my-test-resource-512176194-token-svbc9, namespace=null, resourceVersion=null, uid=null, additionalProperties={})]>
[ERROR]   Run 3: ServiceAccountOperatorIT.testCreateModifyDelete(VertxTestContext) java.lang.AssertionError: 
Expected: is <[]>
     but: was <[ObjectReference(apiVersion=null, fieldPath=null, kind=null, name=my-test-resource-211562170-token-2jndc, namespace=null, resourceVersion=null, uid=null, additionalProperties={})]>
[INFO]
```

The problem is, that we cannot simply wait for the secrets to be assigned because on new Kubernetes versions they are not assigned anymore by default. So while that would make the test stable with older versions, it would break it on new versions such as Kube 1.24.

This PR therefore removes the problematic check for the secrets to (hopefully) make the test stable and working on all environments regardless the Kube version. Patching of the secrets is covered in `ServiceAccountOperatorTest#testSecretsPatching` where it is properly tested. So removing this check (which actually in many cases did not test it anyway, depending on the timing) should not cause any problems.

### Checklist

- [x] Make sure all tests pass