### PR TITLE
[MO] - [system test] -> Un-necessary creation of additional namespace in ParallelSuites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,11 @@
                 <artifactId>junit-platform-launcher</artifactId>
                 <version>${junit.platform.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>${junit.platform.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -132,6 +132,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/IsolatedTest.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/IsolatedTest.java
@@ -15,7 +15,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static io.strimzi.systemtest.Constants.ISOLATED_TEST;
-import static io.strimzi.systemtest.Constants.PARALLEL_TEST;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /***

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/IsolatedTest.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/IsolatedTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.annotations;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -13,6 +14,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static io.strimzi.systemtest.Constants.ISOLATED_TEST;
+import static io.strimzi.systemtest.Constants.PARALLEL_TEST;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /***
@@ -24,6 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Inherited
 @ResourceLock(mode = ResourceAccessMode.READ_WRITE, value = "global")
+@Tag(ISOLATED_TEST)
 @Test
 public @interface IsolatedTest {
     String value() default "";

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/ParallelTest.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/ParallelTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.annotations;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -14,6 +15,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static io.strimzi.systemtest.Constants.PARALLEL_NAMESPACE;
+import static io.strimzi.systemtest.Constants.PARALLEL_TEST;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /***
@@ -25,6 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Execution(ExecutionMode.CONCURRENT)
 @ResourceLock(mode = ResourceAccessMode.READ, value = "global")
+@Tag(PARALLEL_TEST)
 @Test
 public @interface ParallelTest {
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/ParallelTest.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/ParallelTest.java
@@ -15,7 +15,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static io.strimzi.systemtest.Constants.PARALLEL_NAMESPACE;
 import static io.strimzi.systemtest.Constants.PARALLEL_TEST;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -117,7 +117,11 @@ public class ExecutionListener implements TestExecutionListener {
 
         for (TestIdentifier testIdentifier : testCases) {
             for (TestTag testTag : testIdentifier.getTags()) {
-                if (testTag.getName().equals(Constants.PARALLEL_TEST) || testTag.getName().equals(Constants.ISOLATED_TEST)) {
+                if (testTag.getName().equals(Constants.PARALLEL_TEST) || testTag.getName().equals(Constants.ISOLATED_TEST) ||
+                    // Dynamic configuration also because in DynamicConfSharedST we use @TestFactory
+                    testTag.getName().equals(Constants.DYNAMIC_CONFIGURATION) ||
+                    // Tracing, because we deploy Jaeger operator inside additinal namespace
+                    testTag.getName().equals(Constants.TRACING)) {
                     return true;
                 }
             }

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -10,6 +10,7 @@ import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.engine.TestTag;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
@@ -17,12 +18,14 @@ import org.junit.platform.launcher.TestPlan;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ExecutionListener implements TestExecutionListener {
     private static final Logger LOGGER = LogManager.getLogger(TestExecutionListener.class);
 
     private static List<String> testSuitesNamesToExecute;
+    /* read only */ private static TestPlan testPlan;
 
     @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
     public void testPlanExecutionStarted(TestPlan plan) {
@@ -31,8 +34,9 @@ public class ExecutionListener implements TestExecutionListener {
         LOGGER.info("                        Test run started");
         LOGGER.info("=======================================================================");
         LOGGER.info("=======================================================================");
-        printSelectedTestClasses(plan);
-        testSuitesNamesToExecute = new ArrayList<>(plan.getChildren(plan.getRoots().toArray(new TestIdentifier[0])[0])).stream()
+        testPlan = plan;
+        printSelectedTestClasses(testPlan);
+        testSuitesNamesToExecute = new ArrayList<>(testPlan.getChildren(testPlan.getRoots().toArray(new TestIdentifier[0])[0])).stream()
             .map(testIdentifier -> testIdentifier.getDisplayName()).collect(Collectors.toList());
     }
 
@@ -95,6 +99,27 @@ public class ExecutionListener implements TestExecutionListener {
             final String followingTestSuiteName = testSuitesNamesToExecute.get(followingTestSuite);
             if (followingTestSuiteName.endsWith(Constants.ST) && testSuitesNamesToExecute.get(followingTestSuite).contains(Constants.ISOLATED)) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if test suite has test case, which is labeled as {@link io.strimzi.systemtest.annotations.ParallelTest} or
+     * {@link io.strimzi.systemtest.annotations.IsolatedTest}. We check such condition only if we run {@link io.strimzi.systemtest.annotations.ParallelSuite}
+     * and thus we create additional namespace only if test suite contains these type of test cases.
+     *
+     * @param extensionContext  ExtensionContext of the test case
+     * @return                  true if test suite contains Parallel or Isolated test case. Otherwise, false.
+     */
+    public static boolean hasSuiteParallelOrIsolatedTest(final ExtensionContext extensionContext) {
+        Set<TestIdentifier> testCases = testPlan.getChildren(extensionContext.getUniqueId());
+
+        for (TestIdentifier testIdentifier : testCases) {
+            for (TestTag testTag : testIdentifier.getTags()) {
+                if (testTag.getName().equals(Constants.PARALLEL_TEST) || testTag.getName().equals(Constants.ISOLATED_TEST)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

When the @ParallelSuite test suite contains only @ParallelNamespaceTests it creates an unnecessary namespace. When one runs the tests, we need to dynamically check if such a test suite contains @ParallelTest or @IsolatedTest, and then we need to create an additional namespace. Otherwise not. This PR solves such a problem.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass


