### PR TITLE
fix: Update TopicOperatorTest to handle async flow correctly

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicStore.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/MockTopicStore.java
@@ -76,7 +76,10 @@ public class MockTopicStore implements TopicStore {
     }
 
     public void assertContains(VertxTestContext context, Topic topic) {
-        context.verify(() -> assertThat(topics.get(topic.getTopicName()), is(topic)));
+        // Don't compare metadata since the topic store doesn't retain metadata, only k8s does.
+        context.verify(() -> assertThat("The topic " + topic.getTopicName() + " has an unexpected state",
+                new Topic.Builder(topics.get(topic.getTopicName())).withMetadata(null).build(),
+                is(new Topic.Builder(topic).withMetadata(null).build())));
     }
 
     public MockTopicStore setCreateTopicResponse(TopicName createTopic, Exception exception) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Update the TopicOperatorTest to fix problems with asynchronous tests being completed early before all assertions are run. This fixes issue #7072.

Main changes are:
 - Update the resourceAdded and similar functions so they return a future, rather than creating and flagging a checkpoint
 - Change checkpoints to context.completeNow() where possible
 - Remove the use of CountdownLatch in favour of vertx future composition

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

