### PR TITLE
Move CR validation from AbstractOperator to StatusUtils

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -22,8 +22,6 @@ import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
-import io.strimzi.operator.common.model.ResourceVisitor;
-import io.strimzi.operator.common.model.ValidationVisitor;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -36,8 +34,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.Lock;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -57,7 +53,7 @@ import static io.strimzi.operator.common.Util.async;
  * {@link #reconcile(Reconciliation)} by delegating to abstract {@link #createOrUpdate(Reconciliation, CustomResource)}
  * and {@link #delete(Reconciliation)} methods for subclasses to implement.
  *
- * <li>add support for operator-side {@linkplain #validate(Reconciliation, CustomResource) validation}.
+ * <li>add support for operator-side {@linkplain StatusUtils#validate(Reconciliation, CustomResource)} validation}.
  *     This can be used to automatically log warnings about source resources which used deprecated part of the CR API.
  *ą
  * </ul>
@@ -184,7 +180,7 @@ public abstract class AbstractOperator<
                 Promise<Void> createOrUpdate = Promise.promise();
                 if (Annotations.isReconciliationPausedWithAnnotation(cr)) {
                     S status = createStatus();
-                    Set<Condition> conditions = validate(reconciliation, cr);
+                    Set<Condition> conditions = StatusUtils.validate(reconciliation, cr);
                     conditions.add(StatusUtils.getPausedCondition());
                     status.setConditions(new ArrayList<>(conditions));
                     status.setObservedGeneration(cr.getStatus() != null ? cr.getStatus().getObservedGeneration() : 0);
@@ -221,7 +217,7 @@ public abstract class AbstractOperator<
                     return createOrUpdate.future();
                 }
 
-                Set<Condition> unknownAndDeprecatedConditions = validate(reconciliation, cr);
+                Set<Condition> unknownAndDeprecatedConditions = StatusUtils.validate(reconciliation, cr);
 
                 LOGGER.infoCr(reconciliation, "{} {} will be checked for creation or modification", kind, name);
 
@@ -439,27 +435,6 @@ public abstract class AbstractOperator<
         lock.release();
         LOGGER.debugCr(reconciliation, "Lock {} released", lockName);
         return Future.succeededFuture();
-    }
-
-    /**
-     * Validate the Custom Resource.
-     * This should log at the WARN level (rather than throwing)
-     * if the resource can safely be reconciled (e.g. it merely using deprecated API).
-     * @param reconciliation The reconciliation
-     * @param resource The custom resource
-     * @throws InvalidResourceException if the resource cannot be safely reconciled.
-     * @return set of conditions
-     */
-    /*test*/ public Set<Condition> validate(Reconciliation reconciliation, T resource) {
-        if (resource != null) {
-            Set<Condition> warningConditions = new LinkedHashSet<>(0);
-
-            ResourceVisitor.visit(reconciliation, resource, new ValidationVisitor(resource, LOGGER, warningConditions));
-
-            return warningConditions;
-        }
-
-        return Collections.emptySet();
     }
 
     public Future<Set<NamespaceAndName>> allResourceNames(String namespace) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -226,7 +226,7 @@ public abstract class AbstractOperator<
                             if (res.succeeded()) {
                                 S status = res.result();
 
-                                addWarningsToStatus(status, unknownAndDeprecatedConditions);
+                                StatusUtils.addConditionsToStatus(status, unknownAndDeprecatedConditions);
                                 updateStatus(reconciliation, status).onComplete(statusResult -> {
                                     if (statusResult.succeeded()) {
                                         createOrUpdate.complete();
@@ -238,7 +238,7 @@ public abstract class AbstractOperator<
                                 if (res.cause() instanceof ReconciliationException) {
                                     ReconciliationException e = (ReconciliationException) res.cause();
                                     Status status = e.getStatus();
-                                    addWarningsToStatus(status, unknownAndDeprecatedConditions);
+                                    StatusUtils.addConditionsToStatus(status, unknownAndDeprecatedConditions);
 
                                     LOGGER.errorCr(reconciliation, "createOrUpdate failed", e.getCause());
 
@@ -279,12 +279,6 @@ public abstract class AbstractOperator<
         });
 
         return result.future();
-    }
-
-    protected void addWarningsToStatus(Status status, Set<Condition> unknownAndDeprecatedConditions)   {
-        if (status != null)  {
-            status.addConditions(unknownAndDeprecatedConditions);
-        }
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -160,11 +160,11 @@ public class StatusUtils {
      * Adds additional conditions to te status (this expects)
      *
      * @param status                            The Status instance where additonal conditions should be added
-     * @param unknownAndDeprecatedConditions    The Set with the new conditions
+     * @param conditions    The Set with the new conditions
      */
-    public static void addConditionsToStatus(Status status, Set<Condition> unknownAndDeprecatedConditions)   {
+    public static void addConditionsToStatus(Status status, Set<Condition> conditions)   {
         if (status != null)  {
-            status.addConditions(unknownAndDeprecatedConditions);
+            status.addConditions(conditions);
         }
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -159,7 +159,7 @@ public class StatusUtils {
     /**
      * Adds additional conditions to te status (this expects)
      *
-     * @param status                            The Status instance where additonal conditions should be added
+     * @param status        The Status instance where additonal conditions should be added
      * @param conditions    The Set with the new conditions
      */
     public static void addConditionsToStatus(Status status, Set<Condition> conditions)   {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -155,4 +155,16 @@ public class StatusUtils {
 
         return Collections.emptySet();
     }
+
+    /**
+     * Adds additional conditions to te status (this expects)
+     *
+     * @param status                            The Status instance where additonal conditions should be added
+     * @param unknownAndDeprecatedConditions    The Set with the new conditions
+     */
+    public static void addConditionsToStatus(Status status, Set<Condition> unknownAndDeprecatedConditions)   {
+        if (status != null)  {
+            status.addConditions(unknownAndDeprecatedConditions);
+        }
+    }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -6,9 +6,15 @@
 package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.Spec;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.model.ResourceVisitor;
+import io.strimzi.operator.common.model.ValidationVisitor;
 import io.vertx.core.AsyncResult;
 
 import java.time.ZoneOffset;
@@ -16,11 +22,15 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class StatusUtils {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StatusUtils.class);
+
     /**
      * Returns the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
-     * 
+     *
      * @return the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
      */
     public static String iso8601Now() {
@@ -84,18 +94,15 @@ public class StatusUtils {
                 .build();
     }
 
-    @SuppressWarnings({ "rawtypes" })
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, AsyncResult<Void> result) {
+    public static <R extends CustomResource<P, S>, P extends Spec, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, AsyncResult<Void> result) {
         setStatusConditionAndObservedGeneration(resource, status, result.cause());
     }
 
-    @SuppressWarnings({ "rawtypes" })
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, Throwable error) {
+    public static <R extends CustomResource<P, S>, P extends Spec, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, Throwable error) {
         setStatusConditionAndObservedGeneration(resource, status, error == null ? "Ready" : "NotReady", "True", error);
     }
 
-    @SuppressWarnings({ "rawtypes" })
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, String conditionStatus, Throwable error) {
+    public static <R extends CustomResource<P, S>, P extends Spec, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, String conditionStatus, Throwable error) {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
@@ -103,26 +110,11 @@ public class StatusUtils {
         status.setConditions(Collections.singletonList(readyCondition));
     }
 
-    @SuppressWarnings({ "rawtypes" })
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, Throwable error) {
+    public static <R extends CustomResource<P, S>, P extends Spec, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, Throwable error) {
         setStatusConditionAndObservedGeneration(resource, status, type, "True", error);
     }
 
-    @SuppressWarnings({ "rawtypes" })
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type, String conditionStatus) {
-        if (resource.getMetadata().getGeneration() != null)    {
-            status.setObservedGeneration(resource.getMetadata().getGeneration());
-        }
-        Condition condition = StatusUtils.buildCondition(type, conditionStatus, null);
-        status.setConditions(Collections.singletonList(condition));
-    }
-
-    @SuppressWarnings({ "rawtypes" })
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, String type) {
-        setStatusConditionAndObservedGeneration(resource, status, type, "True");
-    }
-
-    public static <R extends CustomResource, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, Condition condition) {
+    public static <R extends CustomResource<P, S>, P extends Spec, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, Condition condition) {
         if (resource.getMetadata().getGeneration() != null)    {
             status.setObservedGeneration(resource.getMetadata().getGeneration());
         }
@@ -135,5 +127,32 @@ public class StatusUtils {
                 .withType("ReconciliationPaused")
                 .withStatus("True")
                 .build();
+    }
+
+    /**
+     * Validate the Custom Resource. This should log at the WARN level (rather than throwing) if the resource can safely
+     * be reconciled (e.g. it merely using deprecated API).
+     *
+     * @param <T>               Custom Resource type
+     * @param <P>               Custom Resource spec type
+     * @param <S>               Custom Resource status type
+     *
+     * @param reconciliation    The reconciliation
+     * @param resource          The custom resource
+     *
+     * @throws InvalidResourceException if the resource cannot be safely reconciled.
+     *
+     * @return set of conditions
+     */
+    public static <T extends CustomResource<P, S>, P extends Spec, S extends Status> Set<Condition> validate(Reconciliation reconciliation, T resource) {
+        if (resource != null) {
+            Set<Condition> warningConditions = new LinkedHashSet<>(0); // LinkedHashSet is used to maintain ordering
+
+            ResourceVisitor.visit(reconciliation, resource, new ValidationVisitor(resource, LOGGER, warningConditions));
+
+            return warningConditions;
+        }
+
+        return Collections.emptySet();
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `validate` method in `AbstractOperator` class is used to get warnings from the Custom Resource (for example due to the use of deprecated fields) for the conditions section of the custom resource status. This PR moves this method from `AbstractOperator` class to `StatusUtils` where it can be used as a static method and available to other classes as well. It moves in the sme direction also the method `addWarningsToStatus` for adding additional conditions to the existing `Status` object. (This is related to my UserOperator refactoring, just want to do this as a separate PR to make reviews easier)

This PR also removes some warnings and unused methods from the `StatusUtils` class. 

It also does refactoring to the `OperatorMetricsTest`. This was needed to get the tests passing with the moved `validate` method => the nested `Foo` classes were not accessible to the method from a different class. This refactoring seems to also simplify the code in general.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally