### PR TITLE
Allow kafka-connect to run in cluster on dual-stack clusters

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
@@ -115,7 +115,7 @@ cat <<EOF
 bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
 # REST Listeners
 rest.port=8083
-rest.advertised.host.name=$(hostname -I)
+rest.advertised.host.name=$(hostname -I | awk '{ print $1 }')
 rest.advertised.port=8083
 # Plugins
 plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}


### PR DESCRIPTION
Currently when running kafka-connect in dual-stack cluster 'hostname -I' returns string "ipv4 ipv6" and most of the time it's not possible to add connector. This change will return only one ipv4 address and for single-stack it'll behaviour as previously.

Signed-off-by: Roman Volchanskii <106171439+rvolchanskii@users.noreply.github.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

