### PR TITLE
Fix issue with running KafkaConnect build with a sidecar

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -100,7 +100,8 @@ public class KafkaConnectBuildUtils {
      * @return ContainerStatus of the build container
      */
     public static ContainerState getConnectBuildContainerStatus(Pod pod, String containerName)   {
-        return pod.getStatus().getContainerStatuses().stream().filter(conStatus -> conStatus.getName().equals(containerName))
-            .findFirst().orElseGet(ContainerStatus::new).getState();
+        ContainerStatus containerStatus = pod.getStatus().getContainerStatuses().stream().filter(conStatus -> conStatus.getName().equals(containerName))
+            .findFirst().orElse(null);
+        return containerStatus != null ? containerStatus.getState() : null;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -15,15 +15,17 @@ public class KafkaConnectBuildUtils {
      *
      * @param pod   Pod which should be checked for completion
      *
+     * @param containerName Name of the Connect build container
+     *
      * @return      True if the Pod is already complete, false otherwise
      */
     @SuppressWarnings("BooleanExpressionComplexity")
-    public static boolean buildPodComplete(Pod pod)   {
+    public static boolean buildPodComplete(Pod pod, String containerName)   {
         return pod != null
                 && pod.getStatus() != null
                 && pod.getStatus().getContainerStatuses() != null
                 && pod.getStatus().getContainerStatuses().size() > 0
-                && getConnectBuildContainerStatus(pod).getTerminated() != null;
+                && getConnectBuildContainerStatus(pod, containerName).getTerminated() != null;
     }
 
     /**
@@ -31,11 +33,13 @@ public class KafkaConnectBuildUtils {
      *
      * @param pod   Pod which should be checked for completion
      *
+     * @param containerName Name of the Connect build container
+     *
      * @return      True if the Pod is complete with success, false otherwise
      */
-    public static boolean buildPodSucceeded(Pod pod)   {
-        return buildPodComplete(pod)
-                && getConnectBuildContainerStatus(pod).getTerminated().getExitCode() == 0;
+    public static boolean buildPodSucceeded(Pod pod, String containerName)   {
+        return buildPodComplete(pod, containerName)
+                && getConnectBuildContainerStatus(pod, containerName).getTerminated().getExitCode() == 0;
     }
 
     /**
@@ -43,11 +47,13 @@ public class KafkaConnectBuildUtils {
      *
      * @param pod   Pod which should be checked for completion
      *
+     * @param containerName Name of the Connect build container
+     *
      * @return      True if the Pod is complete with error, false otherwise
      */
-    public static boolean buildPodFailed(Pod pod)   {
-        return buildPodComplete(pod)
-                && getConnectBuildContainerStatus(pod).getTerminated().getExitCode() != 0;
+    public static boolean buildPodFailed(Pod pod, String containerName)   {
+        return buildPodComplete(pod, containerName)
+                && getConnectBuildContainerStatus(pod, containerName).getTerminated().getExitCode() != 0;
     }
 
     /**
@@ -89,11 +95,12 @@ public class KafkaConnectBuildUtils {
      *
      * @param pod Pod which contains ContainerStatus of the Connect build
      *
+     * @param containerName Name of the Connect build container
+     *
      * @return ContainerStatus of the build container
      */
-    public static ContainerState getConnectBuildContainerStatus(Pod pod)   {
-        ContainerStatus containerStatus = pod.getStatus().getContainerStatuses().stream()
-            .filter(conStatus -> conStatus.getName().equals(pod.getMetadata().getName())).findFirst().orElseGet(ContainerStatus::new);
-        return containerStatus.getState() != null ? containerStatus.getState() : new ContainerState();
+    public static ContainerState getConnectBuildContainerStatus(Pod pod, String containerName)   {
+        return pod.getStatus().getContainerStatuses().stream().filter(conStatus -> conStatus.getName().equals(containerName))
+            .findFirst().orElseGet(ContainerStatus::new).getState();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
@@ -22,9 +23,7 @@ public class KafkaConnectBuildUtils {
                 && pod.getStatus() != null
                 && pod.getStatus().getContainerStatuses() != null
                 && pod.getStatus().getContainerStatuses().size() > 0
-                && getConnectBuildContainerStatus(pod) != null
-                && getConnectBuildContainerStatus(pod).getState() != null
-                && getConnectBuildContainerStatus(pod).getState().getTerminated() != null;
+                && getConnectBuildContainerStatus(pod).getTerminated() != null;
     }
 
     /**
@@ -36,7 +35,7 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildPodSucceeded(Pod pod)   {
         return buildPodComplete(pod)
-                && getConnectBuildContainerStatus(pod).getState().getTerminated().getExitCode() == 0;
+                && getConnectBuildContainerStatus(pod).getTerminated().getExitCode() == 0;
     }
 
     /**
@@ -48,7 +47,7 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildPodFailed(Pod pod)   {
         return buildPodComplete(pod)
-                && getConnectBuildContainerStatus(pod).getState().getTerminated().getExitCode() != 0;
+                && getConnectBuildContainerStatus(pod).getTerminated().getExitCode() != 0;
     }
 
     /**
@@ -88,11 +87,13 @@ public class KafkaConnectBuildUtils {
     /**
      * Get ContainerStatus of the Connect build container
      *
-     * @param pod - Pod which contains ContainerStatus of the Connect build
+     * @param pod Pod which contains ContainerStatus of the Connect build
      *
      * @return ContainerStatus of the build container
      */
-    public static ContainerStatus getConnectBuildContainerStatus(Pod pod)   {
-        return pod.getStatus().getContainerStatuses().stream().filter(containerStatus -> containerStatus.getName().equals(pod.getMetadata().getName())).findFirst().orElseGet(ContainerStatus::new);
+    public static ContainerState getConnectBuildContainerStatus(Pod pod)   {
+        ContainerStatus containerStatus = pod.getStatus().getContainerStatuses().stream()
+            .filter(conStatus -> conStatus.getName().equals(pod.getMetadata().getName())).findFirst().orElseGet(ContainerStatus::new);
+        return containerStatus.getState() != null ? containerStatus.getState() : new ContainerState();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
 
@@ -21,9 +22,9 @@ public class KafkaConnectBuildUtils {
                 && pod.getStatus() != null
                 && pod.getStatus().getContainerStatuses() != null
                 && pod.getStatus().getContainerStatuses().size() > 0
-                && pod.getStatus().getContainerStatuses().get(0) != null
-                && pod.getStatus().getContainerStatuses().get(0).getState() != null
-                && pod.getStatus().getContainerStatuses().get(0).getState().getTerminated() != null;
+                && getConnectBuildContainerStatus(pod) != null
+                && getConnectBuildContainerStatus(pod).getState() != null
+                && getConnectBuildContainerStatus(pod).getState().getTerminated() != null;
     }
 
     /**
@@ -35,7 +36,7 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildPodSucceeded(Pod pod)   {
         return buildPodComplete(pod)
-                && pod.getStatus().getContainerStatuses().get(0).getState().getTerminated().getExitCode() == 0;
+                && getConnectBuildContainerStatus(pod).getState().getTerminated().getExitCode() == 0;
     }
 
     /**
@@ -47,7 +48,7 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildPodFailed(Pod pod)   {
         return buildPodComplete(pod)
-                && pod.getStatus().getContainerStatuses().get(0).getState().getTerminated().getExitCode() != 0;
+                && getConnectBuildContainerStatus(pod).getState().getTerminated().getExitCode() != 0;
     }
 
     /**
@@ -74,7 +75,7 @@ public class KafkaConnectBuildUtils {
     }
 
     /**
-     * Checks if the build completed with wuccess
+     * Checks if the build completed with success
      *
      * @param build Build which should be checked for completion
      *
@@ -82,5 +83,16 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildComplete(Build build)   {
         return buildSucceeded(build) || buildFailed(build);
+    }
+
+    /**
+     * Get ContainerStatus of the Connect build container
+     *
+     * @param pod - Pod which contains ContainerStatus of the Connect build
+     *
+     * @return ContainerStatus of the build container
+     */
+    public static ContainerStatus getConnectBuildContainerStatus(Pod pod)   {
+        return pod.getStatus().getContainerStatuses().stream().filter(containerStatus -> containerStatus.getName().equals(pod.getMetadata().getName())).findFirst().orElseGet(ContainerStatus::new);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.fabric8.kubernetes.api.model.ContainerState;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
@@ -25,7 +25,7 @@ public class KafkaConnectBuildUtils {
                 && pod.getStatus() != null
                 && pod.getStatus().getContainerStatuses() != null
                 && pod.getStatus().getContainerStatuses().size() > 0
-                && getConnectBuildContainerStatus(pod, containerName).getTerminated() != null;
+                && getConnectBuildContainerStateTerminated(pod, containerName) != null;
     }
 
     /**
@@ -39,7 +39,7 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildPodSucceeded(Pod pod, String containerName)   {
         return buildPodComplete(pod, containerName)
-                && getConnectBuildContainerStatus(pod, containerName).getTerminated().getExitCode() == 0;
+                && getConnectBuildContainerStateTerminated(pod, containerName).getExitCode() == 0;
     }
 
     /**
@@ -53,7 +53,7 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildPodFailed(Pod pod, String containerName)   {
         return buildPodComplete(pod, containerName)
-                && getConnectBuildContainerStatus(pod, containerName).getTerminated().getExitCode() != 0;
+                && getConnectBuildContainerStateTerminated(pod, containerName).getExitCode() != 0;
     }
 
     /**
@@ -91,17 +91,19 @@ public class KafkaConnectBuildUtils {
     }
 
     /**
-     * Get ContainerStatus of the Connect build container
+     * Get ContainerStateTerminated of the Connect build container
      *
      * @param pod Pod which contains ContainerStatus of the Connect build
      *
      * @param containerName Name of the Connect build container
      *
-     * @return ContainerStatus of the build container
+     * @return ContainerStateTerminated of the build container
      */
-    public static ContainerState getConnectBuildContainerStatus(Pod pod, String containerName)   {
+    public static ContainerStateTerminated getConnectBuildContainerStateTerminated(Pod pod, String containerName)   {
         ContainerStatus containerStatus = pod.getStatus().getContainerStatuses().stream().filter(conStatus -> conStatus.getName().equals(containerName))
             .findFirst().orElse(null);
-        return containerStatus != null ? containerStatus.getState() : null;
+
+        return containerStatus != null
+                && containerStatus.getState() != null ? containerStatus.getState().getTerminated() : null;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -221,12 +221,12 @@ public class ConnectBuildOperator {
                 .compose(ignore -> podOperator.getAsync(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster())))
                 .compose(pod -> {
                     if (KafkaConnectBuildUtils.buildPodSucceeded(pod)) {
-                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStatus(pod).getState().getTerminated();
+                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStatus(pod).getTerminated();
                         String image = state.getMessage().trim();
                         LOGGER.infoCr(reconciliation, "Build completed successfully. New image is {}.", image);
                         return Future.succeededFuture(image);
                     } else {
-                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStatus(pod).getState().getTerminated();
+                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStatus(pod).getTerminated();
                         LOGGER.warnCr(reconciliation, "Build failed with code {}: {}", state.getExitCode(), state.getMessage());
                         return Future.failedFuture("The Kafka Connect build failed");
                     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -221,12 +221,12 @@ public class ConnectBuildOperator {
                 .compose(ignore -> podOperator.getAsync(namespace, KafkaConnectResources.buildPodName(connectBuild.getCluster())))
                 .compose(pod -> {
                     if (KafkaConnectBuildUtils.buildPodSucceeded(pod)) {
-                        ContainerStateTerminated state = pod.getStatus().getContainerStatuses().get(0).getState().getTerminated();
+                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStatus(pod).getState().getTerminated();
                         String image = state.getMessage().trim();
                         LOGGER.infoCr(reconciliation, "Build completed successfully. New image is {}.", image);
                         return Future.succeededFuture(image);
                     } else {
-                        ContainerStateTerminated state = pod.getStatus().getContainerStatuses().get(0).getState().getTerminated();
+                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStatus(pod).getState().getTerminated();
                         LOGGER.warnCr(reconciliation, "Build failed with code {}: {}", state.getExitCode(), state.getMessage());
                         return Future.failedFuture("The Kafka Connect build failed");
                     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
+import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KafkaConnectBuildUtilsTest {
+
+    private static final String NAME = "my-connect";
+    private static final String NAMESPACE = "my-connect-namespace";
+
+    @Test
+    void testMultiContainerPod() {
+        String buildPodName = KafkaConnectResources.buildPodName(NAME);
+        String messageImg = "my-connect-build@sha256:blablabla";
+
+        Pod terminatedPod = new PodBuilder()
+            .withNewMetadata()
+                .withName(buildPodName)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .withNewStatus()
+                .withContainerStatuses(
+                    new ContainerStatusBuilder()
+                    .withName(buildPodName)
+                    .withNewState()
+                        .withNewTerminated()
+                            .withExitCode(0)
+                            .withMessage(messageImg)
+                        .endTerminated()
+                    .endState()
+                    .build(),
+                    new ContainerStatusBuilder()
+                        .withName("my-sidecar")
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(1)
+                                .withMessage("Container failed with random error")
+                            .endTerminated()
+                        .endState()
+                        .build())
+                .endStatus()
+            .build();
+
+        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStateTerminated(terminatedPod, buildPodName);
+
+        assertNotNull(state);
+        assertEquals(state.getMessage(), messageImg);
+
+        assertTrue(KafkaConnectBuildUtils.buildPodSucceeded(terminatedPod, buildPodName));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -183,7 +183,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:blablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
@@ -333,7 +341,14 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(1).endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(1)
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
@@ -473,7 +488,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:blablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
@@ -636,7 +659,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build-2@sha256:blablabla").endTerminated().endState().build())
+                .withContainerStatuses(new ContainerStatusBuilder()
+                    .withName(KafkaConnectResources.buildPodName(NAME))
+                    .withNewState()
+                        .withNewTerminated()
+                            .withExitCode(0)
+                            .withMessage("my-connect-build-2@sha256:blablabla")
+                        .endTerminated()
+                    .endState()
+                    .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
@@ -811,7 +842,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:blablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
@@ -983,7 +1022,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:blablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
 
@@ -1162,7 +1209,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:blablabla").endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:blablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
@@ -1354,6 +1409,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     }
 
     @Test
+    @SuppressWarnings({"checkstyle:MethodLength"})
     public void testUpdateWithForcedRebuildOnKube(VertxTestContext context) {
         Plugin plugin1 = new PluginBuilder()
                 .withName("plugin1")
@@ -1439,7 +1495,15 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 .withNewSpec()
                 .endSpec()
                 .withNewStatus()
-                    .withContainerStatuses(new ContainerStatusBuilder().withNewState().withNewTerminated().withExitCode(0).withMessage("my-connect-build@sha256:rebuiltblablabla").endTerminated().endState().build())
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:rebuiltblablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
                 .endStatus()
                 .build();
         when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

How mentioned in #4604 , when running KafkaConnect build with sidecar, the build is basically never completed, as we are checking always the first container status (which could be status of the sidecar).

This PR fixes this behavior - adding possibility to run KafkaConnect build with the sidecar.

Fixes #4604 

### Checklist

- [ ] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

