### PR TITLE
[systemtest] Remove fabric8 deprecations from the code

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -298,7 +298,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
             .endMetadata()
             .build();
 
-        kubeClient().getClient().adapt(OpenShiftClient.class).imageStreams().inNamespace(storage.getNamespaceName()).create(imageStream);
+        kubeClient().getClient().adapt(OpenShiftClient.class).imageStreams().inNamespace(storage.getNamespaceName()).resource(imageStream).create();
 
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(storage.getClusterName(), storage.getNamespaceName(), storage.getNamespaceName(), 1)
             .editMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1099,8 +1099,9 @@ class ConnectIsolatedST extends AbstractST {
 
         kubeClient(namespaceName).createSecret(connectSecret);
         kubeClient(namespaceName).createSecret(dotedConnectSecret);
-        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
-        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).createOrReplace(dotedConfigMap);
+        
+        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(dotedConfigMap).createOrReplace();
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(clusterName, 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -72,7 +72,7 @@ public class ConfigProviderST extends AbstractST {
             .withData(configData)
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).create(connectorConfig);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(connectorConfig).create();
 
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnectWithFilePlugin(namespaceName, clusterName, 1)
             .editOrNewMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -199,11 +199,10 @@ class LoggingChangeST extends AbstractST {
             .addToData("log4j2.properties", loggersConfigCO)
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapKafka);
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapOperators);
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapZookeeper);
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapOperators);
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).createOrReplace(configMapCO);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapKafka).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapOperators).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapZookeeper).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(configMapCO).createOrReplace();
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3)
             .editOrNewSpec()
@@ -256,7 +255,7 @@ class LoggingChangeST extends AbstractST {
 
         // set loggers of CO back to original
         configMapCO.getData().put("log4j2.properties", originalCoLoggers);
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).createOrReplace(configMapCO);
+        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(configMapCO).createOrReplace();
     }
 
     @ParallelNamespaceTest
@@ -349,8 +348,8 @@ class LoggingChangeST extends AbstractST {
                 "rootLogger.additivity=false"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapTo);
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapUo);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapTo).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapUo).createOrReplace();
 
         ExternalLogging elTo = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -432,8 +431,8 @@ class LoggingChangeST extends AbstractST {
                 "rootLogger.additivity=false"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapTo);
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapUo);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapTo).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapUo).createOrReplace();
 
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -545,7 +544,7 @@ class LoggingChangeST extends AbstractST {
                     "logger.ready.level = OFF"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(configMapBridge);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(configMapBridge).createOrReplace();
 
         ExternalLogging bridgeXternalLogging = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -623,7 +622,7 @@ class LoggingChangeST extends AbstractST {
         assertThat(log4jConfig, not(equalTo(cmdKubeClient().namespace(clusterOperator.getDeploymentNamespace()).execInPod(coPodName, "/bin/bash", "-c", command).out().trim())));
 
         LOGGER.info("Changing logging for cluster-operator");
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).createOrReplace(coMap);
+        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coMap).createOrReplace();
 
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -649,7 +648,7 @@ class LoggingChangeST extends AbstractST {
         coMap.setData(Collections.singletonMap("log4j2.properties", log4jConfig));
 
         LOGGER.info("Changing logging for cluster-operator");
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).createOrReplace(coMap);
+        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coMap).createOrReplace();
 
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -751,7 +750,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", log4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(connectLoggingMap);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(connectLoggingMap).createOrReplace();
 
         ExternalLogging connectXternalLogging = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -883,7 +882,7 @@ class LoggingChangeST extends AbstractST {
                 "log4j.logger.kafka.authorizer.logger=INFO"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
 
         ExternalLogging elKafka = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -1002,7 +1001,7 @@ class LoggingChangeST extends AbstractST {
                         ))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
         ExternalLogging el = new ExternalLoggingBuilder()
             .withNewValueFrom()
                 .withConfigMapKeyRef(
@@ -1052,7 +1051,7 @@ class LoggingChangeST extends AbstractST {
                         ))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
         RollingUpdateUtils.waitForNoRollingUpdate(namespaceName, kafkaSelector, kafkaPods);
         assertThat("Kafka pod should not roll", RollingUpdateUtils.componentHasRolled(namespaceName, kafkaSelector, kafkaPods), is(false));
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -1084,7 +1083,7 @@ class LoggingChangeST extends AbstractST {
                 ))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
         RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
 
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -1168,7 +1167,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", log4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(mm2LoggingMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(mm2LoggingMap).createOrReplace();
 
         ExternalLogging mm2XternalLogging = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -1232,7 +1231,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", log4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(mm2LoggingMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(mm2LoggingMap).createOrReplace();
 
         ExternalLogging mm2XternalLogging = new ExternalLoggingBuilder()
                 .withNewValueFrom()
