### PR TITLE
[systemtest] Update upgrade/downgrade tests with Kafka 3.2.1

### DIFF
--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
@@ -32,8 +32,8 @@
     toConversionTool: api-conversion-0.22.0
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.0
-    kafka: strimzi/kafka:latest-kafka-3.2.0
+    zookeeper: strimzi/kafka:latest-kafka-3.2.1
+    kafka: strimzi/kafka:latest-kafka-3.2.1
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:
@@ -51,8 +51,8 @@
   urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.0
-    kafka: strimzi/kafka:latest-kafka-3.2.0
+    zookeeper: strimzi/kafka:latest-kafka-3.2.1
+    kafka: strimzi/kafka:latest-kafka-3.2.1
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:
@@ -70,8 +70,8 @@
   urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.0
-    kafka: strimzi/kafka:latest-kafka-3.2.0
+    zookeeper: strimzi/kafka:latest-kafka-3.2.1
+    kafka: strimzi/kafka:latest-kafka-3.2.1
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR updates version of Kafka in `imagesAfterOperations` section inside the `StrimziUpgradeST.yaml` and `deployKafkaVersion` in `StrimziDowngradeST.yaml` to version `3.2.1` after it was added in #7131 

### Checklist

- [x] Make sure all tests pass
