### PR TITLE
Add a dev guide section for using IntelliJ IDE

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -91,6 +91,28 @@ before running the `make` commands.
 
     export TEST_CLUSTER=minikube
 
+## Using an IDE
+### IntelliJ IDEA
+The project includes a lot of code generation which takes place within the maven build process, that is why just importing the project might end up with a lot of `Cannot resolve symbol` errors.
+
+Follow these steps to import the project in IntelliJ IDEA, run code generation and trigger a reindex in IntelliJ.
+
+1. After cloning the repo, open the folder in IntelliJ IDEA.
+2. From the toolbar in the [Maven tool window](https://www.jetbrains.com/help/idea/maven-projects-tool-window.html#toolbar), click on `Generate Sources and Update Folders For All Projects` button to initiate the code generation.
+3. Restart the IDE via **Find Action**: press `Ctrl+Shift+A` and type **Restart IDE**.
+
+Afterwards IntelliJ should no longer have any`Cannot resolve symbol` errors. 
+
+## IDE build problems
+
+The build also uses a Java annotation processor. Some IDEs (such as IntelliJ's IDEA) by default don't run the annotation
+processor in their build process. You can run `mvn clean install -DskipTests` to run the annotation processor
+as part of the `maven` build, and the IDE should then be able to use the generated classes. It is also possible to
+configure the IDE to run the annotation processor directly.
+
+Eclipse users may find the [m2e-apt plugin](https://marketplace.eclipse.org/content/m2e-apt) useful for the automatic
+configuration of Eclipse projects for annotation processing.
+
 ## Build and deploy from source
 
 To build Strimzi from a source the operator and Kafka code needs to be compiled into container images and placed
@@ -362,16 +384,6 @@ the commit if errors are detected:
 ```
 ./tools/git-hooks/checkstyle-pre-commit
 ```
-
-## IDE build problems
-
-The build also uses a Java annotation processor. Some IDEs (such as IntelliJ's IDEA) by default don't run the annotation
-processor in their build process. You can run `mvn clean install -DskipTests` to run the annotation processor
-as part of the `maven` build, and the IDE should then be able to use the generated classes. It is also possible to
-configure the IDE to run the annotation processor directly.
-
-Eclipse users may find the [m2e-apt plugin](https://marketplace.eclipse.org/content/m2e-apt) useful for the automatic
-configuration of Eclipse projects for annotation processing.
 
 ## Building container images for other platforms with Docker `buildx`
 

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -6,6 +6,9 @@ This document gives a detailed breakdown of the various build processes and opti
 
 - [Developer Quick Start](#developer-quick-start)
 - [Build Pre-Requisites](#build-pre-requisites)
+- [Using an IDE](#using-an-ide)
+   - [IntelliJ IDEA](#intellij-idea)
+   - [IDE build problems](#ide-build-problems)
 - [Build and deploy Strimzi from source](#build-and-deploy-from-source)
 - [Build details](#build-details)
    - [Make targets](#make-targets)
@@ -18,7 +21,6 @@ This document gives a detailed breakdown of the various build processes and opti
 - [Helm Chart](#helm-chart)
 - [Running system tests](#running-system-tests)
 - [DCO Signoff](#dco-signoff)
-- [IDE build problems](#ide-build-problems)
 - [Building container images for other platforms with Docker `buildx`](#building-container-images-for-other-platforms-with-docker-buildx)
 
 <!-- /TOC -->
@@ -101,7 +103,9 @@ Follow these steps to import the project in IntelliJ IDEA, run code generation a
 2. From the toolbar in the [Maven tool window](https://www.jetbrains.com/help/idea/maven-projects-tool-window.html#toolbar), click on `Generate Sources and Update Folders For All Projects` button to initiate the code generation.
 3. Restart the IDE via **Find Action**: press `Ctrl+Shift+A` and type **Restart IDE**.
 
-Afterwards IntelliJ should no longer have any`Cannot resolve symbol` errors. 
+Afterwards IntelliJ should no longer have any`Cannot resolve symbol` errors.
+
+Note: After running the Maven build in the terminal you might need to [reload the project](https://www.jetbrains.com/help/idea/delegate-build-and-run-actions-to-maven.html#maven_reimport) from the Maven tool window.
 
 ### IDE build problems
 

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -103,7 +103,7 @@ Follow these steps to import the project in IntelliJ IDEA, run code generation a
 2. From the toolbar in the [Maven tool window](https://www.jetbrains.com/help/idea/maven-projects-tool-window.html#toolbar), click on `Generate Sources and Update Folders For All Projects` button to initiate the code generation.
 3. Restart the IDE via **Find Action**: press `Ctrl+Shift+A` and type **Restart IDE**.
 
-Afterwards IntelliJ should no longer have any`Cannot resolve symbol` errors.
+Afterwards IntelliJ should no longer have any `Cannot resolve symbol` errors.
 
 Note: After running the Maven build in the terminal you might need to [reload the project](https://www.jetbrains.com/help/idea/delegate-build-and-run-actions-to-maven.html#maven_reimport) from the Maven tool window.
 

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -103,7 +103,7 @@ Follow these steps to import the project in IntelliJ IDEA, run code generation a
 
 Afterwards IntelliJ should no longer have any`Cannot resolve symbol` errors. 
 
-## IDE build problems
+### IDE build problems
 
 The build also uses a Java annotation processor. Some IDEs (such as IntelliJ's IDEA) by default don't run the annotation
 processor in their build process. You can run `mvn clean install -DskipTests` to run the annotation processor


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adds a new IDE section for new contributors using IntelliJ which brings code generation to their attention and instructs them on how to generate the sources in IDE to resolve the "Cannot resolve symbol" errors.

### Checklist

- [x] Update documentation
- [ ] Update CHANGELOG.md