### PR TITLE
Bump CC version to pick up Jetty and Netty CVE fixes

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.95</cruise-control.version>
+        <cruise-control.version>2.5.97</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.95</cruise-control.version>
+        <cruise-control.version>2.5.97</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.95</cruise-control.version>
+        <cruise-control.version>2.5.97</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Cruise control 2.5.97 upgrades Jetty and Netty
dependencies to mitigate CVEs
Netty: [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823)
Jetty: [CVE-2022-2047](https://nvd.nist.gov/vuln/detail/CVE-2022-2047)
and [CVE-2022-2048](https://nvd.nist.gov/vuln/detail/CVE-2022-2048)

Signed-off-by: Andrew Borley <borley@uk.ibm.com>
