### PR TITLE
[systemtest] Add 0.31.0 to upgrade/downgrade and remove 0.22.x

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeDowngradeData.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeDowngradeData.java
@@ -28,7 +28,6 @@ public class UpgradeDowngradeData {
     private String startingKafkaVersion;
     private String featureGatesBefore;
     private String featureGatesAfter;
-    private Map<String, String> conversionTool;
     private Map<String, String> imagesAfterOperations;
     private Map<String, Object> client;
     private Map<String, String> environmentInfo;
@@ -77,18 +76,6 @@ public class UpgradeDowngradeData {
 
     public String getFeatureGatesAfter() {
         return featureGatesAfter;
-    }
-
-    public Map<String, String> getConversionTool() {
-        return conversionTool;
-    }
-
-    public String getToConversionTool() {
-        return conversionTool.get("toConversionTool");
-    }
-
-    public String getUrlToConversionTool() {
-        return conversionTool.get("urlToConversionTool");
     }
 
     public Map<String, String> getImagesAfterOperations() {
@@ -208,11 +195,6 @@ public class UpgradeDowngradeData {
         this.featureGatesAfter = featureGatesAfter;
     }
 
-    public void setConversionTool(Map<String, String> conversionTool) {
-        this.conversionTool = conversionTool;
-    }
-
-
     public void setClient(Map<String, Object> client) {
         this.client = client;
     }
@@ -298,7 +280,6 @@ public class UpgradeDowngradeData {
                 ", startingKafkaVersion='" + startingKafkaVersion + '\'' +
                 ", featureGatesBefore='" + featureGatesBefore + '\'' +
                 ", featureGatesAfter='" + featureGatesAfter + '\'' +
-                ", conversionTool=" + conversionTool +
                 ", imagesAfterOperations=" + imagesAfterOperations +
                 ", client=" + client +
                 ", environmentInfo=" + environmentInfo +

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -30,11 +30,8 @@ import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
-import io.strimzi.test.executor.Exec;
-import io.strimzi.test.executor.ExecResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
@@ -45,8 +42,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import static io.strimzi.systemtest.Constants.GLOBAL_POLL_INTERVAL;
-import static io.strimzi.systemtest.Constants.GLOBAL_TIMEOUT;
 import static io.strimzi.systemtest.Constants.PATH_TO_KAFKA_TOPIC_CONFIG;
 import static io.strimzi.systemtest.Constants.PATH_TO_PACKAGING_EXAMPLES;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -450,43 +445,5 @@ public class AbstractUpgradeST extends AbstractST {
         } else {
             return resourcePlural + "." + Constants.V1BETA1 + "." + Constants.RESOURCE_GROUP_NAME;
         }
-    }
-
-    protected void convertCRDs(String urlToConversionTool, String toConversionTool, String namespace) throws IOException {
-        File dir = FileUtils.downloadAndUnzip(urlToConversionTool);
-        String convertorPath = dir.getAbsolutePath() + "/" + toConversionTool + "/bin/api-conversion.sh";
-
-        Exec.exec("chmod", "+x", convertorPath);
-
-        LOGGER.info("Converting CRs ...");
-        // run conversion of crs
-        // CRs conversion may fail, because for 0.23 for example it's already done
-        // CRS conversion needs old versions of Strimzi CRDs, which are not available after 0.22
-        if (cmdKubeClient().exec(true, Level.DEBUG, "get", "crd", "kafkas.kafka.strimzi.io", "-o", "jsonpath={.spec.versions}").out().trim().contains(Constants.V1ALPHA1)) {
-            ExecResult execResult = Exec.exec(convertorPath, "cr", "-n=" + namespace);
-            LOGGER.debug("CRs conversion STDOUT:");
-            LOGGER.debug(execResult.out());
-            LOGGER.debug("CRs conversion STDERR:");
-            LOGGER.debug(execResult.err());
-            LOGGER.info("CRs conversion done!");
-
-            // run crd-upgrade
-            LOGGER.info("Converting CRDs");
-            execResult = Exec.exec(convertorPath, "crd");
-            LOGGER.debug("CRDs conversion STDOUT:");
-            LOGGER.debug(execResult.out());
-            LOGGER.debug("CRDs conversion STDERR:");
-            LOGGER.debug(execResult.err());
-            LOGGER.info("CRDs conversion done!");
-
-            waitForKafkaCRDChange();
-        } else {
-            LOGGER.info("CRs and CRDs already have v1beta2 versions");
-        }
-    }
-
-    protected void waitForKafkaCRDChange() {
-        TestUtils.waitFor("Kafka CRD kafkas.kafka.strimzi.io will change it's api version", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
-            () -> cmdKubeClient().exec(true, Level.TRACE, "get", "crd", "kafkas.kafka.strimzi.io", "-o", "jsonpath={.status.storedVersions}").out().trim().contains(Constants.V1BETA2));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -134,8 +134,7 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
 
         // Setup env
         setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, producerName, consumerName, continuousTopicName, continuousConsumerGroup, acrossUpgradeData.getStartingKafkaVersion(), clusterOperator.getDeploymentNamespace());
-        UpgradeDowngradeData conversionData = new UpgradeDowngradeDatalist().getUpgradeData(0);
-        convertCRDs(conversionData.getUrlToConversionTool(), conversionData.getToConversionTool(), clusterOperator.getDeploymentNamespace());
+
         // Make snapshots of all pods
         makeSnapshots();
 
@@ -166,8 +165,6 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
 
         // Setup env
         setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, producerName, consumerName, continuousTopicName, continuousConsumerGroup, null, clusterOperator.getDeploymentNamespace());
-        UpgradeDowngradeData conversionTool = new UpgradeDowngradeDatalist().getUpgradeData(0);
-        convertCRDs(conversionTool.getUrlToConversionTool(), conversionTool.getToConversionTool(), clusterOperator.getDeploymentNamespace());
 
         // Upgrade CO
         changeClusterOperator(acrossUpgradeData, clusterOperator.getDeploymentNamespace(), extensionContext);
@@ -207,13 +204,6 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
 
         // Setup env
         setupEnvAndUpgradeClusterOperator(extensionContext, upgradeData, producerName, consumerName, continuousTopicName, continuousConsumerGroup, "", clusterOperator.getDeploymentNamespace());
-
-        logPodImages(clusterName);
-
-        // Upgrade CRDs and upgrade CO to 0.24
-        if (upgradeData.getConversionTool() != null) {
-            convertCRDs(upgradeData.getUrlToConversionTool(), upgradeData.getToConversionTool(), clusterOperator.getDeploymentNamespace());
-        }
 
         // Upgrade CO to HEAD
         logPodImages(clusterName);

--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.yaml
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.yaml
@@ -25,18 +25,18 @@
 # --- Structure ---
   
 - fromVersion: HEAD
-  toVersion: 0.30.0
+  toVersion: 0.31.0
   fromExamples: HEAD
-  toExamples: strimzi-0.30.0
+  toExamples: strimzi-0.31.0
   urlFrom: HEAD
-  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
+  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.31.0/strimzi-0.31.0.zip
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.30.0-kafka-3.2.0
-    kafka: strimzi/kafka:0.30.0-kafka-3.2.0
-    topicOperator: strimzi/operator:0.30.0
-    userOperator: strimzi/operator:0.30.0
-  deployKafkaVersion: 3.2.0
+    zookeeper: strimzi/kafka:0.31.0-kafka-3.2.1
+    kafka: strimzi/kafka:0.31.0-kafka-3.2.1
+    topicOperator: strimzi/operator:0.31.0
+    userOperator: strimzi/operator:0.31.0
+  deployKafkaVersion: 3.2.1
   client:
     continuousClientsMessages: 500
   environmentInfo:
@@ -47,18 +47,18 @@
   featureGatesBefore: "+UseStrimziPodSets"
   featureGatesAfter: "-UseStrimziPodSets"
 - fromVersion: HEAD
-  toVersion: 0.30.0
+  toVersion: 0.31.0
   fromExamples: HEAD
-  toExamples: strimzi-0.30.0
+  toExamples: strimzi-0.31.0
   urlFrom: HEAD
-  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
+  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.31.0/strimzi-0.31.0.zip
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.30.0-kafka-3.2.0
-    kafka: strimzi/kafka:0.30.0-kafka-3.2.0
-    topicOperator: strimzi/operator:0.30.0
-    userOperator: strimzi/operator:0.30.0
-  deployKafkaVersion: 3.2.0
+    zookeeper: strimzi/kafka:0.31.0-kafka-3.2.1
+    kafka: strimzi/kafka:0.31.0-kafka-3.2.1
+    topicOperator: strimzi/operator:0.31.0
+    userOperator: strimzi/operator:0.31.0
+  deployKafkaVersion: 3.2.1
   client:
     continuousClientsMessages: 500
   environmentInfo:

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
@@ -23,32 +23,10 @@
 #  featureGatesAfter: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on upgrade of CO
 #  --- Structure ---
 
-- fromVersion: 0.22.1
-  fromExamples: strimzi-0.22.1
-  oldestKafka: 2.6.0
-  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.1/strimzi-0.22.1.zip
-  conversionTool:
-    urlToConversionTool: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.0/api-conversion-0.22.0.zip
-    toConversionTool: api-conversion-0.22.0
-  additionalTopics: 2
-  imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.2.1
-    kafka: strimzi/kafka:latest-kafka-3.2.1
-    topicOperator: strimzi/operator:latest
-    userOperator: strimzi/operator:latest
-  client:
-    continuousClientsMessages: 500
-  environmentInfo:
-    maxK8sVersion: "1.21"
-    status: stable
-    flakyEnvVariable: none
-    reason: Test is working on environment, where k8s server version is < 1.22
-  featureGatesBefore: ""
-  featureGatesAfter: "-ControlPlaneListener"
-- fromVersion: 0.30.0
-  fromExamples: strimzi-0.30.0
+- fromVersion: 0.31.0
+  fromExamples: strimzi-0.31.0
   oldestKafka: 3.1.0
-  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
+  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.31.0/strimzi-0.31.0.zip
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.2.1
@@ -64,10 +42,10 @@
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: ""
   featureGatesAfter: ""
-- fromVersion: 0.30.0
-  fromExamples: strimzi-0.30.0
+- fromVersion: 0.31.0
+  fromExamples: strimzi-0.31.0
   oldestKafka: 3.1.0
-  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.30.0/strimzi-0.30.0.zip
+  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.31.0/strimzi-0.31.0.zip
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.2.1


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

After release of 0.31.0, we are dropping support for k8s 1.16-1.18 - that's why I'm removing the 0.22.1 version from the `StrimziUpgradeST.yaml`.

As part of this PR, the conversion tool logic was removed from the STs.

Also, after the release, this PR adds it to our upgrade/downgrade tests.

### Checklist

- [x] Make sure all tests pass

