### PR TITLE
Update some dependencies before the 0.31.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,11 @@
         <fasterxml.jackson-databind.version>2.12.6.1</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.12.6</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.12.6</fasterxml.jackson-annotations.version>
-        <vertx.version>4.2.4</vertx.version>
-        <vertx-junit5.version>4.2.4</vertx-junit5.version>
+        <vertx.version>4.2.7</vertx.version>
+        <vertx-junit5.version>4.2.7</vertx-junit5.version>
         <kafka.version>3.2.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
-        <scala-library.version>2.13.6</scala-library.version>
+        <scala-library.version>2.13.8</scala-library.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <zkclient.version>0.11</zkclient.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates some dependencies before the 0.31.0 release:
* Vert.x to 4.2.7 (Vert.x 4.3 currently does ot work with Strimzi)
* Scala to 2.13.8 (to align with Kafka 3.2.1 which we already use)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally