### PR TITLE
Fix `MetricsIsolatedST.testStrimziPodSetMetrics` in KRaft mode

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -582,8 +582,8 @@ public class MetricsIsolatedST extends AbstractST {
             .collectMetricsFromPods();
 
         // check StrimziPodSet metrics in CO
-        assertCoMetricResources(StrimziPodSet.RESOURCE_KIND, clusterOperator.getDeploymentNamespace(), 2);
-        assertCoMetricResources(StrimziPodSet.RESOURCE_KIND, SECOND_NAMESPACE, 2);
+        assertCoMetricResources(StrimziPodSet.RESOURCE_KIND, clusterOperator.getDeploymentNamespace(), Environment.isKRaftModeEnabled() ? 1 : 2);
+        assertCoMetricResources(StrimziPodSet.RESOURCE_KIND, SECOND_NAMESPACE, Environment.isKRaftModeEnabled() ? 1 : 2);
 
         assertCoMetricNotNull("strimzi_reconciliations_duration_seconds_bucket", StrimziPodSet.RESOURCE_KIND, clusterOperatorMetricsData);
         assertCoMetricNotNull("strimzi_reconciliations_duration_seconds_count", StrimziPodSet.RESOURCE_KIND, clusterOperatorMetricsData);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `MetricsIsolatedST.testStrimziPodSetMetrics` always expects 2 StrimziPodSets resources to exist. But in the KRaft mode, only one of them exists and the test fails.

### Checklist

- [x] Make sure all tests pass