### PR TITLE
Update Fabric8 to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
 
         <!-- Runtime dependencies -->
         <fabric8.kubernetes-client.version>6.1.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.1.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.1.0</fabric8.kubernetes-model.version>
+        <fabric8.openshift-client.version>6.1.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.1.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.12.6</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.12.6.1</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

There was a small bug in Fabric8 6.1.1 around proxy handling. It might not affect many Strimzi users, but just in case, this Pr upgrades Fabric8 to version 6.1.1.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally