### PR TITLE
Add support for IPv6 addresses in our TLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Pluggable Pod Security Profiles with built-in support for _restricted_ Kubernetes Security Profile
 * Add support for leader election and running multiple operator replicas (1 active leader replicas and one or more stand-by replicas)
 * Update Strimzi Kafka Bridge to 0.22.0
+* Add support for IPv6 addresses being used in Strimzi issued certificates
 
 ### Deprecations and removals
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
@@ -12,32 +12,37 @@ import java.util.regex.Pattern;
  */
 public class IpAndDnsValidation {
     // Pattern for matching IPv4 address (requires additional check for segments to be equal or less than 255 - this is done in the isValidIpv4Address method)
-    private static final Pattern IPV4_ADDRESS = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+    private static final Pattern IPV4_ADDRESS = Pattern.compile("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$");
 
     // Pattern for uncompressed IPv6 address -> case-insensitive, tolerates leading 0s
     private static final Pattern IPV6_ADDRESS = Pattern.compile("^(?:[\\da-fA-F]{1,4}:){7}[\\da-fA-F]{1,4}$");
 
-    // Pattern for compressed IPv6 address -> case-insensitive, tolerates leading 0s
+    // Pattern for compressed IPv6 address -> case-insensitive, tolerates leading 0s (requires additional check for number of segments)
     private static final Pattern IPV6_COMPRESSED_ADDRESS = Pattern.compile("^((?:[\\dA-Fa-f]{1,4}(?::[\\dA-Fa-f]{1,4})*)?)::((?:[\\dA-Fa-f]{1,4}(?::[\\dA-Fa-f]{1,4})*)?)$");
 
     // Pattern for DNS names
-    private static final Pattern DNS_NAME = Pattern.compile("^(" +
-            // a single char dns name
-            "[a-zA-Z\\d]|" +
-            // can't begin or end with -                followed by more labels of same
-            "[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d])(\\.([a-zA-Z\\d]|[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d]))*$");
+    private static final Pattern DNS_NAME;
+    static {
+        String dnsLabel = "(" +
+                // a single char dns name (can't begin or end with)
+                "[a-zA-Z\\d]|" +
+                // followed by more labels of same
+                "[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d])";
+        DNS_NAME = Pattern.compile("^" + dnsLabel + "(\\." + dnsLabel + ")*");
+    }
 
     // Pattern used to normalize the segments of the IPv6 address
     private static final Pattern IPV6_LEADING_ZEROS_TRIMMING = Pattern.compile("(^|:)0+([\\da-f]+)(:|$)");
 
     /**
-     * Returns true if the name is a valid DNS name. That means that it matches the DNS_NAME pattern
+     * Returns true if the name is a valid DNS name or a wildcard DNS name. That means that it matches the DNS_NAME
+     * pattern or starts with *. followed up with a string which matches the DNS_PATTERN.
      *
      * @param name   Name which should be validated
      *
      * @return  True if the name is valid DNS name. False otherwise.
      */
-    public static boolean isValidDnsName(String name) {
+    public static boolean isValidDnsNameOrWildcard(String name) {
         return name.length() <= 255
                 && (DNS_NAME.matcher(name).matches()
                 || (name.startsWith("*.") && DNS_NAME.matcher(name.substring(2)).matches()));
@@ -85,23 +90,26 @@ public class IpAndDnsValidation {
      * @return  True if the name is valid IPv4 address. False otherwise.
      */
     public static boolean isValidIpv6Address(String ip) {
-        return IPV6_ADDRESS.matcher(ip).matches() || IPV6_COMPRESSED_ADDRESS.matcher(ip).matches();
+        return IPV6_ADDRESS.matcher(ip).matches()
+                // Includes additional segment count check for the compressed address
+                || (IPV6_COMPRESSED_ADDRESS.matcher(ip).matches() && ip.split(":").length > 0 && ip.split(":").length <= 7);
     }
 
     /**
-     * Normalizes the IPv6 address. Normalized address in Strimzi means that the IPv6 address is:
+     * Normalizes the IPv6 address. The address passed to thus method should be already validated. Normalized address
+     * in Strimzi means that the IPv6 address is:
      *     - uncompressed
      *     - without leading 0
      *     - lowercase
      * This is based on the OpenSSL output. OpenSSL will normalize the IPv6 addresses in SANs this way. And we need to
      * be able to compare the SANs to know when the SANs changed and a new cert should be generated.
      *
-     * @param ip    IPv6 address which should be normalized
+     * @param validIp    IPv6 address which should be normalized. The IPv6 address passed here should be already validated.
      *
      * @return  Normalized IPv6 address
      */
-    public static String normalizeIpv6Address(String ip)   {
-        String normalized = ip;
+    public static String normalizeIpv6Address(String validIp)   {
+        String normalized = validIp;
 
         // Normalize compressed address
         // We insert the required number of 0 segments instead of :: to uncompress the address

--- a/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.certs;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class to help with validation of IP addresses and DNS addresses
+ */
+public class IpAndDnsValidation {
+    // Pattern for matching IPv4 address (requires additional check for segments to be equal or less than 255 - this is done in the isValidIpv4Address method)
+    private static final Pattern IPV4_ADDRESS = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+
+    // Pattern for uncompressed IPv6 address -> case-insensitive, tolerates leading 0s
+    private static final Pattern IPV6_ADDRESS = Pattern.compile("^(?:[\\da-fA-F]{1,4}:){7}[\\da-fA-F]{1,4}$");
+
+    // Pattern for compressed IPv6 address -> case-insensitive, tolerates leading 0s
+    private static final Pattern IPV6_COMPRESSED_ADDRESS = Pattern.compile("^((?:[\\dA-Fa-f]{1,4}(?::[\\dA-Fa-f]{1,4})*)?)::((?:[\\dA-Fa-f]{1,4}(?::[\\dA-Fa-f]{1,4})*)?)$");
+
+    // Pattern for DNS names
+    private static final Pattern DNS_NAME = Pattern.compile("^(" +
+            // a single char dns name
+            "[a-zA-Z\\d]|" +
+            // can't begin or end with -                followed by more labels of same
+            "[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d])(\\.([a-zA-Z\\d]|[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d]))*$");
+
+    // Pattern used to normalize the segments of the IPv6 address
+    private static final Pattern IPV6_LEADING_ZEROS_TRIMMING = Pattern.compile("(^|:)0+([\\da-f]+)(:|$)");
+
+    /**
+     * Returns true if the name is a valid DNS name. That means that it matches the DNS_NAME pattern
+     *
+     * @param name   Name which should be validated
+     *
+     * @return  True if the name is valid DNS name. False otherwise.
+     */
+    public static boolean isValidDnsName(String name) {
+        return name.length() <= 255
+                && (DNS_NAME.matcher(name).matches()
+                || (name.startsWith("*.") && DNS_NAME.matcher(name.substring(2)).matches()));
+    }
+
+    /**
+     * Returns true if the name is a valid IPv4 or IPv6 address.
+     *
+     * @param ip    IP address which should be validated
+     *
+     * @return  True if the name is valid IP address. False otherwise.
+     */
+    public static boolean isValidIpAddress(String ip) {
+        return isValidIpv4Address(ip) || isValidIpv6Address(ip);
+    }
+
+    /**
+     * Returns true if the name is a valid IPv4 address. Valid IPv4 address is an address which matches the IPV6_ADDRESS
+     * or IPV6_COMPRESSED_ADDRESS pattern.
+     *
+     * @param ip    IP address which should be validated
+     *
+     * @return  True if the name is valid IPv6 address. False otherwise.
+     */
+    public static boolean isValidIpv4Address(String ip) {
+        boolean matches = IPV4_ADDRESS.matcher(ip).matches();
+        if (matches) {
+            String[] split = ip.split("\\.");
+            for (String num : split) {
+                int i = Integer.parseInt(num);
+                if (i > 255) {
+                    return false;
+                }
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * Returns true if the name is a valid IPv6 address. Valid IPv6 address is an address which matches the IPV4_ADDRESS
+     * pattern and each segment is equal or less than 255.
+     *
+     * @param ip    IP address which should be validated
+     *
+     * @return  True if the name is valid IPv4 address. False otherwise.
+     */
+    public static boolean isValidIpv6Address(String ip) {
+        return IPV6_ADDRESS.matcher(ip).matches() || IPV6_COMPRESSED_ADDRESS.matcher(ip).matches();
+    }
+
+    /**
+     * Normalizes the IPv6 address. Normalized address in Strimzi means that the IPv6 address is:
+     *     - uncompressed
+     *     - without leading 0
+     *     - lowercase
+     * This is based on the OpenSSL output. OpenSSL will normalize the IPv6 addresses in SANs this way. And we need to
+     * be able to compare the SANs to know when the SANs changed and a new cert should be generated.
+     *
+     * @param ip    IPv6 address which should be normalized
+     *
+     * @return  Normalized IPv6 address
+     */
+    public static String normalizeIpv6Address(String ip)   {
+        String normalized = ip;
+
+        // Normalize compressed address
+        // We insert the required number of 0 segments instead of :: to uncompress the address
+        if (normalized.contains("::"))  {
+            int segments = normalized.split(":").length - 1;
+            normalized = normalized.replace("::", ":" + "0:".repeat(8 - segments));
+
+            if (normalized.startsWith(":")) {
+                normalized = "0" + normalized;
+            } else if (normalized.endsWith(":"))    {
+                normalized = normalized.substring(0, normalized.length() - 3);
+            }
+        }
+
+        // Continue with uncompressed IP address
+        // Make it lowercase
+        normalized = normalized.toLowerCase(Locale.ENGLISH);
+
+        // Remove leading zeros (this intentionally runs twice, because I do not know how to write a better REGEX which would do everything in one go)
+        normalized = IPV6_LEADING_ZEROS_TRIMMING.matcher(normalized).replaceAll("$1$2$3");
+        normalized = IPV6_LEADING_ZEROS_TRIMMING.matcher(normalized).replaceAll("$1$2$3");
+
+        // return the normalized IPv6 address
+        return normalized;
+    }
+}

--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -36,7 +36,7 @@ public class Subject {
             return this;
         }
         public Builder addDnsName(String dnsName) {
-            if (!IpAndDnsValidation.isValidDnsName(dnsName)) {
+            if (!IpAndDnsValidation.isValidDnsNameOrWildcard(dnsName)) {
                 throw new IllegalArgumentException("Invalid DNS name: " + dnsName);
             }
             if (dnsNames == null) {

--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,14 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Can be serialized as JSON.
  */
 public class Subject {
-
     public static class Builder {
-        private static final Pattern IPV4_ADDRESS = Pattern.compile("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}");
-        private static final Pattern DNS_NAME = Pattern.compile("^(" +
-                // a single char dns name
-                "[a-zA-Z0-9]|" +
-                // can't begin or end with -                followed by more labels of same
-                "[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$");
+
         private String organizationName;
         private String commonName;
         private Set<String> dnsNames = null;
@@ -43,7 +36,7 @@ public class Subject {
             return this;
         }
         public Builder addDnsName(String dnsName) {
-            if (!isValidDnsName(dnsName)) {
+            if (!IpAndDnsValidation.isValidDnsName(dnsName)) {
                 throw new IllegalArgumentException("Invalid DNS name: " + dnsName);
             }
             if (dnsNames == null) {
@@ -53,35 +46,29 @@ public class Subject {
             return this;
         }
 
-        public boolean isValidDnsName(String dnsName) {
-            return dnsName.length() <= 255
-                    && (DNS_NAME.matcher(dnsName).matches()
-                    || (dnsName.startsWith("*.") && DNS_NAME.matcher(dnsName.substring(2)).matches()));
-        }
-
-        public Builder addIpAddress(String ip) {
-            if (!isValidIpv4Address(ip)) {
-                throw new IllegalArgumentException("Invalid IPv4 address");
-            }
+        /**
+         * Adds the IP address to the list of IP address based SANs. The IP address will be validated to be a valid IPv4
+         * or IPv6 address. The IPv6 address will be also normalized into the format used by OpenSSL to make it possible
+         * to diff them.
+         *
+         * @param ip    IP address which should be added
+         *
+         * @return  The Subject.Builder instance
+         */
+        public Subject.Builder addIpAddress(String ip) {
             if (ipAddresses == null) {
                 ipAddresses = new HashSet<>();
             }
-            ipAddresses.add(ip);
-            return this;
-        }
 
-        public boolean isValidIpv4Address(String ip) {
-            boolean matches = IPV4_ADDRESS.matcher(ip).matches();
-            if (matches) {
-                String[] split = ip.split("\\.");
-                for (String num : split) {
-                    int i = Integer.parseInt(num);
-                    if (i > 255) {
-                        return false;
-                    }
-                }
+            if (IpAndDnsValidation.isValidIpv4Address(ip)) {
+                ipAddresses.add(ip);
+            } else if (IpAndDnsValidation.isValidIpv6Address(ip))   {
+                ipAddresses.add(IpAndDnsValidation.normalizeIpv6Address(ip));
+            } else {
+                throw new IllegalArgumentException("Invalid IPv4 or IPv6 address address " + ip);
             }
-            return matches;
+
+            return this;
         }
 
         public Subject build() {

--- a/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
@@ -13,15 +13,22 @@ public class IpAndDnsValidationTest {
     @Test
     public void testIPv6()   {
         assertThat(IpAndDnsValidation.isValidIpv6Address("::1"), is(true));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::"), is(true));
         assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::8d1c"), is(true));
         assertThat(IpAndDnsValidation.isValidIpv6Address("::fc01:8d1c"), is(true));
         assertThat(IpAndDnsValidation.isValidIpv6Address("fc01:8d1c::"), is(true));
         assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:B03:1:AF18"), is(true));
 
-        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::8j1c"), is(false));
-        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::176j::8j1c"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("::"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::8j1c"), is(false)); // j is not allowed character
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::176d::8d1c"), is(false)); // Too many ::
+        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:B03::0:1:AF18"), is(false)); // Too many segements
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01c::8d1c"), is(false)); // Segment with too many characters
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01:::8d1c"), is(false)); // Triple :
         assertThat(IpAndDnsValidation.isValidIpv6Address("176J:0:0:0:0:B03:1:AF18"), is(false));
-        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:1:B03:1:AF18"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:1:B03:1:AF18"), is(false)); // Too many segments
+        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:B03:1:2AF18"), is(false)); // Segment with too many characters
+        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:53B03:1:AF18"), is(false)); // Segment with too many characters
     }
 
     @Test
@@ -30,16 +37,18 @@ public class IpAndDnsValidationTest {
         assertThat(IpAndDnsValidation.isValidIpv4Address("123.123.123.123"), is(true));
 
         assertThat(IpAndDnsValidation.isValidIpv4Address("127.0.0.0.1"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv4Address("127.0.1"), is(false));
         assertThat(IpAndDnsValidation.isValidIpv4Address("321.321.321.321"), is(false));
         assertThat(IpAndDnsValidation.isValidIpv4Address("some.domain.name"), is(false));
     }
 
     @Test
     public void testDnsNames()   {
-        assertThat(IpAndDnsValidation.isValidDnsName("example"), is(true));
-        assertThat(IpAndDnsValidation.isValidDnsName("example.com"), is(true));
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("example"), is(true));
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("example.com"), is(true));
 
-        assertThat(IpAndDnsValidation.isValidDnsName("example:com"), is(false));
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("example:com"), is(false));
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongexample.com"), is(false));
     }
 
     @Test
@@ -56,6 +65,7 @@ public class IpAndDnsValidationTest {
 
         assertThat(IpAndDnsValidation.normalizeIpv6Address("1762:0000:0000:0000:0000:0B03:0001:AF18"), is("1762:0:0:0:0:b03:1:af18"));
         assertThat(IpAndDnsValidation.normalizeIpv6Address("0000:0000:0000:1762:0000:0B03:0001:AF18"), is("0:0:0:1762:0:b03:1:af18"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("0000:0000:0000:1762:0000:0B03::0001:AF18"), is("0:0:0:1762:0:b03:1:af18"));
         assertThat(IpAndDnsValidation.normalizeIpv6Address("1762:0000:0000:0000:0000:0B03:0001:00"), is("1762:0:0:0:0:b03:1:0"));
     }
 }

--- a/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
@@ -63,6 +63,7 @@ public class IpAndDnsValidationTest {
         assertThat(IpAndDnsValidation.normalizeIpv6Address("fc01::"), is("fc01:0:0:0:0:0:0:0"));
         assertThat(IpAndDnsValidation.normalizeIpv6Address("::1"), is("0:0:0:0:0:0:0:1"));
 
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("1762:0000:000:00:0:0B03:0001:AF18"), is("1762:0:0:0:0:b03:1:af18"));
         assertThat(IpAndDnsValidation.normalizeIpv6Address("1762:0000:0000:0000:0000:0B03:0001:AF18"), is("1762:0:0:0:0:b03:1:af18"));
         assertThat(IpAndDnsValidation.normalizeIpv6Address("0000:0000:0000:1762:0000:0B03:0001:AF18"), is("0:0:0:1762:0:b03:1:af18"));
         assertThat(IpAndDnsValidation.normalizeIpv6Address("0000:0000:0000:1762:0000:0B03::0001:AF18"), is("0:0:0:1762:0:b03:1:af18"));

--- a/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.certs;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class IpAndDnsValidationTest {
+    @Test
+    public void testIPv6()   {
+        assertThat(IpAndDnsValidation.isValidIpv6Address("::1"), is(true));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::8d1c"), is(true));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("::fc01:8d1c"), is(true));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01:8d1c::"), is(true));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:B03:1:AF18"), is(true));
+
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::8j1c"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("fc01::176j::8j1c"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("176J:0:0:0:0:B03:1:AF18"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv6Address("1762:0:0:0:0:1:B03:1:AF18"), is(false));
+    }
+
+    @Test
+    public void testIPv4()   {
+        assertThat(IpAndDnsValidation.isValidIpv4Address("127.0.0.1"), is(true));
+        assertThat(IpAndDnsValidation.isValidIpv4Address("123.123.123.123"), is(true));
+
+        assertThat(IpAndDnsValidation.isValidIpv4Address("127.0.0.0.1"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv4Address("321.321.321.321"), is(false));
+        assertThat(IpAndDnsValidation.isValidIpv4Address("some.domain.name"), is(false));
+    }
+
+    @Test
+    public void testDnsNames()   {
+        assertThat(IpAndDnsValidation.isValidDnsName("example"), is(true));
+        assertThat(IpAndDnsValidation.isValidDnsName("example.com"), is(true));
+
+        assertThat(IpAndDnsValidation.isValidDnsName("example:com"), is(false));
+    }
+
+    @Test
+    public void testIpv6Normalization() {
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("fc01::8d1c"), is("fc01:0:0:0:0:0:0:8d1c"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("FC01::8D1C"), is("fc01:0:0:0:0:0:0:8d1c"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("00FC::0D1C"), is("fc:0:0:0:0:0:0:d1c"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("fc01::af18:8d1c"), is("fc01:0:0:0:0:0:af18:8d1c"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("::fc01:8d1c"), is("0:0:0:0:0:0:fc01:8d1c"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("fc01:8d1c::"), is("fc01:8d1c:0:0:0:0:0:0"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("::8d1c"), is("0:0:0:0:0:0:0:8d1c"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("fc01::"), is("fc01:0:0:0:0:0:0:0"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("::1"), is("0:0:0:0:0:0:0:1"));
+
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("1762:0000:0000:0000:0000:0B03:0001:AF18"), is("1762:0:0:0:0:b03:1:af18"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("0000:0000:0000:1762:0000:0B03:0001:AF18"), is("0:0:0:1762:0:b03:1:af18"));
+        assertThat(IpAndDnsValidation.normalizeIpv6Address("1762:0000:0000:0000:0000:0B03:0001:00"), is("1762:0:0:0:0:b03:1:0"));
+    }
+}

--- a/certificate-manager/src/test/java/io/strimzi/certs/SubjectTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SubjectTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SubjectTests {
+public class SubjectTest {
     @Test
     public void testSubjectOpensslDn()   {
         Subject.Builder subject = new Subject.Builder()
@@ -75,6 +75,20 @@ public class SubjectTests {
         new Subject.Builder().addDnsName("*.example.com");
         assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("foo.*.example.come"));
         assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("54t8g#'/.l"));
+    }
 
+    @Test
+    public void testIPV6()   {
+        Subject subject = new Subject.Builder()
+                .withCommonName("joe")
+                .addIpAddress("fc01::8d1c")
+                .addIpAddress("1762:0000:0000:00:0000:0B03:0001:AF18")
+                .addIpAddress("1974:0:0:0:0:B03:1:AF74")
+                .build();
+        assertEquals(Map.of(
+                        "IP.0", "fc01:0:0:0:0:0:0:8d1c",
+                        "IP.1", "1974:0:0:0:0:b03:1:af74",
+                        "IP.2", "1762:0:0:0:0:b03:1:af18"),
+                subject.subjectAltNames());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
@@ -18,6 +17,7 @@ import io.strimzi.api.kafka.model.KafkaExporterResources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
+import io.strimzi.certs.IpAndDnsValidation;
 import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.common.PasswordGenerator;
@@ -34,8 +34,6 @@ public class ClusterCa extends Ca {
 
     private Secret brokersSecret;
     private Secret zkNodesSecret;
-
-    private final Pattern ipv4Address = Pattern.compile("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}");
 
     public ClusterCa(Reconciliation reconciliation, CertManager certManager, PasswordGenerator passwordGenerator, String clusterName, Secret caCertSecret, Secret caKeySecret) {
         this(reconciliation, certManager, passwordGenerator, clusterName, caCertSecret, caKeySecret, 365, 30, true, null);
@@ -200,20 +198,20 @@ public class ClusterCa extends Ca {
 
             if (externalBootstrapAddresses != null)   {
                 for (String dnsName : externalBootstrapAddresses) {
-                    if (!ipv4Address.matcher(dnsName).matches()) {
-                        subject.addDnsName(dnsName);
-                    } else {
+                    if (IpAndDnsValidation.isValidIpAddress(dnsName))   {
                         subject.addIpAddress(dnsName);
+                    } else {
+                        subject.addDnsName(dnsName);
                     }
                 }
             }
 
             if (externalAddresses.get(i) != null)   {
                 for (String dnsName : externalAddresses.get(i)) {
-                    if (!ipv4Address.matcher(dnsName).matches()) {
-                        subject.addDnsName(dnsName);
-                    } else {
+                    if (IpAndDnsValidation.isValidIpAddress(dnsName))   {
                         subject.addIpAddress(dnsName);
+                    } else {
+                        subject.addDnsName(dnsName);
                     }
                 }
             }


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Addresses added to certificate SANs have to be added either as IP addresses or as DNS addresses. So Strimzi does a validation to decide if the address is IP or DNS and adds them. However, we currently support only IPv4 addresses. And if user tries to add IPv6 address, it will be rejected as invalid.

This PR adds support for IPv6 addresses to Strimzi. It is non-trivial task because the format of IPv6 addresses is more complicated compared to IPv4. And also, we need to normalize the IPv6 address, because the certificate management tool (currently OpenSSL) will do that as well and we need to compare the different addresses against each other. To achieve this, we add:
* New class `IpAndDnsValidation` where we centralize the logic for validating IP and DNS addresses, which was currently duplicated between multiple different classes. So now it is in one central class.
* Support for validating IPv6 addresses in both compressed and uncompressed formats
* Support for normalizing the IPv6 address. We use lowercase uncompressed address without any leading zeros. This allows us to compare the existing certificates and decide if new certificates should be issued.
* Tests for the IP address validation and normalization and also a test which compares the OpenSSL generated certificate with our configuration to make sure the normalization works.

This should close #7217.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging