### PR TITLE
docs(cluster operator): Edit to the prereq description for cluster operator

### DIFF
--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -10,8 +10,7 @@ This procedure shows how to deploy the Cluster Operator to watch Strimzi resourc
 
 .Prerequisites
 
-* This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinitions`, `ClusterRoles` and `ClusterRoleBindings`.
-Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit, and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
 
 .Procedure
 

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-namespace.adoc
@@ -10,8 +10,7 @@ This procedure shows how to deploy the Cluster Operator to watch Strimzi resourc
 
 .Prerequisites
 
-* This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinitions`, `ClusterRoles` and `ClusterRoleBindings`.
-Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit, and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
 
 .Procedure
 

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -12,8 +12,7 @@ When running in this mode, the Cluster Operator automatically manages clusters i
 
 .Prerequisites
 
-* This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinitions`, `ClusterRoles` and `ClusterRoleBindings`.
-Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit, and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
 
 .Procedure
 

--- a/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
+++ b/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
@@ -19,9 +19,7 @@ To set up a proxy with a name and password, the format is _\http://USERNAME:PASS
 
 .Prerequisites
 
-This procedure requires use of a Kubernetes user account which is able to create `CustomResourceDefinitions`, `ClusterRoles` and `ClusterRoleBindings`.
-Use of Role Base Access Control (RBAC) in the Kubernetes cluster usually means that permission to create, edit,
-and delete these resources is limited to Kubernetes cluster administrators, such as `system:admin`.
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
 
 .Procedure
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
The [Configuring Cluster Operator replicas](https://strimzi.io/docs/operators/in-development/configuring.html#assembly-configuring-proxy-config-cluster-operator-str) procedure in the _Configuring_ guide includes a prereq for the type of account needed. 

This PR updates the prereqs of related Cluster Operator procedures to say the same thing. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

