### PR TITLE
Use correct container name for KafkaConnect build on Openshift

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -153,16 +153,4 @@ public class KafkaConnectResources {
     public static String buildName(String clusterName, Long buildVersion) {
         return buildConfigName(clusterName) + "-" + buildVersion;
     }
-
-    /**
-     * Returns the name of the Kafka Connect {@code Build} container.
-     *
-     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
-     * @param isOpenshift Flag for determining, if we are running on Openshift
-     *
-     * @return The name of the corresponding Kafka Connect {@code Build} Container.
-     */
-    public static String buildContainerName(String clusterName, boolean isOpenshift) {
-        return isOpenshift ? "docker-build" : buildPodName(clusterName);
-    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectResources.java
@@ -153,4 +153,16 @@ public class KafkaConnectResources {
     public static String buildName(String clusterName, Long buildVersion) {
         return buildConfigName(clusterName) + "-" + buildVersion;
     }
+
+    /**
+     * Returns the name of the Kafka Connect {@code Build} container.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @param isOpenshift Flag for determining, if we are running on Openshift
+     *
+     * @return The name of the corresponding Kafka Connect {@code Build} Container.
+     */
+    public static String buildContainerName(String clusterName, boolean isOpenshift) {
+        return isOpenshift ? "docker-build" : buildPodName(clusterName);
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
 
 public class KafkaConnectBuildUtils {
     /**
@@ -88,6 +89,18 @@ public class KafkaConnectBuildUtils {
      */
     public static boolean buildComplete(Build build)   {
         return buildSucceeded(build) || buildFailed(build);
+    }
+
+    /**
+     * Returns the name of the Kafka Connect {@code Build} container.
+     *
+     * @param clusterName  The {@code metadata.name} of the {@code KafkaConnect} resource.
+     * @param isOpenshift Flag for determining, if we are running on Openshift
+     *
+     * @return The name of the corresponding Kafka Connect {@code Build} Container.
+     */
+    public static String getBuildContainerName(String clusterName, boolean isOpenshift) {
+        return isOpenshift ? "docker-build" : KafkaConnectResources.buildPodName(clusterName);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -144,7 +144,6 @@ public class ConnectBuildOperator {
      */
     private Future<String> kubernetesBuild(Reconciliation reconciliation, String namespace, KafkaConnectBuild connectBuild, boolean forceRebuild, ConfigMap dockerFileConfigMap, String newBuildRevision)  {
         final AtomicReference<String> buildImage = new AtomicReference<>();
-        // Build pod name is same as the container name
         String buildPodName = KafkaConnectResources.buildPodName(connectBuild.getCluster());
 
         return podOperator.getAsync(namespace, buildPodName)
@@ -152,7 +151,7 @@ public class ConnectBuildOperator {
                     if (pod != null)    {
                         String existingBuildRevision = Annotations.stringAnnotation(pod, Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
                         if (newBuildRevision.equals(existingBuildRevision)
-                                && !KafkaConnectBuildUtils.buildPodFailed(pod, buildPodName)
+                                && !KafkaConnectBuildUtils.buildPodFailed(pod, KafkaConnectResources.buildContainerName(connectBuild.getCluster(), pfa.isOpenshift()))
                                 && !forceRebuild) {
                             // Builder pod exists, is not failed, and is building the same Dockerfile and we are not
                             // asked to force re-build by the annotation => we re-use the existing build
@@ -220,22 +219,22 @@ public class ConnectBuildOperator {
      * @return                      Future which completes with the built image when the build is finished (or fails if it fails)
      */
     private Future<String> kubernetesBuildWaitForFinish(Reconciliation reconciliation, String namespace, KafkaConnectBuild connectBuild)  {
-        // Build pod name is same as the container name
         String buildPodName = KafkaConnectResources.buildPodName(connectBuild.getCluster());
+        String containerName = KafkaConnectResources.buildContainerName(connectBuild.getCluster(), pfa.isOpenshift());
 
-        return podOperator.waitFor(reconciliation, namespace, buildPodName, "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> kubernetesBuildPodFinished(namespace, buildPodName, buildPodName))
+        return podOperator.waitFor(reconciliation, namespace, buildPodName, "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> kubernetesBuildPodFinished(namespace, buildPodName, containerName))
                 .compose(ignore -> podOperator.getAsync(namespace, buildPodName))
                 .compose(pod -> {
-                    if (KafkaConnectBuildUtils.buildPodSucceeded(pod, buildPodName)) {
-                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStateTerminated(pod, buildPodName);
+                    if (KafkaConnectBuildUtils.buildPodSucceeded(pod, containerName)) {
+                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStateTerminated(pod, containerName);
                         String image = state.getMessage().trim();
                         LOGGER.infoCr(reconciliation, "Build completed successfully. New image is {}.", image);
                         return Future.succeededFuture(image);
                     } else if (KafkaConnectBuildUtils.buildPodFailed(pod, buildPodName)) {
-                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStateTerminated(pod, buildPodName);
+                        ContainerStateTerminated state = KafkaConnectBuildUtils.getConnectBuildContainerStateTerminated(pod, containerName);
                         LOGGER.warnCr(reconciliation, "Build failed with code {}: {}", state.getExitCode(), state.getMessage());
                     } else {
-                        LOGGER.warnCr(reconciliation, "Build failed - no container with name {}", buildPodName);
+                        LOGGER.warnCr(reconciliation, "Build failed - no container with name {}", containerName);
                     }
                     return Future.failedFuture("The Kafka Connect build failed");
                 });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -151,7 +151,7 @@ public class ConnectBuildOperator {
                     if (pod != null)    {
                         String existingBuildRevision = Annotations.stringAnnotation(pod, Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
                         if (newBuildRevision.equals(existingBuildRevision)
-                                && !KafkaConnectBuildUtils.buildPodFailed(pod, KafkaConnectResources.buildContainerName(connectBuild.getCluster(), pfa.isOpenshift()))
+                                && !KafkaConnectBuildUtils.buildPodFailed(pod, KafkaConnectBuildUtils.getBuildContainerName(connectBuild.getCluster(), pfa.isOpenshift()))
                                 && !forceRebuild) {
                             // Builder pod exists, is not failed, and is building the same Dockerfile and we are not
                             // asked to force re-build by the annotation => we re-use the existing build
@@ -220,7 +220,7 @@ public class ConnectBuildOperator {
      */
     private Future<String> kubernetesBuildWaitForFinish(Reconciliation reconciliation, String namespace, KafkaConnectBuild connectBuild)  {
         String buildPodName = KafkaConnectResources.buildPodName(connectBuild.getCluster());
-        String containerName = KafkaConnectResources.buildContainerName(connectBuild.getCluster(), pfa.isOpenshift());
+        String containerName = KafkaConnectBuildUtils.getBuildContainerName(connectBuild.getCluster(), pfa.isOpenshift());
 
         return podOperator.waitFor(reconciliation, namespace, buildPodName, "complete", 1_000, connectBuildTimeoutMs, (ignore1, ignore2) -> kubernetesBuildPodFinished(namespace, buildPodName, containerName))
                 .compose(ignore -> podOperator.getAsync(namespace, buildPodName))


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In #7292 the checks for right container for KafkaConnect build were added, but it's only functional on K8s. OCP uses different name of the build container than Kaniko, which ends in `NotReady` state for every KafkaConnect build on OCP.

### Checklist

- [ ] Make sure all tests pass
