### PR TITLE
[systemtest] Fix collecting of logs inside the tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -151,10 +151,20 @@ public class LogCollector {
                 if (StUtils.isIsolatedTest(extensionContext) ||
                     StUtils.isParallelTest(extensionContext) ||
                     StUtils.isParallelNamespaceTest(extensionContext))  {
+
+                    String testMethod = extensionContext.getTestMethod().isPresent() ? extensionContext.getTestMethod().get().getName() : "";
+
                     final Set<String> generatedTestSuiteNamespaces =
                         KubeClusterResource.getMapWithSuiteNamespaces().get(
-                            CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()));
-                    namespaces.addAll(generatedTestSuiteNamespaces);
+                            CollectorElement.createCollectorElement(
+                                extensionContext.getRequiredTestClass().getName(),
+                                testMethod
+                            ));
+
+                    if (generatedTestSuiteNamespaces != null) {
+                        namespaces.addAll(generatedTestSuiteNamespaces);
+                    }
+
                     LOGGER.debug("{} adding to all namespaces, which should be collected: {}", generatedTestSuiteNamespaces, namespaces.toString());
                 }
             }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In STs we are getting namespaces, from which we should grab all the logs, by the `CollectorElement`, which should match to already created `CollectorElement` in the namespaces stack. But, we are not looking for the test method name, so the filter just returns `null`. The `Set` should then be added  overall namespaces `Set`, where it throws NPE (because of the `null` returned from the filter).

This PR fixes this behavior .

### Checklist

- [ ] Make sure all tests pass
