### PR TITLE
KafkaConnector Ready status reflects connector and task state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## 0.32.0
 
+* Update KafkaConnector CR status so the 'NotReady' condition is added if the connector or any tasks are reporting a 'FAILED' state.
+
+### Deprecations and removals
+
+* A connector or task failing triggers a 'NotReady' condition to be added to the KafkaConnector CR status. This is different from previous versions where the CR would report 'Ready' even if the connector or a task had failed.
 
 ## 0.31.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -745,7 +745,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             List<String> failedTaskIds;
             if (connectorHasFailed(statusResultJson)) {
                 connectorReadiness = Future.failedFuture(new Throwable("Connector has failed, see connectorStatus for more details."));
-            } else if ((failedTaskIds = failedTasks(statusResultJson)).size() > 0) {
+            } else if ((failedTaskIds = failedTaskIds(statusResultJson)).size() > 0) {
                 connectorReadiness = Future.failedFuture(new Throwable(String.format("The following tasks have failed: %s, see connectorStatus for more details.", String.join(", ", failedTaskIds))));
             }
             topics = connectorStatus.topics.stream().sorted().collect(Collectors.toList());
@@ -777,7 +777,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         return connectorStatus != null && "FAILED".equals(connectorStatus.getString("state"));
     }
 
-    private List<String> failedTasks(JsonObject statusResult) {
+    private List<String> failedTaskIds(JsonObject statusResult) {
         JsonArray tasks = Optional.ofNullable(statusResult.getJsonArray("tasks")).orElse(new JsonArray());
         List<String> failedTasks = new ArrayList<>();
         for (Object task : tasks) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -72,6 +72,7 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
@@ -736,8 +737,17 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         List<String> topics = new ArrayList<>();
         List<Condition> conditions = new ArrayList<>();
 
+        Future<Void> connectorReadiness = Future.succeededFuture();
+
         if (connectorStatus != null) {
             statusResult = connectorStatus.statusResult;
+            JsonObject statusResultJson = new JsonObject(statusResult);
+            List<String> failedTaskIds;
+            if (connectorHasFailed(statusResultJson)) {
+                connectorReadiness = Future.failedFuture(new Throwable("Connector has failed, see connectorStatus for more details."));
+            } else if ((failedTaskIds = failedTasks(statusResultJson)).size() > 0) {
+                connectorReadiness = Future.failedFuture(new Throwable(String.format("The following tasks have failed: %s, see connectorStatus for more details.", String.join(", ", failedTaskIds))));
+            }
             topics = connectorStatus.topics.stream().sorted().collect(Collectors.toList());
             connectorStatus.conditions.forEach(condition -> conditions.add(condition));
         }
@@ -746,7 +756,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         unknownAndDeprecatedConditions.forEach(condition -> conditions.add(condition));
 
         if (!Annotations.isReconciliationPausedWithAnnotation(connector)) {
-            StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? Future.failedFuture(error) : Future.succeededFuture());
+            StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? Future.failedFuture(error) : connectorReadiness);
             status.setConnectorStatus(statusResult);
             status.setTasksMax(getActualTaskCount(connector, statusResult));
             status.setTopics(topics);
@@ -760,6 +770,22 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             (connector1, status1) -> {
                 return new KafkaConnectorBuilder(connector1).withStatus(status1).build();
             });
+    }
+
+    private boolean connectorHasFailed(JsonObject statusResult) {
+        JsonObject connectorStatus = statusResult.getJsonObject("connector");
+        return connectorStatus != null && "FAILED".equals(connectorStatus.getString("state"));
+    }
+
+    private List<String> failedTasks(JsonObject statusResult) {
+        JsonArray tasks = Optional.ofNullable(statusResult.getJsonArray("tasks")).orElse(new JsonArray());
+        List<String> failedTasks = new ArrayList<>();
+        for (Object task : tasks) {
+            if (task instanceof JsonObject && "FAILED".equals(((JsonObject) task).getString("state"))) {
+                failedTasks.add(((JsonObject) task).getString("id"));
+            }
+        }
+        return failedTasks;
     }
 
     /**


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

The KafkaConnector status "Ready" condition should not be there if one of the connector or the tasks are failed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

