### PR TITLE
Add Drain Cleaner 0.3.1 release to the installation files and docs

### DIFF
--- a/.checksums
+++ b/.checksums
@@ -14,7 +14,7 @@ HELM_CHART_CHECKSUM="9a6351be5b558b954fc53ff5b0d814fe047ff979  -"
 # if this checksum has changed as part of any non-release specific changes, please apply your changes to the
 #   development version of the helm charts in ./packaging/install
 ### IMPORTANT ###
-INSTALL_CHECKSUM="fbcc600c86aea736a02a4f4fcfe2bdf5d576b910  -"
+INSTALL_CHECKSUM="95e8c384f6c9a2ed439e9af2713b44ecf961d85d  -"
 
 ### IMPORTANT ###
 # if the below line has changed, this means the ./examples directory has changed

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -115,7 +115,7 @@
 :DockerOrg: quay.io/strimzi
 :DockerTag: {ProductVersion}
 :BridgeDockerTag: {BridgeVersion}
-:DrainCleanerDockerTag: 0.3.0
+:DrainCleanerDockerTag: 0.3.1
 :DockerRepository: https://quay.io/organization/strimzi[Container Registry^]
 :DockerZookeeper: quay.io/strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaImageCurrent: quay.io/strimzi/kafka:{DockerTag}-kafka-{KafkaVersionHigher}

--- a/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.3.0
+          image: quay.io/strimzi/drain-cleaner:0.3.1
           ports:
             - containerPort: 8080
               name: http

--- a/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.3.0
+          image: quay.io/strimzi/drain-cleaner:0.3.1
           ports:
             - containerPort: 8080
               name: http

--- a/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.3.0
+          image: quay.io/strimzi/drain-cleaner:0.3.1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.3.0
+          image: quay.io/strimzi/drain-cleaner:0.3.1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.3.0
+          image: quay.io/strimzi/drain-cleaner:0.3.1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.3.0
+          image: quay.io/strimzi/drain-cleaner:0.3.1
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the new 0.3.1 release of Strimzi Drain Cleaner to the installation files and updates the version in docs.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally