### PR TITLE
Ignore errors when trying to clean the `/tmp` directory

### DIFF
--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -2,7 +2,8 @@
 set -e
 
 # Clean-up /tmp directory from files which might have remained from previous container restart
-rm -rfv /tmp/*
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/* || true
 
 export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.operator.cluster.Main

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -2,7 +2,8 @@
 set -e
 
 # Clean-up /tmp directory from files which might have remained from previous container restart
-rm -rfv /tmp/*
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/* || true
 
 if [ -f /opt/topic-operator/custom-config/log4j2.properties ];
 then

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -2,7 +2,8 @@
 set -e
 
 # Clean-up /tmp directory from files which might have remained from previous container restart
-rm -rfv /tmp/*
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/* || true
 
 if [ -f /opt/user-operator/custom-config/log4j2.properties ];
 then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #6966 we added a cleanup of the `/tmp` directory when the container restarts. However, it turns out that in some casis various weird tools inject their own files into the `/tmp` dir often with various permissions which do not allow us to delete the files. One such example is discussed in https://cloud-native.slack.com/archives/CMH3Q3SNP/p1659351813745469

While we in general do not support this kind of tools, we should make the container scripts more resilient against this. The `/tmp` clean-up is done as a prevention of the disk getting full. Skipping deletion of these files might not mean we run out of disk space. Trying to delete them and failing the operator startup causes failure every time. So this Pr changes the code to ignore the result of the deletion commend and does the deletion only as a _best-effort_. That way, the files injected with wrong permissions will be simply ignored and will not cause the operators to loop.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally