### PR TITLE
docs(operators): Adds instructions for adding Cluster Operator replicas

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
@@ -10,7 +10,9 @@ The Cluster Operator is responsible for deploying and managing Kafka clusters wi
 
 When the Cluster Operator is running, it starts to watch for updates of Kafka resources.
 
-By default, a single Cluster Operator is deployed. You can add replicas with leader election so that additional Cluster Operators are on standby in case of disruption. For more information, see link:{BookURLUsing}#assembly-using-multiple-cluster-operator-replicas-str[Running multiple Cluster Operator replicas with leader election]. 
+By default, a single replica of the Cluster Operator is deployed. 
+You can add replicas with leader election so that additional Cluster Operators are on standby in case of disruption. 
+For more information, see link:{BookURLUsing}#assembly-using-multiple-cluster-operator-replicas-str[Running multiple Cluster Operator replicas with leader election]. 
 
 //Options for deploying the Cluster Operator
 include::modules/con-deploy-cluster-operator-watch-options.adoc[leveloffset=+1]

--- a/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
@@ -10,6 +10,8 @@ The Cluster Operator is responsible for deploying and managing Kafka clusters wi
 
 When the Cluster Operator is running, it starts to watch for updates of Kafka resources.
 
+By default, a single Cluster Operator is deployed. You can add replicas with leader election so that additional Cluster Operators are on standby in case of disruption. For more information, see link:{BookURLUsing}#assembly-using-multiple-cluster-operator-replicas-str[Running multiple Cluster Operator replicas with leader election]. 
+
 //Options for deploying the Cluster Operator
 include::modules/con-deploy-cluster-operator-watch-options.adoc[leveloffset=+1]
 //Deploy the Cluster Operator to watch a single namespace

--- a/documentation/assemblies/operators/assembly-using-multiple-cluster-operators.adoc
+++ b/documentation/assemblies/operators/assembly-using-multiple-cluster-operators.adoc
@@ -1,0 +1,24 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-using-the-cluster-operator.adoc
+
+[id='assembly-using-multiple-cluster-operator-replicas-{context}']
+= Running multiple Cluster Operator replicas with leader election
+
+[role="_abstract"]
+Enable xref:ref-operator-cluster-leader-election-{context}[leader election] in the Cluster Operator configuration to run multiple parallel replicas of the Cluster Operator.
+One replica is elected as the active leader and operates the deployed resources.
+The other replicas run in standby mode.
+When the leader stops or fails, one of the standby replicas is elected as the new leader and starts operating the deployed resources.
+
+By default, Strimzi runs with a single Cluster Operator that is always the leader replica. 
+When a single Cluster Operator replica stops or fails, Kubernetes starts a new replica.
+
+Running the Cluster Operator with multiple replicas is not essential.
+But it's useful to have replicas on standby in case of large-scale disruptions. 
+For example, suppose multiple worker nodes or an entire availability zone fails. 
+This failure might cause the Cluster Operator pod and many Kafka pods to go down at the same time.  
+If subsequent pod scheduling causes congestion through lack of resources, this can delay operations when running a single Cluster Operator.  
+
+// Configuring Cluster Operator replicas
+include::../../modules/operators/proc-configuring-multiple-cluster-operators.adoc[leveloffset=+1]

--- a/documentation/assemblies/operators/assembly-using-multiple-cluster-operators.adoc
+++ b/documentation/assemblies/operators/assembly-using-multiple-cluster-operators.adoc
@@ -6,12 +6,13 @@
 = Running multiple Cluster Operator replicas with leader election
 
 [role="_abstract"]
-Enable xref:ref-operator-cluster-leader-election-{context}[leader election] in the Cluster Operator configuration to run multiple parallel replicas of the Cluster Operator.
+The default Cluster Operator configuration enables xref:ref-operator-cluster-leader-election-{context}[leader election]. 
+Use leader election to run multiple parallel replicas of the Cluster Operator.
 One replica is elected as the active leader and operates the deployed resources.
 The other replicas run in standby mode.
 When the leader stops or fails, one of the standby replicas is elected as the new leader and starts operating the deployed resources.
 
-By default, Strimzi runs with a single Cluster Operator that is always the leader replica. 
+By default, Strimzi runs with a single Cluster Operator replica that is always the leader replica. 
 When a single Cluster Operator replica stops or fails, Kubernetes starts a new replica.
 
 Running the Cluster Operator with multiple replicas is not essential.

--- a/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
@@ -3,7 +3,6 @@
 // assembly-operators.adoc
 
 [id='using-the-cluster-operator-{context}']
-
 = Using the Cluster Operator
 
 [role="_abstract"]
@@ -14,5 +13,7 @@ For information on deploying the Cluster Operator, see link:{BookURLDeploying}#c
 include::../../modules/operators/ref-operator-cluster.adoc[leveloffset=+1]
 //Passing proxy configuration variables from Cluster Operator
 include::../../modules/operators/proc-configuring-proxy-config-cluster-operator.adoc[leveloffset=+1]
+//Enabling leader election
+include::../../assemblies/operators/assembly-using-multiple-cluster-operators.adoc[leveloffset=+1]
 // Configuring FIPS mode from Cluster Operator
 include::../../modules/operators/proc-configuring-fips-mode-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -9,13 +9,13 @@
 To run additional Cluster Operator replicas in standby mode, you will need to increase the number of replicas and enable leader election.
 To configure leader election, use the leader election environment variables.
 
-To make the required changes, you can configure the following Cluster Operator installation files located in `install/cluster-operator/`: 
+To make the required changes, configure the following Cluster Operator installation files located in `install/cluster-operator/`: 
 
 * 060-Deployment-strimzi-cluster-operator.yaml
 * 022-ClusterRole-strimzi-cluster-operator-role.yaml
 * 022-RoleBinding-strimzi-cluster-operator.yaml
 
-Leader election has its own its own `ClusterRole` and `RoleBinding` RBAC resources that target the namespace where Cluster Operator is running, rather than the namespace it is watching. 
+Leader election has its own `ClusterRole` and `RoleBinding` RBAC resources that target the namespace where the Cluster Operator is running, rather than the namespace it is watching. 
 
 The default deployment configuration creates a `Lease` resource called `strimzi-cluster-operator` in the same namespace as the Cluster Operator.
 The Cluster Operator uses leases to manage leader election. 
@@ -29,7 +29,7 @@ Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means t
 
 .Procedure
 
-Edit the `Deployment` resource used to deploy the Cluster Operator in the `060-Deployment-strimzi-cluster-operator.yaml` file.
+Edit the `Deployment` resource that is used to deploy the Cluster Operator, which is defined in the `060-Deployment-strimzi-cluster-operator.yaml` file.
 
 . Change the `replicas` property from the default (1) to a value that matches the required number of replicas.
 +

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -24,8 +24,7 @@ If you use a different `Lease` name or namespace, update the `ClusterRole` and `
 
 .Prerequisites
 
-* This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinition`, `ClusterRole`, and `ClusterRoleBinding` resources.
-Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit, and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
 
 .Procedure
 
@@ -40,7 +39,9 @@ include::../install/cluster-operator/060-Deployment-strimzi-cluster-operator.yam
   replicas: 3 
 ----
 
-. Configure leader election `env` properties.
+. Check that the leader election `env` properties are set.
++
+If they are not set, configure them.
 +
 To enable leader election, `STRIMZI_LEADER_ELECTION_ENABLED` must be set to `true` (default).
 +

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -6,7 +6,7 @@
 = Configuring Cluster Operator replicas
 
 [role="_abstract"]
-Increase the number of replicas and enable leader election to run additional Cluster Operator replicas in standby mode.
+To run additional Cluster Operator replicas in standby mode, you will need to increase the number of replicas and enable leader election.
 To configure leader election, use leader election environment variables.
 
 To make the required changes, you can configure the following Cluster Operator installation files located in `install/cluster-operator/`: 

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -114,7 +114,7 @@ kubectl get deployments -n myproject
 [source,shell,subs="+quotes"]
 ----
 NAME                      READY  UP-TO-DATE  AVAILABLE
-strimzi-cluster-operator  1/1    1           3
+strimzi-cluster-operator  3/3    3           3
 ----
 +
 `READY` shows the number of replicas that are ready/expected.

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 To run additional Cluster Operator replicas in standby mode, you will need to increase the number of replicas and enable leader election.
-To configure leader election, use leader election environment variables.
+To configure leader election, use the leader election environment variables.
 
 To make the required changes, you can configure the following Cluster Operator installation files located in `install/cluster-operator/`: 
 

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -1,0 +1,122 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-using-multiple-cluster-operators.adoc
+
+[id='assembly-configuring-proxy-config-cluster-operator-{context}']
+= Configuring Cluster Operator replicas
+
+[role="_abstract"]
+Increase the number of replicas and enable leader election to run additional Cluster Operator replicas in standby mode.
+To configure leader election, use leader election environment variables.
+
+To make the required changes, you can configure the following Cluster Operator installation files located in `install/cluster-operator/`: 
+
+* 060-Deployment-strimzi-cluster-operator.yaml
+* 022-ClusterRole-strimzi-cluster-operator-role.yaml
+* 022-RoleBinding-strimzi-cluster-operator.yaml
+
+Leader election has its own its own `ClusterRole` and `RoleBinding` RBAC resources that target the namespace where Cluster Operator is running, rather than the namespace it is watching. 
+
+The default deployment configuration creates a `Lease` resource called `strimzi-cluster-operator` in the same namespace as the Cluster Operator.
+The Cluster Operator uses leases to manage leader election. 
+The RBAC resources provide the permissions to use the `Lease` resource.
+If you use a different `Lease` name or namespace, update the `ClusterRole` and `RoleBinding` files accordingly.
+
+.Prerequisites
+
+* This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinition`, `ClusterRole`, and `ClusterRoleBinding` resources.
+Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit, and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+
+.Procedure
+
+Edit the `Deployment` resource used to deploy the Cluster Operator in the `060-Deployment-strimzi-cluster-operator.yaml` file.
+
+. Change the `replicas` property from the default (1) to a value that matches the required number of replicas.
++
+[source,yaml,numbered,options="nowrap",highlight='12']
+.Increasing the number of Cluster Operator replicas
+----
+include::../install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml[lines=1..7] 
+  replicas: 3 
+----
+
+. Configure leader election `env` properties.
++
+To enable leader election, `STRIMZI_LEADER_ELECTION_ENABLED` must be set to `true` (default).
++
+In this example, the name of the lease is changed to `my-strimzi-cluster-operator`.
++
+[source,yaml,numbered,options="nowrap",highlight='12']
+.Configuring leader election environment variables for the Cluster Operator
+----
+# ... 
+spec
+  containers:
+    - name: strimzi-cluster-operator
+      # ...
+      env:
+        - name: STRIMZI_LEADER_ELECTION_ENABLED
+          value: "true"
+        - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+          value: "my-strimzi-cluster-operator"
+        - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        - name: STRIMZI_LEADER_ELECTION_IDENTITY
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+----
++
+For a description of the available environment variables, see xref:ref-operator-cluster-leader-election-{context}[].
++
+If you specified a different name or namespace for the `Lease` resource used in leader election, update the RBAC resources.
+
+. (optional) Edit the `ClusterRole` resource in the `022-ClusterRole-strimzi-cluster-operator-role.yaml` file.
++
+Update `resourceNames` with the name of the `Lease` resource.
++ 
+[source,yaml,numbered,options="nowrap",highlight='12']
+.Updating the ClusterRole references to the lease 
+----
+include::../install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml[lines=1..7;21]
+      - my-strimzi-cluster-operator
+# ...      
+----
+
+. (optional) Edit the the `RoleBinding` resource in the `022-RoleBinding-strimzi-cluster-operator.yaml` file.
++
+Update `subjects.name` and `subjects.namespace` with the name of the `Lease` resource and the namespace where it was created.
++ 
+[source,yaml,numbered,options="nowrap",highlight='12']
+.Updating the RoleBinding references to the lease 
+----
+include::../install/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml[lines=1..8]
+    name: my-strimzi-cluster-operator
+    namespace: myproject
+# ...
+----
+
+. Deploy the Cluster Operator:
++
+[source,shell,subs="+quotes,attributes+"]
+kubectl create -f install/cluster-operator -n myproject
+
+. Check the status of the deployment:
++
+[source,shell,subs="+quotes"]
+----
+kubectl get deployments -n myproject
+----
++
+.Output shows the deployment name and readiness
+[source,shell,subs="+quotes"]
+----
+NAME                      READY  UP-TO-DATE  AVAILABLE
+strimzi-cluster-operator  1/1    1           3
+----
++
+`READY` shows the number of replicas that are ready/expected.
+The deployment is successful when the `AVAILABLE` output shows the correct number of replicas.
+

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -33,7 +33,7 @@ The timeout for internal operations, in milliseconds. This value should be
 increased when using Strimzi on clusters where regular Kubernetes operations take longer than usual (because of slow downloading of Docker images, for example).
 
 `STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS`:: Optional, default 10000 ms.
-
++
 The session timeout (in milliseconds) for the Cluster Operator's ZooKeeper admin client.
 This value should be increased if ZooKeeper requests from the Cluster Operator are regularly failing due to timeout issues.
 There is a maximum allowed session time set on the ZooKeeper server side via the `maxSessionTimeout` config.
@@ -217,17 +217,21 @@ Enables or disables features and functionality controlled by xref:ref-operator-c
 `STRIMZI_POD_SECURITY_PROVIDER_CLASS`:: Optional.
 Configures the pluggable `PodSecurityProvider` class which can be used to provide the security context configuration for Pods and containers.
 
-[[STRIMZI_LEADER_ELECTION_ENABLED]]
-`STRIMZI_LEADER_ELECTION_ENABLED`:: Optional, default `false`.
-Enables or disables the leader election which allows to run additional operator instances as a hot-stand-by.
-Disabled by default.
+[id='ref-operator-cluster-leader-election-{context}']
+== Leader election environment variables 
+
+Use leader election environment variables when xref:assembly-using-multiple-cluster-operator-replicas-{context}[running additional Cluster Operator replicas].
+You might run additional replicas to safeguard against disruption caused by major failure.
+
+`STRIMZI_LEADER_ELECTION_ENABLED`:: Optional, disabled (`false`) by default.
+Enables or disables leader election that allows additional Cluster Operator replicas to run on standby.
 
 `STRIMZI_LEADER_ELECTION_LEASE_NAME`:: Required when leader election is enabled.
-The name of the Kubernetes Lease resource which is used for the leader election.
+The name of the Kubernetes `Lease` resource that is used for the leader election.
 
 `STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE`:: Required when leader election is enabled.
-The namespace where the Kubernetes Lease resource used for the leader election will be created.
-You can use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API^] to configure it to the namespace where the operator is deployed.
+The namespace where the Kubernetes `Lease` resource used for leader election is created.
+You can use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API^] to configure it to the namespace where the Cluster Operator is deployed.
 +
 [source,yaml,options="nowrap"]
 ----
@@ -239,9 +243,9 @@ env:
 ----
 
 `STRIMZI_LEADER_ELECTION_IDENTITY`:: Required when leader election is enabled.
-Configures the identity of given operator instance used during the leader election.
-Should be unique for each operator instance
-You can use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API^] to configure it to the name of the operator pod.
+Configures the identity of a given Cluster Operator instance used during the leader election.
+The identity must be unique for each operator instance.
+You can use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API^] to configure it to the name of the pod where the Cluster Operator is deployed.
 +
 [source,yaml,options="nowrap"]
 ----
@@ -253,13 +257,13 @@ env:
 ----
 
 `STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS`:: Optional, default 15000 ms.
-Configures the duration for which the acquired lease is valid.
+Specifies the duration the acquired lease is valid.
 
 `STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS`:: Optional, default 10000 ms.
-Configures the duration for which should the leader retry to maintain the leadership
+Specifies the period the leader should try to maintain leadership.
 
 `STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS`:: Optional, default 2000 ms.
-Configures how often does the leader update the lease lock
+Specifies the frequency of updates to the lease lock by the leader.
 
 == Logging configuration by ConfigMap
 
@@ -314,24 +318,6 @@ if the operator is not running, or if a notification is not received for any rea
 
 In order to handle failovers properly, a periodic reconciliation process is executed by the Cluster Operator so that it can compare the state of the desired resources with the current cluster deployments in order to have a consistent state across all of them.
 You can set the time interval for the periodic reconciliations using the xref:STRIMZI_FULL_RECONCILIATION_INTERVAL_MS[] variable.
-
-== Running multiple operator replicas
-
-With the xref:STRIMZI_LEADER_ELECTION_ENABLED[leader election] enabled in the Cluster Operator configuration, you can run multiple parallel replicas of the operator.
-One of them will be elected as a leader and will actively operate the deployed operands.
-The other replicas will be running in a stand-by mode.
-When the leader stops or crashes, one of the stand-by replicas will be elected as a new leader and will start operating the deployed resources.
-
-Running the operator with multiple replicas is not required.
-When using only single replica, the single replica will be always the leader replica.
-And when the single replica is stopped or crashed, Kubernetes will automatically start a new replica.
-
-But in some situations it might be an advantage to have the stand-by replicas already scheduled and running.
-For example during large scale disruptions such as crash of multiple worker nodes or of a whole availability zone.
-
-NOTE::
-The default installation files contain the RBAC permissions to use the Kubernetes `Lease` resource with name `strimzi-cluster-operator` in the same namespace where the Cluster Operator runs.
-If you decide to use other `Lease` name or a different namespace, you have to update the `ClusterRole` and `RoleBinding` files accordingly.
 
 == Provisioning Role-Based Access Control (RBAC)
 

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -224,7 +224,10 @@ Use leader election environment variables when xref:assembly-using-multiple-clus
 You might run additional replicas to safeguard against disruption caused by major failure.
 
 `STRIMZI_LEADER_ELECTION_ENABLED`:: Optional, disabled (`false`) by default.
-Enables or disables leader election that allows additional Cluster Operator replicas to run on standby.
+Enables or disables leader election, which allows additional Cluster Operator replicas to run on standby.
+
+NOTE: Leader election is disabled by default.
+It is only enabled when applying this environment variable on installation.  
 
 `STRIMZI_LEADER_ELECTION_LEASE_NAME`:: Required when leader election is enabled.
 The name of the Kubernetes `Lease` resource that is used for the leader election.

--- a/documentation/modules/overview/con-overview-components-cluster-operator.adoc
+++ b/documentation/modules/overview/con-overview-components-cluster-operator.adoc
@@ -6,24 +6,29 @@
 [id='overview-components-cluster-operator-{context}']
 = Cluster Operator
 
-Strimzi uses the Cluster Operator to deploy and manage clusters for:
+[role="_abstract"]
+Strimzi uses the Cluster Operator to deploy and manage clusters.
+By default, when you deploy Strimzi a single Cluster Operator is deployed. 
+You can add replicas with leader election so that additional Cluster Operators are on standby in case of disruption.  
+
+The Cluster Operator manages the clusters of the following Kafka components:
 
 * Kafka (including ZooKeeper, Entity Operator, Kafka Exporter, and Cruise Control)
 * Kafka Connect
 * Kafka MirrorMaker
 * Kafka Bridge
 
-Custom resources are used to deploy the clusters.
+The clusters are deployed using custom resources.
 
 For example, to deploy a Kafka cluster:
 
 * A `Kafka` resource with the cluster configuration is created within the Kubernetes cluster.
 * The Cluster Operator deploys a corresponding Kafka cluster, based on what is declared in the `Kafka` resource.
 
-The Cluster Operator can also deploy (through configuration of the `Kafka` resource):
+The Cluster Operator can also deploy the following Strimzi operators through configuration of the `Kafka` resource:
 
-* A Topic Operator to provide operator-style topic management through `KafkaTopic` custom resources
-* A User Operator to provide operator-style user management through `KafkaUser` custom resources
+* Topic Operator to provide operator-style topic management through `KafkaTopic` custom resources
+* User Operator to provide operator-style user management through `KafkaUser` custom resources
 
 The Topic Operator and User Operator function within the Entity Operator on deployment.
 

--- a/documentation/modules/overview/con-overview-components-cluster-operator.adoc
+++ b/documentation/modules/overview/con-overview-components-cluster-operator.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 Strimzi uses the Cluster Operator to deploy and manage clusters.
-By default, when you deploy Strimzi a single Cluster Operator is deployed. 
+By default, when you deploy Strimzi a single Cluster Operator replica is deployed. 
 You can add replicas with leader election so that additional Cluster Operators are on standby in case of disruption.  
 
 The Cluster Operator manages the clusters of the following Kafka components:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Adds a new assembly with concepts and a procedure for running multiple Cluster Operator replicas with leader election.
Also adds a reference to this new functionality in the Deploying and Overview guides.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

