### PR TITLE
docs(security context): New section on security context config for Cluster Operator

### DIFF
--- a/documentation/assemblies/configuring/assembly-security-providers.adoc
+++ b/documentation/assemblies/configuring/assembly-security-providers.adoc
@@ -18,5 +18,5 @@ include::../../modules/configuring/proc-config-restricted-security-provider.adoc
 //implementing your own provider
 include::../../modules/configuring/con-config-custom-security-providers.adoc[leveloffset=+1]
 endif::Section[]
-//security context on openshift
-include::../../modules/configuring/con-config-openshift-security-providers.adoc[leveloffset=+1]
+//security context on other platforms
+include::../../modules/configuring/con-config-platform-security-providers.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-security-providers.adoc
+++ b/documentation/assemblies/configuring/assembly-security-providers.adoc
@@ -1,0 +1,22 @@
+// This assembly is included in the following assemblies:
+//
+// configuring/configuring.adoc
+
+[id='assembly-security-providers-{context}']
+= Applying security context to Strimzi pods and containers
+
+[role="_abstract"]
+Security context defines constraints on pods and containers.
+By specifying a security context, pods and containers only have the permissions they need.
+For example, permissions can control runtime operations or access to resources.
+
+ifdef::Section[]
+//how security context and security providers work
+include::../../modules/configuring/con-config-security-providers.adoc[leveloffset=+1]
+//implementing your own provider
+include::../../modules/configuring/proc-config-restricted-security-provider.adoc[leveloffset=+1]
+//implementing your own provider
+include::../../modules/configuring/con-config-custom-security-providers.adoc[leveloffset=+1]
+endif::Section[]
+//security context on openshift
+include::../../modules/configuring/con-config-openshift-security-providers.adoc[leveloffset=+1]

--- a/documentation/configuring/configuring.adoc
+++ b/documentation/configuring/configuring.adoc
@@ -12,6 +12,9 @@ include::assemblies/configuring/assembly-deployment-configuration.adoc[leveloffs
 //Load configuration from external sources for all Kafka components
 include::assemblies/configuring/assembly-external-config.adoc[leveloffset=+1]
 
+//security context for all pods
+include::assemblies/configuring/assembly-security-providers.adoc[leveloffset=+1]
+
 include::assemblies/security/assembly-securing-external-listeners.adoc[leveloffset=+1]
 
 include::assemblies/security/assembly-securing-access.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-config-custom-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-custom-security-providers.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// assembly-security-providers.adoc
+
+[id='con-config-custom-security-providers-{context}']
+= Implementing a custom pod security provider
+
+[role="_abstract"]
+If Strimzi's Baseline Provider and Restricted Provider don't quite match your needs, you can develop a custom pod security provider to deliver all-encompassing pod and container security context constraints.
+
+Implement a custom pod security provider to apply your own security context profile.
+You can decide what applications and privileges to include in the profile.
+
+Your custom pod security provider can implement the `PodSecurityProvider.java` interface that gets the security context for pods and containers. 
+Or it can extend the Baseline Provider or Restricted Provider classes. 
+
+The pod security provider plugins use the Java Service Provider Interface, so your custom pod security provider also requires a provider configuration file for service discovery. 
+
+To implement your own provider, the general steps are as follows:
+
+. Build the JAR file for the provider.
+. Add the JAR file to the Cluster Operator image.
+. Specify the custom pod security provider when setting the Cluster Operator environment variable `STRIMZI_POD_SECURITY_PROVIDER_CLASS`.
+
+[role="_additional-resources"]
+.Additional resources
+* {PodSecurityInterface}
+* {PodSecurityProviders}
+* {PodSecurityProvidersConfig}
+* {JavaServiceProvider}

--- a/documentation/modules/configuring/con-config-openshift-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-openshift-security-providers.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// assembly-security-providers.adoc
+
+[id='con-config-openshift-security-providers-{context}']
+= Applying security context to pods and containers on OpenShift
+
+[role="_abstract"]
+OpenShift uses security context constraints (SCCs) to control permissions for pods.
+Security context constraints (SCCs) are composed of settings and strategies that control the security features a pod has access to.
+
+By default, OpenShift injects security context configuration automatically.
+In most cases, this means you don't need to configure security context for the pods and containers created by the Cluster Operator.  
+Although it is possible to create your own SCCs.
+
+For more information, see the {OpenShiftDocs}. 

--- a/documentation/modules/configuring/con-config-platform-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-platform-security-providers.adoc
@@ -3,14 +3,16 @@
 // assembly-security-providers.adoc
 
 [id='con-config-openshift-security-providers-{context}']
-= Applying security context to pods and containers on OpenShift
+= Handling of security context by Kubernetes platform
 
 [role="_abstract"]
-OpenShift uses security context constraints (SCCs) to control permissions for pods.
-Security context constraints (SCCs) are composed of settings and strategies that control the security features a pod has access to.
+Handling of security context depends on the tooling of the Kubernetes platform you are using.  
+
+For example, OpenShift uses built-in security context constraints (SCCs) to control permissions.  
+SCCs are the settings and strategies that control the security features a pod has access to.
 
 By default, OpenShift injects security context configuration automatically.
 In most cases, this means you don't need to configure security context for the pods and containers created by the Cluster Operator.  
-Although it is possible to create your own SCCs.
+Although it is possible to create and manage your own SCCs.
 
 For more information, see the {OpenShiftDocs}. 

--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -21,6 +21,7 @@ Pod security provider plugins:: Use pod security provider plugins to automatical
 Pod security providers offer a simpler alternative to specifying security context through `template` configuration.
 You can use both approaches.
 The `template` approach has a higher priority.
+Security context configured through `template` properties overrides the configuration set by pod security providers.  
 So you might use pod security providers to automatically configure the security context for most containers.
 And also use `template` configuration to set container-specific security context where needed.
 
@@ -83,7 +84,7 @@ env:
   # ...
 ----
 
-Instead of specifying `baseline` as the value, you can specify the `io.strimzi.plugin.security.profiles.impl.BaselinePodSecurityProvider` classpath.
+Instead of specifying `baseline` as the value, you can specify the `io.strimzi.plugin.security.profiles.impl.BaselinePodSecurityProvider` fully-qualified domain name.
 
 == Restricted Provider for pod security
 
@@ -103,7 +104,7 @@ env:
   # ...
 ----
 
-Instead of specifying `restricted` as the value, you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` classpath.
+Instead of specifying `restricted` as the value, you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` fully-qualified domain name.
 
 If you change to the Restricted Provider from the default Baseline Provider, the following restrictions are implemented in addition to the constraints defined in the baseline security profile:
 

--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -29,10 +29,11 @@ For example, you'll need to apply the configuration to each pod in a Kafka clust
 
 To avoid repeating the same configuration, you can use the following pod security provider plugins so that the security configuration is in one place.
 
-* Baseline Provider
-* Restricted Provider
+Baseline Provider:: The Baseline Provider is based on the Kubernetes _baseline_ security profile. The baseline profile prevents privilege escalations and defines other standard access controls and limitations.
+Restricted Provider:: The Restricted Provider is based on the Kubernetes _restricted_ security profile. The restricted profile is more restrictive than the baseline profile, and is used where security needs to be tighter. 
 
-The providers are based on Kubernetes _baseline_ and _restricted_ security profiles.  
+For more information on the Kubernetes security profiles, see {K8sSecurityStandards}.
+
 
 == Template configuration for security context
 
@@ -131,7 +132,7 @@ securityContext:
 
 [NOTE]
 ====
-Container capabilities and `seecomp` are Linux kernel features that support container security. 
+Container capabilities and `seccomp` are Linux kernel features that support container security. 
 
 * Capabilities add fine-grained privileges for processes running on a container. The `NET_BIND_SERVICE` capability allows non-root user applications to bind to ports below 1024. 
 * `seccomp` profiles limit the processes running in a container to only a subset of system calls.  

--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -1,0 +1,149 @@
+// Module included in the following assemblies:
+//
+// assembly-security-providers.adoc
+
+[id='con-config-security-providers-{context}']
+= How to configure security context
+
+[role="_abstract"]
+Use security provider plugins or template configuration to apply security context to Strimzi pods and containers.
+
+Apply security context at the pod or container level:
+
+Pod-level security context:: Pod-level security context is applied to all containers in a specific pod.
+Container-level security context:: Container-level security context is applied to a specific container.
+
+With Strimzi, security context is applied through one or both of the following methods:
+
+Template configuration:: Use `template` configuration of Strimzi custom resources to specify security context at the pod or container level.
+Pod security provider plugins:: Use pod security provider plugins to automatically set security context across all pods and containers using preconfigured settings.  
+  
+Pod security providers offer a simpler alternative to specifying security context through `template` configuration.
+You can use both approaches.
+The `template` approach has a higher priority.
+So you might use pod security providers to automatically configure the security context for most containers.
+And also use `template` configuration to set container-specific security context where needed.
+
+The `template` approach provides flexibility, but it also means you have to configure security context in numerous places to capture the security you want for all pods and containers. 
+For example, you'll need to apply the configuration to each pod in a Kafka cluster, as well as the pods for deployments of other Kafka components.
+
+To avoid repeating the same configuration, you can use the following pod security provider plugins so that the security configuration is in one place.
+
+* Baseline Provider
+* Restricted Provider
+
+The providers are based on Kubernetes _baseline_ and _restricted_ security profiles.  
+
+== Template configuration for security context
+
+In the following example, security context is configured for Kafka brokers in the `template` configuration of the `Kafka` resource.  
+Security context is specified at the pod and container level.
+
+[source,yaml]
+.Example `template` configuration for security context
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  # ...
+  kafka:
+    template:
+      pod: # <1>
+        securityContext:
+          runAsUser: 1000001
+          fsGroup: 0
+      kafkaContainer: # <2>
+        securityContext:
+          runAsUser: 2000
+  # ...      
+----
+<1> Pod security context
+<2> Container security context of the Kafka broker container
+
+== Baseline Provider for pod security
+
+The Baseline Provider is the default pod security provider.
+It configures the pods managed by Strimzi with a baseline security profile.
+The baseline profile is compatible with previous versions of Strimzi.
+
+The Baseline Provider is enabled by default if you don't specify a provider.
+Though you can enable it explicitly by setting the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable to `baseline` when xref:ref-operator-cluster-str[configuring the Cluster Operator]. 
+
+.Configuration for the Baseline Provider
+[source,yaml,options="nowrap"]
+----
+# ...
+env:
+  # ...
+  - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+    value: baseline
+  # ...
+----
+
+Instead of specifying `baseline` as the value, you can specify the `io.strimzi.plugin.security.profiles.impl.BaselinePodSecurityProvider` classpath.
+
+== Restricted Provider for pod security
+
+The Restricted Provider provides a higher level of security than the Baseline Provider.
+It configures the pods managed by Strimzi with a restricted security profile.
+
+You enable the Restricted Provider by setting the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable to `restricted` when xref:ref-operator-cluster-str[configuring the Cluster Operator].
+
+.Configuration for the Restricted Provider
+[source,yaml,options="nowrap"]
+----
+# ...
+env:
+  # ...
+  - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+    value: restricted
+  # ...
+----
+
+Instead of specifying `restricted` as the value, you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` classpath.
+
+If you change to the Restricted Provider from the default Baseline Provider, the following restrictions are implemented in addition to the constraints defined in the baseline security profile:
+
+* Limits allowed volume types
+* Disallows privilege escalation
+* Requires applications to run under a non-root user 
+* Requires `seccomp` (secure computing mode) profiles to be set as `RuntimeDefault` or `Localhost`
+* Limits container capabilities to use only the `NET_BIND_SERVICE` capability
+
+With the Restricted Provider enabled, containers created by the Cluster Operator are set with the following security context.
+
+.Cluster Operator with restricted security context configuration
+[source,yaml,options="nowrap"]
+----
+# ...
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+# ...
+----
+
+[NOTE]
+====
+Container capabilities and `seecomp` are Linux kernel features that support container security. 
+
+* Capabilities add fine-grained privileges for processes running on a container. The `NET_BIND_SERVICE` capability allows non-root user applications to bind to ports below 1024. 
+* `seccomp` profiles limit the processes running in a container to only a subset of system calls.  
+The `RuntimeDefault` profile provides a default set of system calls.
+A `LocalHost` profile uses a profile defined in a file on the node.   
+
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* {K8sSecurityContext} on Kubernetes
+* {K8sSecurityStandards} on Kubernetes (including profile descriptions)
+* xref:type-ContainerTemplate-reference[]
+

--- a/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
+++ b/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
@@ -28,11 +28,12 @@ Edit the `Deployment` resource that is used to deploy the Cluster Operator, whic
 .Cluster Operator configuration for the Restricted Provider
 [source,yaml,numbered,options="nowrap"]
 ----
-include::../install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml[lines=1..13;18;28..29]
-          env:
-            - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
-              value: restricted
-          # ...
+# ...
+env:
+  # ...
+  - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+    value: restricted
+  # ...
 ----
 +
 Or you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` classpath.
@@ -48,11 +49,11 @@ kubectl create -f install/cluster-operator -n myproject
 .Adding security context through `template` configuration
 ----
 template:
-  pod: # <1>
+  pod: 
     securityContext:
       runAsUser: 1000001
       fsGroup: 0
-  kafkaContainer: # <2>
+  kafkaContainer:
     securityContext:
     runAsUser: 2000
   # ...      

--- a/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
+++ b/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// assembly-security-providers.adoc
+
+[id='proc-config-restricted-security-providers-{context}']
+= Enabling the Restricted Provider for the Cluster Operator
+
+[role="_abstract"]
+Security pod providers configure the security context constraints of the pods and containers created by the Cluster Operator.
+The Baseline Provider is the default pod security provider used by Strimzi.
+You can switch to the Restricted Provider by changing the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable in the Cluster Operator configuration.
+
+To make the required changes, configure the `060-Deployment-strimzi-cluster-operator.yaml` Cluster Operator installation file located in `install/cluster-operator/`. 
+
+By enabling a new pod security provider, any pods or containers created by the Cluster Operator are subject to the limitations it imposes.
+Pods and containers that are already running are restarted for the changes to take affect.
+
+.Prerequsites
+
+* You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
+
+.Procedure
+
+Edit the `Deployment` resource that is used to deploy the Cluster Operator, which is defined in the `060-Deployment-strimzi-cluster-operator.yaml` file.
+
+. Add or amend the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable with a value of `restricted`.
++
+.Cluster Operator configuration for the Restricted Provider
+[source,yaml,numbered,options="nowrap"]
+----
+include::../install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml[lines=1..13;18;28..29]
+          env:
+            - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+              value: restricted
+          # ...
+----
++
+Or you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` classpath.
+
+. Deploy the Cluster Operator:
++
+[source,shell,subs="+quotes,attributes+"]
+kubectl create -f install/cluster-operator -n myproject
+
+. (Optional) Use `template` configuration to set security context for specific components at the pod or container level.
++
+[source,yaml]
+.Adding security context through `template` configuration
+----
+template:
+  pod: # <1>
+    securityContext:
+      runAsUser: 1000001
+      fsGroup: 0
+  kafkaContainer: # <2>
+    securityContext:
+    runAsUser: 2000
+  # ...      
+----
++
+If you apply specific security context for a component using `template` configuration, it takes priority over the general configuration provided by the pod security provider.

--- a/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
+++ b/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
@@ -36,7 +36,7 @@ env:
   # ...
 ----
 +
-Or you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` classpath.
+Or you can specify the `io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider` fully-qualified domain name.
 
 . Deploy the Cluster Operator:
 +

--- a/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
+++ b/documentation/modules/operators/proc-configuring-multiple-cluster-operators.adoc
@@ -81,7 +81,7 @@ Update `resourceNames` with the name of the `Lease` resource.
 [source,yaml,numbered,options="nowrap",highlight='12']
 .Updating the ClusterRole references to the lease 
 ----
-include::../install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml[lines=1..7;21]
+include::../install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml[lines=1..9;21]
       - my-strimzi-cluster-operator
 # ...      
 ----

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -57,6 +57,7 @@
 
 // External links
 :aws-ebs: link:https://aws.amazon.com/ebs/[Amazon Elastic Block Store (EBS)^]
+:JavaServiceProvider: link:https://www.baeldung.com/java-spi[Java Service Provider Interface^]
 :kubernetes-docs: link:https://kubernetes.io/docs/home/
 :kafkaDoc: link:https://kafka.apache.org/documentation/[Apache Kafka documentation^]
 :K8sAffinity: link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Kubernetes node and pod affinity documentation^]
