### PR TITLE
Handle `Failed` or `Succeeded` `Pods` in `StrimziPodSetController`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodSetUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodSetUtils.java
@@ -76,4 +76,17 @@ public class PodSetUtils {
     public static List<Pod> mapsToPods(List<Map<String, Object>> maps)  {
         return maps.stream().map(m -> mapToPod(m)).collect(Collectors.toList());
     }
+
+    /**
+     * Check whether the Pod reached one of its terminal phases: Succeeded or Failed. This is checked based on
+     * the .status.phase field.
+     *
+     * @param pod   The Pod object
+     *
+     * @return  True if the Pod is in terminal phase. False otherwise.
+     */
+    public static boolean isInTerminalState(Pod pod)   {
+        return pod.getStatus() != null
+                && ("Failed".equals(pod.getStatus().getPhase()) || "Succeeded".equals(pod.getStatus().getPhase()));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In some situation, the Pods managed by `StrimziPodSetController` might end up in the state `Failed` or `Succeeded`. This might happen for example during node failures. This PR adds handling for this. Since we do not expect any pods to be `Failed` or `Succeeded` as intended state, it deletes the pods in this state so that they can be recreated and rescheduled.

This is related to #7290.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging