### PR TITLE
docs(exporter): Adds note on Kafka Exporter requiring consumer groups data

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -223,7 +223,7 @@ Having a stable and highly available ZooKeeper cluster is crucial for Strimzi.
 <30> Entity Operator xref:type-TlsSidecar-reference[TLS sidecar configuration]. Entity Operator uses the TLS sidecar for secure communication with ZooKeeper.
 <31> Specified xref:property-topic-operator-logging-reference[Topic Operator loggers and log levels]. This example uses `inline` logging.
 <32> Specified xref:property-user-operator-logging-reference[User Operator loggers and log levels].
-<33> Kafka Exporter configuration. link:{BookURLDeploying}#assembly-metrics-kafka-exporter-str[Kafka Exporter] is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data.
+<33> Kafka Exporter configuration. link:{BookURLDeploying}#con-metrics-kafka-exporter-lag-str[Kafka Exporter] is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use. 
 <34> Optional configuration for Cruise Control, which is used to xref:cruise-control-concepts-str[rebalance the Kafka cluster].
 
 . Create or update the resource:

--- a/documentation/modules/metrics/con_kafka-exporter-lag.adoc
+++ b/documentation/modules/metrics/con_kafka-exporter-lag.adoc
@@ -13,6 +13,9 @@ Kafka Exporter extracts additional metrics data from Kafka brokers related to of
 The metrics data is used, for example, to help identify slow consumers.
 Lag data is exposed as Prometheus metrics, which can then be presented in Grafana for analysis.
 
+Kafka Exporter reads from the  `__consumer_offsets` topic, which stores information on committed offsets for consumer groups. 
+For Kafka Exporter to be able to work properly, consumer groups needs to be in use. 
+
 A Grafana dashboard for Kafka Exporter is one of a number of xref:ref-metrics-dashboards-{context}[example Grafana dashboards] provided by Strimzi.
 
 IMPORTANT: Kafka Exporter provides only additional metrics related to consumer lag and consumer offsets.

--- a/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
+++ b/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
@@ -26,7 +26,7 @@ To apply the relabeling rules and metrics configuration, do one of the following
 * Copy the example configuration to your own custom resources
 * Deploy the custom resource with the metrics configuration
 
-If you want to include Kafka Exporter metrics, add `kafkaExporter` configuration to your `Kafka` resource.
+If you want to include xref:con-metrics-kafka-exporter-lag-str[Kafka Exporter] metrics, add `kafkaExporter` configuration to your `Kafka` resource.
 
 IMPORTANT: Kafka Exporter provides only additional metrics related to consumer lag and consumer offsets.
 For regular Kafka metrics, you have to configure the Prometheus metrics in xref:proc-metrics-kafka-deploy-options-{context}[Kafka brokers].
@@ -160,6 +160,8 @@ spec:
 <7> link:{BookURLUsing}#assembly-customizing-kubernetes-resources-str[Customization of deployment templates and pods].
 <8> link:{BookURLUsing}#con-common-configuration-healthchecks-reference[Healthcheck readiness probes].
 <9> link:{BookURLUsing}#con-common-configuration-healthchecks-reference[Healthcheck liveness probes].
+
+NOTE: For Kafka Exporter to be able to work properly, consumer groups need to be in use. 
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>
**Documentation**

Adds a couple of notes in the _Deploying_ guide that Kafka Exporter won't work without consumer groups.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

