### PR TITLE
Deprecate Jaeger / OpenTracing based tracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Strimzi 0.31.0 (and any possible patch releases) is the last Strimzi version with support for Kubernetes 1.16, 1.17 and 1.18.
   From Strimzi 0.32.0 on, we will support only Kubernetes 1.19 and newer.
   The supported Kubernetes versions will be re-evaluated again in Q1/2023.
+* The `type: jaeger` tracing support based on Jaeger clients and OpenTracing API is now deprecated.
+  Because the Jaeger clients are retired and the OpenTracing project is archived, we cannot guarantee their support for future Kafka versions.
+  In the future, we plan to replace it with a new tracing feature based on the OpenTelemetry project.
 
 ## 0.30.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/JaegerTracing.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.tracing;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -21,6 +22,8 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type"})
 @EqualsAndHashCode
+@Deprecated
+@DeprecatedType(replacedWithType = void.class)
 public class JaegerTracing extends Tracing {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
@@ -32,7 +32,8 @@ public abstract class Tracing implements UnknownPropertyPreserving, Serializable
     private Map<String, Object> additionalProperties;
 
     @Description("Type of the tracing used. " +
-            "Currently the only supported type is `jaeger` for Jaeger tracing")
+            "Currently the only supported type is `jaeger` for Jaeger tracing. " +
+            "The Jaeger tracing is deprecated")
     public abstract String getType();
 
     @Override

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -421,9 +421,12 @@ public class DocGenerator {
                 }
                 out.append(".*").append(NL);
 
-                out.append("Please use ");
-                typeLink(crd, out, replacementClss);
-                out.append(" instead.").append(NL);
+                if (replacementClss != void.class) {
+                    out.append("Please use ");
+                    typeLink(crd, out, replacementClss);
+                    out.append(" instead.").append(NL);
+                }
+
                 out.append(NL);
             }
         }

--- a/documentation/assemblies/tracing/assembly-distributed-tracing.adoc
+++ b/documentation/assemblies/tracing/assembly-distributed-tracing.adoc
@@ -19,6 +19,13 @@ Support for tracing is built in to the following components:
 * MirrorMaker 2.0
 * Strimzi Kafka Bridge
 
+[NOTE]
+====
+The `type: jaeger` tracing support based on Jaeger clients and OpenTracing API is deprecated.
+Because the Jaeger clients are retired and the OpenTracing project is archived, we cannot guarantee their support for future Kafka versions.
+In the future, we plan to replace it with a new tracing feature based on the OpenTelemetry project.
+====
+
 You enable and configure tracing for these components using template configuration properties in their custom resources.
 
 To enable tracing in Kafka producers, consumers, and Kafka Streams API applications, you _instrument_ application code using the link:https://github.com/opentracing-contrib/java-kafka-client/blob/master/README.md[OpenTracing Apache Kafka Client Instrumentation^] library (included with Strimzi). When instrumented, clients generate trace data; for example, when producing messages or writing offsets to the log.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1877,6 +1877,8 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 [id='type-JaegerTracing-{context}']
 ### `JaegerTracing` schema reference
 
+*The type `JaegerTracing` has been deprecated.*
+
 Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -364,7 +364,7 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka Connect.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -512,7 +512,7 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka MirrorMaker.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1001,7 +1001,7 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka Bridge.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -458,7 +458,7 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka Connect.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -363,7 +363,7 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka Connect.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -511,7 +511,7 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka MirrorMaker.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1000,7 +1000,7 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka Bridge.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -457,7 +457,7 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing.
+                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka Connect.


### PR DESCRIPTION
### Type of change

- Task

### Description

Currently, we support tracing using Jaeger clients and the OpenTracing API. However, the Jaeger clients are retired and the OpenTracing project is archived. Especially the OpenTracing archiving is a problem for us since there are no new releases of the OpenTracing Kafka tooling. It already isn't compatible with Kafka Streams API in Kafka 3.0+ and it might happen that in the future it also isn't compatible anymore with the Consumer / Producer APIs. Therefore, I do not think we are able to guarantee that it will work with the _next_ Kafka release and should deprecate it.

This PR deprecates the API and adds a note to the docs. It does not plan the removal yet -> we can keep supporting it while it works (especially since there is no replacement right now).

We plan to support tracing based on OpenTelemetry in the future. However, this work is not complete yet, so there is no replacement at this point. However, due to the risks of the future compatibility around OpenTracing, it seems fair to deprecate it even without replacement.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md