### PR TITLE
Fix flaky `LeaderElectionManagerMockTest`

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @EnableKubernetesMockClient(crud = true)
@@ -52,7 +54,7 @@ public class LeaderElectionManagerMockTest {
         // Stop the second member => the leadership in the lease resource will stay as it was
         le2.stop();
         le2NotLeader.await();
-        assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
+        assertThat(getLease().getSpec().getHolderIdentity(), anyOf(is("le-2"), nullValue()));
     }
 
     private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Runnable stopLeadershipCallback)   {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After the upgrade to Fabric8 6.1.0, the `LeaderElectionManagerMockTest` test seems to be a little bit flaky. In 6.1.0, the canceling of the leader election lock triggers release of the lock. That creates a race condition between just not being a leader anymore and the lock being cleared. This PR fixes it by handling both situations. This impacts only the test, not any actual functionality used in production code.

### Checklist

- [x] Make sure all tests pass