### PR TITLE
[systemtest] Fix two race conditions inside ReconciliationST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -124,6 +124,12 @@ public class KafkaConnectorUtils {
         );
     }
 
+    public static void waitForConnectorsTaskMaxChangeViaAPI(String namespaceName, String connectPodName, String connectorName, int taskMax) {
+        TestUtils.waitFor("Wait for KafkaConnector taskMax will change via API", Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
+            ResourceOperation.getTimeoutForResourceReadiness(KafkaConnector.RESOURCE_KIND),
+            () -> getConnectorSpecFromConnectAPI(namespaceName, connectPodName, connectorName).contains("\"tasks.max\":\"" + taskMax + "\""));
+    }
+
     public static String getConnectorSpecFromConnectAPI(String namespaceName, String podName, String connectorName) {
         return cmdKubeClient(namespaceName).execInPod(podName, "/bin/bash", "-c",
             "curl http://localhost:8083/connectors/" + connectorName).out();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -227,6 +227,12 @@ public class KafkaTopicUtils {
             () -> !KafkaCmdClient.listTopicsUsingPodCliWithConfigProperties(namespace, scraperPodName, bootstrapName, properties).contains(prefix));
     }
 
+    public static void waitForTopicWillBePresentInKafka(String namespaceName, String topicName, String bootstrapName, String scraperPodName) {
+        LOGGER.info("Waiting for KafkaTopic: {} will be present in Kafka", topicName);
+        TestUtils.waitFor(String.format("KafkaTopic: %s will be present in Kafka", topicName), Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
+            () -> KafkaCmdClient.listTopicsUsingPodCli(namespaceName, scraperPodName, bootstrapName).contains(topicName));
+    }
+
     public static List<String> getKafkaTopicReplicasForEachPartition(String namespaceName, String topicName, String podName, String bootstrapServer) {
         return Arrays.stream(KafkaCmdClient.describeTopicUsingPodCli(namespaceName, podName, bootstrapServer, topicName)
             .replaceFirst("Topic.*\n", "")

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -53,8 +53,6 @@ import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(REGRESSION)
 @ParallelSuite
@@ -130,7 +128,7 @@ public class ReconciliationST extends AbstractST {
         String oldConfig = new JsonObject(connectorSpec).getValue("config").toString();
         JsonObject newConfig = new JsonObject(KafkaConnectorUtils.waitForConnectorConfigUpdate(namespaceName, connectPodName, clusterName, oldConfig, "localhost"));
 
-        assertThat(newConfig.getValue("tasks.max"), is(Integer.toString(SCALE_TO)));
+        KafkaConnectorUtils.waitForConnectorsTaskMaxChangeViaAPI(namespaceName, connectPodName, clusterName, SCALE_TO);
     }
 
     @ParallelNamespaceTest
@@ -150,6 +148,9 @@ public class ReconciliationST extends AbstractST {
         final String scraperPodName = kubeClient().listPodsByPrefixInName(namespaceName, scraperName).get(0).getMetadata().getName();
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
+
+        // to prevent race condition when reconciliation is paused before KafkaTopic is actually created in Kafka
+        KafkaTopicUtils.waitForTopicWillBePresentInKafka(namespaceName, topicName, KafkaResources.plainBootstrapAddress(clusterName), scraperPodName);
 
         LOGGER.info("Adding pause annotation into KafkaTopic resource and changing replication factor");
         KafkaTopicResource.replaceTopicResourceInSpecificNamespace(topicName, topic -> {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Test fixups

### Description

There are 2 race conditions which are happening in our `ReconciliationST` -> one is that we are waiting for spec to change for the connector (not just task max), so sometimes we hit moment, when the spec is changed, but taskMax is still on `2`.

Second is with KafkaTopic -> when we pause reconciliation right after KafkaTopic is ready, sometimes happen that the KafkaTopic is not in the Kafka yet.

This PR fix those.

### Checklist

- [x] Make sure all tests pass
