### PR TITLE
docs(drain cleaner): Adds condition around deployment options

### DIFF
--- a/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
@@ -97,6 +97,7 @@ kubectl apply -f _<kafka-configuration-file>_
 
 . Deploy the Strimzi Drain Cleaner.
 +
+ifdef::Section[]
 --
 You can use link:https://cert-manager.io/docs/[`cert-manager`^] in the deployment process.
 
@@ -109,13 +110,6 @@ kubectl apply -f ./install/drain-cleaner/certmanager
 +
 The TLS certificates for the webhook are generated automatically and injected into the webhook configuration.
 
-* If you are using OpenShift, apply the resources in the `/install/drain-cleaner/openshift` directory.
-+
-[source,shell,subs="attributes+"]
-----
-kubectl apply -f ./install/drain-cleaner/openshift
-----
-
 * If you are not using `cert-manager` with Kubernetes, apply the resources in the `/install/drain-cleaner/kubernetes` directory.
 +
 [source,shell,subs="attributes+"]
@@ -125,8 +119,17 @@ kubectl apply -f ./install/drain-cleaner/kubernetes
 +
 The resources are configured with TLS certificates that have already been generated.
 Use these certificates if you are not changing any configuration for the Strimzi Drain Cleaner, such as namespaces, service names, or pod names.
+Otherwise, you can generate and use your own certificates. 
 +
 NOTE: You can use the build script and files provided in link:https://github.com/strimzi/drain-cleaner/tree/main/install/kubernetes/webhook-certificates[`webhook-certificates`^]
 to generate your own certificates. The script uses the link:https://github.com/cloudflare/cfssl[`CFSSL`^] and link:https://www.openssl.org/[openSSL] tools to generate the certificates.
 After you have generated the certificates, you need to add them to the `040-Secret.yaml` and `070-ValidatingWebhookConfiguration.yaml` files.
 --
+endif::Section[]
+
+* To run the Drain Cleaner on OpenShift, apply the resources in the `/install/drain-cleaner/openshift` directory.
++
+[source,shell,subs="attributes+"]
+----
+kubectl apply -f ./install/drain-cleaner/openshift
+----

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -152,6 +152,7 @@
 :InstallationAppendix:
 :Metrics:
 :Downloading:
+:Section:
 
 //EXCLUSIVE TO STRIMZI
 :sectlinks:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds option to leave out deployment options for drain cleaner.
Procedure can present kubernetes and openshift options or just openshift

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

