### PR TITLE
Revert the MinRAMPercentage change from 10% to 20%

### DIFF
--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -28,7 +28,7 @@ JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
 
 # Default memory options used when the user didn't configured any of these options, we set the defaults
 if [[ "$JAVA_OPTS" != *"MinRAMPercentage"* && "$JAVA_OPTS" != *"MaxRAMPercentage"* ]]; then
-  JAVA_OPTS="${JAVA_OPTS} -XX:MinRAMPercentage=20 -XX:MaxRAMPercentage=20"
+  JAVA_OPTS="${JAVA_OPTS} -XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=20"
 fi
 
 # Disable FIPS if needed


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Pr #7186 changed the `MinRAMPercentage` setting used by the operator from 10% to 20%. It looks like this however led to the operator running frequently out of memory with the default settings and restarting.

This PR reverts it to the original value of 10%.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally