### PR TITLE
Update SnakeYAML in Kafka 3.2.3 3rd party libs

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
@@ -336,7 +336,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.31</version>
+            <version>1.32</version>
         </dependency>
         <!-- EnvVar Configuration Provider for Apache Kafka -->
         <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka 3.2.3 3rd party libs seem to be still using SnakeYAML 1.31 due to the PR bumping the SankeYAML to 1.32 being done in parallel with the Pr adding Kafka 3.2.3 support. This PR updates SnakeYAMl to 1.32 even for Kafka 3.2.3.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally