### PR TITLE
Make the certificate-manager tests which depend on OpenSSL IT tests

### DIFF
--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class OpenSslCertManagerTest {
+public class OpenSslCertManagerIT {
 
     private static CertificateFactory certFactory;
     private static OpenSslCertManager ssl;
@@ -258,7 +258,7 @@ public class OpenSslCertManagerTest {
     @Test
     public void testGenerateClientCert() throws Exception {
 
-        Path path = Files.createTempDirectory(OpenSslCertManagerTest.class.getSimpleName());
+        Path path = Files.createTempDirectory(OpenSslCertManagerIT.class.getSimpleName());
         path.toFile().deleteOnExit();
         long fileCount = Files.list(path).count();
         File caKey = File.createTempFile("ca-key-", ".key");

--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static java.util.Collections.emptyMap;
 
-public class SecretCertProviderTest {
+public class SecretCertProviderIT {
 
     private static CertManager ssl;
     private static SecretCertProvider secretCertProvider;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `certificate-manager` module has several tests which test the integration with the OpenSSL used to generate certificates. These are currently marked as unit tests, but maybe because of the dependency on the OpenSSL tool, it might make more sense to call them IT tests.

### Checklist

- [x] Make sure all tests pass