### PR TITLE
Add CustomResourceConditions containing predicates to await CRD readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add support for leader election and running multiple operator replicas (1 active leader replicas and one or more stand-by replicas)
 * Update Strimzi Kafka Bridge to 0.22.0
 * Add support for IPv6 addresses being used in Strimzi issued certificates
+* Make it easier to wait for custom resource readiness when using the Strimzi api module
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/CustomResourceConditions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CustomResourceConditions.java
@@ -32,33 +32,13 @@ class CustomResourceConditions {
     private CustomResourceConditions() {
     }
 
-    /**
-     * Returns a predicate that determines if a CustomResource is ready. A CustomResource is
-     * ready if the observedGeneration of its status is equal to the generation of its metadata
-     * and any of the conditions of its status has type:"Ready" and status:"True"
-     *
-     * @param <Y> the type of the custom resources Status
-     * @param <T> the type of the custom resource
-     * @return a predicate that checks if a CustomResource is ready
-     */
     static <Y extends Status, T extends CustomResource<?, Y>> Predicate<T> isReady() {
         return isLatestGenerationAndAnyConditionMatches("Ready", "True");
     }
 
-    /**
-     * Returns a predicate that determines if a CustomResource's status is the latest generation
-     * and any of the conditions of its status matches the type and status specified.
-     *
-     * @param <Y>    the type of the custom resources Status
-     * @param <T>    the type of the custom resource
-     * @param type   the Type of the condition we expect to be present in the status
-     * @param status the Status of the condition we expect to be present in the status
-     * @return a predicate that checks if a CustomResource is ready
-     */
     static <Y extends Status, T extends CustomResource<?, Y>> Predicate<T> isLatestGenerationAndAnyConditionMatches(String type, String status) {
         return isStatusLatestGenerationAndMatches(anyCondition(type, status));
     }
-
 
     private static <Y extends Status> Predicate<Y> anyCondition(String expectedType, String expectedStatus) {
         return (status) -> {

--- a/api/src/main/java/io/strimzi/api/kafka/model/CustomResourceConditions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CustomResourceConditions.java
@@ -21,10 +21,10 @@ import java.util.function.Predicate;
  * Crds.kafkaOperation(client).inNamespace(NAMESPACE).resource(kafka).create();
  * Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(NAME).waitUntilCondition(Kafka.isReady(), 5, TimeUnit.MINUTES);
  * </pre>
- * and to wait on a specific KafkaRebalance state using {@link io.strimzi.api.kafka.model.KafkaRebalance#isState(KafkaRebalanceState) KafkaRebalance::isState}:
+ * and to wait on a specific KafkaRebalance state using {@link io.strimzi.api.kafka.model.KafkaRebalance#isInState(KafkaRebalanceState) KafkaRebalance::isInState}:
  * <pre>
  * Crds.kafkaRebalanceOperation(client).inNamespace(NAMESPACE).withName(REBALANCE_NAME)
- *     .waitUntilCondition(KafkaRebalance.isState(KafkaRebalanceState.ProposalReady), 5, TimeUnit.MINUTES);
+ *     .waitUntilCondition(KafkaRebalance.isInState(KafkaRebalanceState.ProposalReady), 5, TimeUnit.MINUTES);
  * </pre>
  */
 class CustomResourceConditions {

--- a/api/src/main/java/io/strimzi/api/kafka/model/CustomResourceConditions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CustomResourceConditions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.api.kafka.model.status.Status;
+
+import java.util.function.Predicate;
+
+public class CustomResourceConditions {
+
+    /**
+     * Returns a predicate that determines if a CustomResource is ready. A CustomResource is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     *
+     * @param <Y> the type of the custom resources Status
+     * @param <T> the type of the custom resource
+     * @return a predicate that checks if a CustomResource is ready
+     */
+    public static <Y extends Status, T extends CustomResource<?, Y>> Predicate<T> isReady() {
+        return isStatusLatestGenerationAndMatches(anyCondition("Ready", "True"));
+    }
+
+    /**
+     * Returns a predicate that determines if a KafkaRebalance is in a ProposalReady state. A KafkaRebalance is
+     * in proposal ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"ProposalReady" and status:"True"
+     *
+     * @return a predicate that checks if a KafkaRebalance is in ProposalReady state
+     */
+    public static Predicate<KafkaRebalance> isKafkaRebalanceProposalReady() {
+        return isStatusLatestGenerationAndMatches(anyCondition("ProposalReady", "True"));
+    }
+
+
+    private static <Y extends Status> Predicate<Y> anyCondition(String expectedType, String expectedStatus) {
+        return (status) -> {
+            if (status.getConditions() == null) {
+                return false;
+            } else {
+                return status.getConditions().stream().anyMatch(
+                        condition -> expectedType.equals(condition.getType()) && expectedStatus.equals(condition.getStatus())
+                );
+            }
+        };
+    }
+
+    private static <Y extends Status, T extends CustomResource<?, Y>> Predicate<T> isStatusLatestGenerationAndMatches(Predicate<Y> predicate) {
+        return (T resource) -> {
+            if (resource.getStatus() == null) {
+                return false;
+            } else {
+                boolean expectedGeneration = resource.getMetadata().getGeneration() == resource.getStatus().getObservedGeneration();
+                return expectedGeneration && predicate.test(resource.getStatus());
+            }
+        };
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -26,6 +26,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @JsonDeserialize
 @Crd(
@@ -147,4 +148,9 @@ public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Nam
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
+
+    public static Predicate<Kafka> isReady() {
+        return CustomResourceConditions.isReady();
+    }
+
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -149,6 +149,15 @@ public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Nam
         this.additionalProperties.put(name, value);
     }
 
+    /**
+     * Returns a predicate that determines if Kafka is ready. A Kafka CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a Kafka is ready
+     */
     public static Predicate<Kafka> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -23,6 +23,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -145,6 +146,10 @@ public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStat
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Predicate<KafkaBridge> isReady() {
+        return CustomResourceConditions.isReady();
     }
 
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridge.java
@@ -148,6 +148,15 @@ public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStat
         }
     }
 
+    /**
+     * Returns a predicate that determines if KafkaBridge is ready. A KafkaBridge CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a KafkaBridge is ready
+     */
     public static Predicate<KafkaBridge> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -25,6 +25,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @JsonDeserialize
 @Crd(
@@ -142,5 +143,9 @@ public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectS
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+
+    public static Predicate<KafkaConnect> isReady() {
+        return CustomResourceConditions.isReady();
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -145,6 +145,15 @@ public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectS
         this.additionalProperties.put(name, value);
     }
 
+    /**
+     * Returns a predicate that determines if KafkaConnect is ready. A KafkaConnect CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a KafkaConnect is ready
+     */
     public static Predicate<KafkaConnect> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -138,6 +138,15 @@ public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConn
         this.additionalProperties.put(name, value);
     }
 
+    /**
+     * Returns a predicate that determines if KafkaConnector is ready. A KafkaConnector CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a KafkaConnector is ready
+     */
     public static Predicate<KafkaConnector> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -22,6 +22,7 @@ import lombok.ToString;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -135,6 +136,10 @@ public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConn
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+
+    public static Predicate<KafkaConnector> isReady() {
+        return CustomResourceConditions.isReady();
     }
 }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -24,6 +24,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @JsonDeserialize
 @Crd(
@@ -140,5 +141,9 @@ public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, Kaf
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+
+    public static Predicate<KafkaMirrorMaker2> isReady() {
+        return CustomResourceConditions.isReady();
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -143,6 +143,15 @@ public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, Kaf
         this.additionalProperties.put(name, value);
     }
 
+    /**
+     * Returns a predicate that determines if KafkaMirrorMaker2 is ready. A KafkaMirrorMaker2 CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a KafkaMirrorMaker2 is ready
+     */
     public static Predicate<KafkaMirrorMaker2> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -167,7 +167,7 @@ public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaReba
      * @param state the expected state of the CRD
      * @return a predicate that checks if a KafkaRebalance is in a particular state
      */
-    public static Predicate<KafkaRebalance> isState(KafkaRebalanceState state) {
+    public static Predicate<KafkaRebalance> isInState(KafkaRebalanceState state) {
         return CustomResourceConditions.isLatestGenerationAndAnyConditionMatches(state.name(), "True");
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -157,6 +157,16 @@ public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaReba
         }
     }
 
+    /**
+     * Returns a predicate that determines if KafkaRebalance is in a specified state. A KafkaRebalance CRD is
+     * in that state if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:expectedState and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @param state the expected state of the CRD
+     * @return a predicate that checks if a KafkaRebalance is in a particular state
+     */
     public static Predicate<KafkaRebalance> isState(KafkaRebalanceState state) {
         return CustomResourceConditions.isLatestGenerationAndAnyConditionMatches(state.name(), "True");
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
+import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -24,6 +25,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @JsonDeserialize
 @Crd(
@@ -153,5 +155,9 @@ public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaReba
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Predicate<KafkaRebalance> isState(KafkaRebalanceState state) {
+        return CustomResourceConditions.isLatestGenerationAndAnyConditionMatches(state.name(), "True");
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -147,6 +147,15 @@ public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus>
         }
     }
 
+    /**
+     * Returns a predicate that determines if KafkaTopic is ready. A KafkaTopic CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a KafkaTopic is ready
+     */
     public static Predicate<KafkaTopic> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaTopic.java
@@ -23,6 +23,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -144,6 +145,10 @@ public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus>
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Predicate<KafkaTopic> isReady() {
+        return CustomResourceConditions.isReady();
     }
 
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -23,6 +23,7 @@ import lombok.EqualsAndHashCode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -143,6 +144,10 @@ public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> im
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Predicate<KafkaUser> isReady() {
+        return CustomResourceConditions.isReady();
     }
 
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUser.java
@@ -146,6 +146,15 @@ public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> im
         }
     }
 
+    /**
+     * Returns a predicate that determines if KafkaUser is ready. A KafkaUser CRD is
+     * ready if the observedGeneration of its status is equal to the generation of its metadata
+     * and any of the conditions of its status has type:"Ready" and status:"True"
+     * <p>
+     * See {@link CustomResourceConditions CustomResourceConditions} for explanation/examples
+     *
+     * @return a predicate that checks if a KafkaUser is ready
+     */
     public static Predicate<KafkaUser> isReady() {
         return CustomResourceConditions.isReady();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/CustomResourceConditionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/CustomResourceConditionsTest.java
@@ -4,27 +4,29 @@
  */
 package io.strimzi.api.kafka.model;
 
+import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The purpose of this test is to check that custom resource predicates correctly
- * identify CRDs in specific states
+ * identify CRDs in specific states.
  */
 class CustomResourceConditionsTest {
 
-    Predicate<Kafka> isReady = CustomResourceConditions.isReady();
+    Predicate<Kafka> kafkaIsReady = CustomResourceConditions.isReady();
 
-    Predicate<KafkaRebalance> isProposalReady = CustomResourceConditions.isKafkaRebalanceProposalReady();
+    Predicate<KafkaRebalance> customConditionPresent = CustomResourceConditions.isLatestGenerationAndAnyConditionMatches("ProposalReady", "True");
 
     @Test
-    public void testIsReady_EmptyKafkaNotReady() {
-        Kafka build = new KafkaBuilder().build();
-        assertFalse(isReady.test(build));
+    public void testIsReady_EmptyCrdIsNotReady() {
+        Kafka emptyKafka = new KafkaBuilder().build();
+        assertFalse(kafkaIsReady.test(emptyKafka));
     }
 
     @Test
@@ -34,9 +36,8 @@ class CustomResourceConditionsTest {
                 .withNewStatus()
                 .withObservedGeneration(2L)
                 .addNewCondition().withType("Ready").withStatus("True").endCondition()
-                .endStatus()
-                .build();
-        assertTrue(isReady.test(build));
+                .endStatus().build();
+        assertTrue(kafkaIsReady.test(build));
     }
 
     @Test
@@ -47,7 +48,7 @@ class CustomResourceConditionsTest {
                 .withObservedGeneration(2L)
                 .endStatus()
                 .build();
-        assertFalse(isReady.test(build));
+        assertFalse(kafkaIsReady.test(build));
     }
 
     @Test
@@ -59,7 +60,7 @@ class CustomResourceConditionsTest {
                 .addNewCondition().withType("Ready").withStatus("False").endCondition()
                 .endStatus()
                 .build();
-        assertFalse(isReady.test(build));
+        assertFalse(kafkaIsReady.test(build));
     }
 
     @Test
@@ -67,7 +68,7 @@ class CustomResourceConditionsTest {
         Kafka build = new KafkaBuilder()
                 .editMetadata().withGeneration(2L).endMetadata()
                 .build();
-        assertFalse(isReady.test(build));
+        assertFalse(kafkaIsReady.test(build));
     }
 
     @Test
@@ -79,19 +80,19 @@ class CustomResourceConditionsTest {
                 .addNewCondition().withType("Ready").withStatus("True").endCondition()
                 .endStatus()
                 .build();
-        assertFalse(isReady.test(build));
+        assertFalse(kafkaIsReady.test(build));
     }
 
 
     @Test
-    public void testIsProposalReady_EmptyKafkaRebalanceNotProposalReady() {
+    public void testIsLatestGenerationAndAnyConditionMatches_EmptyCrd() {
         KafkaRebalance build = new KafkaRebalanceBuilder().build();
-        assertFalse(isProposalReady.test(build));
+        assertFalse(customConditionPresent.test(build));
     }
 
 
     @Test
-    public void testIsProposalReady_ReadyProposal() {
+    public void testIsLatestGenerationAndAnyConditionMatches_ReadyProposal() {
         KafkaRebalance build = new KafkaRebalanceBuilder()
                 .editMetadata().withGeneration(2L).endMetadata()
                 .withNewStatus()
@@ -99,22 +100,22 @@ class CustomResourceConditionsTest {
                 .addNewCondition().withType("ProposalReady").withStatus("True").endCondition()
                 .endStatus()
                 .build();
-        assertTrue(isProposalReady.test(build));
+        assertTrue(customConditionPresent.test(build));
     }
 
     @Test
-    public void testIsProposalReady_ConditionMissing() {
+    public void testIsLatestGenerationAndAnyConditionMatches_ConditionMissing() {
         KafkaRebalance build = new KafkaRebalanceBuilder()
                 .editMetadata().withGeneration(2L).endMetadata()
                 .withNewStatus()
                 .withObservedGeneration(2L)
                 .endStatus()
                 .build();
-        assertFalse(isProposalReady.test(build));
+        assertFalse(customConditionPresent.test(build));
     }
 
     @Test
-    public void testIsProposalReady_ConditionNotTrue() {
+    public void testIsLatestGenerationAndAnyConditionMatches_ConditionNotTrue() {
         KafkaRebalance build = new KafkaRebalanceBuilder()
                 .editMetadata().withGeneration(2L).endMetadata()
                 .withNewStatus()
@@ -122,19 +123,19 @@ class CustomResourceConditionsTest {
                 .addNewCondition().withType("ProposalReady").withStatus("False").endCondition()
                 .endStatus()
                 .build();
-        assertFalse(isProposalReady.test(build));
+        assertFalse(customConditionPresent.test(build));
     }
 
     @Test
-    public void testIsProposalReady_NullStatus() {
+    public void testIsLatestGenerationAndAnyConditionMatches_NullStatus() {
         KafkaRebalance build = new KafkaRebalanceBuilder()
                 .editMetadata().withGeneration(2L).endMetadata()
                 .build();
-        assertFalse(isProposalReady.test(build));
+        assertFalse(customConditionPresent.test(build));
     }
 
     @Test
-    public void testIsProposalReady_ObservedGenerationNotEqualToMetadataGeneration() {
+    public void testIsLatestGenerationAndAnyConditionMatches_ObservedGenerationNotEqualToMetadataGeneration() {
         KafkaRebalance build = new KafkaRebalanceBuilder()
                 .editMetadata().withGeneration(2L).endMetadata()
                 .withNewStatus()
@@ -142,7 +143,98 @@ class CustomResourceConditionsTest {
                 .addNewCondition().withType("ProposalReady").withStatus("True").endCondition()
                 .endStatus()
                 .build();
-        assertFalse(isProposalReady.test(build));
+        assertFalse(customConditionPresent.test(build));
     }
 
+    @Test
+    public void testKafkaIsReady() {
+        Kafka build = new KafkaBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(Kafka.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaConnectorIsReady() {
+        KafkaConnector build = new KafkaConnectorBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(KafkaConnector.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaConnectIsReady() {
+        KafkaConnect build = new KafkaConnectBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(KafkaConnect.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaTopicIsReady() {
+        KafkaTopic build = new KafkaTopicBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(KafkaTopic.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaBridgeIsReady() {
+        KafkaBridge build = new KafkaBridgeBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(KafkaBridge.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaMirrorMaker2IsReady() {
+        KafkaMirrorMaker2 build = new KafkaMirrorMaker2Builder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(KafkaMirrorMaker2.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaUserIsReady() {
+        KafkaUser build = new KafkaUserBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus().build();
+        assertTrue(KafkaUser.isReady().test(build));
+    }
+
+    @Test
+    public void testKafkaRebalanceIsState() {
+        for (KafkaRebalanceState crdState : KafkaRebalanceState.values()) {
+            KafkaRebalance build = new KafkaRebalanceBuilder()
+                    .editMetadata().withGeneration(2L).endMetadata()
+                    .withNewStatus()
+                    .withObservedGeneration(2L)
+                    .addNewCondition().withType(crdState.name()).withStatus("True").endCondition()
+                    .endStatus().build();
+            for (KafkaRebalanceState testState : KafkaRebalanceState.values()) {
+                assertEquals(KafkaRebalance.isState(testState).test(build), testState == crdState);
+            }
+        }
+    }
 }

--- a/api/src/test/java/io/strimzi/api/kafka/model/CustomResourceConditionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/CustomResourceConditionsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The purpose of this test is to check that custom resource predicates correctly
+ * identify CRDs in specific states
+ */
+class CustomResourceConditionsTest {
+
+    Predicate<Kafka> isReady = CustomResourceConditions.isReady();
+
+    Predicate<KafkaRebalance> isProposalReady = CustomResourceConditions.isKafkaRebalanceProposalReady();
+
+    @Test
+    public void testIsReady_EmptyKafkaNotReady() {
+        Kafka build = new KafkaBuilder().build();
+        assertFalse(isReady.test(build));
+    }
+
+    @Test
+    public void testIsReady_ReadyKafka() {
+        Kafka build = new KafkaBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus()
+                .build();
+        assertTrue(isReady.test(build));
+    }
+
+    @Test
+    public void testIsReady_ConditionMissing() {
+        Kafka build = new KafkaBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .endStatus()
+                .build();
+        assertFalse(isReady.test(build));
+    }
+
+    @Test
+    public void testIsReady_ConditionNotTrue() {
+        Kafka build = new KafkaBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("Ready").withStatus("False").endCondition()
+                .endStatus()
+                .build();
+        assertFalse(isReady.test(build));
+    }
+
+    @Test
+    public void testIsReady_NullStatus() {
+        Kafka build = new KafkaBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .build();
+        assertFalse(isReady.test(build));
+    }
+
+    @Test
+    public void testIsReady_ObservedGenerationNotEqualToMetadataGeneration() {
+        Kafka build = new KafkaBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(1L)
+                .addNewCondition().withType("Ready").withStatus("True").endCondition()
+                .endStatus()
+                .build();
+        assertFalse(isReady.test(build));
+    }
+
+
+    @Test
+    public void testIsProposalReady_EmptyKafkaRebalanceNotProposalReady() {
+        KafkaRebalance build = new KafkaRebalanceBuilder().build();
+        assertFalse(isProposalReady.test(build));
+    }
+
+
+    @Test
+    public void testIsProposalReady_ReadyProposal() {
+        KafkaRebalance build = new KafkaRebalanceBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("ProposalReady").withStatus("True").endCondition()
+                .endStatus()
+                .build();
+        assertTrue(isProposalReady.test(build));
+    }
+
+    @Test
+    public void testIsProposalReady_ConditionMissing() {
+        KafkaRebalance build = new KafkaRebalanceBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .endStatus()
+                .build();
+        assertFalse(isProposalReady.test(build));
+    }
+
+    @Test
+    public void testIsProposalReady_ConditionNotTrue() {
+        KafkaRebalance build = new KafkaRebalanceBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .addNewCondition().withType("ProposalReady").withStatus("False").endCondition()
+                .endStatus()
+                .build();
+        assertFalse(isProposalReady.test(build));
+    }
+
+    @Test
+    public void testIsProposalReady_NullStatus() {
+        KafkaRebalance build = new KafkaRebalanceBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .build();
+        assertFalse(isProposalReady.test(build));
+    }
+
+    @Test
+    public void testIsProposalReady_ObservedGenerationNotEqualToMetadataGeneration() {
+        KafkaRebalance build = new KafkaRebalanceBuilder()
+                .editMetadata().withGeneration(2L).endMetadata()
+                .withNewStatus()
+                .withObservedGeneration(1L)
+                .addNewCondition().withType("ProposalReady").withStatus("True").endCondition()
+                .endStatus()
+                .build();
+        assertFalse(isProposalReady.test(build));
+    }
+
+}

--- a/api/src/test/java/io/strimzi/api/kafka/model/CustomResourceConditionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/CustomResourceConditionsTest.java
@@ -233,7 +233,7 @@ class CustomResourceConditionsTest {
                     .addNewCondition().withType(crdState.name()).withStatus("True").endCondition()
                     .endStatus().build();
             for (KafkaRebalanceState testState : KafkaRebalanceState.values()) {
-                assertEquals(KafkaRebalance.isState(testState).test(build), testState == crdState);
+                assertEquals(KafkaRebalance.isInState(testState).test(build), testState == crdState);
             }
         }
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Waiting for CRDs to become ready takes a few lines of boilerplate code. This should make it easier for users to wait for programmatically created resources to become ready (or enter other desired states)

See [strimzi-api-examples](https://github.com/scholzj/strimzi-api-examples/compare/main...robobario:strimzi-api-examples:wait-condition-api?expand=1) fork for usage (updated to 0.31.0-SNAPSHOT, fixed up some fabric8 6.0.0 changes, added cruisecontrol rebalance code).

fixes issue #7138

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [NA] Supply screenshots for visual changes, such as Grafana dashboards