### PR TITLE
ST: Propagate configuration for pod policy provider into helm and olm resources during STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -231,7 +231,7 @@ public class SetupClusterOperator {
             extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
         }
         olmResource = new OlmResource(this.namespaceInstallTo);
-        olmResource.create(this.namespaceInstallTo, OlmInstallationStrategy.Manual, fromVersion, channelName);
+        olmResource.create(this.namespaceInstallTo, OlmInstallationStrategy.Manual, fromVersion, channelName, extraEnvVars);
 
         return this;
     }
@@ -240,7 +240,7 @@ public class SetupClusterOperator {
         LOGGER.info("Install ClusterOperator via Helm");
         helmResource = new HelmResource(namespaceInstallTo, namespaceToWatch);
         createCONamespaceIfNeeded();
-        helmResource.create(extensionContext, operationTimeout, reconciliationInterval);
+        helmResource.create(extensionContext, operationTimeout, reconciliationInterval, extraEnvVars);
     }
 
     private void bundleInstallation() {
@@ -286,13 +286,13 @@ public class SetupClusterOperator {
                 createCONamespaceIfNeeded();
                 createClusterRoleBindings();
                 olmResource = new OlmResource(namespaceInstallTo);
-                olmResource.create(extensionContext, operationTimeout, reconciliationInterval);
+                olmResource.create(extensionContext, operationTimeout, reconciliationInterval, extraEnvVars);
             }
             // single-namespace olm co-operator
         } else {
             createCONamespaceIfNeeded();
             olmResource = new OlmResource(namespaceInstallTo);
-            olmResource.create(extensionContext, operationTimeout, reconciliationInterval);
+            olmResource.create(extensionContext, operationTimeout, reconciliationInterval, extraEnvVars);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.operator.specific;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceItem;
@@ -18,6 +19,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
@@ -46,13 +48,13 @@ public class HelmResource implements SpecificResourceType {
     }
 
     public void create(ExtensionContext extensionContext) {
-        this.create(extensionContext, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL);
+        this.create(extensionContext, Constants.CO_OPERATION_TIMEOUT_DEFAULT, Constants.RECONCILIATION_INTERVAL, null);
     }
 
-    public void create(ExtensionContext extensionContext, long operationTimeout, long reconciliationInterval) {
+    public void create(ExtensionContext extensionContext, long operationTimeout, long reconciliationInterval, List<EnvVar> extraEnvVars) {
         ResourceManager.STORED_RESOURCES.computeIfAbsent(extensionContext.getDisplayName(), k -> new Stack<>());
         ResourceManager.STORED_RESOURCES.get(extensionContext.getDisplayName()).push(new ResourceItem(this::delete));
-        this.clusterOperator(operationTimeout, reconciliationInterval);
+        this.clusterOperator(operationTimeout, reconciliationInterval, extraEnvVars);
     }
 
     @Override
@@ -60,11 +62,7 @@ public class HelmResource implements SpecificResourceType {
         this.deleteClusterOperator();
     }
 
-    private void clusterOperator(long operationTimeout) {
-        clusterOperator(operationTimeout, Constants.RECONCILIATION_INTERVAL);
-    }
-
-    private void clusterOperator(long operationTimeout, long reconciliationInterval) {
+    private void clusterOperator(long operationTimeout, long reconciliationInterval, List<EnvVar> extraEnvVars) {
 
         Map<String, Object> values = new HashMap<>();
         // image registry config
@@ -93,6 +91,16 @@ public class HelmResource implements SpecificResourceType {
         values.put("watchAnyNamespace", this.namespaceToWatch.equals(Constants.WATCH_ALL_NAMESPACES));
         if (!this.namespaceToWatch.equals("*") && !this.namespaceToWatch.equals(this.namespaceInstallTo)) {
             values.put("watchNamespaces", buildWatchNamespaces());
+        }
+
+        // Set extraEnvVars into Helm Chart
+        if (extraEnvVars != null) {
+            int envVarIndex = 0;
+            for (EnvVar envVar: extraEnvVars) {
+                values.put("extraEnvs[" + envVarIndex + "].name", envVar.getName());
+                values.put("extraEnvs[" + envVarIndex + "].value", envVar.getValue());
+                envVarIndex++;
+            }
         }
 
         Path pathToChart = new File(HELM_CHART).toPath();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.security;
 
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.SecurityContext;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -196,11 +194,11 @@ public class PodSecurityProfilesIsolatedST extends AbstractST {
         clusterOperator.unInstall();
         clusterOperator = clusterOperator
             .defaultInstallation()
-            .withExtraEnvVars(Collections.singletonList(new EnvVarBuilder()
-                .withName("STRIMZI_POD_SECURITY_PROVIDER_CLASS")
-                // default is `baseline` and thus other tests suites are testing it
-                .withValue("restricted")
-                .build()))
+//            .withExtraEnvVars(Collections.singletonList(new EnvVarBuilder()
+//                .withName("STRIMZI_POD_SECURITY_PROVIDER_CLASS")
+//                // default is `baseline` and thus other tests suites are testing it
+//                .withValue("restricted")
+//                .build()))
             .createInstallation()
             .runInstallation();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
@@ -194,11 +194,11 @@ public class PodSecurityProfilesIsolatedST extends AbstractST {
         clusterOperator.unInstall();
         clusterOperator = clusterOperator
             .defaultInstallation()
-//            .withExtraEnvVars(Collections.singletonList(new EnvVarBuilder()
-//                .withName("STRIMZI_POD_SECURITY_PROVIDER_CLASS")
-//                // default is `baseline` and thus other tests suites are testing it
-//                .withValue("restricted")
-//                .build()))
+            .withExtraEnvVars(Collections.singletonList(new EnvVarBuilder()
+                .withName("STRIMZI_POD_SECURITY_PROVIDER_CLASS")
+                // default is `baseline` and thus other tests suites are testing it
+                .withValue("restricted")
+                .build()))
             .createInstallation()
             .runInstallation();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.security;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.SecurityContext;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Bugfix

### Description

This PR propagate extra env vars into helm and OLM resources used within system tests module. This should fix issues with running system tests with pod security policy when we specify different than default policy also for helm and OLM.

### Checklist

- [ ] Make sure all tests pass

