### PR TITLE
Fix mix-up between Fabric8 Kubernetes client versions 6.1.0 and 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <lombok.version>1.18.4</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.1.0</fabric8.kubernetes-client.version>
+        <fabric8.kubernetes-client.version>6.1.1</fabric8.kubernetes-client.version>
         <fabric8.openshift-client.version>6.1.1</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>6.1.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Unfortunately, I screwed up #7265 and didn't updated all fields with Fabric8 versions 🤦‍♂️. So as a result, we have now a mixup where some libraries are 6.1.0 and some are 6.1.1. This PR updates the remaining version field as well and fixes it.

This should be back-ported to 0.31.0 befroe the release.