### PR TITLE
Update the operators launch script to reflect the cgroups v2 handling in the new OpenJDK

### DIFF
--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -2,8 +2,6 @@
 set -e
 set +x
 
-mem_file_cgroups_v2="/sys/fs/cgroup/memory.max"
-
 # expand gc options based upon java version
 function get_gc_opts {
   if [ "${STRIMZI_GC_LOG_ENABLED}" == "true" ]; then
@@ -12,22 +10,6 @@ function get_gc_opts {
     # no gc options
     echo ""
   fi
-}
-
-calc_maximum_size_opt() {
-  local max_mem="$1"
-  local percentage="$2"
-
-  local value_in_mb=$((max_mem*percentage/100/1048576))
-  echo "-Xmx${value_in_mb}m"
-}
-
-# Calculate the value of -Xmx options base on cgroups_v2 values
-calc_max_memory() {
-  local mem_limit
-  mem_limit="$(cat ${mem_file_cgroups_v2})"
-
-  calc_maximum_size_opt "${mem_limit}" "20"
 }
 
 export MALLOC_ARENA_MAX=2
@@ -44,25 +26,9 @@ JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
 # Exit when we run out of heap memory
 JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
 
-DEFAULT_MEMORY_OPTIONS="-XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=20 -XX:InitialRAMPercentage=10"
-
 # Default memory options used when the user didn't configured any of these options, we set the defaults
-if [[ ! -r "${mem_file_cgroups_v2}" && "$JAVA_OPTS" != *"MinRAMPercentage"* && "$JAVA_OPTS" != *"MaxRAMPercentage"* && "$JAVA_OPTS" != *"InitialRAMPercentage"* ]]; then
-  JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_MEMORY_OPTIONS}"
-elif [[ -r "${mem_file_cgroups_v2}" && "$JAVA_OPTS" != *"Xmx"* ]]; then
-  # This workaround for cgroups v2 must be removed once java version used by the operator is updated.
-  # https://developers.redhat.com/articles/2022/04/19/java-17-whats-new-openjdks-container-awareness#
-
-  # Check whether /sys/fs/cgroup/memory.max contains 'max' or a number
-  value=$(cat "${mem_file_cgroups_v2}")
-
-  if [[ $value != "max" ]]; then
-    # Calculate -Xmx java option
-    JAVA_OPTS="${JAVA_OPTS} $(calc_max_memory)"
-  else
-    # Because /sys/fs/cgroup/memory.max contains 'max', pick defaults
-    JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_MEMORY_OPTIONS}"
-  fi
+if [[ "$JAVA_OPTS" != *"MinRAMPercentage"* && "$JAVA_OPTS" != *"MaxRAMPercentage"* ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -XX:MinRAMPercentage=20 -XX:MaxRAMPercentage=20"
 fi
 
 # Disable FIPS if needed


### PR DESCRIPTION
### Type of change

- Task

### Description

From OpenJDK 11.0.16, the Cgroups v2 are now supported. So it makes probably sense to switch back to OpenJDK for memory calculation to be consistent between different cgroups versions. So this PR removes the workarounds from #6920 and #7003.

In addition to that it:
* Removes the `InitialRAMPercentage` and leaves that to JVM (it defaults to ~1.5%)
* Changes the `MinRAMPercentage` to 20%. The `MinRAMPercentage` does not define minimal heap size. It defines the maximum heap size when the heap is small. So we want to use the 20% here as well.

CC @im-konge @joseacl 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally