### PR TITLE
Revert changes from #1212

### DIFF
--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-external-configuration.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-external-configuration.yaml
@@ -24,17 +24,15 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: username
-#          path: my-group/my-username
+        items:
+        - key: username
+          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: log_level
-#          path: log_level
+        items:
+        - key: log_level
+          path: log_level

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.out.yaml
@@ -38,10 +38,16 @@ spec:
         secretName: "ssh-key-secret"
     - name: "foo"
       secret:
+        items:
+        - key: "username"
+          path: "my-group/my-username"
         secretName: "mysecret"
     - name: "config-map-volume"
       configMap:
         name: "my-config-map"
     - name: "config-vol"
       configMap:
+        items:
+        - key: "log_level"
+          path: "log_level"
         name: "log-config"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect.yaml
@@ -38,17 +38,15 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-    # Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: username
-#          path: my-group/my-username
+        items:
+        - key: username
+          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: log_level
-#          path: log_level
+        items:
+        - key: log_level
+          path: log_level

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-external-configuration.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2-with-external-configuration.yaml
@@ -33,17 +33,15 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: username
-#          path: my-group/my-username
+        items:
+        - key: username
+          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: log_level
-#          path: log_level
+        items:
+        - key: log_level
+          path: log_level

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -59,10 +59,16 @@ spec:
         secretName: "ssh-key-secret"
     - name: "foo"
       secret:
+        items:
+        - key: "username"
+          path: "my-group/my-username"
         secretName: "mysecret"
     - name: "config-map-volume"
       configMap:
         name: "my-config-map"
     - name: "config-vol"
       configMap:
+        items:
+        - key: "log_level"
+          path: "log_level"
         name: "log-config"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.yaml
@@ -36,20 +36,18 @@ spec:
     - name: foo
       secret:
         secretName: mysecret
-    # Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: username
-#          path: my-group/my-username
+        items:
+        - key: username
+          path: my-group/my-username
     - name: config-map-volume
       configMap:
         name: my-config-map
     - name: config-vol
       configMap:
         name: log-config
-# Uncomment after kubernetes/kubernetes#68466 is fixed
-#        items:
-#        - key: log_level
-#          path: log_level
+        items:
+        - key: log_level
+          path: log_level
   clusters:
   - alias: source
     bootstrapServers: my-source-kafka:9092


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

How mentioned in https://github.com/strimzi/strimzi-kafka-operator/issues/2072 , changes from #1224 should be reverted once we drop support for k8s v1.16 and v1.17 - we are currently on v1.19, so it should be safe to revert it. 

### Checklist

- [ ] Make sure all tests pass

