### PR TITLE
[systemtest] Add timeout for consumer in external clients

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/ExternalKafkaClient.java
@@ -199,6 +199,7 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
         CompletableFuture<Integer> received = new CompletableFuture<>();
 
         int[] size = {0};
+        long currentTimeMs = System.currentTimeMillis();
 
         Runnable poll = new Runnable() {
             @Override
@@ -211,6 +212,8 @@ public class ExternalKafkaClient extends AbstractKafkaClient<ExternalKafkaClient
 
                 if (size[0] >= messageCount) {
                     received.complete(size[0]);
+                } else if (System.currentTimeMillis() - currentTimeMs > Constants.GLOBAL_TIMEOUT) {
+                    received.completeExceptionally(new WaitException("Timeout for polling all the messages"));
                 } else {
                     this.run();
                 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

When we are running tests which are using external clients, it can happen that consumer polls infinitely, causing `StackOverFlow` error. This PR adds timeout for consumer and fixes this issue.

### Checklist

- [ ] Make sure all tests pass
