### PR TITLE
Add metrics to StrimziPodSetController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add support for leader election and running multiple operator replicas (1 active leader replicas and one or more stand-by replicas)
 * Update Strimzi Kafka Bridge to 0.22.0
 * Add support for IPv6 addresses being used in Strimzi issued certificates
+* Add StrimziPodSet reconciliation metrics
 
 ### Deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -133,7 +133,7 @@ public class ClusterOperator extends AbstractVerticle {
             try {
                 if (config.featureGates().useStrimziPodSetsEnabled()) {
                     strimziPodSetController = new StrimziPodSetController(namespace, config.getCustomResourceSelector(), resourceOperatorSupplier.kafkaOperator,
-                            resourceOperatorSupplier.strimziPodSetOperator, resourceOperatorSupplier.podOperations, config.getPodSetControllerWorkQueueSize());
+                            resourceOperatorSupplier.strimziPodSetOperator, resourceOperatorSupplier.podOperations, resourceOperatorSupplier.metricsProvider, config.getPodSetControllerWorkQueueSize());
                     strimziPodSetController.start();
                 }
                 future.complete();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectOperatorMetricsHolder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectOperatorMetricsHolder.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Util class which holds the different metrics used by operators which deal with connectors
+ */
+public class ConnectOperatorMetricsHolder extends OperatorMetricsHolder {
+    private final Map<String, Counter> connectorsReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Counter> connectorsFailedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Counter> connectorsSuccessfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Timer> connectorsReconciliationsTimerMap = new ConcurrentHashMap<>(1);
+    private final Map<String, AtomicInteger> connectorsResourceCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, AtomicInteger> pausedConnectorsResourceCounterMap = new ConcurrentHashMap<>(1);
+
+    /**
+     * Constructs the operator metrics holder for connect operators
+     *
+     * @param kind              Kind of the resources for which these metrics apply
+     * @param selectorLabels    Selector labels to select the controller resources
+     * @param metricsProvider   Metrics provider
+     */
+    public ConnectOperatorMetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
+        super(kind, selectorLabels, metricsProvider);
+    }
+
+    /**
+     * Counter metric for number of connector reconciliations. Each reconciliation should increment it (i.e. it increments
+     * once per resource). This metric is implemented in the AbstractController.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter connectorsReconciliationsCounter(String namespace) {
+        return getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations", metricsProvider, null, connectorsReconciliationsCounterMap,
+                "Number of reconciliations done by the operator for individual resources");
+    }
+
+    /**
+     * Counter metric for number of failed connector reconciliations.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter connectorsFailedReconciliationsCounter(String namespace) {
+        return getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.failed", metricsProvider, null, connectorsFailedReconciliationsCounterMap,
+                "Number of reconciliations done by the operator for individual resources which failed");
+    }
+
+    /**
+     * Counter metric for number of successful connector reconciliations.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter connectorsSuccessfulReconciliationsCounter(String namespace) {
+        return getCounter(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.successful", metricsProvider, null, connectorsSuccessfulReconciliationsCounterMap,
+                "Number of reconciliations done by the operator for individual resources which were successful");
+    }
+
+    /**
+     * Counter metric for number of connector resources.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public AtomicInteger connectorsResourceCounter(String namespace) {
+        return getGauge(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "resources",
+                metricsProvider, null, connectorsResourceCounterMap,
+                "Number of custom resources the operator sees");
+    }
+
+    /**
+     * Counter metric for number of paused connector resources which are not reconciled.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public AtomicInteger pausedConnectorsResourceCounter(String namespace) {
+        return getGauge(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "resources.paused",
+                metricsProvider, null, pausedConnectorsResourceCounterMap,
+                "Number of connectors the connect operator sees but does not reconcile due to paused reconciliations");
+    }
+
+    /**
+     * Timer which measures how long do the connector reconciliations take.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics timer
+     */
+    public Timer connectorsReconciliationsTimer(String namespace) {
+        return getTimer(namespace, KafkaConnector.RESOURCE_KIND, METRICS_PREFIX + "reconciliations.duration",
+                metricsProvider, null, connectorsReconciliationsTimerMap,
+                "The time the reconciliation takes to complete");
+    }
+
+    /**
+     * Resets all values in the connector resource counter map and paused resource counter map to 0. This is used to
+     * handle removed connector resources from various namespaces during the periodical reconciliation in operators.
+     *
+     * @param namespace Namespace for which should the metrics be reset to 0
+     */
+    public void resetConnectorsCounters(String namespace) {
+        if (namespace.equals("*")) {
+            connectorsResourceCounterMap.forEach((key, counter) -> counter.set(0));
+            pausedConnectorsResourceCounterMap.forEach((key, counter) -> counter.set(0));
+        } else {
+            connectorsResourceCounter(namespace).set(0);
+            pausedConnectorsResourceCounter(namespace).set(0);
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -1840,7 +1840,7 @@ public class ConnectorMockTest {
             Gauge resources = meterRegistry.get("strimzi.resources").tags(tags).gauge();
             assertThat(resources.value(), is(1.0));
 
-            kafkaConnectOperator.pausedConnectorsResourceCounter(NAMESPACE); // to create metric, otherwise MeterNotFoundException will be thrown
+            kafkaConnectOperator.metrics().pausedConnectorsResourceCounter(NAMESPACE); // to create metric, otherwise MeterNotFoundException will be thrown
             Gauge resourcesPaused = meterRegistry.get("strimzi.resources.paused").tags(tags).gauge();
             assertThat(resourcesPaused.value(), is(0.0));
             async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -140,7 +140,7 @@ public class JbodStorageMockTest {
                         ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
                         ResourceUtils.metricsProvider(), pfa, 60_000L);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, ros.kafkaOperator, ros.strimziPodSetOperator, ros.podOperations, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, ros.kafkaOperator, ros.strimziPodSetOperator, ros.podOperations, ros.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         this.operator = new KafkaAssemblyOperator(JbodStorageMockTest.vertx, pfa, new MockCertManager(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -84,7 +84,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
         supplier = supplier(client, pfa);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -130,7 +130,7 @@ public class KafkaUpgradeDowngradeMockTest {
         supplier =  new ResourceOperatorSupplier(vertx, client, ResourceUtils.zookeeperLeaderFinder(vertx, client),
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(), ResourceUtils.metricsProvider(), PFA, 2_000);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -133,7 +133,7 @@ public class PartialRollingUpdateMockTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
         supplier = supplier(client, pfa);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         kco = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -25,6 +25,7 @@ import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
@@ -227,7 +228,7 @@ public class StrimziPodSetControllerIT {
     }
 
     private static void startController()  {
-        controller = new StrimziPodSetController(NAMESPACE, Labels.fromMap(MATCHING_LABELS), kafkaOperator, podSetOperator, podOperator, POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        controller = new StrimziPodSetController(NAMESPACE, Labels.fromMap(MATCHING_LABELS), kafkaOperator, podSetOperator, podOperator, ResourceUtils.metricsProvider(), POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         controller.start();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -165,7 +165,7 @@ public class KubernetesRestartEventsMockTest {
                 PFA,
                 60_000);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         // Initial reconciliation to create cluster

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -21,14 +21,15 @@ public class MicrometerMetricsProvider implements MetricsProvider {
     private final MeterRegistry metrics;
 
     /**
-     * Constructor of the Micrometer metrics provider
+     * Constructor of the Micrometer metrics provider which uses the Vert.x provided metrics registry
      */
     public MicrometerMetricsProvider() {
         this.metrics = BackendRegistries.getDefaultNow();
     }
 
     /**
-     * Constructor of the Micrometer metrics provider. Mainly for test purposes
+     * Constructor of the Micrometer metrics provider.
+     *
      * @param metrics   Meter registry
      */
     public MicrometerMetricsProvider(MeterRegistry metrics) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/AbstractMetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/AbstractMetricsHolder.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Util class which holds the different metrics used by controllers
+ */
+public abstract class AbstractMetricsHolder {
+    protected static final String METRICS_PREFIX = "strimzi.";
+
+    protected final String kind;
+    protected final Labels selectorLabels;
+    protected final MetricsProvider metricsProvider;
+
+    protected final Map<String, AtomicInteger> resourceCounterMap = new ConcurrentHashMap<>(1);
+    protected final Map<String, AtomicInteger> pausedResourceCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Counter> periodicReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Counter> reconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Counter> failedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Counter> successfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+    private final Map<String, Timer> reconciliationsTimerMap = new ConcurrentHashMap<>(1);
+
+    /**
+     * Constructs the metrics holder
+     *
+     * @param kind              Kind of the resources for which these metrics apply
+     * @param selectorLabels    Selector labels to select the controller resources
+     * @param metricsProvider   Metrics provider
+     */
+    public AbstractMetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
+        this.kind = kind;
+        this.selectorLabels = selectorLabels;
+        this.metricsProvider = metricsProvider;
+    }
+
+    /**
+     * Metrics provider used for the metrics by this holder class
+     *
+     * @return  Metrics provider
+     */
+    public MetricsProvider metricsProvider()    {
+        return metricsProvider;
+    }
+
+    ////////////////////
+    // Methods for individual counters
+    ////////////////////
+
+    /**
+     * Counter metric for number of periodic reconciliations. It should be incremented only once per timer-trigger. It
+     * should not be incremented for every resource found by the periodical reconciliation.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter periodicReconciliationsCounter(String namespace) {
+        return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.periodical", metricsProvider, selectorLabels, periodicReconciliationsCounterMap,
+                "Number of periodical reconciliations done by the operator");
+    }
+
+    /**
+     * Counter metric for number of reconciliations. Each reconciliation should increment it (i.e. it increments once
+     * per resource).
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter reconciliationsCounter(String namespace) {
+        return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations", metricsProvider, selectorLabels, reconciliationsCounterMap,
+                "Number of reconciliations done by the operator for individual resources");
+    }
+
+    /**
+     * Counter metric for number of failed reconciliations.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter failedReconciliationsCounter(String namespace) {
+        return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.failed", metricsProvider, selectorLabels, failedReconciliationsCounterMap,
+                "Number of reconciliations done by the operator for individual resources which failed");
+    }
+
+    /**
+     * Counter metric for number of successful reconciliations.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter successfulReconciliationsCounter(String namespace) {
+        return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.successful", metricsProvider, selectorLabels, successfulReconciliationsCounterMap,
+                "Number of reconciliations done by the operator for individual resources which were successful");
+    }
+
+    /**
+     * Counter metric for number of resources.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public AtomicInteger resourceCounter(String namespace) {
+        return getGauge(namespace, kind, METRICS_PREFIX + "resources", metricsProvider, selectorLabels, resourceCounterMap,
+                "Number of custom resources the operator sees");
+    }
+
+    /**
+     * Counter metric for number of paused resources which are not reconciled.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public AtomicInteger pausedResourceCounter(String namespace) {
+        return getGauge(namespace, kind, METRICS_PREFIX + "resources.paused", metricsProvider, selectorLabels, pausedResourceCounterMap,
+                "Number of custom resources the operator sees but does not reconcile due to paused reconciliations");
+    }
+
+    /**
+     * Timer which measures how long do the reconciliations take.
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics timer
+     */
+    public Timer reconciliationsTimer(String namespace) {
+        return getTimer(namespace, kind, METRICS_PREFIX + "reconciliations.duration", metricsProvider, selectorLabels, reconciliationsTimerMap,
+                "The time the reconciliation takes to complete");
+    }
+
+    ////////////////////
+    // Static methods for handling metrics
+    ////////////////////
+
+    /**
+     * Utility method which gets or creates the metric.
+     *
+     * @param namespace         Namespace or the resource
+     * @param kind              Kind of the resource
+     * @param selectorLabels    Selector labels used to filter the resources
+     * @param metricMap         The map with the metrics
+     * @param fn                Method fo generating the metrics tags
+     *
+     * @return  Metric
+     *
+     * @param <M>   Type of the metric
+     */
+    private static <M> M metric(String namespace, String kind, Labels selectorLabels, Map<String, M> metricMap, Function<Tags, M> fn) {
+        String selectorValue = selectorLabels != null ? selectorLabels.toSelectorString() : "";
+        Tags metricTags;
+        String metricKey = namespace + "/" + kind;
+        if (namespace.equals("*")) {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", ""), Tag.of("selector", selectorValue));
+        } else {
+            metricTags = Tags.of(Tag.of("kind", kind), Tag.of("namespace", namespace), Tag.of("selector", selectorValue));
+        }
+        Tags finalMetricTags = metricTags;
+
+        return metricMap.computeIfAbsent(metricKey, x -> fn.apply(finalMetricTags));
+    }
+
+    /**
+     * Creates or gets a counter-type metric.
+     *
+     * @param namespace         Namespace of the resource
+     * @param kind              Kind of the resource
+     * @param metricName        Name of the metric
+     * @param metrics           Metrics provider
+     * @param selectorLabels    Selector labels used to filter the resources
+     * @param counterMap        Map with counters
+     * @param metricHelp        Help description of the metric
+     *
+     * @return  Counter metric
+     */
+    public static Counter getCounter(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, Counter> counterMap, String metricHelp) {
+        return metric(namespace, kind, selectorLabels, counterMap, tags -> metrics.counter(metricName, metricHelp, tags));
+    }
+
+    /**
+     * Creates or gets a gauge-type metric.
+     *
+     * @param namespace         Namespace of the resource
+     * @param kind              Kind of the resource
+     * @param metricName        Name of the metric
+     * @param metrics           Metrics provider
+     * @param selectorLabels    Selector labels used to filter the resources
+     * @param gaugeMap          Map with gauges
+     * @param metricHelp        Help description of the metric
+     *
+     * @return  Gauge metric
+     */
+    public static AtomicInteger getGauge(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, AtomicInteger> gaugeMap, String metricHelp) {
+        return metric(namespace, kind, selectorLabels, gaugeMap, tags -> metrics.gauge(metricName, metricHelp, tags));
+    }
+
+    /**
+     * Creates or gets a timer-type metric.
+     *
+     * @param namespace         Namespace of the resource
+     * @param kind              Kind of the resource
+     * @param metricName        Name of the metric
+     * @param metrics           Metrics provider
+     * @param selectorLabels    Selector labels used to filter the resources
+     * @param timerMap          Map with timers
+     * @param metricHelp        Help description of the metric
+     *
+     * @return  Timer metric
+     */
+    public static Timer getTimer(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, Timer> timerMap, String metricHelp) {
+        return metric(namespace, kind, selectorLabels, timerMap, tags -> metrics.timer(metricName, metricHelp, tags));
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/ControllerMetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/ControllerMetricsHolder.java
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Util class which holds the different metrics used by controllers
+ * A metrics holder for controllers.
  */
-public class ControllerMetricsHolder extends AbstractMetricsHolder {
+public class ControllerMetricsHolder extends MetricsHolder {
     private final Map<String, Counter> alreadyQueuedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/ControllerMetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/ControllerMetricsHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Util class which holds the different metrics used by controllers
+ */
+public class ControllerMetricsHolder extends AbstractMetricsHolder {
+    private final Map<String, Counter> alreadyQueuedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+
+    /**
+     * Constructs the controller metrics holder
+     *
+     * @param kind              Kind of the resources for which these metrics apply
+     * @param selectorLabels    Selector labels to select the controller resources
+     * @param metricsProvider   Metrics provider
+     */
+    public ControllerMetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
+        super(kind, selectorLabels, metricsProvider);
+    }
+
+    /**
+     * Counter metric for number of reconciliations which are already queued when we try to enqueue them again. This
+     * might indicate for example that the periodic reconciliations are triggering too often (faster than the operator
+     * reconciles them).
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter alreadyEnqueuedReconciliationsCounter(String namespace) {
+        return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.already.enqueued", metricsProvider, selectorLabels, alreadyQueuedReconciliationsCounterMap,
+                "Number of reconciliations skipped because another reconciliation for the same resource was still running");
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
@@ -17,9 +17,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**
- * Util class which holds the different metrics used by controllers
+ * Abstract base class holding common metrics used by operators and controllers.
+ * Subclasses can add more specialized metrics.
  */
-public abstract class AbstractMetricsHolder {
+public abstract class MetricsHolder {
     protected static final String METRICS_PREFIX = "strimzi.";
 
     protected final String kind;
@@ -41,7 +42,7 @@ public abstract class AbstractMetricsHolder {
      * @param selectorLabels    Selector labels to select the controller resources
      * @param metricsProvider   Metrics provider
      */
-    public AbstractMetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
+    public MetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
         this.kind = kind;
         this.selectorLabels = selectorLabels;
         this.metricsProvider = metricsProvider;
@@ -111,7 +112,7 @@ public abstract class AbstractMetricsHolder {
     }
 
     /**
-     * Counter metric for number of resources.
+     * Counter metric for number of resources managed by this operator.
      *
      * @param namespace     Namespace of the resources being reconciled
      *
@@ -190,7 +191,7 @@ public abstract class AbstractMetricsHolder {
      *
      * @return  Counter metric
      */
-    public static Counter getCounter(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, Counter> counterMap, String metricHelp) {
+    protected static Counter getCounter(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, Counter> counterMap, String metricHelp) {
         return metric(namespace, kind, selectorLabels, counterMap, tags -> metrics.counter(metricName, metricHelp, tags));
     }
 
@@ -207,7 +208,7 @@ public abstract class AbstractMetricsHolder {
      *
      * @return  Gauge metric
      */
-    public static AtomicInteger getGauge(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, AtomicInteger> gaugeMap, String metricHelp) {
+    protected static AtomicInteger getGauge(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, AtomicInteger> gaugeMap, String metricHelp) {
         return metric(namespace, kind, selectorLabels, gaugeMap, tags -> metrics.gauge(metricName, metricHelp, tags));
     }
 
@@ -224,7 +225,7 @@ public abstract class AbstractMetricsHolder {
      *
      * @return  Timer metric
      */
-    public static Timer getTimer(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, Timer> timerMap, String metricHelp) {
+    protected static Timer getTimer(String namespace, String kind, String metricName, MetricsProvider metrics, Labels selectorLabels, Map<String, Timer> timerMap, String metricHelp) {
         return metric(namespace, kind, selectorLabels, timerMap, tags -> metrics.timer(metricName, metricHelp, tags));
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/OperatorMetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/OperatorMetricsHolder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Util class which holds the different metrics used by operators
+ */
+public class OperatorMetricsHolder extends AbstractMetricsHolder {
+    private final Map<String, Counter> lockedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
+
+    /**
+     * Constructs the operator metrics holder
+     *
+     * @param kind              Kind of the resources for which these metrics apply
+     * @param selectorLabels    Selector labels to select the controller resources
+     * @param metricsProvider   Metrics provider
+     */
+    public OperatorMetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
+        super(kind, selectorLabels, metricsProvider);
+    }
+
+    /**
+     * Counter metric for number of reconciliations which did not happen because they did not get the lock (which means
+     * that other reconciliation for the same resource was in progress).
+     *
+     * @param namespace     Namespace of the resources being reconciled
+     *
+     * @return  Metrics counter
+     */
+    public Counter lockedReconciliationsCounter(String namespace) {
+        return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.locked", metricsProvider, selectorLabels, lockedReconciliationsCounterMap,
+                "Number of reconciliations skipped because another reconciliation for the same resource was still running");
+    }
+
+    /**
+     * Resets all values in the resource counter map and paused resource counter map to 0. This is used to handle
+     * removed resources from various namespaces during the periodical reconciliation in operators.
+     */
+    public void resetResourceAndPausedResourceCounters() {
+        resourceCounterMap.forEach((key, value) -> value.set(0));
+        pausedResourceCounterMap.forEach((key, value) -> value.set(0));
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/OperatorMetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/OperatorMetricsHolder.java
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Util class which holds the different metrics used by operators
+ * A metrics holder for operators.
  */
-public class OperatorMetricsHolder extends AbstractMetricsHolder {
+public class OperatorMetricsHolder extends MetricsHolder {
     private final Map<String, Counter> lockedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceDiff.java
@@ -12,8 +12,12 @@ import io.strimzi.operator.common.ReconciliationLogger;
 
 import java.util.regex.Pattern;
 
-class ResourceDiff<T extends HasMetadata> extends AbstractJsonDiff {
+public class ResourceDiff<T extends HasMetadata> extends AbstractJsonDiff {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ResourceDiff.class.getName());
+
+    public static final Pattern DEFAULT_IGNORABLE_PATHS = Pattern.compile(
+            "^(/metadata/managedFields" +
+                    "|/status)$");
 
     private final boolean isEmpty;
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceDiff.java
@@ -12,12 +12,8 @@ import io.strimzi.operator.common.ReconciliationLogger;
 
 import java.util.regex.Pattern;
 
-public class ResourceDiff<T extends HasMetadata> extends AbstractJsonDiff {
+class ResourceDiff<T extends HasMetadata> extends AbstractJsonDiff {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ResourceDiff.class.getName());
-
-    public static final Pattern DEFAULT_IGNORABLE_PATHS = Pattern.compile(
-            "^(/metadata/managedFields" +
-                    "|/status)$");
 
     private final boolean isEmpty;
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds metrics to the `StrimziPodSetController` The metrics follow the metrics already provided by out `*AssemblyOperator` classes and deviate only where necessary:
* The Controllers do not use resource locking. So this metric is not used for StrimziPodSets
* The Controller use work queue and it might happen that the resource whcih should be enqueued for some event is already in the queue. There is a new metric provided for this event. Similarly to locks, this might indicate a problems, but can also happen in a regular run.
* The resource state metrics are not exposed. First of all because they make the code very complicated (I might follow with a proposal to remove the existing ones in operators later) and second because the StrimziPodSets do not have a clear ready / not ready state. Some pods might be ready, some not etc.

This Pr also refactors how metrics are done in the `*AssemblyOperator` classes and in the `Operator` interface. The metrics used to be hardcoded in these classes. In this PR, I have created a new _metrics holder_ pattern. `AbstractMetricsHolder` and its subclasses are used to hold the metrics in a separate class. Since the metrics differ a bit between different operators and controllers, it creates a hierarchy:

```mermaid
classDiagram
    AbstractMetricsHolder <|-- ControllerMetricsHolder
    AbstractMetricsHolder <|-- OperatorMetricsHolder
    OperatorMetricsHolder <|-- ConnectOperatorMetricsHolder
    AbstractMetricsHolder: Shared metrics
    ControllerMetricsHolder: Already Queued metric
    OperatorMetricsHolder: Without Lock metric
    ConnectOperatorMetricsHolder: Connector metrics
```

I believe this nicely separates the metrics from the operator and controller logic. It also allows us to share the code between the classes.

This PR also does some minor refactoring of the `StrimziPodSetController`. Apart from adding the metrics, it also separates some calls to new methods, setups the informer handlers only in later phase etc. The StrimziPodSet metrics were developed as part of the User Operator rewrite. A separate PR is opened for the StrimziPodSet metrics to simplify review and testing via more smaller PRs. So these changes are not completely related to the metrics themselves, but are generally useful and separating them into yet another PR would be too complicated.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md