### PR TITLE
[MO] - [system test] -> drain cleaner uses dynamically generated cert…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
@@ -21,6 +21,8 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.x509.GeneralName;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
@@ -45,11 +47,12 @@ public class SetupDrainCleaner {
         final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
             .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
                 // add hostnames (i.e., SANs) to the certificate
-//                "strimzi-drain-cleaner," +
-//                "strimzi-drain-cleaner.strimzi-drain-cleaner," +
-                "strimzi-drain-cleaner.strimzi-drain-cleaner.svc"
-//                "strimzi-drain-cleaner.strimzi-drain-cleaner.svc.cluster.local"
-                );
+                new ASN1Encodable[] {
+                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner"),
+                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner.strimzi-drain-cleaner"),
+                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner.strimzi-drain-cleaner.svc"),
+                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner.strimzi-drain-cleaner.svc.cluster.local")
+                });
         final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
 
         final Map<String, String> certsPaths = new HashMap<>();

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.resources.draincleaner;
 
-import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
@@ -14,6 +14,10 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.security.CertAndKeyFiles;
+import io.strimzi.systemtest.security.SystemTestCertAndKey;
+import io.strimzi.systemtest.security.SystemTestCertManager;
+import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,7 +25,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SetupDrainCleaner {
@@ -33,6 +40,25 @@ public class SetupDrainCleaner {
         List<File> drainCleanerFiles = Arrays.stream(new File(PATH_TO_DC_CONFIG).listFiles()).sorted()
             .filter(File::isFile)
             .collect(Collectors.toList());
+
+        // we need to create our own certificates before applying install-files
+        final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
+            .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
+                // add hostnames (i.e., SANs) to the certificate
+//                "strimzi-drain-cleaner," +
+//                "strimzi-drain-cleaner.strimzi-drain-cleaner," +
+                "strimzi-drain-cleaner.strimzi-drain-cleaner.svc"
+//                "strimzi-drain-cleaner.strimzi-drain-cleaner.svc.cluster.local"
+                );
+        final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
+
+        final Map<String, String> certsPaths = new HashMap<>();
+        certsPaths.put("tls.crt", drainCleanerKeyPairPemFormat.getCertPath());
+        certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
+
+        final SecretBuilder customDrainCleanerSecretBuilder = SecretUtils.retrieveSecretBuilderFromFile(certsPaths,
+            "strimzi-drain-cleaner", "strimzi-drain-cleaner",
+            Collections.singletonMap("app", "strimzi-drain-cleaner"), "kubernetes.io/tls");
 
         drainCleanerFiles.forEach(file -> {
             if (!file.getName().contains("README") && !file.getName().contains("Namespace") && !file.getName().contains("Deployment")) {
@@ -56,8 +82,7 @@ public class SetupDrainCleaner {
                         ResourceManager.getInstance().createResource(extensionContext, new ClusterRoleBindingBuilder(clusterRoleBinding).build());
                         break;
                     case Constants.SECRET:
-                        Secret secret = TestUtils.configFromYaml(file, Secret.class);
-                        ResourceManager.getInstance().createResource(extensionContext, secret);
+                        ResourceManager.getInstance().createResource(extensionContext, customDrainCleanerSecretBuilder.build());
                         break;
                     case Constants.SERVICE:
                         Service service = TestUtils.configFromYaml(file, Service.class);
@@ -65,6 +90,10 @@ public class SetupDrainCleaner {
                         break;
                     case Constants.VALIDATION_WEBHOOK_CONFIG:
                         ValidatingWebhookConfiguration webhookConfiguration = TestUtils.configFromYaml(file, ValidatingWebhookConfiguration.class);
+
+                        // we fetch public key from strimzi-drain-cleaner Secret and then patch ValidationWebhookConfiguration.
+                        webhookConfiguration.getWebhooks().stream().findFirst().get().getClientConfig().setCaBundle(customDrainCleanerSecretBuilder.getData().get("tls.crt"));
+
                         ResourceManager.getInstance().createResource(extensionContext, webhookConfiguration);
                         break;
                     default:

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
@@ -48,10 +48,10 @@ public class SetupDrainCleaner {
             .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
                 // add hostnames (i.e., SANs) to the certificate
                 new ASN1Encodable[] {
-                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner"),
-                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner.strimzi-drain-cleaner"),
-                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner.strimzi-drain-cleaner.svc"),
-                    new GeneralName(GeneralName.dNSName, "strimzi-drain-cleaner.strimzi-drain-cleaner.svc.cluster.local")
+                    new GeneralName(GeneralName.dNSName, Constants.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                    new GeneralName(GeneralName.dNSName, Constants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + Constants.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                    new GeneralName(GeneralName.dNSName, Constants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + Constants.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc"),
+                    new GeneralName(GeneralName.dNSName, Constants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + Constants.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc.cluster.local")
                 });
         final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
 
@@ -60,8 +60,8 @@ public class SetupDrainCleaner {
         certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
 
         final SecretBuilder customDrainCleanerSecretBuilder = SecretUtils.retrieveSecretBuilderFromFile(certsPaths,
-            "strimzi-drain-cleaner", "strimzi-drain-cleaner",
-            Collections.singletonMap("app", "strimzi-drain-cleaner"), "kubernetes.io/tls");
+            Constants.DRAIN_CLEANER_DEPLOYMENT_NAME, Constants.DRAIN_CLEANER_NAMESPACE,
+            Collections.singletonMap("app", Constants.DRAIN_CLEANER_DEPLOYMENT_NAME), "kubernetes.io/tls");
 
         drainCleanerFiles.forEach(file -> {
             if (!file.getName().contains("README") && !file.getName().contains("Namespace") && !file.getName().contains("Deployment")) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.security;
 
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -151,6 +152,14 @@ public class SystemTestCertAndKeyBuilder {
         final GeneralName dnsName = new GeneralName(dNSName, hostName);
         final byte[] subjectAltName = encode(GeneralNames.getInstance(new DERSequence(dnsName)));
         extensions.add(new Extension(subjectAlternativeName, false, subjectAltName));
+        return this;
+    }
+
+    public SystemTestCertAndKeyBuilder withSanDnsNames(final ASN1Encodable[] sanDnsNames) {
+        final DERSequence subjectAlternativeNames = new DERSequence(sanDnsNames);
+        final byte[] subjectAltName = encode(GeneralNames.getInstance(subjectAlternativeNames));
+        extensions.add(new Extension(subjectAlternativeName, false, subjectAltName));
+
         return this;
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -147,9 +147,9 @@ public class SystemTestCertAndKeyBuilder {
         return this;
     }
 
-    public SystemTestCertAndKeyBuilder withSanDnsName(String hostName) {
-        GeneralName dnsName = new GeneralName(dNSName, hostName);
-        byte[] subjectAltName = encode(GeneralNames.getInstance(new DERSequence(dnsName)));
+    public SystemTestCertAndKeyBuilder withSanDnsName(final String hostName) {
+        final GeneralName dnsName = new GeneralName(dNSName, hostName);
+        final byte[] subjectAltName = encode(GeneralNames.getInstance(new DERSequence(dnsName)));
         extensions.add(new Extension(subjectAlternativeName, false, subjectAltName));
         return this;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -87,13 +87,12 @@ public class SystemTestCertManager {
                 .build();
     }
 
-    public static SystemTestCertAndKey generateRootCaCertAndKey(final String rootCaDn, final String sanDnsNames) {
-        final SystemTestCertAndKeyBuilder systemTestCertAndKey = rootCaCertBuilder()
+    public static SystemTestCertAndKey generateRootCaCertAndKey(final String rootCaDn, final ASN1Encodable[] sanDnsNames) {
+        return rootCaCertBuilder()
             .withIssuerDn(rootCaDn)
             .withSubjectDn(rootCaDn)
-            .withSanDnsName(sanDnsNames);
-
-        return systemTestCertAndKey.build();
+            .withSanDnsNames(sanDnsNames)
+            .build();
     }
 
     public static SystemTestCertAndKey generateIntermediateCaCertAndKey(SystemTestCertAndKey rootCert) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -67,11 +67,7 @@ public class SystemTestCertManager {
             cmd.add("-key " + path + podName + ".key");
         }
 
-        if (component.equals("kafka")) {
-            return cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c", String.join(" ", cmd)).out();
-        } else {
-            return cmdKubeClient(namespaceName).execInPod(podName,  "/bin/bash", "-c", String.join(" ", cmd)).out();
-        }
+        return cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c", String.join(" ", cmd)).out();
     }
 
     public static List<String> getCertificateChain(String certificateName) {
@@ -89,6 +85,15 @@ public class SystemTestCertManager {
                 .withIssuerDn(STRIMZI_ROOT_CA)
                 .withSubjectDn(STRIMZI_ROOT_CA)
                 .build();
+    }
+
+    public static SystemTestCertAndKey generateRootCaCertAndKey(final String rootCaDn, final String sanDnsNames) {
+        final SystemTestCertAndKeyBuilder systemTestCertAndKey = rootCaCertBuilder()
+            .withIssuerDn(rootCaDn)
+            .withSubjectDn(rootCaDn)
+            .withSanDnsName(sanDnsNames);
+
+        return systemTestCertAndKey.build();
     }
 
     public static SystemTestCertAndKey generateIntermediateCaCertAndKey(SystemTestCertAndKey rootCert) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -449,6 +449,7 @@ public class StUtils {
                 .withKind("Secret")
                 .withNewMetadata()
                     .withName(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET)
+                    .withNamespace(namespace)
                 .endMetadata()
                 .withType("kubernetes.io/dockerconfigjson")
                 .withData(Collections.singletonMap(".dockerconfigjson", pullSecret.getData().get(".dockerconfigjson")))

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -114,6 +114,33 @@ public class SecretUtils {
         }
     }
 
+    public static SecretBuilder retrieveSecretBuilderFromFile(final Map<String, String> certFilesPath, final String name,
+                                                              final String namespace, final Map<String, String> labels,
+                                                              final String secretType) {
+        byte[] encoded;
+        final Map<String, String> data = new HashMap<>();
+
+        try {
+            for (final Map.Entry<String, String> entry : certFilesPath.entrySet()) {
+                encoded = Files.readAllBytes(Paths.get(entry.getValue()));
+
+                final Base64.Encoder encoder = Base64.getEncoder();
+                data.put(entry.getKey(), encoder.encodeToString(encoded));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return new SecretBuilder()
+            .withType(secretType)
+            .withData(data)
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .addToLabels(labels)
+            .endMetadata();
+    }
+
     public static void createCustomSecret(String name, String clusterName, String namespace, CertAndKeyFiles certAndKeyFiles) {
         Map<String, String> secretLabels = new HashMap<>();
         secretLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1068,6 +1068,7 @@ class ConnectIsolatedST extends AbstractST {
         Secret connectSecret = new SecretBuilder()
             .withNewMetadata()
                 .withName(secretName)
+                .withNamespace(namespaceName)
             .endMetadata()
             .withType("Opaque")
             .addToData(secretKey, encodedPassword)
@@ -1083,6 +1084,7 @@ class ConnectIsolatedST extends AbstractST {
         Secret dotedConnectSecret = new SecretBuilder()
             .withNewMetadata()
                 .withName(dotedSecretName)
+                .withNamespace(namespaceName)
             .endMetadata()
             .withType("Opaque")
             .addToData(secretKey, encodedPassword)
@@ -1271,6 +1273,7 @@ class ConnectIsolatedST extends AbstractST {
         Secret passwordSecret = new SecretBuilder()
                 .withNewMetadata()
                     .withName("custom-pwd-secret")
+                    .withNamespace(namespaceName)
                 .endMetadata()
                 .addToData("pwd", "MTIzNDU2Nzg5")
                 .build();
@@ -1321,6 +1324,7 @@ class ConnectIsolatedST extends AbstractST {
         Secret newPasswordSecret = new SecretBuilder()
                 .withNewMetadata()
                     .withName("new-custom-pwd-secret")
+                    .withNamespace(namespaceName)
                 .endMetadata()
                 .addToData("pwd", newPassword)
                 .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2054,6 +2054,7 @@ public class ListenersST extends AbstractST {
         Secret password = new SecretBuilder()
             .withNewMetadata()
                 .withName(secretName)
+                .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .addToData("password", firstEncodedPassword)
             .build();

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -517,7 +517,7 @@ public class KubeClient {
     // ============================
 
     public Secret createSecret(Secret secret) {
-        return client.secrets().inNamespace(getNamespace()).resource(secret).createOrReplace();
+        return client.secrets().inNamespace(secret.getMetadata().getNamespace()).resource(secret).createOrReplace();
     }
 
     public void patchSecret(String namespaceName, String secretName, Secret secret) {


### PR DESCRIPTION
…ificate

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR changes how we test Drain cleaners. Currently, we use pre-generated certificates. In this PR, we dynamically create our own self-signed certificate and use it inside Drain cleaner Secret and ValidationWebhookConfiguration.

Note: We should also make a similar changes inside Strimzi Drain cleaner repository. 

### Checklist

- [x] Make sure all tests pass