### PR TITLE
[docs] Fix minor typo in restart events doc

### DIFF
--- a/documentation/modules/deploying/proc-operator-restart-events.adoc
+++ b/documentation/modules/deploying/proc-operator-restart-events.adoc
@@ -51,7 +51,7 @@ kubectl -n kafka get events --field-selector source=strimzi.io/cluster-operator,
 kubectl -n kafka get events --field-selector source=strimzi.io/cluster-operator,reason=PodForceRestartOnError -o yaml
 ----
 +
-.Example showng detailed events output
+.Example showing detailed events output
 [source,yaml]
 ----
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Fix of typo

### Description

This PR fixes minor typo inside the `documentation/modules/deploying/proc-operator-restart-events.adoc`

### Checklist

- [x] Update documentation

