### PR TITLE
Minor typo over the `reconcileKafka` method

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -516,7 +516,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         /**
-         * Run the reconciliation pipeline for the ZooKeeper
+         * Run the reconciliation pipeline for Kafka
          *
          * @param   dateSupplier  Date supplier used to check maintenance windows
          *


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

This PR fixes the minor typo regarding the comment over the `reconcileKafka` method which is for Kafka but the comment was referring to Zookeeper.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

