### PR TITLE
Update Maven Surefire and Failsafe versions to 3.0.0-M7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
 
         <!-- Maven plugin versions -->
         <maven.compiler.version>3.8.1</maven.compiler.version>
-        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
-        <maven.failsafe.version>3.0.0-M5</maven.failsafe.version>
+        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+        <maven.failsafe.version>3.0.0-M7</maven.failsafe.version>
         <maven.assembly.version>3.3.0</maven.assembly.version>
         <maven.shade.version>3.1.0</maven.shade.version>
         <maven.javadoc.version>3.1.0</maven.javadoc.version>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR updates Maven Surefire & Failsafe to version `3.0.0-M7`. From version `3.0.0-M5`, there was a lot of bug fixes. The whole list can be seen [Surefire 3.0.0-M7](https://github.com/apache/maven-surefire/releases/tag/surefire-3.0.0-M7) and [Surefire 3.0.0-M6](https://github.com/apache/maven-surefire/releases/tag/surefire-3.0.0-M6)

### Checklist

- [ ] Make sure all tests pass

