### PR TITLE
Fix various issues in the standalone UO and TO installation files

### DIFF
--- a/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -15,11 +15,19 @@ spec:
         name: strimzi-topic-operator
     spec:
       serviceAccountName: strimzi-topic-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 5Mi
       containers:
         - name: strimzi-topic-operator
           image: quay.io/strimzi/operator:latest
           args:
-          - /opt/strimzi/bin/topic_operator_run.sh
+            - /opt/strimzi/bin/topic_operator_run.sh
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
           env:
             - name: STRIMZI_RESOURCE_LABELS
               value: "strimzi.io/cluster=my-cluster"
@@ -55,10 +63,10 @@ spec:
             periodSeconds: 30
           resources:
             limits:
-              memory: 96Mi
-              cpu: 100m
+              memory: 256Mi
+              cpu: 500m
             requests:
-              memory: 96Mi
+              memory: 256Mi
               cpu: 100m
   strategy:
     type: Recreate

--- a/packaging/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/packaging/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -15,22 +15,34 @@ spec:
         name: strimzi-user-operator
     spec:
       serviceAccountName: strimzi-user-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 5Mi
       containers:
         - name: strimzi-user-operator
           image: quay.io/strimzi/operator:latest
           args:
-          - /opt/strimzi/bin/user_operator_run.sh
+            - /opt/strimzi/bin/user_operator_run.sh
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
           env:
             - name: STRIMZI_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_LABELS
               value: "strimzi.io/cluster=my-cluster"
             - name: STRIMZI_CA_CERT_NAME
               value: my-cluster-clients-ca-cert
             - name: STRIMZI_CA_KEY_NAME
               value: my-cluster-clients-ca
+            - name: STRIMZI_ACLS_ADMIN_API_SUPPORTED
+              value: "true"
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
             - name: STRIMZI_LOG_LEVEL


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The installation files for the standalone Topic and User Operator currently don't work properly. There are several issues with them:
* They are missing the volumes for the `/tmp` directories
* The TO does not have enough resources to start and immediately crashes with not enough heap space
* The UO is missing the bootstrap server configuration which is always needed

This PR improves the installation files to fix these issues.

This should close #7143 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging