### PR TITLE
Add leader election to the Cluster Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for Kafka 3.2.1
 * Update Kaniko builder to 1.9.0 and Maven builder to 1.14
 * Pluggable Pod Security Profiles with built-in support for _restricted_ Kubernetes Security Profile
+* Add support for leader election and running multiple operator replicas (1 active leader replicas and one or more stand-by replicas)
 
 ### Deprecations and removals
 

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -77,6 +77,10 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-coordination</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>openshift-model</artifactId>
         </dependency>
         <dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManager.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.leaderelection;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.extended.leaderelection.LeaderCallbacks;
+import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectionConfigBuilder;
+import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LeaseLock;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.function.Consumer;
+
+/**
+ * LeaderElectionManager class is responsible for the leader election process. It has its own long-running thread to
+ * handle the servicing of the Kubernetes Lease lock. It waits for it until it get available and when it becomes the
+ * leader, it also periodically updates the lock to make sure it stays the leader as well. It offers callbacks which
+ * the operators can use to integrate with it.
+ */
+public class LeaderElectionManager implements Runnable  {
+    private static final Logger LOGGER = LogManager.getLogger(LeaderElectionManager.class);
+
+    private final KubernetesClient client;
+    private final LeaderElectionManagerConfig config;
+    private final Runnable startLeadershipCallback;
+    private final Runnable stopLeadershipCallback;
+    private final Consumer<String> leadershipChangeCallback;
+    private final Thread managerThread;
+
+    private boolean isLeader = false;
+
+    /**
+     * LeaderElectionManager constructor
+     *
+     * @param client                    Kubernetes client
+     * @param config                    LeaderElectionManager configuration
+     * @param startLeadershipCallback   Callback which is called when this instance becomes a leader
+     * @param stopLeadershipCallback    Callback which is called when this instance stops being a leader
+     * @param leadershipChangeCallback  Callback which is called when the leadership changes and a new leader is elected
+     */
+    public LeaderElectionManager(KubernetesClient client, LeaderElectionManagerConfig config, Runnable startLeadershipCallback, Runnable stopLeadershipCallback, Consumer<String> leadershipChangeCallback) {
+        this.client = client;
+        this.config = config;
+        this.startLeadershipCallback = startLeadershipCallback;
+        this.stopLeadershipCallback = stopLeadershipCallback;
+        this.leadershipChangeCallback = leadershipChangeCallback;
+
+        this.managerThread = new Thread(this);
+    }
+
+    /**
+     * The run() method which just calls into the Fabric8 Kubernetes client API.
+     */
+    @Override
+    public void run() {
+        // TODO: Do we need handle interrupted here any exit?
+        client.leaderElector()
+                .withConfig(
+                        new LeaderElectionConfigBuilder()
+                                .withName(config.getLeaseName())
+                                .withLock(new LeaseLock(config.getNamespace(), config.getLeaseName(), config.getIdentity()))
+                                .withLeaseDuration(config.getLeaseDuration())
+                                .withRenewDeadline(config.getRenewDeadline())
+                                .withRetryPeriod(config.getRetryPeriod())
+                                .withLeaderCallbacks(new LeaderCallbacks(
+                                        () -> startLeadership(),
+                                        () -> stopLeadership(),
+                                        newLeader -> leadershipChange(newLeader)))
+                                .withReleaseOnCancel(true)
+                                .build())
+                .build().run();
+
+        // Existing the leader election thread => if we are leader, we will loose the leadership
+        if (isLeader)   {
+            stopLeadership();
+        }
+    }
+
+    /**
+     * Start method to start the election thread
+     */
+    public void start() {
+        managerThread.start();
+    }
+
+    /**
+     * Stop method to stop the election thread
+     */
+    public void stop()  {
+        managerThread.interrupt();
+    }
+
+    /**
+     * Internal method which logs that this instance is the leader now calls the configured callback. This is called
+     * from the leaderElector.
+     */
+    private void startLeadership()  {
+        isLeader = true;
+        LOGGER.info("Started being a leader");
+        startLeadershipCallback.run();
+    }
+
+    /**
+     * Internal method which logs that this instance is NOT the leader anymore and calls the configured callback. This
+     * is called from the leaderElector.
+     */
+    private void stopLeadership()   {
+        isLeader = false;
+        LOGGER.info("Stopped being a leader");
+        stopLeadershipCallback.run();
+    }
+
+    /**
+     * Internal method which logs that the leadership changed and calls the configured callback. This is called
+     * from the leaderElector.
+     */
+    private void leadershipChange(String newLeader) {
+        LOGGER.info("The new leader is {}", newLeader);
+        leadershipChangeCallback.accept(newLeader);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManager.java
@@ -55,7 +55,6 @@ public class LeaderElectionManager implements Runnable  {
      */
     @Override
     public void run() {
-        // TODO: Do we need handle interrupted here any exit?
         client.leaderElector()
                 .withConfig(
                         new LeaderElectionConfigBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerConfig.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.leaderelection;
+
+import io.strimzi.operator.common.InvalidConfigurationException;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Configuration class for the Leader Election Manager
+ */
+public class LeaderElectionManagerConfig {
+    // Environment variables
+    public final static String ENV_VAR_LEADER_ELECTION_LEASE_NAME = "STRIMZI_LEADER_ELECTION_LEASE_NAME";
+    public final static String ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE = "STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE";
+    public final static String ENV_VAR_LEADER_ELECTION_IDENTITY = "STRIMZI_LEADER_ELECTION_IDENTITY";
+    public final static String ENV_VAR_LEADER_ELECTION_LEASE_DURATION_MS = "STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS";
+    public final static String ENV_VAR_LEADER_ELECTION_RENEW_DEADLINE_MS = "STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS";
+    public final static String ENV_VAR_LEADER_ELECTION_RETRY_PERIOD_MS = "STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS";
+
+    // Default values
+    private final static Duration DEFAULT_STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS = Duration.ofSeconds(15);
+    private final static Duration DEFAULT_STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS = Duration.ofSeconds(10);
+    private final static Duration DEFAULT_STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS = Duration.ofSeconds(2);
+
+    private final String leaseName;
+    private final String namespace;
+    private final String identity;
+    private final Duration leaseDuration;
+    private final Duration renewDeadline;
+    private final Duration retryPeriod;
+
+    /**
+     * Constructs the LeaderElectionManagerConfig object
+     *
+     * @param leaseName     Name of the Kubernetes Lease resource
+     * @param namespace     Namespace of the Kubernetes Lease resource
+     * @param identity      Identity of this instance of the operator (should be unique: for example Pod name)
+     * @param leaseDuration Duration for which the acquired lease is valid
+     * @param renewDeadline Duration for which should the leader retry to maintain the leadership
+     * @param retryPeriod   How often does the leader update the lease lock
+     */
+    public LeaderElectionManagerConfig(String leaseName, String namespace, String identity, Duration leaseDuration, Duration renewDeadline, Duration retryPeriod) {
+        this.leaseName = leaseName;
+        this.namespace = namespace;
+        this.identity = identity;
+        this.leaseDuration = leaseDuration;
+        this.renewDeadline = renewDeadline;
+        this.retryPeriod = retryPeriod;
+    }
+
+    public static LeaderElectionManagerConfig fromMap(Map<String, String> map) {
+        String leaseName = map.get(ENV_VAR_LEADER_ELECTION_LEASE_NAME);
+        String namespace = map.get(ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE);
+        String identity = map.get(ENV_VAR_LEADER_ELECTION_IDENTITY);
+
+        if (leaseName == null || namespace == null || identity == null) {
+            // Required options are not provided
+            throw new InvalidConfigurationException("The " + ENV_VAR_LEADER_ELECTION_LEASE_NAME + ", " + ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE + " and " + ENV_VAR_LEADER_ELECTION_IDENTITY + " options are required and have to be set when leader election is enabled.");
+        }
+
+        Duration leaseDuration = parseDuration(map.get(ENV_VAR_LEADER_ELECTION_LEASE_DURATION_MS), DEFAULT_STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS);
+        Duration renewDeadline = parseDuration(map.get(ENV_VAR_LEADER_ELECTION_RENEW_DEADLINE_MS), DEFAULT_STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS);
+        Duration retryPeriod = parseDuration(map.get(ENV_VAR_LEADER_ELECTION_RETRY_PERIOD_MS), DEFAULT_STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS);
+
+        return new LeaderElectionManagerConfig(leaseName, namespace, identity, leaseDuration, renewDeadline, retryPeriod);
+    }
+
+    private static Duration parseDuration(String durationValue, Duration defaultDuration) {
+        Duration duration = defaultDuration;
+
+        if (durationValue != null) {
+            duration = Duration.ofMillis(Long.parseLong(durationValue));
+        }
+
+        return duration;
+    }
+
+    /**
+     * @return  Returns the name of the Kubernetes Lease resource
+     */
+    public String getLeaseName() {
+        return leaseName;
+    }
+
+    /**
+     * @return  Returns the namespace of the Kubernetes Lease resource
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * @return  Returns the identity of this instance of the operator
+     */
+    public String getIdentity() {
+        return identity;
+    }
+
+    /**
+     * @return  Returns the duration for which the acquired lease is valid
+     */
+    public Duration getLeaseDuration() {
+        return leaseDuration;
+    }
+
+    /**
+     * @return  Returns the duration for which should the leader retry to maintain the leadership
+     */
+    public Duration getRenewDeadline() {
+        return renewDeadline;
+    }
+
+    /**
+     * @return  Returns how often does the leader update the lease lock
+     */
+    public Duration getRetryPeriod() {
+        return retryPeriod;
+    }
+
+    @Override
+    public String toString() {
+        return "LeaderElectionConfig{" +
+                "leaseName='" + leaseName + '\'' +
+                ", namespace='" + namespace + '\'' +
+                ", identity='" + identity + '\'' +
+                ", leaseDuration=" + leaseDuration +
+                ", renewDeadline=" + renewDeadline +
+                ", retryPeriod=" + retryPeriod +
+                '}';
+    }
+}

--- a/cluster-operator/src/main/resources/cluster-roles/022-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/022-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      # The cluster operator needs to access and manage leases for leader election
+      # The "create" verb cannot be used with "resourceNames"
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      # The cluster operator needs to access and manage leases for leader election
+      - leases
+    resourceNames:
+      # The default RBAC files give the operator only access to the Lease resource names strimzi-cluster-operator
+      # If you want to use another resource name or resource namespace, you have to configure the RBAC resources accordingly
+      - strimzi-cluster-operator
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster;
 
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
+import io.strimzi.operator.cluster.leaderelection.LeaderElectionManagerConfig;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.UnsupportedVersionException;
@@ -23,6 +24,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -70,6 +72,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.isNetworkPolicyGeneration(), is(true));
         assertThat(config.isPodSetReconciliationOnly(), is(false));
         assertThat(config.getPodSecurityProviderClass(), is(ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS));
+        assertThat(config.getLeaderElectionConfig(), is(nullValue()));
     }
 
     @Test
@@ -94,7 +97,7 @@ public class ClusterOperatorConfigTest {
                 false,
                 1024,
                 "operator_name",
-                null);
+                null, null);
 
         assertThat(config.getNamespaces(), is(singleton("namespace")));
         assertThat(config.getReconciliationIntervalMs(), is(60_000L));
@@ -385,5 +388,16 @@ public class ClusterOperatorConfigTest {
         assertThat(ClusterOperatorConfig.parsePodSecurityProviderClass("RESTRICTED"), is(ClusterOperatorConfig.POD_SECURITY_PROVIDER_RESTRICTED_CLASS));
         assertThat(ClusterOperatorConfig.parsePodSecurityProviderClass("restricted"), is(ClusterOperatorConfig.POD_SECURITY_PROVIDER_RESTRICTED_CLASS));
         assertThat(ClusterOperatorConfig.parsePodSecurityProviderClass("my.package.MyClass"), is("my.package.MyClass"));
+    }
+
+    @Test
+    public void testLeaderElectionConfig() {
+        Map<String, String> envVars = new HashMap<>(ClusterOperatorConfigTest.ENV_VARS);
+        envVars.put(ClusterOperatorConfig.STRIMZI_LEADER_ELECTION_ENABLED, "true");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME, "my-lease");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE, "my-namespace");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_IDENTITY, "my-pod");
+
+        assertThat(ClusterOperatorConfig.fromMap(envVars, KafkaVersionTestUtils.getKafkaVersionLookup()).getLeaderElectionConfig(), is(notNullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -749,7 +749,7 @@ public class ResourceUtils {
                 false,
                 1024,
                 "cluster-operator-name",
-                ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS);
+                ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS, null);
     }
 
     public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions, long operationTimeoutMs) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerConfigTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.leaderelection;
+
+import io.strimzi.operator.common.InvalidConfigurationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LeaderElectionManagerConfigTest {
+    @Test
+    public void testDefaultConfig() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME, "my-lease");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE, "my-namespace");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_IDENTITY, "my-pod");
+
+        LeaderElectionManagerConfig config = LeaderElectionManagerConfig.fromMap(envVars);
+
+        assertThat(config.getLeaseName(), is("my-lease"));
+        assertThat(config.getNamespace(), is("my-namespace"));
+        assertThat(config.getIdentity(), is("my-pod"));
+        assertThat(config.getLeaseDuration().toMillis(), is(15_000L));
+        assertThat(config.getRenewDeadline().toMillis(), is(10_000L));
+        assertThat(config.getRetryPeriod().toMillis(), is(2_000L));
+    }
+
+    @Test
+    public void testConfiguredTiming() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME, "my-lease");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE, "my-namespace");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_IDENTITY, "my-pod");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_DURATION_MS, "30000");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_RENEW_DEADLINE_MS, "20000");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_RETRY_PERIOD_MS, "5000");
+
+        LeaderElectionManagerConfig config = LeaderElectionManagerConfig.fromMap(envVars);
+
+        assertThat(config.getLeaseName(), is("my-lease"));
+        assertThat(config.getNamespace(), is("my-namespace"));
+        assertThat(config.getIdentity(), is("my-pod"));
+        assertThat(config.getLeaseDuration().toMillis(), is(30_000L));
+        assertThat(config.getRenewDeadline().toMillis(), is(20_000L));
+        assertThat(config.getRetryPeriod().toMillis(), is(5_000L));
+    }
+
+    @Test
+    public void testMissingAllRequired() {
+        Map<String, String> envVars = new HashMap<>();
+
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> LeaderElectionManagerConfig.fromMap(envVars));
+        assertThat(e.getMessage(), is("The STRIMZI_LEADER_ELECTION_LEASE_NAME, STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE and STRIMZI_LEADER_ELECTION_IDENTITY options are required and have to be set when leader election is enabled."));
+    }
+
+    @Test
+    public void testMissingSomeRequired() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE, "my-namespace");
+        envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_IDENTITY, "my-pod");
+
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> LeaderElectionManagerConfig.fromMap(envVars));
+        assertThat(e.getMessage(), is("The STRIMZI_LEADER_ELECTION_LEASE_NAME, STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE and STRIMZI_LEADER_ELECTION_IDENTITY options are required and have to be set when leader election is enabled."));
+
+        Map<String, String> envVars2 = new HashMap<>();
+        envVars2.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME, "my-lease");
+        envVars2.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_IDENTITY, "my-pod");
+
+        e = assertThrows(InvalidConfigurationException.class, () -> LeaderElectionManagerConfig.fromMap(envVars2));
+        assertThat(e.getMessage(), is("The STRIMZI_LEADER_ELECTION_LEASE_NAME, STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE and STRIMZI_LEADER_ELECTION_IDENTITY options are required and have to be set when leader election is enabled."));
+
+        Map<String, String> envVars3 = new HashMap<>();
+        envVars3.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME, "my-lease");
+        envVars3.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE, "my-namespace");
+
+        e = assertThrows(InvalidConfigurationException.class, () -> LeaderElectionManagerConfig.fromMap(envVars3));
+        assertThat(e.getMessage(), is("The STRIMZI_LEADER_ELECTION_LEASE_NAME, STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE and STRIMZI_LEADER_ELECTION_IDENTITY options are required and have to be set when leader election is enabled."));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.leaderelection;
+
+import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class LeaderElectionManagerIT {
+    private final static String NAMESPACE = "my-le-namespace";
+    private final static String LEASE_NAME = "my-lease";
+
+    private final static KubeClusterResource CLUSTER = KubeClusterResource.getInstance();
+
+    private static KubernetesClient client;
+
+    @BeforeAll
+    static void setupEnvironment() {
+        CLUSTER.createNamespace(NAMESPACE);
+        client = new KubernetesClientBuilder().build();
+    }
+
+    @AfterAll
+    static void teardownEnvironment() {
+        CLUSTER.deleteNamespaces();
+    }
+
+    @Test
+    public void testLeaderElectionManager() throws InterruptedException {
+        CountDownLatch le1Leader = new CountDownLatch(1);
+        CountDownLatch le1NotLeader = new CountDownLatch(1);
+        CountDownLatch le2Leader = new CountDownLatch(1);
+        CountDownLatch le2NotLeader = new CountDownLatch(1);
+
+        LeaderElectionManager le1 = createLeaderElectionManager("le-1", le1Leader::countDown, le1NotLeader::countDown);
+        LeaderElectionManager le2 = createLeaderElectionManager("le-2", le2Leader::countDown, le2NotLeader::countDown);
+
+        // Start the first member => it should become a leader
+        le1.start();
+        le1Leader.await();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-1"));
+
+        // Start the second member => leadership should not change
+        le2.start();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-1"));
+
+        // Stop the first member => leadership should change
+        le1.stop();
+        le1NotLeader.await();
+        le2Leader.await();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+
+        // Stop the second member => the leadership in the lease resource will stay as it was
+        le2.stop();
+        le2NotLeader.await();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+    }
+
+    private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Runnable stopLeadershipCallback)   {
+        return new LeaderElectionManager(
+                client, new LeaderElectionManagerConfig(LEASE_NAME, NAMESPACE, identity, Duration.ofMillis(1_000L), Duration.ofMillis(800L), Duration.ofMillis(200L)),
+                startLeadershipCallback,
+                stopLeadershipCallback,
+                s -> {
+                    // Do nothing
+                });
+    }
+
+    private Lease getLease()    {
+        return client.leases().inNamespace(NAMESPACE).withName(LEASE_NAME).get();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.leaderelection;
+
+import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@EnableKubernetesMockClient(crud = true)
+public class LeaderElectionManagerMockTest {
+    private final static String NAMESPACE = "my-le-namespace";
+    private final static String LEASE_NAME = "my-lease";
+
+    // Injected by Fabric8 Mock Kubernetes Server
+    @SuppressWarnings("unused")
+    private KubernetesClient client;
+
+    @Test
+    public void testLeaderElectionManager() throws InterruptedException {
+        CountDownLatch le1Leader = new CountDownLatch(1);
+        CountDownLatch le1NotLeader = new CountDownLatch(1);
+        CountDownLatch le2Leader = new CountDownLatch(1);
+        CountDownLatch le2NotLeader = new CountDownLatch(1);
+
+        LeaderElectionManager le1 = createLeaderElectionManager("le-1", le1Leader::countDown, le1NotLeader::countDown);
+        LeaderElectionManager le2 = createLeaderElectionManager("le-2", le2Leader::countDown, le2NotLeader::countDown);
+
+        // Start the first member => it should become a leader
+        le1.start();
+        le1Leader.await();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-1"));
+
+        // Start the second member => leadership should not change
+        le2.start();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-1"));
+
+        // Stop the first member => leadership should change
+        le1.stop();
+        le1NotLeader.await();
+        le2Leader.await();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+
+        // Stop the second member => the leadership in the lease resource will stay as it was
+        le2.stop();
+        le2NotLeader.await();
+        assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+    }
+
+    private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Runnable stopLeadershipCallback)   {
+        return new LeaderElectionManager(
+                client, new LeaderElectionManagerConfig(LEASE_NAME, NAMESPACE, identity, Duration.ofMillis(1_000L), Duration.ofMillis(800L), Duration.ofMillis(200L)),
+                startLeadershipCallback,
+                stopLeadershipCallback,
+                s -> {
+                    // Do nothing
+                });
+    }
+
+    private Lease getLease()    {
+        return client.leases().inNamespace(NAMESPACE).withName(LEASE_NAME).get();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -402,7 +402,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 false,
                 1024,
                 "cluster-operator-name",
-                ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS);
+                ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS, null);
 
         KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_19), certManager, passwordGenerator,
                 supplier, config);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1278,7 +1278,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 false,
                 1024,
                 "cluster-operator-name",
