### PR TITLE
Fix race condition in the Kafka Connect IT tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -58,8 +58,8 @@ public class ConnectCluster {
                 try {
                     ConnectDistributed connectDistributed = new ConnectDistributed();
                     Connect connect = connectDistributed.startConnect(workerProps);
-                    l.countDown();
                     connectInstances.add(connect);
+                    l.countDown();
                     connect.awaitStop();
                 } catch (ConnectException e)    {
                     startupException.set(e);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The code from #7092 seems to have a race condition which is sometimes triggered and causes Index out of bounds exception. It is caused by the Connect instance being added to the list only after the latch countdown is called. That means that in some situation, the startup method is already complete before the Connect instance is added to the list and when the test tries to get the port of the REST API, it triggers the IndexOutOfBounds exception.

This PR moves the calls to make sure the Connect instance is added to the list before calling the latch countdown. That should ensure this does not happen anymore.

### Checklist

- [x] Make sure all tests pass