### PR TITLE
 refactor Metric assertions in TopicOperatorTests

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.RequiredSearch;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
@@ -30,6 +31,7 @@ import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -170,9 +172,9 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterValueIsZero("reconciliations");
+                    assertCounterValueIsZero("reconciliations.successful");
+                    assertCounterValueIsZero("reconciliations.failed");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
@@ -392,9 +394,9 @@ public class TopicOperatorTest {
             context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                assertCounterMatches("reconciliations", is(1.0));
+                assertCounterMatches("reconciliations.successful", is(1.0));
+                assertCounterValueIsZero("reconciliations.failed");
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -438,9 +440,9 @@ public class TopicOperatorTest {
             context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                assertCounterMatches("reconciliations", is(1.0));
+                assertCounterValueIsZero("reconciliations.successful");
+                assertCounterValueIsZero("reconciliations.failed");
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
@@ -491,9 +493,9 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterMatches("reconciliations", is(1.0));
+                    assertCounterMatches("reconciliations.successful", is(1.0));
+                    assertCounterValueIsZero("reconciliations.failed");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -609,10 +611,10 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.locked").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterMatches("reconciliations", is(1.0));
+                    assertCounterMatches("reconciliations.successful", is(1.0));
+                    assertCounterValueIsZero("reconciliations.failed");
+                    assertCounterValueIsZero("reconciliations.locked");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -697,9 +699,9 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterMatches("reconciliations", is(1.0));
+                    assertCounterMatches("reconciliations.successful", is(1.0));
+                    assertCounterValueIsZero("reconciliations.failed");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -746,9 +748,9 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterMatches("reconciliations", is(1.0));
+                    assertCounterMatches("reconciliations.successful", is(1.0));
+                    assertCounterValueIsZero("reconciliations.failed");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -798,9 +800,9 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterMatches("reconciliations", is(1.0));
+                    assertCounterMatches("reconciliations.successful", is(1.0));
+                    assertCounterValueIsZero("reconciliations.failed");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -1140,9 +1142,9 @@ public class TopicOperatorTest {
             context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+                assertCounterMatches("reconciliations", is(1.0));
+                assertCounterValueIsZero("reconciliations.successful");
+                assertCounterMatches("reconciliations.failed", is(1.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -1174,19 +1176,18 @@ public class TopicOperatorTest {
             .compose(v -> topicOperator.reconcileAllTopics("periodic"))
             .onComplete(context.succeeding(e -> context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
-
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
+                assertCounterMatches("reconciliations", is(1.0));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resources.paused").tag("kind", "KafkaTopic").gauge().value(), is(0.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                assertCounterMatches("reconciliations.successful", is(1.0));
+                assertCounterValueIsZero("reconciliations.failed");
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                         .tag("kind", "KafkaTopic")
-                        .tag("name", topicName.toString())
-                        .tag("resource-namespace", "default-namespace")
+                                .tag("name", topicName.toString())
+                                .tag("resource-namespace", "default-namespace")
                         .gauge().value(), is(1.0));
 
                 context.completeNow();
@@ -1204,10 +1205,10 @@ public class TopicOperatorTest {
                 context.verify(() -> {
                     MeterRegistry registry = metrics.meterRegistry();
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resources.paused").tag("kind", "KafkaTopic").gauge().value(), is(0.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(1.0));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                    assertCounterMatches("reconciliations", is(1.0));
+                    assertCounterMatches("resources.paused", is(0.0));
+                    assertCounterMatches("reconciliations.successful", is(1.0));
+                    assertCounterValueIsZero("reconciliations.failed");
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -1225,10 +1226,10 @@ public class TopicOperatorTest {
             .onComplete(context.succeeding(f -> context.verify(() -> {
                 MeterRegistry registry = metrics.meterRegistry();
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(2.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resources.paused").tag("kind", "KafkaTopic").gauge().value(), is(1.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(2.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                assertCounterMatches("reconciliations", is(2.0));
+                assertCounterMatches("resources.paused", is(1.0));
+                assertCounterMatches("reconciliations.successful", is(2.0));
+                assertCounterValueIsZero("reconciliations.failed");
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(2L));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
@@ -1253,9 +1254,9 @@ public class TopicOperatorTest {
                 MeterRegistry registry = metrics.meterRegistry();
                 // The reconciliation metrics are only incremented for topics that are in the reconcileState at the end of reconciliation.
                 // Since the topic has been deleted we expect the metric to show reconciliations as 0.
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.successful").tag("kind", "KafkaTopic").counter().count(), is(0.0));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.failed").tag("kind", "KafkaTopic").counter().count(), is(0.0));
+                assertCounterValueIsZero("reconciliations");
+                assertCounterValueIsZero("reconciliations.successful");
+                assertCounterValueIsZero("reconciliations.failed");
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
@@ -1277,6 +1278,17 @@ public class TopicOperatorTest {
         });
 
         return metrics;
+    }
+
+    private void assertCounterValueIsZero(String counterName) {
+        final Matcher<Double> valueMatcher = is(0.0);
+        assertCounterMatches(counterName, valueMatcher);
+    }
+
+    private void assertCounterMatches(String counterName, Matcher<Double> valueMatcher) {
+        MeterRegistry registry = metrics.meterRegistry();
+        final RequiredSearch requiredSearch = registry.get(TopicOperator.METRICS_PREFIX + counterName).tag("kind", "KafkaTopic");
+        assertThat(requiredSearch.counter().count(), valueMatcher);
     }
 
     // TODO tests for nasty races (e.g. create on both ends, update on one end and delete on the other)

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -182,9 +182,8 @@ public class TopicOperatorTest {
                                 "resource-namespace", "default-namespace",
                                 "reason", errorMessage),
                             is(0.0));
-            });
-            context.completeNow();
-
+                });
+                context.completeNow();
             }));
     }
 
@@ -489,9 +488,9 @@ public class TopicOperatorTest {
                                 "name", topicName.toString(),
                                 "resource-namespace", "default-namespace"),
                             is(1.0));
-            });
-            async.flag();
-        }));
+                });
+                async.flag();
+            }));
     }
 
     // TODO error getting full topic metadata, and then reconciliation
@@ -1168,7 +1167,7 @@ public class TopicOperatorTest {
             .compose(v -> {
                 context.verify(() -> {
                     assertCounterMatches("reconciliations", is(1.0));
-                    assertCounterMatches("resources.paused", is(0.0));
+                    assertGaugeMatches("resources.paused", Map.of("kind", "KafkaTopic"),  is(0.0));
                     assertCounterMatches("reconciliations.successful", is(1.0));
                     assertCounterValueIsZero("reconciliations.failed");
 
@@ -1179,14 +1178,13 @@ public class TopicOperatorTest {
                             "name", topicName.toString(),
                             "resource-namespace", "default-namespace"),
                             is(1.0));
-});
+                });
                 metadata.getAnnotations().put("strimzi.io/pause-reconciliation", "true");
                 return resourceAdded(context, null, null);
             })
-            .compose(v -> topicOperator.reconcileAllTopics("periodic"))
-            .onComplete(context.succeeding(f -> context.verify(() -> {
+            .compose(v -> topicOperator.reconcileAllTopics("periodic")).onComplete(context.succeeding(f -> context.verify(() -> {
                 assertCounterMatches("reconciliations", is(2.0));
-                assertCounterMatches("resources.paused", is(1.0));
+                assertGaugeMatches("resources.paused", Map.of("kind", "KafkaTopic"), is(1.0));
                 assertCounterMatches("reconciliations.successful", is(2.0));
                 assertCounterValueIsZero("reconciliations.failed");
 
@@ -1194,8 +1192,8 @@ public class TopicOperatorTest {
 
                 assertGaugeMatches("resource.state",
                         Map.of("kind", "KafkaTopic",
-                            "name", topicName.toString(),
-                            "resource-namespace", "default-namespace"),
+                                "name", topicName.toString(),
+                                "resource-namespace", "default-namespace"),
                         is(1.0));
 
                 context.completeNow();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -176,8 +176,7 @@ public class TopicOperatorTest {
                     assertCounterValueIsZero("reconciliations.successful");
                     assertCounterValueIsZero("reconciliations.failed");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
+                    assertTimerMatches(0L, is(0.0));
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                             .tag("kind", "KafkaTopic")
@@ -398,8 +397,7 @@ public class TopicOperatorTest {
                 assertCounterMatches("reconciliations.successful", is(1.0));
                 assertCounterValueIsZero("reconciliations.failed");
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                assertTimerMatches(1L, greaterThan(0.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                         .tag("kind", "KafkaTopic")
@@ -444,8 +442,7 @@ public class TopicOperatorTest {
                 assertCounterValueIsZero("reconciliations.successful");
                 assertCounterValueIsZero("reconciliations.failed");
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
+                assertTimerMatches(0L, is(0.0));
             });
             context.completeNow();
         }));
@@ -497,8 +494,7 @@ public class TopicOperatorTest {
                     assertCounterMatches("reconciliations.successful", is(1.0));
                     assertCounterValueIsZero("reconciliations.failed");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertTimerMatches(1L, greaterThan(0.0));
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                             .tag("kind", "KafkaTopic")
@@ -616,8 +612,7 @@ public class TopicOperatorTest {
                     assertCounterValueIsZero("reconciliations.failed");
                     assertCounterValueIsZero("reconciliations.locked");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertTimerMatches(1L, greaterThan(0.0));
 
                     // No assertions on resource.state metric because that is updated
                     // by executeWithTopicLockHeld which is not on the call path of reconcile()
@@ -703,8 +698,7 @@ public class TopicOperatorTest {
                     assertCounterMatches("reconciliations.successful", is(1.0));
                     assertCounterValueIsZero("reconciliations.failed");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertTimerMatches(1L, greaterThan(0.0));
 
                     // No assertions on resource.state metric because that is updated
                     // by executeWithTopicLockHeld which is not on the call path of reconcile()
@@ -752,8 +746,7 @@ public class TopicOperatorTest {
                     assertCounterMatches("reconciliations.successful", is(1.0));
                     assertCounterValueIsZero("reconciliations.failed");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertTimerMatches(1L, greaterThan(0.0));
 
                     // No assertions on resource.state metric because that is updated
                     // by executeWithTopicLockHeld which is not on the call path of reconcile()
@@ -804,8 +797,7 @@ public class TopicOperatorTest {
                     assertCounterMatches("reconciliations.successful", is(1.0));
                     assertCounterValueIsZero("reconciliations.failed");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertTimerMatches(1L, greaterThan(0.0));
 
                     // No assertions on resource.state metric because that is updated
                     // by executeWithTopicLockHeld which is not on the call path of reconcile()
@@ -1146,8 +1138,7 @@ public class TopicOperatorTest {
                 assertCounterValueIsZero("reconciliations.successful");
                 assertCounterMatches("reconciliations.failed", is(1.0));
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                assertTimerMatches(1L, greaterThan(0.0));
             });
             context.completeNow();
         }));
@@ -1181,8 +1172,7 @@ public class TopicOperatorTest {
                 assertCounterMatches("reconciliations.successful", is(1.0));
                 assertCounterValueIsZero("reconciliations.failed");
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                assertTimerMatches(1L, greaterThan(0.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                         .tag("kind", "KafkaTopic")
@@ -1210,8 +1200,7 @@ public class TopicOperatorTest {
                     assertCounterMatches("reconciliations.successful", is(1.0));
                     assertCounterValueIsZero("reconciliations.failed");
 
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(1L));
-                    assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                    assertTimerMatches(1L, greaterThan(0.0));
 
                     assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                             .tag("kind", "KafkaTopic")
@@ -1231,8 +1220,7 @@ public class TopicOperatorTest {
                 assertCounterMatches("reconciliations.successful", is(2.0));
                 assertCounterValueIsZero("reconciliations.failed");
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(2L));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), greaterThan(0.0));
+                assertTimerMatches(2L, greaterThan(0.0));
 
                 assertThat(registry.get(TopicOperator.METRICS_PREFIX + "resource.state")
                         .tag("kind", "KafkaTopic")
@@ -1258,8 +1246,7 @@ public class TopicOperatorTest {
                 assertCounterValueIsZero("reconciliations.successful");
                 assertCounterValueIsZero("reconciliations.failed");
 
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(0L));
-                assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), is(0.0));
+                assertTimerMatches(0L, is(0.0));
                 context.completeNow();
             }));
     }
@@ -1289,6 +1276,12 @@ public class TopicOperatorTest {
         MeterRegistry registry = metrics.meterRegistry();
         final RequiredSearch requiredSearch = registry.get(TopicOperator.METRICS_PREFIX + counterName).tag("kind", "KafkaTopic");
         assertThat(requiredSearch.counter().count(), valueMatcher);
+    }
+
+    private void assertTimerMatches(long expectedCount, Matcher<Double> durationMatcher) {
+        MeterRegistry registry = metrics.meterRegistry();
+        assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().count(), is(expectedCount));
+        assertThat(registry.get(TopicOperator.METRICS_PREFIX + "reconciliations.duration").tag("kind", "KafkaTopic").timer().totalTime(TimeUnit.MILLISECONDS), durationMatcher);
     }
 
     // TODO tests for nasty races (e.g. create on both ends, update on one end and delete on the other)


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Reviewing https://github.com/strimzi/strimzi-kafka-operator/pull/7338 I noticed a lot of repeated code about asserting values of various metrics. In each block asserting metrics there is a lot of "noise" around finding the appropriate metrics in the repository and then matching the value. 

So this change pulls out some custom assertion methods so that its easier to see what each assertion is trying to prove about the metrics. 


It might be judicious to wait for #7338 to be merged before merging this change as that ensures all the tests actually pass before refactoring them. However I based the PR on main as there is no direct dependency between them.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