-                ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS);
+                ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS, null);
 
         kcrao = new KafkaRebalanceAssemblyOperator(Vertx.vertx(), supplier, config);
 

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -252,13 +252,13 @@ env:
         fieldPath: metadata.name
 ----
 
-`STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS`:: Optional, default `15` seconds.
+`STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS`:: Optional, default 15000 ms.
 Configures the duration for which the acquired lease is valid.
 
-`STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS`:: Optional, default `10` seconds.
+`STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS`:: Optional, default 10000 ms.
 Configures the duration for which should the leader retry to maintain the leadership
 
-`STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS`:: Optional, default `2` seconds.
+`STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS`:: Optional, default 2000 ms.
 Configures how often does the leader update the lease lock
 
 == Logging configuration by ConfigMap

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -195,7 +195,7 @@ The DNS domain name is added to the Kafka broker certificates used for hostname 
 If you are using a different DNS domain name suffix in your cluster, change the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable from the default to the one you are using in order to establish a connection with the Kafka brokers.
 
 `STRIMZI_CONNECT_BUILD_TIMEOUT_MS`:: Optional, default 300000 ms.
-The timeout for building new Kafka Connect images with additional connectots, in milliseconds.
+The timeout for building new Kafka Connect images with additional connectors, in milliseconds.
 This value should be increased when using Strimzi to build container images containing many connectors or using a slow container registry.
 
 `STRIMZI_NETWORK_POLICY_GENERATION` :: Optional, default `true`.
@@ -216,6 +216,50 @@ Enables or disables features and functionality controlled by xref:ref-operator-c
 
 `STRIMZI_POD_SECURITY_PROVIDER_CLASS`:: Optional.
 Configures the pluggable `PodSecurityProvider` class which can be used to provide the security context configuration for Pods and containers.
+
+[[STRIMZI_LEADER_ELECTION_ENABLED]]
+`STRIMZI_LEADER_ELECTION_ENABLED`:: Optional, default `false`.
+Enables or disables the leader election which allows to run additional operator instances as a hot-stand-by.
+Disabled by default.
+
+`STRIMZI_LEADER_ELECTION_LEASE_NAME`:: Required when leader election is enabled.
+The name of the Kubernetes Lease resource which is used for the leader election.
+
+`STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE`:: Required when leader election is enabled.
+The namespace where the Kubernetes Lease resource used for the leader election will be created.
+You can use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API^] to configure it to the namespace where the operator is deployed.
++
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+----
+
+`STRIMZI_LEADER_ELECTION_IDENTITY`:: Required when leader election is enabled.
+Configures the identity of given operator instance used during the leader election.
+Should be unique for each operator instance
+You can use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API^] to configure it to the name of the operator pod.
++
+[source,yaml,options="nowrap"]
+----
+env:
+  - name: STRIMZI_LEADER_ELECTION_IDENTITY
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+----
+
+`STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS`:: Optional, default `15` seconds.
+Configures the duration for which the acquired lease is valid.
+
+`STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS`:: Optional, default `10` seconds.
+Configures the duration for which should the leader retry to maintain the leadership
+
+`STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS`:: Optional, default `2` seconds.
+Configures how often does the leader update the lease lock
 
 == Logging configuration by ConfigMap
 
@@ -270,6 +314,24 @@ if the operator is not running, or if a notification is not received for any rea
 
 In order to handle failovers properly, a periodic reconciliation process is executed by the Cluster Operator so that it can compare the state of the desired resources with the current cluster deployments in order to have a consistent state across all of them.
 You can set the time interval for the periodic reconciliations using the xref:STRIMZI_FULL_RECONCILIATION_INTERVAL_MS[] variable.
+
+== Running multiple operator replicas
+
+With the xref:STRIMZI_LEADER_ELECTION_ENABLED[leader election] enabled in the Cluster Operator configuration, you can run multiple parallel replicas of the operator.
+One of them will be elected as a leader and will actively operate the deployed operands.
+The other replicas will be running in a stand-by mode.
+When the leader stops or crashes, one of the stand-by replicas will be elected as a new leader and will start operating the deployed resources.
+
+Running the operator with multiple replicas is not required.
+When using only single replica, the single replica will be always the leader replica.
+And when the single replica is stopped or crashed, Kubernetes will automatically start a new replica.
+
+But in some situations it might be an advantage to have the stand-by replicas already scheduled and running.
+For example during large scale disruptions such as crash of multiple worker nodes or of a whole availability zone.
+
+NOTE::
+The default installation files contain the RBAC permissions to use the Kubernetes `Lease` resource with name `strimzi-cluster-operator` in the same namespace where the Cluster Operator runs.
+If you decide to use other `Lease` name or a different namespace, you have to update the `ClusterRole` and `RoleBinding` files accordingly.
 
 == Provisioning Role-Based Access Control (RBAC)
 
@@ -346,6 +408,14 @@ The second includes the permissions needed for cluster-scoped resources.
 .`ClusterRole` with cluster-scoped resources for the Cluster Operator
 ----
 include::../install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml[]
+----
+
+The `strimzi-cluster-operator-leader-election` `ClusterRole` represents the permissions needed for the leader election.
+
+[source,yaml,options="nowrap"]
+.`ClusterRole` with leader election permissions
+----
+include::../install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml[]
 ----
 
 The `strimzi-kafka-broker` `ClusterRole` represents the access needed by the init container in Kafka pods that is used for the rack feature. As described in the xref:delegated-privileges-str[Delegated privileges] section, this role is also needed by the Cluster Operator in order to be able to delegate this access.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: role
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+    # The cluster operator needs to access and manage leases for leader election
+    # The "create" verb cannot be used with "resourceNames"
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+    # The cluster operator needs to access and manage leases for leader election
+  - leases
+  resourceNames:
+    # The default RBAC files give the operator only access to the Lease resource names strimzi-cluster-operator
+    # If you want to use another resource name or resource namespace, you have to configure the RBAC resources accordingly
+  - strimzi-cluster-operator
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+  - update
+{{- end -}}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/022-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: role-binding
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-leader-election
+  apiGroup: rbac.authorization.k8s.io

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -131,6 +131,18 @@ spec:
             {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 12 }}
             {{- end }}
