### PR TITLE
Start the health and metrics webserver only once per operator pod

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -126,7 +126,6 @@ public class ClusterOperator extends AbstractVerticle {
                         }
                     });
 
-                    //start.complete();
                     return Future.succeededFuture((Void) null);
                 })
                 .onComplete(start);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -10,19 +10,20 @@ import io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaBridgeAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator;
+import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AbstractOperator;
-import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.http.HttpServer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,9 +32,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * An "operator" for managing assemblies of various types <em>in a particular namespace</em>.
@@ -46,8 +44,6 @@ public class ClusterOperator extends AbstractVerticle {
 
     private static final String NAME_SUFFIX = "-cluster-operator";
     private static final String CERTS_SUFFIX = NAME_SUFFIX + "-certs";
-
-    private static final int HEALTH_SERVER_PORT = 8080;
 
     private final KubernetesClient client;
     private final String namespace;
@@ -129,7 +125,9 @@ public class ClusterOperator extends AbstractVerticle {
                             reconcileAll("timer");
                         }
                     });
-                    return startHealthServer().map((Void) null);
+
+                    //start.complete();
+                    return Future.succeededFuture((Void) null);
                 })
                 .onComplete(start);
     }
@@ -167,35 +165,6 @@ public class ClusterOperator extends AbstractVerticle {
             kafkaBridgeAssemblyOperator.reconcileAll(trigger, namespace, ignore);
             kafkaRebalanceAssemblyOperator.reconcileAll(trigger, namespace, ignore);
         }
-    }
-
-    /**
-     * Start an HTTP health server
-     */
-    private Future<HttpServer> startHealthServer() {
-        Promise<HttpServer> result = Promise.promise();
-        this.vertx.createHttpServer()
-                .requestHandler(request -> {
-
-                    if (request.path().equals("/healthy")) {
-                        request.response().setStatusCode(200).end();
-                    } else if (request.path().equals("/ready")) {
-                        request.response().setStatusCode(200).end();
-                    } else if (request.path().equals("/metrics")) {
-                        PrometheusMeterRegistry metrics = (PrometheusMeterRegistry) resourceOperatorSupplier.metricsProvider.meterRegistry();
-                        request.response().setStatusCode(200)
-                                .end(metrics.scrape());
-                    }
-                })
-                .listen(HEALTH_SERVER_PORT, ar -> {
-                    if (ar.succeeded()) {
-                        LOGGER.info("ClusterOperator is now ready (health server listening on {})", HEALTH_SERVER_PORT);
-                    } else {
-                        LOGGER.error("Unable to bind health server on {}", HEALTH_SERVER_PORT, ar.cause());
-                    }
-                    result.handle(ar);
-                });
-        return result.future();
     }
 
     public static String secretName(String cluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -19,6 +20,8 @@ import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMakerAssemblyOpe
 import io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator;
 import io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
@@ -41,14 +44,21 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServer;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * The main class used to start the Strimzi Cluster Operator
+ */
 @SuppressFBWarnings("DM_EXIT")
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 public class Main {
     private static final Logger LOGGER = LogManager.getLogger(Main.class.getName());
+
+    private static final int HEALTH_SERVER_PORT = 8080;
 
     static {
         try {
@@ -60,6 +70,7 @@ public class Main {
 
     public static void main(String[] args) {
         LOGGER.info("ClusterOperator {} is starting", Main.class.getPackage().getImplementationVersion());
+        Util.printEnvInfo(); // Prints configured environment variables
         ClusterOperatorConfig config = ClusterOperatorConfig.fromMap(System.getenv());
         LOGGER.info("Cluster Operator configuration is {}", config);
 
@@ -77,39 +88,66 @@ public class Main {
         // Verticle.stop() methods are not executed if you don't call Vertx.close()
         // Vertx registers a shutdown hook for that, but only if you use its Launcher as main class
         Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx)));
-        
+
+        // Setup Micrometer Metrics provider
+        MetricsProvider metricsProvider = new MicrometerMetricsProvider();
+
         KubernetesClient client = new KubernetesClientBuilder().build();
 
-        maybeCreateClusterRoles(vertx, config, client).onComplete(crs -> {
-            if (crs.succeeded())    {
-                PlatformFeaturesAvailability.create(vertx, client).onComplete(pfa -> {
-                    if (pfa.succeeded()) {
-                        LOGGER.info("Environment facts gathered: {}", pfa.result());
-
-                        run(vertx, client, pfa.result(), config).onComplete(ar -> {
-                            if (ar.failed()) {
-                                LOGGER.error("Unable to start operator for 1 or more namespace", ar.cause());
-                                System.exit(1);
-                            }
-                        });
-                    } else {
-                        LOGGER.error("Failed to gather environment facts", pfa.cause());
+        maybeCreateClusterRoles(vertx, config, client)
+                .compose(i -> startHealthServer(vertx, metricsProvider))
+                .compose(i -> createPlatformFeaturesAvailability(vertx, client))
+                .compose(pfa -> deployClusterOperatorVerticles(vertx, client, metricsProvider, pfa, config))
+                .onComplete(res -> {
+                    if (res.failed())   {
+                        LOGGER.error("Unable to start operator for 1 or more namespace", res.cause());
                         System.exit(1);
                     }
                 });
-            } else  {
-                LOGGER.error("Failed to create Cluster Roles", crs.cause());
-                System.exit(1);
-            }
-        });
     }
 
-    static CompositeFuture run(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config) {
-        Util.printEnvInfo();
+    /**
+     * Helper method used to get the PlatformFeaturesAvailability instance with the information about the Kubernetes
+     * cluster we run on.
+     *
+     * @param vertx     Vertx instance
+     * @param client    Kubernetes client instance
+     *
+     * @return  Future with the created PlatformFeaturesAvailability object
+     */
+    private static Future<PlatformFeaturesAvailability> createPlatformFeaturesAvailability(Vertx vertx, KubernetesClient client)    {
+        Promise<PlatformFeaturesAvailability> promise = Promise.promise();
 
+        PlatformFeaturesAvailability.create(vertx, client).onComplete(pfa -> {
+            if (pfa.succeeded()) {
+                LOGGER.info("Environment facts gathered: {}", pfa.result());
+                promise.complete(pfa.result());
+            } else {
+                LOGGER.error("Failed to gather environment facts", pfa.cause());
+                promise.fail(pfa.cause());
+            }
+        });
+
+        return promise.future();
+    }
+
+    /**
+     * Deploys the ClusterOperator verticles responsible for the actual Cluster Operator functionality. One verticle is
+     * started for each namespace the operator watched. In case of watching the whole cluster, only one verticle is started.
+     *
+     * @param vertx             Vertx instance
+     * @param client            Kubernetes client instance
+     * @param metricsProvider   Metrics provider instance
+     * @param pfa               PlatformFeaturesAvailability instance describing the Kubernetes cluster
+     * @param config            Cluster Operator configuration
+     *
+     * @return  Future which completes when all Cluster Operator verticles are started and running
+     */
+    static CompositeFuture deployClusterOperatorVerticles(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config) {
         ResourceOperatorSupplier resourceOperatorSupplier = new ResourceOperatorSupplier(
                 vertx,
                 client,
+                metricsProvider,
                 pfa,
                 config.getOperationTimeoutMs(),
                 config.getOperatorName()
@@ -175,6 +213,16 @@ public class Main {
         return CompositeFuture.join(futures);
     }
 
+    /**
+     * If enabled in the configuration, it creates the cluster roles used by the operator
+     *
+     * @param vertx             Vertx instance
+     * @param config            Cluster Operator configuration
+     * @param client            Kubernetes client instance
+     *
+     * @return  Future which completes when the Cluster Roles are created
+     *                  (or - if their creation is not enabled - it just completes without doing anything).
+     */
     /*test*/ static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
         if (config.isCreateClusterRoles()) {
             @SuppressWarnings({ "rawtypes" })
@@ -219,5 +267,40 @@ public class Main {
         } else {
             return Future.succeededFuture();
         }
+    }
+
+    /**
+     * Start an HTTP health and metrics server
+     *
+     * @param vertx             Vertx instance
+     * @param metricsProvider   Metrics Provider to get the metrics from
+     *
+     * @return Future which completes when the health and metrics webserver is started
+     */
+    private static Future<HttpServer> startHealthServer(Vertx vertx, MetricsProvider metricsProvider) {
+        Promise<HttpServer> result = Promise.promise();
+
+        vertx.createHttpServer()
+                .requestHandler(request -> {
+                    if (request.path().equals("/healthy")) {
+                        request.response().setStatusCode(200).end();
+                    } else if (request.path().equals("/ready")) {
+                        request.response().setStatusCode(200).end();
+                    } else if (request.path().equals("/metrics")) {
+                        PrometheusMeterRegistry metrics = (PrometheusMeterRegistry) metricsProvider.meterRegistry();
+                        request.response().setStatusCode(200)
+                                .end(metrics.scrape());
+                    }
+                })
+                .listen(HEALTH_SERVER_PORT, ar -> {
+                    if (ar.succeeded()) {
+                        LOGGER.info("Health and metrics server is ready on port {})", HEALTH_SERVER_PORT);
+                    } else {
+                        LOGGER.error("Failed to start health and metrics webserver on port {}", HEALTH_SERVER_PORT, ar.cause());
+                    }
+                    result.handle(ar);
+                });
+
+        return result.future();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -25,7 +25,6 @@ import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.MetricsProvider;
-import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.operator.resource.BuildConfigOperator;
 import io.strimzi.operator.common.operator.resource.BuildOperator;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
@@ -90,7 +89,7 @@ public class ResourceOperatorSupplier {
     public final ZookeeperLeaderFinder zookeeperLeaderFinder;
     public final KubernetesRestartEventPublisher restartEventsPublisher;
 
-    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, PlatformFeaturesAvailability pfa, long operationTimeoutMs, String operatorName) {
+    public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, long operationTimeoutMs, String operatorName) {
         this(vertx,
                 client,
                 new ZookeeperLeaderFinder(vertx,
@@ -98,7 +97,7 @@ public class ResourceOperatorSupplier {
                         () -> new BackOff(5_000, 2, 4)),
                 new DefaultAdminClientProvider(),
                 new DefaultZookeeperScalerProvider(),
-                new MicrometerMetricsProvider(),
+                metricsProvider,
                 pfa,
                 operationTimeoutMs,
                 KubernetesRestartEventPublisher.createPublisher(client, operatorName, pfa.hasEventsApiV1())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -204,7 +204,7 @@ public class ClusterOperatorTest {
 
         CountDownLatch latch = new CountDownLatch(namespaceList.size() + 1);
 
-        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_16),
+        Main.deployClusterOperatorVerticles(vertx, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_16),
                     ClusterOperatorConfig.fromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", vertx.deploymentIDs(), hasSize(namespaceList.size()));
@@ -302,7 +302,7 @@ public class ClusterOperatorTest {
         Map<String, String> env = buildEnv(namespaces, strimziPodSets, podSetsOnly);
 
         CountDownLatch latch = new CountDownLatch(2);
-        Main.run(vertx, client, new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_16),
+        Main.deployClusterOperatorVerticles(vertx, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_16),
                 ClusterOperatorConfig.fromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", vertx.deploymentIDs(), hasSize(1));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertStatefulSetMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertStatefulSetMockTest.java
@@ -122,7 +122,7 @@ public class KafkaAssemblyOperatorCustomCertStatefulSetMockTest {
             .build();
         client.secrets().inNamespace(namespace).resource(secret).create();
         PlatformFeaturesAvailability platformFeaturesAvailability = new PlatformFeaturesAvailability(false, kubernetesVersion);
-        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, client, platformFeaturesAvailability, 10000, "op");
+        ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, client, ResourceUtils.metricsProvider(), platformFeaturesAvailability, 10000, "op");
 
         operator = new MockKafkaAssemblyOperator(
                 vertx,


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Today, we start the Vert.x webserver which is used for health checks and for metrics as part of the `ClusterOperator` class / verticle. This does not seem to be right:
* It has nothing to do with the verticle itself, it does not use anything from it
* The `ClusterOperator` verticle is deployed multiple times when watching multiple namespaces. And in that case, each of them creates its own webserver. Somehow, Vert.x deals with it and it does not complain about the port being already used. But it seems weird because the handlers keep existing and the health checks randomly call one of the other handler. You can see it if you enhance the logging:
  ```yaml
  2022-08-06 19:40:23 INFO  ClusterOperator:189 - /metrics for namespace myproject accessed
  2022-08-06 19:40:25 INFO  ClusterOperator:186 - /ready for namespace myproject2 accessed
  2022-08-06 19:40:25 INFO  ClusterOperator:183 - /healthy for namespace myproject accessed
  2022-08-06 19:40:53 INFO  ClusterOperator:189 - /metrics for namespace myproject accessed
  2022-08-06 19:40:55 INFO  ClusterOperator:183 - /healthy for namespace myproject2 accessed
  2022-08-06 19:40:55 INFO  ClusterOperator:186 - /ready for namespace myproject accessed
  ```

This PR improves the logic and moves the webserver into the `Main` class. That way, it is always needed to start only once. This needed only little bit of refactoring to make the MetricsProvider available to it. In the future, this will be important to be able to possibly use leases and leader election.

It also does a minor refactoring of the `main` method in `Main` class to avoid the deep-nesting of the futures and instead compose them. And it adds some more Javadoc to the `Main` class.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally