### PR TITLE
Add client rack-awareness support to Strimzi Bridge pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update KafkaConnector CR status so the 'NotReady' condition is added if the connector or any tasks are reporting a 'FAILED' state.
 * Add auto-approval mechanism on KafkaRebalance resource when an optimization proposal is ready
 * The `ControlPlaneListener` feature gate moves to GA
+* Add client rack-awareness support to Strimzi Bridge pods
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeResources.java
@@ -58,4 +58,16 @@ public class KafkaBridgeResources {
     public static String url(String clusterName, String namespace, int port) {
         return "http://" + serviceName(clusterName) + "." + namespace + ".svc:" + port;
     }
+
+    /**
+     * Get the name of the init container role binding given the name of the {@code cluster} and {@code namespace}.
+     *
+     * @param clusterName   The cluster name.
+     * @param namespace     The namespace.
+     *
+     * @return The name of the init container's cluster role binding.
+     */
+    public static String initContainerClusterRoleBindingName(String clusterName, String namespace) {
+        return "strimzi-" + namespace + "-" + deploymentName(clusterName) + "-init";
+    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "replicas", "image", "bootstrapServers", "tls", "authentication", "http", "adminClient", "consumer",
-    "producer", "resources", "jvmOptions", "logging",
+    "producer", "resources", "jvmOptions", "logging", "clientRackInitImage", "rack",
     "enableMetrics", "livenessProbe", "readinessProbe", "template", "tracing"})
 @EqualsAndHashCode
 public class KafkaBridgeSpec extends Spec {
@@ -51,6 +51,8 @@ public class KafkaBridgeSpec extends Spec {
     private Probe readinessProbe;
     private KafkaBridgeTemplate template;
     private Tracing tracing;
+    private String clientRackInitImage;
+    private Rack rack;
 
     @Description("The number of pods in the `Deployment`.")
     @Minimum(0)
@@ -224,5 +226,26 @@ public class KafkaBridgeSpec extends Spec {
 
     public void setTracing(Tracing tracing) {
         this.tracing = tracing;
+    }
+
+
+    @Description("The image of the init container used for initializing the `client.rack`.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public String getClientRackInitImage() {
+        return clientRackInitImage;
+    }
+
+    public void setClientRackInitImage(String brokerRackInitImage) {
+        this.clientRackInitImage = brokerRackInitImage;
+    }
+
+    @Description("Configuration of the node label which will be used as the client.rack consumer configuration.")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public Rack getRack() {
+        return rack;
+    }
+
+    public void setRack(Rack rack) {
+        this.rack = rack;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "bridgeContainer", "serviceAccount"})
+@JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "bridgeContainer", "serviceAccount", "initContainer"})
 @EqualsAndHashCode
 public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -34,6 +34,7 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
     private InternalServiceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate bridgeContainer;
+    private ContainerTemplate initContainer;
     private ResourceTemplate serviceAccount;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -85,6 +86,16 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
 
     public void setBridgeContainer(ContainerTemplate bridgeContainer) {
         this.bridgeContainer = bridgeContainer;
+    }
+
+    @Description("Template for the Kafka Bridge init container")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ContainerTemplate getInitContainer() {
+        return initContainer;
+    }
+
+    public void setInitContainer(ContainerTemplate initContainer) {
+        this.initContainer = initContainer;
     }
 
     @Description("Template for the Kafka Bridge service account.")

--- a/api/src/main/java/io/strimzi/plugin/security/profiles/PodSecurityProvider.java
+++ b/api/src/main/java/io/strimzi/plugin/security/profiles/PodSecurityProvider.java
@@ -241,18 +241,6 @@ public interface PodSecurityProvider {
 
 
     /**
-     * Provides the (container) security context for the Kafka Bridge init containers. The default implementation just
-     * returns the security context configured by the user in the template section or null (no security context).
-     *
-     * @param context   Provides the context which can be used to generate the security context
-     *
-     * @return  Security context which will be set for the Kafka Bridge init containers
-     */
-    default SecurityContext kafkaBridgeInitContainerSecurityContext(ContainerSecurityProviderContext context) {
-        return securityContextOrNull(context);
-    }
-
-    /**
      * Provides the Pod security context for the Kafka Connect Build (Kaniko) pod. The default implementation just returns
      * the security context configured by the user in the template section or null (no Pod security context).
      *
@@ -323,6 +311,19 @@ public interface PodSecurityProvider {
     default SecurityContext bridgeContainerSecurityContext(ContainerSecurityProviderContext context) {
         return securityContextOrNull(context);
     }
+    
+    /**
+     * Provides the (container) security context for the Kafka Bridge init containers. The default implementation just
+     * returns the security context configured by the user in the template section or null (no security context).
+     *
+     * @param context   Provides the context which can be used to generate the security context
+     *
+     * @return  Security context which will be set for the Kafka Bridge init containers
+     */
+    default SecurityContext bridgeInitContainerSecurityContext(ContainerSecurityProviderContext context) {
+        return securityContextOrNull(context);
+    }
+
 
     /**
      * Internal method to handle the default Pod security context.

--- a/api/src/main/java/io/strimzi/plugin/security/profiles/PodSecurityProvider.java
+++ b/api/src/main/java/io/strimzi/plugin/security/profiles/PodSecurityProvider.java
@@ -239,6 +239,19 @@ public interface PodSecurityProvider {
         return securityContextOrNull(context);
     }
 
+
+    /**
+     * Provides the (container) security context for the Kafka Bridge init containers. The default implementation just
+     * returns the security context configured by the user in the template section or null (no security context).
+     *
+     * @param context   Provides the context which can be used to generate the security context
+     *
+     * @return  Security context which will be set for the Kafka Bridge init containers
+     */
+    default SecurityContext kafkaBridgeInitContainerSecurityContext(ContainerSecurityProviderContext context) {
+        return securityContextOrNull(context);
+    }
+
     /**
      * Provides the Pod security context for the Kafka Connect Build (Kaniko) pod. The default implementation just returns
      * the security context configured by the user in the template section or null (no Pod security context).

--- a/api/src/main/java/io/strimzi/plugin/security/profiles/impl/RestrictedPodSecurityProvider.java
+++ b/api/src/main/java/io/strimzi/plugin/security/profiles/impl/RestrictedPodSecurityProvider.java
@@ -96,11 +96,6 @@ public class RestrictedPodSecurityProvider extends BaselinePodSecurityProvider {
     }
 
     @Override
-    public SecurityContext kafkaBridgeInitContainerSecurityContext(ContainerSecurityProviderContext context) {
-        return createRestrictedContainerSecurityContext(context);
-    }
-
-    @Override
     public SecurityContext kafkaConnectBuildContainerSecurityContext(ContainerSecurityProviderContext context) {
         if (context != null
                 && context.userSuppliedSecurityContext() != null)    {
@@ -119,6 +114,11 @@ public class RestrictedPodSecurityProvider extends BaselinePodSecurityProvider {
 
     @Override
     public SecurityContext bridgeContainerSecurityContext(ContainerSecurityProviderContext context) {
+        return createRestrictedContainerSecurityContext(context);
+    }
+
+    @Override
+    public SecurityContext bridgeInitContainerSecurityContext(ContainerSecurityProviderContext context) {
         return createRestrictedContainerSecurityContext(context);
     }
 }

--- a/api/src/main/java/io/strimzi/plugin/security/profiles/impl/RestrictedPodSecurityProvider.java
+++ b/api/src/main/java/io/strimzi/plugin/security/profiles/impl/RestrictedPodSecurityProvider.java
@@ -96,6 +96,11 @@ public class RestrictedPodSecurityProvider extends BaselinePodSecurityProvider {
     }
 
     @Override
+    public SecurityContext kafkaBridgeInitContainerSecurityContext(ContainerSecurityProviderContext context) {
+        return createRestrictedContainerSecurityContext(context);
+    }
+
+    @Override
     public SecurityContext kafkaConnectBuildContainerSecurityContext(ContainerSecurityProviderContext context) {
         if (context != null
                 && context.userSuppliedSecurityContext() != null)    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -130,8 +130,6 @@ public abstract class AbstractModel {
     protected static final String INIT_VOLUME_NAME = "rack-volume";
     protected static final String INIT_VOLUME_MOUNT = "/opt/kafka/init";
     protected static final String ENV_VAR_KAFKA_INIT_RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
-
-    protected static final String ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY = "INIT_FOLDER";
     protected static final String ENV_VAR_KAFKA_INIT_NODE_NAME = "NODE_NAME";
 
     public static final String ANCILLARY_CM_KEY_METRICS = "metrics-config.json";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -130,6 +130,8 @@ public abstract class AbstractModel {
     protected static final String INIT_VOLUME_NAME = "rack-volume";
     protected static final String INIT_VOLUME_MOUNT = "/opt/kafka/init";
     protected static final String ENV_VAR_KAFKA_INIT_RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
+
+    protected static final String ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY = "INIT_FOLDER";
     protected static final String ENV_VAR_KAFKA_INIT_NODE_NAME = "NODE_NAME";
 
     public static final String ANCILLARY_CM_KEY_METRICS = "metrics-config.json";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
@@ -17,18 +19,24 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Subject;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.strimzi.api.kafka.model.CertSecretSource;
+import io.strimzi.api.kafka.model.ClientTls;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
+import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeAdminClientSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeHttpConfig;
-import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBridgeProducerSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.KafkaBridgeSpec;
-import io.strimzi.api.kafka.model.ClientTls;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
+import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.template.KafkaBridgeTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
@@ -112,7 +120,7 @@ public class KafkaBridgeCluster extends AbstractModel {
     protected static final String ENV_VAR_KAFKA_BRIDGE_CORS_ALLOWED_METHODS = "KAFKA_BRIDGE_CORS_ALLOWED_METHODS";
 
     protected static final String CO_ENV_VAR_CUSTOM_BRIDGE_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS";
-
+    protected static final String INIT_VOLUME_MOUNT = "/opt/strimzi/init";
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private KafkaBridgeHttpConfig http;
@@ -123,8 +131,16 @@ public class KafkaBridgeCluster extends AbstractModel {
     private KafkaBridgeConsumerSpec kafkaBridgeConsumer;
     private KafkaBridgeProducerSpec kafkaBridgeProducer;
     private List<ContainerEnvVar> templateContainerEnvVars;
+    private List<ContainerEnvVar> templateInitContainerEnvVars;
     private SecurityContext templateContainerSecurityContext;
+
+    private SecurityContext templateInitContainerSecurityContext;
+
     private Tracing tracing;
+
+    private Rack rack;
+
+    private String initImage;
 
     private static final Map<String, String> DEFAULT_POD_LABELS = new HashMap<>();
     static {
@@ -178,6 +194,12 @@ public class KafkaBridgeCluster extends AbstractModel {
         kafkaBridgeCluster.setKafkaAdminClientConfiguration(spec.getAdminClient());
         kafkaBridgeCluster.setKafkaConsumerConfiguration(spec.getConsumer());
         kafkaBridgeCluster.setKafkaProducerConfiguration(spec.getProducer());
+        kafkaBridgeCluster.setRack(spec.getRack());
+        String initImage = spec.getClientRackInitImage();
+        if (initImage == null) {
+            initImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "quay.io/strimzi/operator:latest");
+        }
+        kafkaBridgeCluster.setInitImage(initImage);
         if (kafkaBridge.getSpec().getLivenessProbe() != null) {
             kafkaBridgeCluster.setLivenessProbe(kafkaBridge.getSpec().getLivenessProbe());
         }
@@ -197,31 +219,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         kafkaBridgeCluster.setAuthentication(spec.getAuthentication());
 
         if (spec.getTemplate() != null) {
-            KafkaBridgeTemplate template = spec.getTemplate();
-
-            ModelUtils.parseDeploymentTemplate(kafkaBridgeCluster, template.getDeployment());
-            ModelUtils.parsePodTemplate(kafkaBridgeCluster, template.getPod());
-            ModelUtils.parseInternalServiceTemplate(kafkaBridgeCluster, template.getApiService());
-
-            if (template.getApiService() != null && template.getApiService().getMetadata() != null)  {
-                kafkaBridgeCluster.templateServiceLabels = template.getApiService().getMetadata().getLabels();
-                kafkaBridgeCluster.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
-            }
-
-            if (template.getBridgeContainer() != null && template.getBridgeContainer().getEnv() != null) {
-                kafkaBridgeCluster.templateContainerEnvVars = template.getBridgeContainer().getEnv();
-            }
-
-            if (template.getBridgeContainer() != null && template.getBridgeContainer().getSecurityContext() != null) {
-                kafkaBridgeCluster.templateContainerSecurityContext = template.getBridgeContainer().getSecurityContext();
-            }
-
-            if (template.getServiceAccount() != null && template.getServiceAccount().getMetadata() != null) {
-                kafkaBridgeCluster.templateServiceAccountLabels = template.getServiceAccount().getMetadata().getLabels();
-                kafkaBridgeCluster.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
-            }
-
-            ModelUtils.parsePodDisruptionBudgetTemplate(kafkaBridgeCluster, template.getPodDisruptionBudget());
+            fromCrdTemplate(kafkaBridgeCluster, spec);
         }
 
         kafkaBridgeCluster.templatePodLabels = Util.mergeLabelsOrAnnotations(kafkaBridgeCluster.templatePodLabels, DEFAULT_POD_LABELS);
@@ -236,7 +234,45 @@ public class KafkaBridgeCluster extends AbstractModel {
 
         return kafkaBridgeCluster;
     }
-    
+
+
+    private static void fromCrdTemplate(final KafkaBridgeCluster kafkaBridgeCluster, final KafkaBridgeSpec spec) {
+        KafkaBridgeTemplate template = spec.getTemplate();
+
+        ModelUtils.parseDeploymentTemplate(kafkaBridgeCluster, template.getDeployment());
+        ModelUtils.parsePodTemplate(kafkaBridgeCluster, template.getPod());
+        ModelUtils.parseInternalServiceTemplate(kafkaBridgeCluster, template.getApiService());
+
+        if (template.getApiService() != null && template.getApiService().getMetadata() != null)  {
+            kafkaBridgeCluster.templateServiceLabels = template.getApiService().getMetadata().getLabels();
+            kafkaBridgeCluster.templateServiceAnnotations = template.getApiService().getMetadata().getAnnotations();
+        }
+
+        if (template.getBridgeContainer() != null && template.getBridgeContainer().getEnv() != null) {
+            kafkaBridgeCluster.templateContainerEnvVars = template.getBridgeContainer().getEnv();
+        }
+
+        if (template.getBridgeContainer() != null && template.getBridgeContainer().getSecurityContext() != null) {
+            kafkaBridgeCluster.templateContainerSecurityContext = template.getBridgeContainer().getSecurityContext();
+        }
+
+        if (template.getInitContainer() != null && template.getInitContainer().getEnv() != null) {
+            kafkaBridgeCluster.templateInitContainerEnvVars = template.getInitContainer().getEnv();
+        }
+
+        if (template.getInitContainer() != null && template.getInitContainer().getSecurityContext() != null) {
+            kafkaBridgeCluster.templateInitContainerSecurityContext = template.getInitContainer().getSecurityContext();
+        }
+
+        if (template.getServiceAccount() != null && template.getServiceAccount().getMetadata() != null) {
+            kafkaBridgeCluster.templateServiceAccountLabels = template.getServiceAccount().getMetadata().getLabels();
+            kafkaBridgeCluster.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
+        }
+
+        ModelUtils.parsePodDisruptionBudgetTemplate(kafkaBridgeCluster, template.getPodDisruptionBudget());
+    }
+
+
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(3);
 
@@ -290,6 +326,9 @@ public class KafkaBridgeCluster extends AbstractModel {
         if (tls != null) {
             VolumeUtils.createSecretVolume(volumeList, tls.getTrustedCertificates(), isOpenShift);
         }
+        if (rack != null) {
+            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
+        }
         AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift);
         return volumeList;
     }
@@ -301,6 +340,9 @@ public class KafkaBridgeCluster extends AbstractModel {
         volumeMountList.add(VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
         if (tls != null) {
             VolumeUtils.createSecretVolumeMount(volumeMountList, tls.getTrustedCertificates(), TLS_CERTS_BASE_VOLUME_MOUNT);
+        }
+        if (rack != null) {
+            volumeMountList.add(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT));
         }
         AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT, "oauth-certs");
         return volumeMountList;
@@ -508,9 +550,100 @@ public class KafkaBridgeCluster extends AbstractModel {
         this.bootstrapServers = bootstrapServers;
     }
 
+
+    protected void setRack(Rack rack) {
+        this.rack = rack;
+    }
+
+    protected void setInitImage(String initImage) {
+        this.initImage = initImage;
+    }
+
     public KafkaBridgeHttpConfig getHttp() {
         return this.http;
     }
+
+    public String getInitContainerClusterRoleBindingName() {
+        return KafkaBridgeResources.initContainerClusterRoleBindingName(cluster, namespace);
+    }
+
+    /**
+     * Returns a combined affinity: Adding the affinity needed for the "kafka-rack" to the {@link #getUserAffinity()}.
+     */
+    @Override
+    protected Affinity getMergedAffinity() {
+        Affinity userAffinity = getUserAffinity();
+        AffinityBuilder builder = new AffinityBuilder(userAffinity == null ? new Affinity() : userAffinity);
+        if (rack != null) {
+            builder = ModelUtils.populateAffinityBuilderWithRackLabelSelector(builder, userAffinity, rack.getTopologyKey());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Creates the ClusterRoleBinding which is used to bind the Kafka Bridge SA to the ClusterRole
+     * which permissions the Kafka init container to access K8S nodes (necessary for rack-awareness).
+     *
+     * @return The cluster role binding.
+     */
+    public ClusterRoleBinding generateClusterRoleBinding() {
+        if (rack == null) {
+            return null;
+        }
+
+        Subject subject = new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName(getServiceAccountName())
+                .withNamespace(namespace)
+                .build();
+
+        RoleRef roleRef = new RoleRefBuilder()
+                .withName("strimzi-kafka-client")
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("ClusterRole")
+                .build();
+
+        return getClusterRoleBinding(getInitContainerClusterRoleBindingName(), subject, roleRef);
+    }
+
+    @Override
+    protected List<Container> getInitContainers(ImagePullPolicy imagePullPolicy) {
+        List<Container> initContainers = new ArrayList<>(1);
+
+        if (rack != null) {
+            Container initContainer = new ContainerBuilder()
+                    .withName(INIT_NAME)
+                    .withImage(initImage)
+                    .withArgs("/opt/strimzi/bin/kafka_init_run.sh")
+                    .withEnv(getInitContainerEnvVars())
+                    .withVolumeMounts(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT))
+                    .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, initImage))
+                    .withSecurityContext(securityProvider.kafkaBridgeInitContainerSecurityContext(new ContainerSecurityProviderContextImpl(templateInitContainerSecurityContext)))
+                    .build();
+
+            if (getResources() != null) {
+                initContainer.setResources(getResources());
+            }
+            initContainers.add(initContainer);
+        }
+
+        return initContainers;
+    }
+
+    protected List<EnvVar> getInitContainerEnvVars() {
+        List<EnvVar> varList = new ArrayList<>();
+        varList.add(buildEnvVarFromFieldRef(ENV_VAR_KAFKA_INIT_NODE_NAME, "spec.nodeName"));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_INIT_RACK_TOPOLOGY_KEY, rack.getTopologyKey()));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY, INIT_VOLUME_MOUNT));
+
+        // Add shared environment variables used for all containers
+        varList.addAll(getRequiredEnvVars());
+
+        addContainerEnvsToExistingEnvs(varList, templateInitContainerEnvVars);
+
+        return varList;
+    }
+
 
     /**
      * Transforms properties to log4j2 properties file format and adds property for reloading the config

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -127,6 +127,21 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         return createOrUpdatePromise.future();
     }
 
+
+    /**
+     * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
+     *
+     * @param reconciliation The Reconciliation identification
+     * @return Future indicating the result of the deletion
+     */
+    @Override
+    protected Future<Boolean> delete(Reconciliation reconciliation) {
+        return super.delete(reconciliation)
+                    .compose(i -> withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, KafkaBridgeResources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null), null))
+                    .map(Boolean.FALSE); // Return FALSE since other resources are still deleted by garbage collection
+    }
+
+
     @Override
     protected KafkaBridgeStatus createStatus() {
         return new KafkaBridgeStatus();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.KafkaBridgeList;
@@ -85,8 +86,13 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         Promise<KafkaBridgeStatus> createOrUpdatePromise = Promise.promise();
 
         boolean bridgeHasZeroReplicas = bridge.getReplicas() == 0;
+
+        String initCrbName = bridge.getInitContainerClusterRoleBindingName();
+        ClusterRoleBinding initCrb = bridge.generateClusterRoleBinding();
+
         LOGGER.debugCr(reconciliation, "Updating Kafka Bridge cluster");
         kafkaBridgeServiceAccount(reconciliation, namespace, bridge)
+            .compose(i -> bridgeInitClusterRoleBinding(reconciliation, initCrbName, initCrb))
             .compose(i -> deploymentOperations.scaleDown(reconciliation, namespace, bridge.getName(), bridge.getReplicas()))
             .compose(scale -> serviceOperations.reconcile(reconciliation, namespace, bridge.getServiceName(), bridge.generateService()))
             .compose(i -> Util.metricsAndLogging(reconciliation, configMapOperations, namespace, bridge.getLogging(), null))
@@ -130,5 +136,9 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         return serviceAccountOperations.reconcile(reconciliation, namespace,
                 KafkaBridgeResources.serviceAccountName(bridge.getCluster()),
                 bridge.generateServiceAccount());
+    }
+
+    protected Future<ReconcileResult<ClusterRoleBinding>> bridgeInitClusterRoleBinding(Reconciliation reconciliation, String crbName, ClusterRoleBinding crb) {
+        return withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, crbName, crb), crb);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -87,7 +87,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
 
         boolean bridgeHasZeroReplicas = bridge.getReplicas() == 0;
 
-        String initCrbName = bridge.getInitContainerClusterRoleBindingName();
+        String initCrbName = KafkaBridgeResources.initContainerClusterRoleBindingName(bridge.getCluster(), namespace);
         ClusterRoleBinding initCrb = bridge.generateClusterRoleBinding();
 
         LOGGER.debugCr(reconciliation, "Updating Kafka Bridge cluster");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.strimzi.operator.cluster.model.KafkaBridgeCluster.ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -845,7 +846,7 @@ public class KafkaBridgeClusterTest {
         final List<EnvVar> initEnv = container.getEnv();
         assertThat(initEnv.stream().filter(var -> AbstractModel.ENV_VAR_KAFKA_INIT_RACK_TOPOLOGY_KEY.equals(var.getName())).findFirst().orElseThrow().getValue(), is(
                 "topology-key"));
-        assertThat(initEnv.stream().filter(var -> AbstractModel.ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY.equals(var.getName())).findFirst().orElseThrow().getValue(), is(KafkaBridgeCluster.INIT_VOLUME_MOUNT));
+        assertThat(initEnv.stream().filter(var -> ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY.equals(var.getName())).findFirst().orElseThrow().getValue(), is(KafkaBridgeCluster.INIT_VOLUME_MOUNT));
         assertThat(initEnv.stream().filter(var -> AbstractModel.ENV_VAR_KAFKA_INIT_NODE_NAME.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getFieldRef().getFieldPath(), is("spec.nodeName"));
 
         assertThat(container.getVolumeMounts(), hasSize(1));

--- a/documentation/api/io.strimzi.api.kafka.model.Rack.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.Rack.adoc
@@ -79,8 +79,8 @@ If the rack ID is not specified, or if it cannot find a replica with the same ra
 .Example showing client consuming from replicas in the same availability zone
 image::rack-config-availability-zones.png[consuming from replicas in the same availability zone]
 
-You can also configure Kafka Connect and MirrorMaker 2.0 so that connectors consume messages from the closest replicas.
-You enable rack awareness in the `KafkaConnect` and `KafkaMirrorMaker2` custom resources.
+You can also configure Kafka Connect, MirrorMaker 2.0 and Kafka Bridge so that connectors consume messages from the closest replicas.
+You enable rack awareness in the `KafkaConnect`, `KafkaMirrorMaker2` and KafkaBridge custom resources.
 The configuration does does not set affinity rules, but you can also configure `affinity` or `topologySpreadConstraints`.
 For more information see xref:assembly-scheduling-str[].
 
@@ -106,6 +106,21 @@ When deploying MirrorMaker 2 using Strimzi, you can use the `rack` section in th
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}
 kind: KafkaMirrorMaker2
+# ...
+spec:
+  # ...
+  rack:
+    topologyKey: topology.kubernetes.io/zone
+  # ...
+----
+
+When deploying Kafka Bridge using Strimzi, you can use the `rack` section in the `KafkaBridge` custom resource to automatically configure the `client.rack` option.
+
+.Example `rack` configuration for Kafka Bridge
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaBridgeApiVersion}
+kind: KafkaBridge
 # ...
 spec:
   # ...

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -642,7 +642,7 @@ It must have the value `custom` for the type `KafkaAuthorizationCustom`.
 [id='type-Rack-{context}']
 ### `Rack` schema reference
 
-Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 
 xref:type-Rack-schema-{context}[Full list of `Rack` schema properties]
 
@@ -2792,42 +2792,46 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 
 [options="header"]
 |====
-|Property                 |Description
-|replicas          1.2+<.<a|The number of pods in the `Deployment`.
+|Property                    |Description
+|replicas             1.2+<.<a|The number of pods in the `Deployment`.
 |integer
-|image             1.2+<.<a|The docker image for the pods.
+|image                1.2+<.<a|The docker image for the pods.
 |string
-|bootstrapServers  1.2+<.<a|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+|bootstrapServers     1.2+<.<a|A list of host:port pairs for establishing the initial connection to the Kafka cluster.
 |string
-|tls               1.2+<.<a|TLS configuration for connecting Kafka Bridge to the cluster.
+|tls                  1.2+<.<a|TLS configuration for connecting Kafka Bridge to the cluster.
 |xref:type-ClientTls-{context}[`ClientTls`]
-|authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
+|authentication       1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|http              1.2+<.<a|The HTTP related configuration.
+|http                 1.2+<.<a|The HTTP related configuration.
 |xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
-|adminClient       1.2+<.<a|Kafka AdminClient related configuration.
+|adminClient          1.2+<.<a|Kafka AdminClient related configuration.
 |xref:type-KafkaBridgeAdminClientSpec-{context}[`KafkaBridgeAdminClientSpec`]
-|consumer          1.2+<.<a|Kafka consumer related configuration.
+|consumer             1.2+<.<a|Kafka consumer related configuration.
 |xref:type-KafkaBridgeConsumerSpec-{context}[`KafkaBridgeConsumerSpec`]
-|producer          1.2+<.<a|Kafka producer related configuration.
+|producer             1.2+<.<a|Kafka producer related configuration.
 |xref:type-KafkaBridgeProducerSpec-{context}[`KafkaBridgeProducerSpec`]
-|resources         1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
+|resources            1.2+<.<a|CPU and memory resources to reserve. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
-|jvmOptions        1.2+<.<a|**Currently not supported** JVM Options for pods.
+|jvmOptions           1.2+<.<a|**Currently not supported** JVM Options for pods.
 |xref:type-JvmOptions-{context}[`JvmOptions`]
-|logging           1.2+<.<a|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
+|logging              1.2+<.<a|Logging configuration for Kafka Bridge. The type depends on the value of the `logging.type` property within the given object, which must be one of [inline, external].
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
-|enableMetrics     1.2+<.<a|Enable the metrics for the Kafka Bridge. Default is false.
+|clientRackInitImage  1.2+<.<a|The image of the init container used for initializing the `client.rack`.
+|string
+|rack                 1.2+<.<a|Configuration of the node label which will be used as the client.rack consumer configuration.
+|xref:type-Rack-{context}[`Rack`]
+|enableMetrics        1.2+<.<a|Enable the metrics for the Kafka Bridge. Default is false.
 |boolean
-|livenessProbe     1.2+<.<a|Pod liveness checking.
+|livenessProbe        1.2+<.<a|Pod liveness checking.
 |xref:type-Probe-{context}[`Probe`]
-|readinessProbe    1.2+<.<a|Pod readiness checking.
+|readinessProbe       1.2+<.<a|Pod readiness checking.
 |xref:type-Probe-{context}[`Probe`]
-|template          1.2+<.<a|Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
+|template             1.2+<.<a|Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
-|tracing           1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
+|tracing              1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`]
 |====
 
@@ -2942,6 +2946,8 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |serviceAccount       1.2+<.<a|Template for the Kafka Bridge service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|initContainer        1.2+<.<a|Template for the Kafka Bridge init container.
+|xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |====
 
 [id='type-KafkaBridgeStatus-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -329,6 +329,19 @@ spec:
                   required:
                     - type
                   description: Logging configuration for Kafka Bridge.
+                clientRackInitImage:
+                  type: string
+                  description: The image of the init container used for initializing the `client.rack`.
+                rack:
+                  type: object
+                  properties:
+                    topologyKey:
+                      type: string
+                      example: topology.kubernetes.io/zone
+                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                  required:
+                    - topologyKey
+                  description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
                 enableMetrics:
                   type: boolean
                   description: Enable the metrics for the Kafka Bridge. Default is false.
@@ -977,6 +990,80 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka Bridge container.
+                    initContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            seccompProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Kafka init container.
                     serviceAccount:
                       type: object
                       properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -341,7 +341,7 @@ spec:
                       description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
                   required:
                     - topologyKey
-                  description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+                  description: Configuration of the node label which will be used as the client.rack consumer configuration.
                 enableMetrics:
                   type: boolean
                   description: Enable the metrics for the Kafka Bridge. Default is false.
@@ -990,6 +990,22 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka Bridge container.
+                    serviceAccount:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          description: Metadata applied to the resource.
+                      description: Template for the Kafka Bridge service account.
                     initContainer:
                       type: object
                       properties:
@@ -1063,23 +1079,7 @@ spec:
                                 runAsUserName:
                                   type: string
                           description: Security context for the container.
-                      description: Template for the Kafka init container.
-                    serviceAccount:
-                      type: object
-                      properties:
-                        metadata:
-                          type: object
-                          properties:
-                            labels:
-                              x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                            annotations:
-                              x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          description: Metadata applied to the resource.
-                      description: Template for the Kafka Bridge service account.
+                      description: Template for the Kafka Bridge init container.
                   description: Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
                 tracing:
                   type: object

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -328,6 +328,19 @@ spec:
                 required:
                 - type
                 description: Logging configuration for Kafka Bridge.
+              clientRackInitImage:
+                type: string
+                description: The image of the init container used for initializing the `client.rack`.
+              rack:
+                type: object
+                properties:
+                  topologyKey:
+                    type: string
+                    example: topology.kubernetes.io/zone
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                required:
+                - topologyKey
+                description: Configuration of the node label which will be used as the client.rack consumer configuration.
               enableMetrics:
                 type: boolean
                 description: Enable the metrics for the Kafka Bridge. Default is false.
@@ -992,6 +1005,80 @@ spec:
                             description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                         description: Metadata applied to the resource.
                     description: Template for the Kafka Bridge service account.
+                  initContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Bridge init container.
                 description: Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
               tracing:
                 type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

Implements #6610

If you configure a rack topologyKey for a KafkaBridge CRD then an init container will be added to the bridge pod to retrieve the value of rack.topologyKey and write it into a file in `/opt/strimzi/init`. This `/opt/strimzi/init` volume is also mounted into the bridge container so it can retrieve the rack.id at runtime and use it for consumer configuration.

There is a corresponding PR for the bridge to add the rack id to it's consumer configuration: https://github.com/strimzi/strimzi-kafka-bridge/pull/659

Why:
You could configure your Kafka Bridge to prefer to consume from a broker in the same zone, potentially saving on inter-zone transfer costs. This may cost in overall message latency as you may be consuming from a follower for a topic-partition.

`/opt/strimzi/init` was selected as the mount because strimzi-bridge startup scripts use a STRIMZI_HOME instead of KAFKA_HOME, this keeps the configuration within /opt/strimzi instead of introducting /opt/kafka to the image.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