+            - name: STRIMZI_LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+              value: "strimzi-cluster-operator"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           livenessProbe:
             httpGet:
               path: /healthy

--- a/packaging/install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      # The cluster operator needs to access and manage leases for leader election
+      # The "create" verb cannot be used with "resourceNames"
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      # The cluster operator needs to access and manage leases for leader election
+      - leases
+    resourceNames:
+      # The default RBAC files give the operator only access to the Lease resource names strimzi-cluster-operator
+      # If you want to use another resource name or resource namespace, you have to configure the RBAC resources accordingly
+      - strimzi-cluster-operator
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update

--- a/packaging/install/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-leader-election
+  apiGroup: rbac.authorization.k8s.io

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -97,6 +97,18 @@ spec:
                   fieldPath: metadata.namespace
             - name: STRIMZI_FEATURE_GATES
               value: ""
+            - name: STRIMZI_LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+              value: "strimzi-cluster-operator"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           livenessProbe:
             httpGet:
               path: /healthy

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,11 @@
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-coordination</artifactId>
+                <version>${fabric8.kubernetes-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
                 <artifactId>openshift-model</artifactId>
                 <version>${fabric8.kubernetes-model.version}</version>
             </dependency>

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -538,11 +538,21 @@ public class SetupClusterOperator {
         }
     }
 
