### PR TITLE
Fixed Kafka Exporter Grafana dashboard with N/A for empty numeric fields

### DIFF
--- a/documentation/modules/metrics/con_kafka-exporter-lag.adoc
+++ b/documentation/modules/metrics/con_kafka-exporter-lag.adoc
@@ -13,6 +13,8 @@ Kafka Exporter extracts additional metrics data from Kafka brokers related to of
 The metrics data is used, for example, to help identify slow consumers.
 Lag data is exposed as Prometheus metrics, which can then be presented in Grafana for analysis.
 
+The Grafana dashboard for Kafka Exporter, provided as an example, is available in the xref:ref-metrics-dashboards-{context}[Example Grafana dashboards] list.
+
 IMPORTANT: Kafka Exporter provides only additional metrics related to consumer lag and consumer offsets.
 For regular Kafka metrics, you have to configure the Prometheus metrics in xref:proc-metrics-kafka-deploy-options-{context}[Kafka brokers].
 

--- a/documentation/modules/metrics/con_kafka-exporter-lag.adoc
+++ b/documentation/modules/metrics/con_kafka-exporter-lag.adoc
@@ -13,7 +13,7 @@ Kafka Exporter extracts additional metrics data from Kafka brokers related to of
 The metrics data is used, for example, to help identify slow consumers.
 Lag data is exposed as Prometheus metrics, which can then be presented in Grafana for analysis.
 
-The Grafana dashboard for Kafka Exporter, provided as an example, is available in the xref:ref-metrics-dashboards-{context}[Example Grafana dashboards] list.
+A Grafana dashboard for Kafka Exporter is one of a number of xref:ref-metrics-dashboards-{context}[example Grafana dashboards] provided by Strimzi.
 
 IMPORTANT: Kafka Exporter provides only additional metrics related to consumer lag and consumer offsets.
 For regular Kafka metrics, you have to configure the Prometheus metrics in xref:proc-metrics-kafka-deploy-options-{context}[Kafka brokers].

--- a/documentation/modules/metrics/ref_metrics-dashboards.adoc
+++ b/documentation/modules/metrics/ref_metrics-dashboards.adoc
@@ -49,3 +49,5 @@ The dashboards are populated with a representative set of metrics for monitoring
 |`strimzi-kafka-exporter.json`
 
 |===
+
+NOTE: When metrics are not available to Kafka Exporter, because there is no traffic in the cluster yet, the corresponding Grafana dashboard will show `N/A` for numeric fields and `No data to show` for graphs.

--- a/documentation/modules/metrics/ref_metrics-dashboards.adoc
+++ b/documentation/modules/metrics/ref_metrics-dashboards.adoc
@@ -50,4 +50,4 @@ The dashboards are populated with a representative set of metrics for monitoring
 
 |===
 
-NOTE: When metrics are not available to Kafka Exporter, because there is no traffic in the cluster yet, the corresponding Grafana dashboard will show `N/A` for numeric fields and `No data to show` for graphs.
+NOTE: When metrics are not available to the Kafka Exporter, because there is no traffic in the cluster yet, the Kafka Exporter Grafana dashboard will show `N/A` for numeric fields and `No data to show` for graphs.

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -125,7 +125,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -206,7 +206,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -287,7 +287,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -368,7 +368,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -449,7 +449,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -531,7 +531,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -613,7 +613,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],
@@ -694,7 +694,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "0",
+          "text": "N/A",
           "value": "null"
         }
       ],


### PR DESCRIPTION
This PR fixes #2628 
It changes the Kafka Exporter Grafana dashboard in order to show `N/A` instead of `0` when metrics are not available to show current data.
It also explains the meaning of this in the corresponding documentation.