### PR TITLE
Disable incremental compilation to avoid problems when the `api` module is being rebuilt

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -123,6 +123,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <useIncrementalCompilation>false</useIncrementalCompilation>
                             <compilerArgs combine.self="override">
                                 <arg>-Xlint:unchecked,deprecation</arg>
                             </compilerArgs>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Since we `package-info.java` files to the `api` module in #7089, it looks like the `api` module cannot be _rebuilt_ once it was already built before. You need to clean the project and do a fresh clean. This seem to be related to the `package-info.java` files breaking the incremental compilation. This PR disables the incremental compilation for the `api` module to make the rebuilds work.