### PR TITLE
Refactor `KafkaAssemblyMockOperatorTest` to use StrimziPodset 

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -173,7 +172,6 @@ public class KafkaAssemblyOperatorMockTest {
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS);
         operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(),
                 new PasswordGenerator(10, "a", "a"), supplier, config);
-
     }
 
     private ResourceOperatorSupplier supplierWithMocks() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -410,15 +410,16 @@ public class KafkaAssemblyOperatorMockTest {
 
 
     private void assertPVCs(VertxTestContext context, String podSetName) {
+
         assertThat(kafkaStorage.getType(), is("persistent-claim"));
 
         context.verify(() -> {
             List<PersistentVolumeClaim> pvc = new ArrayList<>();
             client.persistentVolumeClaims().inNamespace(NAMESPACE).list().getItems().stream().forEach(persistentVolumeClaim -> {
-                if (persistentVolumeClaim.getMetadata().getName().startsWith("data-" + podSetName)){
+                if (persistentVolumeClaim.getMetadata().getName().startsWith("data-" + podSetName)) {
                     pvc.add(persistentVolumeClaim);
-                    System.out.println(persistentVolumeClaim);
-                    assertThat(persistentVolumeClaim.getSpec().getStorageClassName(),  is("foo"));
+                    assertThat(persistentVolumeClaim.getSpec().getStorageClassName(), is("foo"));
+                    assertThat(persistentVolumeClaim.getSpec().getResources().getRequests().toString(), is("{storage=123}"));
                 }
             });
             assertThat(pvc.size(), is(3));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -167,7 +167,7 @@ public class KafkaAssemblyOperatorMockTest {
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, kubernetesVersion);
         supplier = supplierWithMocks();
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -54,7 +54,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.*;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -406,12 +410,15 @@ public class KafkaAssemblyOperatorMockTest {
 
 
     private void assertPVCs(VertxTestContext context, String podSetName) {
+        assertThat(kafkaStorage.getType(), is("persistent-claim"));
+
         context.verify(() -> {
-            assertThat(kafkaStorage.getType(), is("persistent-claim"));
             List<PersistentVolumeClaim> pvc = new ArrayList<>();
             client.persistentVolumeClaims().inNamespace(NAMESPACE).list().getItems().stream().forEach(persistentVolumeClaim -> {
-                if (persistentVolumeClaim.getMetadata().getName().contains(podSetName)){
+                if (persistentVolumeClaim.getMetadata().getName().startsWith("data-" + podSetName)){
                     pvc.add(persistentVolumeClaim);
+                    System.out.println(persistentVolumeClaim);
+                    assertThat(persistentVolumeClaim.getSpec().getStorageClassName(),  is("foo"));
                 }
             });
             assertThat(pvc.size(), is(3));


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_
- Refactoring

### Description

This PR address the issue mentioned in #6903. Several Parameters which are not required are removed form the class like resource and storage. This PR also tend to remove the Stateful set used in the test. The parametized tests are changed to normal test and now all tests run on a single kafka configuration

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