@@ -77,6 +78,8 @@
 :K8sCRDs: link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/[Extend the Kubernetes API with CustomResourceDefinitions^]
 :K8sResizingPersistentVolumesUsingKubernetes: link:https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/[Resizing Persistent Volumes using Kubernetes^]
 :K8sPriorityClass: link:https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption[Pod Priority and Preemption^]
+:K8sSecurityContext: link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security context^]
+:K8sSecurityStandards: link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[Pod security standards^]
 :K8sServiceDiscovery: https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services[Discovering services^]
 :K8sWellKnownLabelsAnnotationsAndTaints: link:https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/[Well-Known Labels, Annotations and Taints^]
 :K8sZoneLabel: link:https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[topology.kubernetes.io/zone^]
@@ -111,6 +114,14 @@
 :OPAAuthorizer: link:https://github.com/anderseknert/opa-kafka-plugin[Open Policy Agent plugin for Kafka authorization^]
 :external-cors-link: link:https://fetch.spec.whatwg.org/[Fetch CORS specification^]
 :HelmCustomResourceDefinitions: link:https://helm.sh/docs/chart_best_practices/custom_resource_definitions/[Custom Resource Definitions for Helm^]
+
+//strimzi github links
+:PodSecurityInterface: link:https://github.com/strimzi/strimzi-kafka-operator/blob/main/api/src/main/java/io/strimzi/plugin/security/profiles/PodSecurityProvider.java[Pod security provider interface^]
+:PodSecurityProviders: link:https://github.com/strimzi/strimzi-kafka-operator/tree/main/api/src/main/java/io/strimzi/plugin/security/profiles/impl[Baseline Provider and Restricted Provider classes^]
+:PodSecurityProvidersConfig: link:https://github.com/strimzi/strimzi-kafka-operator/blob/main/api/src/main/resources/META-INF/services/io.strimzi.plugin.security.profiles.PodSecurityProvider[Provider configuration file^]
+
+//OpenShift documentation
+:OpenShiftDocs: link:https://docs.openshift.com[OpenShift documentation^]
 
 // Container image names and repositories
 :DockerOrg: quay.io/strimzi


### PR DESCRIPTION
**Documentation**
Adds new section to the _Configuring_ guide called **Applying security context to Strimzi pods and containers**.

The section describes how to configure security context using `template` configuration and the pod security providers Baseline Provider and Restricted Provider. Also provides information on implementing a custom pod security provider and how security context differs on OpenShift.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

