### PR TITLE
[systemtest] Upgrade - delete topics all at once and fix the pipeline

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -242,7 +242,7 @@ public class KafkaTopicUtils {
                 try {
                     return getAllKafkaTopicsWithPrefix(namespaceName, topicPrefix).size() == 0;
                 } catch (Exception e) {
-                    return true;
+                    return e.getMessage().contains("Not Found") || e.getMessage().contains("the server doesn't have a resource type");
                 }
             });
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -235,4 +235,9 @@ public class KafkaTopicUtils {
             .split("\n"))
             .collect(Collectors.toList());
     }
+
+    public static void waitForTopicWithPrefixDeletion(String namespaceName, String topicPrefix) {
+        TestUtils.waitFor(String.format("all topics with prefix %s deletion", topicPrefix), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
+            () -> getAllKafkaTopicsWithPrefix(namespaceName, topicPrefix).size() == 0);
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -238,6 +238,12 @@ public class KafkaTopicUtils {
 
     public static void waitForTopicWithPrefixDeletion(String namespaceName, String topicPrefix) {
         TestUtils.waitFor(String.format("all topics with prefix %s deletion", topicPrefix), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
-            () -> getAllKafkaTopicsWithPrefix(namespaceName, topicPrefix).size() == 0);
+            () -> {
+                try {
+                    return getAllKafkaTopicsWithPrefix(namespaceName, topicPrefix).size() == 0;
+                } catch (Exception e) {
+                    return true;
+                }
+            });
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -15,6 +16,7 @@ import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -243,6 +245,11 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
 
     protected void afterEachMayOverride(ExtensionContext extensionContext) throws Exception {
         deleteInstalledYamls(coDir, clusterOperator.getDeploymentNamespace());
+
+        // delete all topics created in test
+        cmdKubeClient(clusterOperator.getDeploymentNamespace()).deleteAllByResource(KafkaTopic.RESOURCE_KIND);
+        KafkaTopicUtils.waitForTopicWithPrefixDeletion(clusterOperator.getDeploymentNamespace(), topicName);
+
         ResourceManager.getInstance().deleteResources(extensionContext);
         cluster.deleteNamespaces();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -23,7 +23,6 @@ import io.strimzi.systemtest.annotations.IsolatedSuite;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -242,9 +241,9 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
     }
 
-    @AfterEach
-    protected void tearDownEnvironmentAfterEach() {
+    protected void afterEachMayOverride(ExtensionContext extensionContext) throws Exception {
         deleteInstalledYamls(coDir, clusterOperator.getDeploymentNamespace());
+        ResourceManager.getInstance().deleteResources(extensionContext);
         cluster.deleteNamespaces();
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -56,6 +56,13 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
         return (K) this;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public K deleteAllByResource(String resourceType) {
+        Exec.exec(namespacedCommand(DELETE, resourceType, "--all"));
+        return (K) this;
+    }
+
     protected static class Context implements AutoCloseable {
         @Override
         public void close() { }

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -59,7 +59,11 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @Override
     @SuppressWarnings("unchecked")
     public K deleteAllByResource(String resourceType) {
-        Exec.exec(namespacedCommand(DELETE, resourceType, "--all"));
+        try {
+            Exec.exec(namespacedCommand(DELETE, resourceType, "--all"));
+        } catch (Exception e) {
+            LOGGER.warn(e.getMessage());
+        }
         return (K) this;
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/KubeCmdClient.java
@@ -31,6 +31,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     /** Deletes the resources by resource name. */
     K deleteByName(String resourceType, String resourceName);
 
+    K deleteAllByResource(String resourceType);
+
     KubeCmdClient<K> namespace(String namespace);
 
     /** Returns namespace for cluster */


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes issue with timeout in our upgrade pipeline - at one point, when we are deleting about 43 topics (and other resources), the whole pipeline just stuck. It seems that there is an issue with overloading the API (with delete and get methods in our waits). Fabric8 is deprecating the methods, which uses `List<resource>`, so doing it that wait would not make sense for the future. Also, if we just rewrite our logic inside `ResourceManager`, the resources stack would then make no sense either. So I'm adding removal of all topics using `cmdKubeClient()` after each test.

Fixes #7161 

### Checklist

- [x] Make sure all tests pass
