### PR TITLE
Fix warnings in different unit tests based on MockKube

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -112,6 +112,7 @@ public class ConnectorMockTest {
 
     private Vertx vertx;
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
     private Watch connectWatch;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -65,6 +65,7 @@ public class JbodStorageMockTest {
     private static Vertx vertx;
     private Kafka kafka;
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
     private KafkaAssemblyOperator operator;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -86,6 +86,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
     private KafkaAssemblyOperator operator;
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -109,6 +109,7 @@ public class KafkaAssemblyOperatorMockTest {
     private ResourceRequirements resources;
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -72,6 +72,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
     private final int replicas = 3;
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -60,6 +60,7 @@ public class KafkaConnectorIT {
     private static Vertx vertx;
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
     private ConnectCluster connectCluster;
@@ -85,7 +86,7 @@ public class KafkaConnectorIT {
     }
 
     @BeforeEach
-    public void beforeEach() throws IOException, InterruptedException {
+    public void beforeEach() throws InterruptedException {
         // Configure the Kubernetes Mock
         mockKube = new MockKube2.MockKube2Builder(client)
                 .withKafkaConnectorCrd()
@@ -128,7 +129,7 @@ public class KafkaConnectorIT {
         config.put(TestingConnector.TOPIC_NAME, "my-topic");
 
         KafkaConnector connector = createKafkaConnector(namespace, connectorName, config);
-        Crds.kafkaConnectorOperation(client).inNamespace(namespace).create(connector);
+        Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
 
         MetricsProvider metrics = new MicrometerMetricsProvider();
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
@@ -157,8 +158,8 @@ public class KafkaConnectorIT {
                 config.put(TestingConnector.START_TIME_MS, 1_000);
                 Crds.kafkaConnectorOperation(client)
                         .inNamespace(namespace)
-                        .withName(connectorName)
-                        .patch(createKafkaConnector(namespace, connectorName, config));
+                        .resource(createKafkaConnector(namespace, connectorName, config))
+                        .patch();
                 return operator.reconcileConnectorAndHandleResult(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
                         "localhost", connectClient, true, connectorName, connector);
             })
@@ -191,6 +192,7 @@ public class KafkaConnectorIT {
                     .build();
     }
 
+    @SuppressWarnings({ "rawtypes" })
     private void assertConnectorIsRunning(VertxTestContext context, KubernetesClient client, String namespace, String connectorName) {
         context.verify(() -> {
             KafkaConnector kafkaConnector = Crds.kafkaConnectorOperation(client).inNamespace(namespace).withName(connectorName).get();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -72,6 +72,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
     private final int replicas = 3;
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -98,6 +98,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private static ClientAndServer ccServer;
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 
@@ -435,7 +436,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     // after a while, apply the "stop" annotation to the resource in the PendingProposal state
                     annotate(client, CLUSTER_NAMESPACE, kr.getMetadata().getName(), KafkaRebalanceAnnotation.stop);
                 }
-                return;
             }
         });
 
@@ -1098,7 +1098,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
                             .withName(kr.getMetadata().getName())
                             .delete();
                 }
-                return;
             }
         });
 
@@ -1182,7 +1181,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     // after a while, apply the "stop" annotation to the resource in the Rebalancing state
                     annotate(client, CLUSTER_NAMESPACE, kr.getMetadata().getName(), KafkaRebalanceAnnotation.stop);
                 }
-                return;
             }
         });
 
@@ -1549,7 +1547,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
      * 4. The KafkaRebalance resource moves to the 'NotReady' state
      */
     @Test
-    public void testIntraBrokerDiskBalanceWithoutJbodConfig(VertxTestContext context) throws IOException, URISyntaxException {
+    public void testIntraBrokerDiskBalanceWithoutJbodConfig(VertxTestContext context) {
         KafkaRebalanceSpec kafkaRebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withRebalanceDisk(true)
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -42,9 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -60,10 +58,10 @@ public class PartialRollingUpdateMockTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
 
     private static Vertx vertx;
-    private Kafka cluster;
     private KafkaAssemblyOperator kco;
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 
@@ -78,8 +76,8 @@ public class PartialRollingUpdateMockTest {
     }
 
     @BeforeEach
-    public void beforeEach(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        this.cluster = new KafkaBuilder()
+    public void beforeEach(VertxTestContext context) throws InterruptedException {
+        Kafka cluster = new KafkaBuilder()
                 .withMetadata(new ObjectMetaBuilder().withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
                 .build())

--- a/mockkube/src/test/java/io/strimzi/test/mockkube2/MockKube2ControllersTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/mockkube2/MockKube2ControllersTest.java
@@ -40,6 +40,7 @@ public class MockKube2ControllersTest {
     private final static String NAMESPACE = "my-namespace";
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorMockTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorMockTest.java
@@ -31,8 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class PodOperatorMockTest {
     public static final String RESOURCE_NAME = "my-resource";
     public static final String NAMESPACE = "test";
-    protected static Vertx vertx;
-    private static Pod pod = new PodBuilder()
+    private final static Pod POD = new PodBuilder()
             .withNewMetadata()
                 .withNamespace(NAMESPACE)
                 .withName(RESOURCE_NAME)
@@ -42,7 +41,10 @@ public class PodOperatorMockTest {
             .endSpec()
             .build();
 
+    protected static Vertx vertx;
+
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
 
     @BeforeAll
@@ -64,7 +66,7 @@ public class PodOperatorMockTest {
         context.verify(() -> assertThat(pr.list(NAMESPACE, Labels.EMPTY), is(emptyList())));
 
         Checkpoint async = context.checkpoint(1);
-        pr.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, pod).onComplete(createResult -> {
+        pr.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, POD).onComplete(createResult -> {
             context.verify(() -> assertThat(createResult.succeeded(), is(true)));
             context.verify(() -> assertThat(pr.list(NAMESPACE, Labels.EMPTY).stream()
                         .map(p -> p.getMetadata().getName())

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockIT.java
@@ -55,6 +55,7 @@ public class TopicOperatorMockIT {
     private static final String NAMESPACE = "my-namespace";
 
     // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
     private Session session;
@@ -175,12 +176,12 @@ public class TopicOperatorMockIT {
     }
 
     private void createInKube(KafkaTopic topic) {
-        Crds.topicOperation(client).create(topic);
+        Crds.topicOperation(client).resource(topic).create();
     }
 
     private void updateInKube(KafkaTopic topic) {
         LOGGER.info("Updating topic {} in kube", topic.getMetadata().getName());
-        Crds.topicOperation(client).withName(topic.getMetadata().getName()).patch(topic);
+        Crds.topicOperation(client).resource(topic).replace();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes various IDE warnings in different unit tests which use the MockKube.

### Checklist

- [x] Make sure all tests pass