### PR TITLE
docs(mm2): Make it clearer that the examples have config for full authz

### DIFF
--- a/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
@@ -25,7 +25,8 @@ Before starting this procedure, take a look at the link:{BookURLDeploying}#deplo
 They include examples for securing a deployment of MirrorMaker 2.0 using TLS or SCRAM-SHA-512 authentication.
 The examples specify internal listeners for connecting within a Kubernetes cluster.
 
-The examples also show the ACLs needed by MirrorMaker 2.0 to allow operations on the source and target Kafka clusters.
+The examples provide the configuration for full authorization, including all the ACLs needed by MirrorMaker 2.0 to allow operations on the source and target Kafka clusters.
+
 
 .Prerequisites
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Update clarifies that the MM2 example files provide the config for full authorization

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

