### PR TITLE
Update Kaniko builder to 1.9.0 and Maven builder to 1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 0.31.0
 
 * Add support for Kafka 3.2.1
+* Update Kaniko builder to 1.9.0 and Maven builder to 1.14
 * Pluggable Pod Security Profiles with built-in support for _restricted_ Kubernetes Security Profile
 
 ## 0.30.0

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.8.1
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.9.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.13
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 
 USER root
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr updates the Kaniko builder to 1.9.0 and Maven builder to 1.14.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md