### PR TITLE
Fix flaky Kafka Connect IT tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -5,18 +5,19 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import org.apache.kafka.connect.cli.ConnectDistributed;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.Connect;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ConnectCluster {
-
-    private static final int STARTING_PORT = 8083;
-
     private int numNodes;
     private String brokerList;
     private final List<Connect> connectInstances = new ArrayList<>();
@@ -35,7 +36,7 @@ public class ConnectCluster {
     public void startup() throws InterruptedException {
         for (int i = 0; i < numNodes; i++) {
             Map<String, String> workerProps = new HashMap<>();
-            workerProps.put("listeners", "http://localhost:" + getPort(i));
+            workerProps.put("listeners", "http://localhost:" + getFreePort());
             workerProps.put("plugin.path", String.join(",", pluginPath));
             workerProps.put("group.id", toString());
             workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
@@ -49,20 +50,31 @@ public class ConnectCluster {
             workerProps.put("status.storage.topic", getClass().getSimpleName() + "-status");
             workerProps.put("status.storage.replication.factor", "3");
             workerProps.put("bootstrap.servers", brokerList);
-            //DistributedConfig config = new DistributedConfig(workerProps);
-            //RestServer rest = new RestServer(config);
-            //rest.initializeServer();
-            CountDownLatch l = new CountDownLatch(1);
+
+            CountDownLatch l = new CountDownLatch(1); // Indicates that the Kafka Connect cluster startup is finished (successfully or not)
+            AtomicReference<Exception> startupException = new AtomicReference<>(); // Indicates whether any exception was raised during the Kafka Connect node start
+
             Thread thread = new Thread(() -> {
-                ConnectDistributed connectDistributed = new ConnectDistributed();
-                Connect connect = connectDistributed.startConnect(workerProps);
-                l.countDown();
-                connectInstances.add(connect);
-                connect.awaitStop();
+                try {
+                    ConnectDistributed connectDistributed = new ConnectDistributed();
+                    Connect connect = connectDistributed.startConnect(workerProps);
+                    l.countDown();
+                    connectInstances.add(connect);
+                    connect.awaitStop();
+                } catch (ConnectException e)    {
+                    startupException.set(e);
+                    l.countDown();
+                }
             });
+
             thread.setDaemon(false);
             thread.start();
             l.await();
+
+            if (startupException.get() != null) {
+                // If the Kafka Connect node failed to start (i.e. raised an exception during the start), we should throw an exception to fail the tests
+                throw new RuntimeException("Failed to start node " + i + " of the Kafka Connect cluster", startupException.get());
+            }
         }
     }
 
@@ -76,13 +88,26 @@ public class ConnectCluster {
     }
 
     /**
-     * Gets the port used for given Connect node. The nudes start from 0.
+     * Gets the port used for given Connect node. The nodes start from 0.
      *
      * @param node  ID of the node for which we want to get the port number (node numbers start with 0)
      *
-     * @return      Port which can be used to connect to given Connect node
+     * @return      Port which is used by given Connect node
      */
     public int getPort(int node) {
-        return STARTING_PORT + node * 10_000;
+        return connectInstances.get(node).adminUrl().getPort();
+    }
+
+    /**
+     * Finds a free server port which can be used by the Connect REST API
+     *
+     * @return  A free TCP port
+     */
+    private int getFreePort()   {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find free port", e);
+        }
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The IT tests using Kafka Connect seem to be flaky lately. It looks like when shutting down Connect, it takes some time until the port used by its REST API is free again. Because all the tests use the same port numbers, it results in the following errors in the tests:

```
2022-07-15T19:35:40.4354420Z 2022-07-15 19:17:50 INFO  RestServer:117 - Added connector for http://localhost:18083
2022-07-15T19:35:40.4355516Z 2022-07-15 19:17:50 INFO  RestServer:188 - Initializing REST server
2022-07-15T19:35:40.4356919Z 2022-07-15 19:17:50 INFO  Server:375 - jetty-9.4.44.v20210927; built: 2021-09-27T23:02:44.612Z; git: 8da83308eeca865e495e53ef315a249d63ba9332; jvm 11.0.15+10-Ubuntu-0ubuntu0.20.04.1
2022-07-15T19:35:40.4358348Z Exception in thread "Thread-151" org.apache.kafka.connect.errors.ConnectException: Unable to initialize REST server
2022-07-15T19:35:40.4359334Z 	at org.apache.kafka.connect.runtime.rest.RestServer.initializeServer(RestServer.java:200)
2022-07-15T19:35:40.4360466Z 	at org.apache.kafka.connect.cli.ConnectDistributed.startConnect(ConnectDistributed.java:101)
2022-07-15T19:35:40.4361422Z 	at io.strimzi.operator.cluster.operator.assembly.ConnectCluster.lambda$startup$0(ConnectCluster.java:58)
2022-07-15T19:35:40.4362247Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2022-07-15T19:35:40.4362948Z Caused by: java.io.IOException: Failed to bind to localhost/127.0.0.1:18083
2022-07-15T19:35:40.4363754Z 	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:349)
2022-07-15T19:35:40.4364603Z 	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:310)
2022-07-15T19:35:40.4365466Z 	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
2022-07-15T19:35:40.4366339Z 	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
2022-07-15T19:35:40.4367193Z 	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
2022-07-15T19:35:40.4368001Z 	at org.eclipse.jetty.server.Server.doStart(Server.java:401)
2022-07-15T19:35:40.4368795Z 	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
2022-07-15T19:35:40.4369671Z 	at org.apache.kafka.connect.runtime.rest.RestServer.initializeServer(RestServer.java:198)
2022-07-15T19:35:40.4370333Z 	... 3 more
2022-07-15T19:35:40.4370880Z Caused by: java.net.BindException: Address already in use
2022-07-15T19:35:40.4371568Z 	at java.base/sun.nio.ch.Net.bind0(Native Method)
2022-07-15T19:35:40.4372214Z 	at java.base/sun.nio.ch.Net.bind(Net.java:459)
2022-07-15T19:35:40.4373054Z 	at java.base/sun.nio.ch.Net.bind(Net.java:448)
2022-07-15T19:35:40.4374083Z 	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
2022-07-15T19:35:40.4374928Z 	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:80)
2022-07-15T19:35:40.4375922Z 	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:344)
2022-07-15T19:35:40.4376593Z 	... 10 more
```

This did not happen in the past while some of the Connect IT tests were marked as unit tests and there was probably longer time between the tests being executed. 

This PR updates the `ConnectCluster` wrapper which we use to start Kafka Connect to not use the same port numbers everytime it is used. That should get this unblocked, since even when the port release takes some time, other port number is used by the next test and does not conflict.

It also improves the error handling. The current behaviour was that when the port was in used, the Connect startup failed. But it was not noticed by the `ConnectCluster` wrapper and as a result the test was _stuck_ untill it timed out on Azure. This PR catches the exception (while the _port in use_ exception should not happen anymore, some other exception might) and fails the test instead.

### Checklist

- [x] Make sure all tests pass