### PR TITLE
Add user-agent to Kubernetes Client (#7163)

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -19,6 +18,7 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOpe
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
@@ -59,7 +59,8 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        LOGGER.info("ClusterOperator {} is starting", Main.class.getPackage().getImplementationVersion());
+        final String strimziVersion = Main.class.getPackage().getImplementationVersion();
+        LOGGER.info("ClusterOperator {} is starting", strimziVersion);
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(System.getenv());
         LOGGER.info("Cluster Operator configuration is {}", config);
 
@@ -78,7 +79,7 @@ public class Main {
         // Vertx registers a shutdown hook for that, but only if you use its Launcher as main class
         Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx)));
         
-        KubernetesClient client = new KubernetesClientBuilder().build();
+        KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-cluster-operator", strimziVersion).build();
 
         maybeCreateClusterRoles(vertx, config, client).onComplete(crs -> {
             if (crs.succeeded())    {

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.kafka.init;
 
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.Version;
+import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,10 +20,7 @@ public class Main {
         LOGGER.info("Init-kafka {} is starting", strimziVersion);
         InitWriterConfig config = InitWriterConfig.fromMap(System.getenv());
 
-        final String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion() 
-                                + " strimzi-init-kafka/" + strimziVersion;
-        final Config kubernetesClientConfig = new ConfigBuilder().withUserAgent(userAgent).build();
-        KubernetesClient client = new KubernetesClientBuilder().withConfig(kubernetesClientConfig).build();
+        final KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-kafka-init", strimziVersion).build();
 
         LOGGER.info("Init-kafka started with config: {}", config);
 

--- a/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
+++ b/kafka-init/src/main/java/io/strimzi/kafka/init/Main.java
@@ -4,8 +4,11 @@
  */
 package io.strimzi.kafka.init;
 
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.Version;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,10 +18,14 @@ public class Main {
 
     public static void main(String[] args) {
 
-        LOGGER.info("Init-kafka {} is starting", Main.class.getPackage().getImplementationVersion());
+        final String strimziVersion = Main.class.getPackage().getImplementationVersion();
+        LOGGER.info("Init-kafka {} is starting", strimziVersion);
         InitWriterConfig config = InitWriterConfig.fromMap(System.getenv());
 
-        KubernetesClient client = new KubernetesClientBuilder().build();
+        final String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion() 
+                                + " strimzi-init-kafka/" + strimziVersion;
+        final Config kubernetesClientConfig = new ConfigBuilder().withUserAgent(userAgent).build();
+        KubernetesClient client = new KubernetesClientBuilder().withConfig(kubernetesClientConfig).build();
 
         LOGGER.info("Init-kafka started with config: {}", config);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/OperatorKubernetesClientBuilder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/OperatorKubernetesClientBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+
+/**
+ * Class for generating Kubernetes Clients for Operators.
+ */
+public class OperatorKubernetesClientBuilder {
+
+    private final String componentName;
+    private final String version;
+
+
+    /**
+     * Constructor to create the OperatorKubernetesClientBuilder with the name of the component and its version.
+     *
+     * @param componentName  The name of the component using the client.
+     * @param version        The version of the component using the client.
+     */
+    public OperatorKubernetesClientBuilder(final String componentName, final String version) {
+        this.componentName = componentName;
+        this.version = version;
+    }
+
+    /**
+     * Builds the KubernetesClient.
+     *
+     * @return String with new password
+     */
+    public KubernetesClient build() {
+        final String userAgent = String.format("%s/%s", componentName, version);
+        final Config kubernetesClientConfig = new ConfigBuilder().withUserAgent(userAgent).build();
+        return new KubernetesClientBuilder().withConfig(kubernetesClientConfig).build();
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/OperatorKubernetesClientBuilder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/OperatorKubernetesClientBuilder.java
@@ -32,7 +32,7 @@ public class OperatorKubernetesClientBuilder {
     /**
      * Builds the KubernetesClient.
      *
-     * @return String with new password
+     * @return the Kubernetes Client
      */
     public KubernetesClient build() {
         final String userAgent = String.format("%s/%s", componentName, version);

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorKubernetesClientBuilderTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorKubernetesClientBuilderTest.java
@@ -14,7 +14,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 public class OperatorKubernetesClientBuilderTest {
     
     @Test
-    void testBuild(){
+    void testBuild() {
         OperatorKubernetesClientBuilder builder = new OperatorKubernetesClientBuilder("test-component", "1.0");
         KubernetesClient client = builder.build();
         assertNotNull(client, "A KubernetesClient should be returned");

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorKubernetesClientBuilderTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorKubernetesClientBuilderTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+public class OperatorKubernetesClientBuilderTest {
+    
+    @Test
+    void testBuild(){
+        OperatorKubernetesClientBuilder builder = new OperatorKubernetesClientBuilder("test-component", "1.0");
+        KubernetesClient client = builder.build();
+        assertNotNull(client, "A KubernetesClient should be returned");
+        final String userAgent = client.getConfiguration().getUserAgent();
+        assertEquals("test-component/1.0", userAgent, "The user agent should be set to the component name and version");
+    }
+}

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
@@ -32,8 +32,8 @@
     toConversionTool: api-conversion-0.22.0
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.0
-    kafka: strimzi/kafka:latest-kafka-3.2.0
+    zookeeper: strimzi/kafka:latest-kafka-3.2.1
+    kafka: strimzi/kafka:latest-kafka-3.2.1
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:
@@ -51,8 +51,8 @@
   urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.0
-    kafka: strimzi/kafka:latest-kafka-3.2.0
+    zookeeper: strimzi/kafka:latest-kafka-3.2.1
+    kafka: strimzi/kafka:latest-kafka-3.2.1
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:
@@ -70,8 +70,8 @@
   urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.0
-    kafka: strimzi/kafka:latest-kafka-3.2.0
+    zookeeper: strimzi/kafka:latest-kafka-3.2.1
+    kafka: strimzi/kafka:latest-kafka-3.2.1
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
@@ -4,8 +4,10 @@
  */
 package io.strimzi.operator.topic;
 
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.Version;
 import io.strimzi.api.kafka.Crds;
 import io.vertx.core.Vertx;
 
@@ -40,7 +42,11 @@ public class Main {
     }
 
     private void deploy(Config config) {
-        KubernetesClient kubeClient = new KubernetesClientBuilder().build();
+        final String strimziVersion = Main.class.getPackage().getImplementationVersion();
+        final String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion() 
+        + " strimzi-operator-topic/" + strimziVersion;
+        final io.fabric8.kubernetes.client.Config kubernetesClientConfig = new ConfigBuilder().withUserAgent(userAgent).build();
+        KubernetesClient kubeClient = new KubernetesClientBuilder().withConfig(kubernetesClientConfig).build();
         Crds.registerCustomKinds();
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Main.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.operator.topic;
 
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.Version;
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.vertx.core.Vertx;
 
 import java.util.HashMap;
@@ -43,10 +41,7 @@ public class Main {
 
     private void deploy(Config config) {
         final String strimziVersion = Main.class.getPackage().getImplementationVersion();
-        final String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion() 
-        + " strimzi-operator-topic/" + strimziVersion;
-        final io.fabric8.kubernetes.client.Config kubernetesClientConfig = new ConfigBuilder().withUserAgent(userAgent).build();
-        KubernetesClient kubeClient = new KubernetesClientBuilder().withConfig(kubernetesClientConfig).build();
+        KubernetesClient kubeClient = new OperatorKubernetesClientBuilder("strimzi-topic-operator", strimziVersion).build();
         Crds.registerCustomKinds();
         VertxOptions options = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -6,17 +6,14 @@ package io.strimzi.operator.user;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.Version;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaUserList;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
+import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
@@ -62,10 +59,7 @@ public class Main {
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
 
-        final String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion() 
-            + " strimzi-operator-user/" + strimziVersion;
-        final Config kubernetesClientConfig = new ConfigBuilder().withUserAgent(userAgent).build();
-        KubernetesClient client = new KubernetesClientBuilder().withConfig(kubernetesClientConfig).build();
+        KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-user-operator", strimziVersion).build();
         AdminClientProvider adminClientProvider = new DefaultAdminClientProvider();
 
         run(vertx, client, adminClientProvider, config).onComplete(ar -> {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Set User-Agent in Kubernetes Clients to identify itself with the following information:

- That we are using the Fabric8 client.
- The version of the Fabric8 client that we are using.
- The name of the Strimzi component.
- The version of the Strimzi component.

Fixes #7163 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

