### PR TITLE
Uniform to use UTC Zone from Clock

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -26,7 +26,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;

--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -60,7 +60,6 @@ public class OpenSslCertManager implements CertManager {
     public static final int MAXIMUM_CN_LENGTH = 64;
 
     private static final Logger LOGGER = LogManager.getLogger(OpenSslCertManager.class);
-    public static final ZoneId UTC = ZoneId.of("UTC");
     private final Clock clock;
 
     public OpenSslCertManager() {
@@ -142,8 +141,8 @@ public class OpenSslCertManager implements CertManager {
     @Override
     public void generateSelfSignedCert(File keyFile, File certFile, Subject sbj, int days) throws IOException {
         Instant now = clock.instant();
-        ZonedDateTime notBefore = now.atZone(UTC);
-        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
+        ZonedDateTime notBefore = now.atZone(Clock.systemUTC().getZone());
+        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(Clock.systemUTC().getZone());
         generateRootCaCert(sbj, keyFile, certFile, notBefore, notAfter, 0);
     }
 
@@ -394,8 +393,8 @@ public class OpenSslCertManager implements CertManager {
     @Override
     public void renewSelfSignedCert(File keyFile, File certFile, Subject subject, int days) throws IOException {
         Instant now = clock.instant();
-        ZonedDateTime notBefore = now.atZone(UTC);
-        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
+        ZonedDateTime notBefore = now.atZone(Clock.systemUTC().getZone());
+        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(Clock.systemUTC().getZone());
         generateCaCert(null, null, subject, keyFile, certFile, notBefore, notAfter, 0);
     }
 
@@ -428,8 +427,8 @@ public class OpenSslCertManager implements CertManager {
     @Override
     public void generateCert(File csrFile, File caKey, File caCert, File crtFile, Subject sbj, int days) throws IOException {
         Instant now = clock.instant();
-        ZonedDateTime notBefore = now.atZone(UTC);
-        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(UTC);
+        ZonedDateTime notBefore = now.atZone(Clock.systemUTC().getZone());
+        ZonedDateTime notAfter = now.plus(days, ChronoUnit.DAYS).atZone(Clock.systemUTC().getZone());
         generateCert(csrFile, caKey, caCert, crtFile, sbj, notBefore, notAfter);
     }
 

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
@@ -26,6 +26,7 @@ import java.security.cert.CertificateParsingException;
 import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -102,8 +103,8 @@ public class OpenSslCertManagerIT {
         Subject sbj = new Subject.Builder().withCommonName("MyCommonName").withOrganizationName("MyOrganization").build();
 
         Instant now = Instant.now();
-        ZonedDateTime notBefore = now.plus(1, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(OpenSslCertManager.UTC);
-        ZonedDateTime notAfter = now.plus(2, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(OpenSslCertManager.UTC);
+        ZonedDateTime notBefore = now.plus(1, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(Clock.systemUTC().getZone());
+        ZonedDateTime notAfter = now.plus(2, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(Clock.systemUTC().getZone());
         ssl.generateRootCaCert(sbj, key, cert, notBefore, notAfter, 0);
         ssl.addCertToTrustStore(cert, "ca", store, "123456");
 
@@ -190,8 +191,8 @@ public class OpenSslCertManagerIT {
 
         // Generate a root cert
         Instant now = Instant.now();
-        ZonedDateTime notBefore = now.plus(1, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(OpenSslCertManager.UTC);
-        ZonedDateTime notAfter = now.plus(2, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(OpenSslCertManager.UTC);
+        ZonedDateTime notBefore = now.plus(1, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(Clock.systemUTC().getZone());
+        ZonedDateTime notAfter = now.plus(2, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS).atZone(Clock.systemUTC().getZone());
         int rootPathLen = 1;
         ssl.generateRootCaCert(rootSubject, rootKey, rootCert, notBefore, notAfter, rootPathLen);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
@@ -15,7 +15,6 @@ import io.strimzi.test.annotations.ParallelTest;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,13 +29,11 @@ public class ClusterCaTest {
     private final String namespace = "test";
     private final String cluster = "my-cluster";
 
-    private static final ZoneId UTC = ZoneId.of("UTC");
-
     @ParallelTest
     public void testRemoveExpiredCertificate() {
         // simulate certificate creation at following time, with expire at 365 days later (by default)
         String instantExpected = "2022-03-23T09:00:00Z";
-        Clock clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        Clock clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
@@ -51,7 +48,7 @@ public class ClusterCaTest {
                 .build();
         // ... simulated at the following time, with expire at 365 days later (by default)
         instantExpected = "2022-03-23T11:00:00Z";
-        clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), caKeySecretWithReplaceAnno);
         clusterCa.setClock(clock);
@@ -61,7 +58,7 @@ public class ClusterCaTest {
 
         // running a CA reconcile simulated at following time (365 days later) expecting expired certificate being removed
         instantExpected = "2023-03-23T10:00:00Z";
-        clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), clusterCa.caKeySecret());
         clusterCa.setClock(clock);
@@ -74,7 +71,7 @@ public class ClusterCaTest {
     public void testIsExpiringCertificate() {
         // simulate certificate creation at following time, with expire at 365 days later (by default) and renewal days at 30 (by default)
         String instantExpected = "2022-03-30T09:00:00Z";
-        Clock clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        Clock clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
@@ -82,13 +79,13 @@ public class ClusterCaTest {
 
         // check certificate expiration out of the renewal period, certificate is not expiring
         instantExpected = "2023-02-15T09:00:00Z";
-        clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
         clusterCa.setClock(clock);
         assertThat(clusterCa.isExpiring(clusterCa.caCertSecret(), Ca.CA_CRT), is(false));
 
         // check certificate expiration within the renewal period, certificate is expiring
         instantExpected = "2023-03-15T09:00:00Z";
-        clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
         clusterCa.setClock(clock);
         assertThat(clusterCa.isExpiring(clusterCa.caCertSecret(), Ca.CA_CRT), is(true));
     }
@@ -97,7 +94,7 @@ public class ClusterCaTest {
     public void testRemoveOldCertificate() {
         // simulate certificate creation at following time, with expire at 365 days later (by default)
         String instantExpected = "2022-03-23T09:00:00Z";
-        Clock clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        Clock clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
@@ -112,7 +109,7 @@ public class ClusterCaTest {
                 .build();
         // ... simulated at the following time, with expire at 365 days later (by default)
         instantExpected = "2022-03-23T11:00:00Z";
-        clock = Clock.fixed(Instant.parse(instantExpected), UTC);
+        clock = Clock.fixed(Instant.parse(instantExpected), Clock.systemUTC().getZone());
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), caKeySecretWithReplaceAnno);
         clusterCa.setClock(clock);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1Beta1RestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1Beta1RestartEventPublisherTest.java
@@ -62,7 +62,7 @@ class V1Beta1RestartEventPublisherTest {
                 .endMetadata()
                 .build();
 
-        Clock clock = Clock.fixed(Instant.parse("2020-10-11T00:00:00Z"), ZoneId.of("UTC"));
+        Clock clock = Clock.fixed(Instant.parse("2020-10-11T00:00:00Z"), Clock.systemUTC().getZone());
 
         V1Beta1RestartEventPublisher eventPublisher = new V1Beta1RestartEventPublisher(clock, client, "cluster-operator-id");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1Beta1RestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1Beta1RestartEventPublisherTest.java
@@ -21,7 +21,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1RestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1RestartEventPublisherTest.java
@@ -62,7 +62,7 @@ class V1RestartEventPublisherTest {
                 .endMetadata()
                 .build();
 
-        Clock clock = Clock.fixed(Instant.parse("2020-10-11T00:00:00Z"), ZoneId.of("UTC"));
+        Clock clock = Clock.fixed(Instant.parse("2020-10-11T00:00:00Z"), Clock.systemUTC().getZone());
 
         V1RestartEventPublisher eventPublisher = new V1RestartEventPublisher(clock, client, "cluster-operator-id");
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1RestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/V1RestartEventPublisherTest.java
@@ -21,7 +21,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
Trivial PR to use the UTC ZoneId coming directly from using Clock instead of parsing the "UTC" string.