### PR TITLE
Improve the operator shutdown hook

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
@@ -5,19 +5,26 @@
 package io.strimzi.operator.common;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.core.Promise;
+import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.Deployment;
+import io.vertx.core.impl.VertxImpl;
 import static java.util.Objects.requireNonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.concurrent.CountDownLatch;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This shutdown hook ensure that {@code Vertx.close()} is called on a clean shutdown,
- * which in turn calls the stop method of all running Verticles.
- * <p>
- * We add a fixed timeout because Vertx has none for stopping running Verticles.
+ * Shutdown hook that retrieves and stops all deployed verticles without invoking Vertx.close.
+ * <br><br>
+ * System.exit is a blocking call that waits all registered shutdown-hook threads to complete before stopping the VM.
+ * Vertx.close stops all deployed verticles and waits for the event-loop threads to complete their current iteration.
+ * We have a deadlock when invoking System.exit from an event-loop thread which triggers a shutdown hook invoking Vertx.close.
+ * There is no issue when invoking System.exit from a non event-loop thread.
  */
 @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class ShutdownHook implements Runnable {
@@ -38,22 +45,48 @@ public class ShutdownHook implements Runnable {
     @Override
     public void run() {
         LOGGER.info("Shutdown started");
-        if (vertx.deploymentIDs().size() > 0) {
-            CountDownLatch latch = new CountDownLatch(1);
-            vertx.close(ar -> {
-                if (!ar.succeeded()) {
-                    LOGGER.error("Vertx close failed", ar.cause());
-                }
-                latch.countDown();
-            });
+        vertx.deploymentIDs()
+                .stream()
+                .map(id -> ((VertxImpl) vertx).getDeployment(id))
+                .forEach(deployment -> stopVerticles(deployment));
+        LOGGER.info("Shutdown completed");
+    }
+
+    private void stopVerticles(Deployment deployment) {
+        Set<Verticle> verticles = deployment.getVerticles();
+        ExecutorService executor = Executors.newFixedThreadPool(verticles.size());
+        verticles.forEach(verticle -> {
             try {
-                if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                    LOGGER.error("Timed out while waiting for Vertx close");
-                }
-            } catch (InterruptedException e) {
-                LOGGER.error("Interrupted while waiting for Vertx close");
+                executor.submit(stopVerticle(verticle));
+            } catch (Throwable t) {
+                LOGGER.error("Error while waiting for verticle stop");
+            }
+        });
+        stopExecutor(executor, timeoutMs);
+    }
+
+    private Runnable stopVerticle(Verticle verticle) {
+        return () -> {
+            try {
+                verticle.stop(Promise.promise());
+            } catch (Throwable t) {
+                LOGGER.error("Failed to stop verticle", t);
+                t.printStackTrace();
+            }
+        };
+    }
+
+    private static boolean stopExecutor(ExecutorService executor, long timeoutMs) {
+        try {
+            executor.shutdown();
+            executor.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS);
+        } finally {
+            if (executor.isTerminated()) {
+                return true;
+            } else {
+                executor.shutdownNow();
+                return false;
             }
         }
-        LOGGER.info("Shutdown completed");
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/ShutdownHookTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/ShutdownHookTest.java
@@ -15,7 +15,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -62,7 +61,6 @@ public class ShutdownHookTest {
         ShutdownHook hook = new ShutdownHook(vertx);
         hook.run();
 
-        assertThat("Verticles were not stopped", vertx.deploymentIDs(), empty());
         for (MyVerticle verticle : verticles) {
             assertThat("Verticle stop was not executed", verticle.getCounter(), is(1));
         }


### PR DESCRIPTION
I did some more investigation on the hanging shutdown issue, and came out with this improved
shutdown hook which completely avoids it. The previous version does not cover the scenario
where System.exit is invoked from an event-loop thread after a successful verticle deployment.

The problem:

System.exit is a blocking call that waits all registered shutdown-hook threads to complete
before stopping the VM. Vertx.close stops all deployed verticles and waits for the event-loop
threads to complete their current iteration. We have a deadlock when invoking System.exit
from an event-loop thread which triggers a shutdown hook invoking Vertx.close. There is no
issue when invoking System.exit from a non event-loop thread.
