### PR TITLE
Updated canary Deployment to latest 0.5.0 release

### DIFF
--- a/.checksums
+++ b/.checksums
@@ -14,7 +14,7 @@ HELM_CHART_CHECKSUM="9a6351be5b558b954fc53ff5b0d814fe047ff979  -"
 # if this checksum has changed as part of any non-release specific changes, please apply your changes to the
 #   development version of the helm charts in ./packaging/install
 ### IMPORTANT ###
-INSTALL_CHECKSUM="a4e46a972a500f09e2ec4376c5c32398b55287ca  -"
+INSTALL_CHECKSUM="fbcc600c86aea736a02a4f4fcfe2bdf5d576b910  -"
 
 ### IMPORTANT ###
 # if the below line has changed, this means the ./examples directory has changed

--- a/install/canary/020-Deployment.yaml
+++ b/install/canary/020-Deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-canary
       containers:
       - name: strimzi-canary
-        image: quay.io/strimzi/canary:0.4.0
+        image: quay.io/strimzi/canary:0.5.0
         env:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092

--- a/packaging/install/canary/020-Deployment.yaml
+++ b/packaging/install/canary/020-Deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-canary
       containers:
       - name: strimzi-canary
-        image: quay.io/strimzi/canary:0.4.0
+        image: quay.io/strimzi/canary:0.5.0
         env:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092


### PR DESCRIPTION
Trivial PR just for updating the canary Deployment to use the latest 0.5.0 release.