@@ -1281,7 +1280,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", updatedLog4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(mm2LoggingMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(mm2LoggingMap).createOrReplace();
 
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://localhost:8083/admin/loggers/root").out().contains("INFO")
@@ -1321,7 +1320,7 @@ class LoggingChangeST extends AbstractST {
             .withData(Collections.singletonMap("log4j.properties", cmData))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
 
         LOGGER.info("Deploying Kafka with custom logging");
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -521,7 +521,7 @@ public class MetricsIsolatedST extends AbstractST {
                 .endMetadata()
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(SECOND_NAMESPACE).createOrReplace(externalMetricsCm);
+        kubeClient().getClient().configMaps().inNamespace(SECOND_NAMESPACE).resource(externalMetricsCm).createOrReplace();
 
         // spec.kafka.metrics -> spec.kafka.jmxExporterMetrics
         ConfigMapKeySelector cmks = new ConfigMapKeySelectorBuilder()
@@ -553,7 +553,7 @@ public class MetricsIsolatedST extends AbstractST {
                 .endMetadata()
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(SECOND_NAMESPACE).createOrReplace(externalMetricsUpdatedCm);
+        kubeClient().getClient().configMaps().inNamespace(SECOND_NAMESPACE).resource(externalMetricsUpdatedCm).createOrReplace();
         PodUtils.verifyThatRunningPodsAreStable(SECOND_NAMESPACE, SECOND_CLUSTER);
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(SECOND_CLUSTER, 1)) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -314,7 +314,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         Deployment coDep = kubeClient().getDeployment(Constants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).withName(Constants.STRIMZI_DEPLOYMENT_NAME).replace(coDep);
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).replace();
 
         coPod = DeploymentUtils.waitTillDepHasRolled(Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
 
@@ -328,7 +328,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         coDep = kubeClient().getDeployment(Constants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).withName(Constants.STRIMZI_DEPLOYMENT_NAME).replace(coDep);
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).replace();
 
         DeploymentUtils.waitTillDepHasRolled(Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
@@ -75,7 +75,7 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
         // Recreate all KafkaTopic resources
         for (KafkaTopic kafkaTopic : kafkaTopicList) {
             kafkaTopic.getMetadata().setResourceVersion(null);
-            KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).createOrReplace(kafkaTopic);
+            KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).resource(kafkaTopic).createOrReplace();
         }
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
@@ -239,11 +239,11 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
     private void recreatePvcAndUpdatePv(List<PersistentVolumeClaim> persistentVolumeClaimList) {
         for (PersistentVolumeClaim pvc : persistentVolumeClaimList) {
             pvc.getMetadata().setResourceVersion(null);
-            kubeClient().getClient().persistentVolumeClaims().inNamespace(clusterOperator.getDeploymentNamespace()).create(pvc);
+            kubeClient().getClient().persistentVolumeClaims().inNamespace(clusterOperator.getDeploymentNamespace()).resource(pvc).create();
 
             PersistentVolume pv = kubeClient().getClient().persistentVolumes().withName(pvc.getSpec().getVolumeName()).get();
             pv.getSpec().setClaimRef(null);
-            kubeClient().getClient().persistentVolumes().createOrReplace(pv);
+            kubeClient().getClient().persistentVolumes().resource(pv).createOrReplace();
         }
     }
 
@@ -268,7 +268,7 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
 
     @BeforeAll
     void createStorageClass() {
-        kubeClient().getClient().storage().storageClasses().withName(storageClassName).delete();
+        kubeClient().getClient().storage().v1().storageClasses().withName(storageClassName).delete();
         StorageClass storageClass = new StorageClassBuilder()
             .withNewMetadata()
                 .withName(storageClassName)
@@ -277,15 +277,15 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
             .withReclaimPolicy("Retain")
             .build();
 
-        kubeClient().getClient().storage().storageClasses().createOrReplace(storageClass);
+        kubeClient().getClient().storage().v1().storageClasses().resource(storageClass).createOrReplace();
     }
 
     @AfterAll
     void teardown() {
-        kubeClient().getClient().storage().storageClasses().withName(storageClassName).delete();
+        kubeClient().getClient().storage().v1().storageClasses().withName(storageClassName).delete();
 
         kubeClient().getClient().persistentVolumes().list().getItems().stream()
             .filter(pv -> pv.getSpec().getClaimRef().getName().contains("kafka") || pv.getSpec().getClaimRef().getName().contains("zookeeper"))
-            .forEach(pv -> kubeClient().getClient().persistentVolumes().delete(pv));
+            .forEach(pv -> kubeClient().getClient().persistentVolumes().resource(pv).delete());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -248,7 +248,7 @@ public class TopicST extends AbstractST {
                 .build());
             KafkaTopicUtils.waitForKafkaTopicReady(namespace, topicName);
 
-            adminClient.describeTopics(singletonList(topicName)).values().get(topicName);
+            adminClient.describeTopics(singletonList(topicName)).topicNameValues().get(topicName);
 
             for (int i = 0; i < 10; i++) {
                 Thread.sleep(2_000);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -160,7 +160,7 @@ class UserST extends AbstractST {
         assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(namespace)));
         assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo("scram-sha-512")));
 
-        Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).delete(kUser);
+        Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(namespace).resource(kUser).delete();
         KafkaUserUtils.waitForKafkaUserDeletion(userName);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -504,7 +504,7 @@ class RollingUpdateST extends AbstractST {
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
             ConfigMap configMap = kubeClient(namespaceName).getConfigMap(namespaceName, cmName);
             configMap.getData().put("new.kafka.config", "new.config.value");
-            kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMap);
+            kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
         }
 
         PodUtils.verifyThatRunningPodsAreStable(namespaceName, clusterName);
@@ -562,7 +562,7 @@ class RollingUpdateST extends AbstractST {
                 .withKey("log4j-custom.properties")
                 .build();
 
-        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapLoggers);
+        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(configMapLoggers).createOrReplace();
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             kafka.getSpec().getKafka().setLogging(new ExternalLoggingBuilder()
@@ -585,7 +585,7 @@ class RollingUpdateST extends AbstractST {
         kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
 
         configMapLoggers.getData().put("log4j-custom.properties", loggersConfig.replace("%p %m (%c) [%t]", "%p %m (%c) [%t]%n"));
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).createOrReplace(configMapLoggers);
+        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapLoggers).createOrReplace();
 
         if (!Environment.isKRaftModeEnabled()) {
             RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, zkSelector, 3, zkPods);
@@ -714,8 +714,8 @@ class RollingUpdateST extends AbstractST {
                 .endValueFrom()
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMK);
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMZk);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMK).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMZk).createOrReplace();
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3, 3)
             .editMetadata()
@@ -785,8 +785,8 @@ class RollingUpdateST extends AbstractST {
                 .withData(singletonMap("metrics-config.yml", mapper.writeValueAsString(kafkaMetrics)))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMK);
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).createOrReplace(metricsCMZk);
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMK).createOrReplace();
+        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMZk).createOrReplace();
 
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.zookeeperStatefulSetName(testStorage.getClusterName()));
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -176,7 +176,8 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
                         .withNamespace(targetNamespace)
                     .endMetadata()
                     .build();
-        kubeClient(targetNamespace).getClient().secrets().inNamespace(targetNamespace).createOrReplace(s);
+
+        kubeClient(targetNamespace).getClient().secrets().inNamespace(targetNamespace).resource(s).createOrReplace();
     }
 
     private void deployTestSpecificResources(ExtensionContext extensionContext) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

After upgrading to the fabric8 `6.1.1`, we have few deprecations in our `systemtest` module.
The `createOrReplace(resource)`, `create(resource)`, `delete(resource)` and other methods, which are directly using the `resource` should be changed to `.resource(resource).createOrReplace()` etc.

Also, few deprecations about moving `storageClass` to `v1` API or other are fixed in this PR.

### Checklist

- [ ] Make sure all tests pass

