### PR TITLE
docs(restart events): Distinguishes between StrimziPodSet and StatefulSet restart events

### DIFF
--- a/documentation/modules/deploying/proc-operator-restart-events.adoc
+++ b/documentation/modules/deploying/proc-operator-restart-events.adoc
@@ -10,8 +10,7 @@
 
 [role="_abstract"]
 Use a `kubectl` command to list restart events initiated by the Cluster Operator.
-
-Filter restart events emitted by the Cluster Operator by setting the Cluster Operator as the reporting component using the `source` or `reportingComponent` event fields.
+Filter restart events emitted by the Cluster Operator by setting the Cluster Operator as the reporting component using the `reportingController` or `source` event fields.
 
 .Prerequisites
 
@@ -23,14 +22,14 @@ Filter restart events emitted by the Cluster Operator by setting the Cluster Ope
 +
 [source,shell]
 ----
-kubectl -n kafka get events --field-selector source=strimzi.io/cluster-operator
+kubectl -n kafka get events --field-selector reportingController=strimzi.io/cluster-operator
 ----
 +
 .Example showing events returned
 [source,shell]
 ----
 LAST SEEN   TYPE     REASON                   OBJECT                        MESSAGE
-2m          Normal   JbodVolumesChanged       pod/strimzi-cluster-kafka-0   JBOD volumes were added or removed
+2m          Normal   CaCertRenewed            pod/strimzi-cluster-kafka-0   CA certificate renewed
 58m         Normal   PodForceRestartOnError   pod/strimzi-cluster-kafka-1   Pod needs to be forcibly restarted due to an error
 5m47s       Normal   ManualRollingUpdate      pod/strimzi-cluster-kafka-2   Pod was manually annotated to be rolled
 ----
@@ -41,14 +40,14 @@ Here, a specific reason is added:
 +
 [source,shell]
 ----
-kubectl -n kafka get events --field-selector source=strimzi.io/cluster-operator,reason=PodForceRestartOnError
+kubectl -n kafka get events --field-selector reportingController=strimzi.io/cluster-operator,reason=PodForceRestartOnError
 ----
 
 . Use an output format, such as YAML, to return more detailed information about one or more events.
 +
 [source,shell-session]
 ----
-kubectl -n kafka get events --field-selector source=strimzi.io/cluster-operator,reason=PodForceRestartOnError -o yaml
+kubectl -n kafka get events --field-selector reportingController=strimzi.io/cluster-operator,reason=PodForceRestartOnError -o yaml
 ----
 +
 .Example showing detailed events output
@@ -75,7 +74,7 @@ items:
       resourceVersion: "432961"
       uid: 29fcdb9e-f2cf-4c95-a165-a5efcd48edfc
   reason: PodForceRestartOnError
-  reportingComponent: strimzi.io/cluster-operator
+  reportingController: strimzi.io/cluster-operator
   reportingInstance: strimzi-cluster-operator-6458cfb4c6-6bpdp
   source: {} <1>
   type: Normal

--- a/documentation/modules/deploying/ref-operator-restart-events-fields.adoc
+++ b/documentation/modules/deploying/ref-operator-restart-events-fields.adoc
@@ -10,21 +10,13 @@ When checking restart events from the command line, you can specify a `field-sel
 
 The following fields are available when filtering events with `field-selector`.
 
-.Event fields for Kubernetes 1.24 and earlier
-
-`involvedObject.kind`:: The object that was restarted, and for restart events, the kind is always `Pod`.
-`involvedObject.namespace`:: The namespace that the pod belongs to.
-`involvedObject.name`:: The pod's name, for example, `strimzi-cluster-kafka-0`.
-`involvedObject.uid`:: The unique ID of the pod.
+`regardingObject.kind`:: The object that was restarted, and for restart events, the kind is always `Pod`.
+`regarding.namespace`:: The namespace that the pod belongs to.
+`regardingObject.name`:: The pod's name, for example, `strimzi-cluster-kafka-0`.
+`regardingObject.uid`:: The unique ID of the pod.
 `reason`:: The reason the pod was restarted, for example, `JbodVolumesChanged`.
-`reportingComponent`:: The reporting component is always `strimzi.io/cluster-operator` for Strimzi restart events.
-`source`:: `source` is an older version of `reportingComponent`. The reporting component is always `strimzi.io/cluster-operator` for Strimzi restart events.
+`reportingController`:: The reporting component is always `strimzi.io/cluster-operator` for Strimzi restart events.
+`source`:: `source` is an older version of `reportingController`. The reporting component is always `strimzi.io/cluster-operator` for Strimzi restart events.
 `type`:: The event type, which is either `Warning` or `Normal`. For Strimzi restart events, the type is `Normal`.
 
-.Additional event fields for Kubernetes 1.25 and later
-
-`regarding.kind`:: Same as `involvedObject.kind`.
-`regarding.namespace`:: Same as `involvedObject.namespace`.
-`regarding.name`:: Same as `involvedObject.name`.
-`regarding.uid`:: Same as `involvedObject.uid`.
-`reportingController`:: Same as `reportingComponent`.
+NOTE: In older versions of Kubernetes, the fields using the `regarding` prefix might use an `involvedObject` prefix instead. `reportingController` was previously called `reportingComponent`.

--- a/documentation/modules/deploying/ref-operator-restart-events-reasons.adoc
+++ b/documentation/modules/deploying/ref-operator-restart-events-reasons.adoc
@@ -9,21 +9,74 @@
 The Cluster Operator initiates a restart event for a specific reason.
 You can check the reason by fetching information on the restart event. 
 
-Restarts are made for the following reasons:
+The reason given depends on whether you are using `StrimziPodSet` or `StatefulSet` resources for the creation and management of pods.
 
-`CaCertHasOldGeneration`:: The pod is still using a server certificate signed with an old CA, so needs to be restarted as part of the certificate update.
-`CaCertRemoved`:: Expired CA certificates have been removed, and the pod is restarted to run with the current certificates.
-`CaCertRenewed`:: CA certificates have been renewed, and the pod is restarted to run with the updated certificates.
-`ClientCaCertKeyReplaced`:: The key used to sign client CA certificates has been replaced, and the pod is being restarted as part of the CA renewal process.
-`ClusterCaCertKeyReplaced`:: The key used to sign the cluster's CA certificates has been replaced, and the pod is being restarted as part of the CA renewal process.
-`ConfigChangeRequiresRestart`:: Some Kafka configuration properties are changed dynamically, but others require that the broker be restarted.
-`CustomListenerCaCertChanged`:: The CA certificate used to secure the Kafka network listeners has changed, and the pod is restarted to use it.
-`FileSystemResizeNeeded`:: The file system size has been increased, and a restart is needed to apply it.
-`JbodVolumesChanged`:: A disk was added or removed from the Kafka volumes, and a restart is needed to apply the change.
-`ManualRollingUpdate`:: A user annotated the pod, or the `StatefulSet`` or `StrimziPodSet` set it belongs to, to trigger a restart.
-`PodForceRestartOnError`:: An error occurred that requires a pod restart to rectify.
-`PodHasOldGeneration`:: The `StatefulSet` that the pod is a member of has been updated, so the pod needs to be recreated.
-`PodHasOldRevision`:: The `StrimziPodSet` that the pod is a member of has been updated, so the pod needs to be recreated.
-`PodStuck`:: The pod is still pending, and either is not scheduled or cannot be scheduled, so the operator has restarted the pod in a final attempt to get it running.
-`PodUnresponsive`:: Strimzi was unable to connect to the pod, which can indicate a broker not starting correctly, so the operator restarted it in an attempt to resolve the issue.
-`KafkaCertificatesChanged`:: One or more TLS certificates used by the Kafka broker have been updated, and a restart is needed to use them.
+.Restart reasons
+[cols="2a,2a,4",options="header"]
+|===
+
+a|StrimziPodSet
+a|StatefulSet
+|Description
+
+|CaCertHasOldGeneration
+|CaCertHasOldGeneration
+|The pod is still using a server certificate signed with an old CA, so needs to be restarted as part of the certificate update.
+
+|CaCertRemoved
+|CaCertRemoved
+|Expired CA certificates have been removed, and the pod is restarted to run with the current certificates.
+
+|CaCertRenewed
+|CaCertRenewed
+|CA certificates have been renewed, and the pod is restarted to run with the updated certificates.
+
+|ClientCaCertKeyReplaced
+|ClientCaCertKeyReplaced
+|The key used to sign client CA certificates has been replaced, and the pod is being restarted as part of the CA renewal process.
+
+|ClusterCaCertKeyReplaced
+|ClusterCaCertKeyReplaced
+|The key used to sign the cluster's CA certificates has been replaced, and the pod is being restarted as part of the CA renewal process.
+
+|ConfigChangeRequiresRestart
+|ConfigChangeRequiresRestart
+|Some Kafka configuration properties are changed dynamically, but others require that the broker be restarted.
+
+|CustomListenerCaCertChanged
+|CustomListenerCaCertChanged
+|The CA certificate used to secure the Kafka network listeners has changed, and the pod is restarted to use it.
+
+|FileSystemResizeNeeded
+|FileSystemResizeRequired
+|The file system size has been increased, and a restart is needed to apply it.
+
+|KafkaCertificatesChanged
+|KafkaCertificatesChanged
+|One or more TLS certificates used by the Kafka broker have been updated, and a restart is needed to use them.
+
+|ManualRollingUpdate
+|ManualRollingUpdate
+|A user annotated the pod, or the `StatefulSet`` or `StrimziPodSet` set it belongs to, to trigger a restart.
+
+|PodForceRestartOnError
+|PodForceRestartOnError
+|An error occurred that requires a pod restart to rectify.
+
+|PodHasOldRevision
+|JbodVolumesChanged
+|A disk was added or removed from the Kafka volumes, and a restart is needed to apply the change. When using `StrimziPodSet` resources, the same reason is given if the pod needs to be recreated.  
+
+|PodHasOldRevision
+|PodHasOldGeneration
+|The `StatefulSet` or `StrimziPodSet` that the pod is a member of has been updated, so the pod needs to be recreated. When using `StrimziPodSet` resources, the same reason is given if a disk was added or removed from the Kafka volumes. 
+
+|PodStuck
+|PodStuck
+|The pod is still pending, and is not scheduled or cannot be scheduled, so the operator has restarted the pod in a final attempt to get it running.
+
+|PodUnresponsive
+|PodUnresponsive
+|Strimzi was unable to connect to the pod, which can indicate a broker not starting correctly, so the operator restarted it in an attempt to resolve the issue.
+
+|===

--- a/documentation/modules/deploying/ref-operator-restart-events-reasons.adoc
+++ b/documentation/modules/deploying/ref-operator-restart-events-reasons.adoc
@@ -48,7 +48,7 @@ a|StatefulSet
 |The CA certificate used to secure the Kafka network listeners has changed, and the pod is restarted to use it.
 
 |FileSystemResizeNeeded
-|FileSystemResizeRequired
+|FileSystemResizeNeeded
 |The file system size has been increased, and a restart is needed to apply it.
 
 |KafkaCertificatesChanged


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Documentation
Updates [Finding information on Kafka restarts](https://strimzi.io/docs/operators/in-development/deploying.html#assembly-deploy-restart-events-str) to distinguish between events returned when using `StrimziPodSet` or `StatefulSet` resources.

- New table to list events for each resource
- Updates event filters list to describe the latest plus a note on naming conventions in older Kubernetes versions
- Updates the procedure to check restarts so it refers to events that apply to StrimziPodSet resources. And also uses the latest naming convention for the reporting component (`reportingController`).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

