### PR TITLE
Updates expected graduation plan for the `ControlPlaneListener` feature gate

### DIFF
--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -17,7 +17,7 @@ Beta stage features are well tested and their functionality is not likely to cha
 GA stage features are stable and should not change in the future.
 Alpha and beta stage features are removed if they do not prove to be useful.
 
-* The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27 and is expected to remain in the beta stage until Strimzi 0.31.
+* The `ControlPlaneListener` feature gate moved to beta stage in Strimzi 0.27 and is expected to move to general availability in Strimzi 0.32.
 * The `ServiceAccountPatching` feature gate moved to GA stage in Strimzi 0.30. It is now permanently enabled and cannot be disabled.
 * The `UseStrimziPodSets` feature gate moved to beta stage in Strimzi 0.30 and is expected to remain in the beta stage until Strimzi 0.32.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `ControlPlaneListener` feature gate was originally planned to move to GA in Strimzi 0.31.0. But we forgot about it and it is still in beta. But the docs are now confusing since they suggest graduation in 0.31. This PR updates the docs to clarify that graduation is planned for 0.32.0. This can be released with 0.31.1 to make this less confusing.

### Checklist

- [x] Update documentation