+    /**
+     * Applies the RoleBindings for the Cluster Operator
+     *
+     * @param extensionContext  Extension Context
+     * @param namespace         Namespace in which the operator is deployed
+     * @param bindingsNamespace Namespace watched by the operator
+     */
     public void applyRoleBindings(ExtensionContext extensionContext, String namespace, String bindingsNamespace) {
-        // 020-RoleBinding
+        // 020-RoleBinding => Cluster Operator rights for managing operands
         File roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
-        // 031-RoleBinding
+        // 022-RoleBinding => Leader election RoleBinding (is only in the operator namespace)
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml");
+        RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, namespace);
+        // 031-RoleBinding => Entity Operator delegation
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
     }
@@ -552,6 +562,9 @@ public class SetupClusterOperator {
         RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
 
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml");
+        RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml");
         RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
 
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml");

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -165,8 +165,11 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
 
         int scaleTo = 4;
 
-        deployCOInNamespace(extensionContext, FIRST_CO_NAME, DEFAULT_NAMESPACE, FIRST_CO_SELECTOR_ENV, false);
-        deployCOInNamespace(extensionContext, SECOND_CO_NAME, DEFAULT_NAMESPACE, SECOND_CO_SELECTOR_ENV, false);
+        deployCOInNamespace(extensionContext, FIRST_CO_NAME, FIRST_NAMESPACE, FIRST_CO_SELECTOR_ENV, true);
+        deployCOInNamespace(extensionContext, SECOND_CO_NAME, SECOND_NAMESPACE, SECOND_CO_SELECTOR_ENV, true);
+
+        cluster.createNamespace(DEFAULT_NAMESPACE);
+        cluster.setNamespace(DEFAULT_NAMESPACE);
 
         LOGGER.info("Deploying Kafka with {} selector of {}", FIRST_CO_SELECTOR, FIRST_CO_NAME);
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for Leader Election. It uses the Fabric8 Leader Election API and the Kubernetes `Lease` resources. When the Cluster Operator starts, it will use the leader election to have one instance of it elected as a leader. When the operator becomes a leader, it will proceed to start the operator verticles and start operate resources. The instances which will not be a leader will be sitting as stand-by and waiting for their chance. The issue #7174 describes the possible reasons why multiple replicas might be useful.

While in the code, the leader election is disabled by default (for backwards compatibility), the installation YAML files will have it enabled. Even if the user runs the operator with a single replica (which remains the default), the leader election will be used => the single replica will be simply always the leader.

The use of the Kubernetes `Lease` resource requires the additional RBAC rights. The configuration in our YAML files uses the `Lease` names `strimzi-cluster-operator` in the namespace where the operator runs. To facilitate this, it has its own `ClusterRole` and `RoleBinding` (a separate RBAC files are used because this RBAC needs to target the namespace where the operator runs and not the one which it watches).

This should close #7174 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md