### PR TITLE
Add OpenTelemetry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Add auto-approval mechanism on KafkaRebalance resource when an optimization proposal is ready
 * The `ControlPlaneListener` feature gate moves to GA
 * Add client rack-awareness support to Strimzi Bridge pods
+* Add support for OpenTelemetry for distributed tracing
+  * Kafka Connect, Mirror Maker, Mirror Maker 2 and Strimzi Bridge can be configured to use OpenTelemetry
+  * Using Jaeger exporter by default for backward compatibility
 
 ### Deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/OpenTelemetryTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/OpenTelemetryTracing.java
@@ -6,14 +6,13 @@ package io.strimzi.api.kafka.model.tracing;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 /**
- * Configures the tracing using the Jaeger OpenTracing implementation
+ * Configures the tracing using the Jaeger OpenTelemetry implementation
  */
 @Buildable(
         editableEnabled = false,
@@ -22,20 +21,18 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type"})
 @EqualsAndHashCode
-@Deprecated
-@DeprecatedType(replacedWithType = void.class)
-public class JaegerTracing extends Tracing {
+public class OpenTelemetryTracing extends Tracing {
     private static final long serialVersionUID = 1L;
 
-    public static final String TYPE_JAEGER = "jaeger";
+    public static final String TYPE_OPENTELEMETRY = "opentelemetry";
 
-    public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentracing.contrib.kafka.TracingConsumerInterceptor";
-    public static final String PRODUCER_INTERCEPTOR_CLASS_NAME = "io.opentracing.contrib.kafka.TracingProducerInterceptor";
+    public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.TracingConsumerInterceptor";
+    public static final String PRODUCER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.TracingProducerInterceptor";
 
-    @Description("Must be `" + TYPE_JAEGER + "`")
+    @Description("Must be `" + TYPE_OPENTELEMETRY + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
-        return TYPE_JAEGER;
+        return TYPE_OPENTELEMETRY;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/tracing/Tracing.java
@@ -23,6 +23,7 @@ import java.util.Map;
         property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = JaegerTracing.TYPE_JAEGER, value = JaegerTracing.class),
+    @JsonSubTypes.Type(name = OpenTelemetryTracing.TYPE_OPENTELEMETRY, value = OpenTelemetryTracing.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
@@ -32,8 +33,8 @@ public abstract class Tracing implements UnknownPropertyPreserving, Serializable
     private Map<String, Object> additionalProperties;
 
     @Description("Type of the tracing used. " +
-            "Currently the only supported type is `jaeger` for Jaeger tracing. " +
-            "The Jaeger tracing is deprecated")
+            "Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. " +
+            "The OpenTracing (Jaeger) tracing is deprecated")
     public abstract String getType();
 
     @Override

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaBridgeCrdIT.java
@@ -81,6 +81,11 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     }
 
     @Test
+    void testKafkaBridgeWithOpenTelemetryTracing() {
+        createDeleteCustomResource("KafkaBridge-with-opentelemetry-tracing.yaml");
+    }
+
+    @Test
     void testLoadKafkaBridgeWithWrongTracingType() {
         Throwable exception = assertThrows(
             RuntimeException.class,
@@ -88,7 +93,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
 
         assertThat(exception.getMessage(), allOf(
                 containsStringIgnoringCase("Could not resolve type id 'wrongtype'"),
-                containsStringIgnoringCase("known type ids = [jaeger]")));
+                containsStringIgnoringCase("known type ids = [jaeger, opentelemetry]")));
     }
 
     @Test
@@ -98,8 +103,8 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
             () -> createDeleteCustomResource("KafkaBridge-with-wrong-tracing-type.yaml"));
 
         assertThat(exception.getMessage(), anyOf(
-                containsStringIgnoringCase("spec.tracing.type in body should be one of [jaeger]"),
-                containsStringIgnoringCase("spec.tracing.type: Unsupported value: \"wrongtype\": supported values: \"jaeger\"")));
+                containsStringIgnoringCase("spec.tracing.type in body should be one of [jaeger, opentelemetry]"),
+                containsStringIgnoringCase("spec.tracing.type: Unsupported value: \"wrongtype\": supported values: \"jaeger\", \"opentelemetry\"")));
     }
 
     @Test

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-opentelemetry-tracing.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaBridge-with-opentelemetry-tracing.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaBridge
+metadata:
+  name: test-kafka-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka:9092
+  tracing:
+    type: opentelemetry

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -25,6 +25,8 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerSpec;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.template.KafkaMirrorMakerTemplate;
+import io.strimzi.api.kafka.model.tracing.JaegerTracing;
+import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.cluster.model.securityprofiles.ContainerSecurityProviderContextImpl;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderContextImpl;
@@ -307,21 +309,31 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         return containers;
     }
 
+    @SuppressWarnings("deprecation")
     private KafkaMirrorMakerConsumerConfiguration getConsumerConfiguration() {
         KafkaMirrorMakerConsumerConfiguration config = new KafkaMirrorMakerConsumerConfiguration(reconciliation, consumer.getConfig().entrySet());
 
         if (tracing != null) {
-            config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
+            if (JaegerTracing.TYPE_JAEGER.equals(tracing.getType())) {
+                config.setConfigOption("interceptor.classes", JaegerTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(tracing.getType())) {
+                config.setConfigOption("interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+            }
         }
 
         return config;
     }
 
+    @SuppressWarnings("deprecation")
     private KafkaMirrorMakerProducerConfiguration getProducerConfiguration()    {
         KafkaMirrorMakerProducerConfiguration config = new KafkaMirrorMakerProducerConfiguration(reconciliation, producer.getConfig().entrySet());
 
         if (tracing != null) {
-            config.setConfigOption("interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+            if (JaegerTracing.TYPE_JAEGER.equals(tracing.getType())) {
+                config.setConfigOption("interceptor.classes", JaegerTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(tracing.getType())) {
+                config.setConfigOption("interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+            }
         }
 
         return config;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Spec;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha256;
 import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.tracing.JaegerTracing;
+import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.ReconciliationLogger;
@@ -363,8 +365,13 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         }
 
         if (mirrorMaker2Cluster.getTracing() != null)   {
-            config.put("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor");
-            config.put("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
+            if (JaegerTracing.TYPE_JAEGER.equals(mirrorMaker2Cluster.getTracing().getType())) {
+                config.put("consumer.interceptor.classes", JaegerTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+                config.put("producer.interceptor.classes", JaegerTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(mirrorMaker2Cluster.getTracing().getType())) {
+                config.put("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+                config.put("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+            }
         }
 
         // setting client.rack here because the consumer is created by the connector

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -60,6 +60,8 @@ import io.strimzi.api.kafka.model.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.api.kafka.model.template.IpFamily;
 import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
+import io.strimzi.api.kafka.model.tracing.JaegerTracing;
+import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
@@ -1375,20 +1377,46 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
-    public void testTracing() {
-        KafkaConnect resource = new KafkaConnectBuilder(this.resource)
-                .editSpec()
-                    .withNewJaegerTracing()
-                    .endJaegerTracing()
-                .endSpec()
-                .build();
+    public void testJaegerTracing() {
+        testTracing(JaegerTracing.TYPE_JAEGER,
+                JaegerTracing.CONSUMER_INTERCEPTOR_CLASS_NAME,
+                JaegerTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+    }
+
+    @ParallelTest
+    public void testOpenTelemetryTracing() {
+        testTracing(OpenTelemetryTracing.TYPE_OPENTELEMETRY,
+                OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME,
+                OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+    }
+
+    public void testTracing(String type, String consumerInterceptor, String producerInterceptor) {
+        KafkaConnectBuilder builder = new KafkaConnectBuilder(this.resource);
+        switch (type) {
+            case JaegerTracing.TYPE_JAEGER:
+                builder.editSpec()
+                            .withNewJaegerTracing()
+                            .endJaegerTracing()
+                        .endSpec();
+                break;
+            case OpenTelemetryTracing.TYPE_OPENTELEMETRY:
+                builder.editSpec()
+                            .withNewOpenTelemetryTracing()
+                            .endOpenTelemetryTracing()
+                        .endSpec();
+                break;
+            default:
+                throw new IllegalArgumentException("The '" + type + "' is not a valid tracing type");
+        }
+        KafkaConnect resource = builder.build();
+
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kc.generateDeployment(Collections.EMPTY_MAP, true, null, null);
         Container cont = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
-        assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_STRIMZI_TRACING.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals("jaeger"), is(true));
-        assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("consumer.interceptor.classes=io.opentracing.contrib.kafka.TracingConsumerInterceptor"), is(true));
-        assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("producer.interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor"), is(true));
+        assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_STRIMZI_TRACING.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals(type), is(true));
+        assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("consumer.interceptor.classes=" + consumerInterceptor), is(true));
+        assertThat(cont.getEnv().stream().filter(env -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("producer.interceptor.classes=" + producerInterceptor), is(true));
     }
 
     @ParallelTest

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.1.x/pom.xml
@@ -29,6 +29,8 @@
         <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
+        <opentelemetry.version>1.18.0</opentelemetry.version>
+        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
     </properties>
 
     <repositories>
@@ -113,6 +115,39 @@
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <version>${opentelemetry.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Aligning with Jackson version 2.12.6 brought by Kafka 3.1.1 and 3.1.2. But Kafka 3.1.0 brings 2.12.3, so we need to exclude jackson-core to avoid conflict -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>2.12.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
@@ -29,6 +29,8 @@
         <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
+        <opentelemetry.version>1.18.0</opentelemetry.version>
+        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
     </properties>
 
     <repositories>
@@ -115,6 +117,21 @@
                     <artifactId>kafka-clients</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -29,6 +29,8 @@
         <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
+        <opentelemetry.version>1.18.0</opentelemetry.version>
+        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
     </properties>
 
     <repositories>
@@ -115,6 +117,33 @@
                     <artifactId>kafka-clients</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <version>${opentelemetry.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Aligning with Jackson version 2.12.6 brought by Kafka 3.2.0 and 3.2.1 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>2.12.6</version>
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -47,10 +47,14 @@ fi
 
 . ./set_kafka_jmx_options.sh "${KAFKA_CONNECT_JMX_ENABLED}" "${KAFKA_CONNECT_JMX_USERNAME}" "${KAFKA_CONNECT_JMX_PASSWORD}"
 
-# enabling Tracing agent (initializes Jaeger tracing) as Java agent
-if [ "$STRIMZI_TRACING" = "jaeger" ]; then
-    KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=jaeger"
+# enabling Tracing agent (initializes tracing) as Java agent
+if [ "$STRIMZI_TRACING" = "jaeger" ] || [ "$STRIMZI_TRACING" = "opentelemetry" ]; then
+    KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=$STRIMZI_TRACING"
     export KAFKA_OPTS
+    if [ "$STRIMZI_TRACING" = "opentelemetry" ] && [ -z "$OTEL_TRACES_EXPORTER" ]; then
+      # auto-set Jaeger exporter
+      export OTEL_TRACES_EXPORTER="jaeger"
+    fi
 fi
 
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
@@ -68,10 +68,14 @@ if [ "$FIPS_MODE" = "disabled" ]; then
     export KAFKA_OPTS="${KAFKA_OPTS} -Dcom.redhat.fips=false"
 fi
 
-# enabling Tracing agent (initializes Jaeger tracing) as Java agent
-if [ "$STRIMZI_TRACING" = "jaeger" ]; then
-  KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=jaeger"
-  export KAFKA_OPTS
+# enabling Tracing agent (initializes tracing) as Java agent
+if [ "$STRIMZI_TRACING" = "jaeger" ] || [ "$STRIMZI_TRACING" = "opentelemetry" ]; then
+    KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/tracing-agent*.jar)=$STRIMZI_TRACING"
+    export KAFKA_OPTS
+    if [ "$STRIMZI_TRACING" = "opentelemetry" ] && [ -z "$OTEL_TRACES_EXPORTER" ]; then
+      # auto-set Jaeger exporter
+      export OTEL_TRACES_EXPORTER="jaeger"
+    fi
 fi
 
 if [ -n "$KAFKA_MIRRORMAKER_INCLUDE" ]; then

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2846,7 +2846,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 |xref:type-Probe-{context}[`Probe`]
 |template             1.2+<.<a|Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
-|tracing           1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
+|tracing              1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1681,8 +1681,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |string
 |rack                   1.2+<.<a|Configuration of the node label which will be used as the `client.rack` consumer configuration.
 |xref:type-Rack-{context}[`Rack`]
-|tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
-|xref:type-JaegerTracing-{context}[`JaegerTracing`]
+|tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
+|xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |template               1.2+<.<a|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
@@ -1882,12 +1882,27 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
 
 
-The `type` property is a discriminator that distinguishes use of the `JaegerTracing` type from other subtypes which may be added in the future.
+The `type` property is a discriminator that distinguishes use of the `JaegerTracing` type from xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`].
 It must have the value `jaeger` for the type `JaegerTracing`.
 [options="header"]
 |====
 |Property     |Description
 |type  1.2+<.<a|Must be `jaeger`.
+|string
+|====
+
+[id='type-OpenTelemetryTracing-{context}']
+### `OpenTelemetryTracing` schema reference
+
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-KafkaMirrorMakerSpec-{context}[`KafkaMirrorMakerSpec`]
+
+
+The `type` property is a discriminator that distinguishes use of the `OpenTelemetryTracing` type from xref:type-JaegerTracing-{context}[`JaegerTracing`].
+It must have the value `opentelemetry` for the type `OpenTelemetryTracing`.
+[options="header"]
+|====
+|Property     |Description
+|type  1.2+<.<a|Must be `opentelemetry`.
 |string
 |====
 
@@ -2654,8 +2669,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMakerSpec.adoc[leveloffset
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |metricsConfig   1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|tracing         1.2+<.<a|The configuration of tracing in Kafka MirrorMaker. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
-|xref:type-JaegerTracing-{context}[`JaegerTracing`]
+|tracing         1.2+<.<a|The configuration of tracing in Kafka MirrorMaker. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
+|xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |template        1.2+<.<a|Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated.
 |xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
 |livenessProbe   1.2+<.<a|Pod liveness checking.
@@ -2831,8 +2846,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 |xref:type-Probe-{context}[`Probe`]
 |template             1.2+<.<a|Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
 |xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`]
-|tracing              1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
-|xref:type-JaegerTracing-{context}[`JaegerTracing`]
+|tracing           1.2+<.<a|The configuration of tracing in Kafka Bridge. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
+|xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |====
 
 [id='type-KafkaBridgeHttpConfig-{context}']
@@ -3076,8 +3091,8 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |string
 |rack                   1.2+<.<a|Configuration of the node label which will be used as the `client.rack` consumer configuration.
 |xref:type-Rack-{context}[`Rack`]
-|tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger].
-|xref:type-JaegerTracing-{context}[`JaegerTracing`]
+|tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
+|xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |template               1.2+<.<a|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -364,7 +364,8 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                        - opentelemetry
+                      description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka Connect.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -512,7 +512,8 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                        - opentelemetry
+                      description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka MirrorMaker.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1088,7 +1088,8 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                        - opentelemetry
+                      description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka Bridge.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -458,7 +458,8 @@ spec:
                       type: string
                       enum:
                         - jaeger
-                      description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                        - opentelemetry
+                      description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                   required:
                     - type
                   description: The configuration of tracing in Kafka Connect.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -363,7 +363,8 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka Connect.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -511,7 +511,8 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka MirrorMaker.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1087,7 +1087,8 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka Bridge.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -457,7 +457,8 @@ spec:
                     type: string
                     enum:
                     - jaeger
-                    description: Type of the tracing used. Currently the only supported type is `jaeger` for Jaeger tracing. The Jaeger tracing is deprecated.
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
                 required:
                 - type
                 description: The configuration of tracing in Kafka Connect.

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <jaeger.version>1.8.1</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
+        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
         <netty.version>4.1.77.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>
@@ -674,6 +675,11 @@
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-util</artifactId>
                 <version>${opentracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+                <version>${opentelemetry.alpha-version}</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>

--- a/tracing-agent/pom.xml
+++ b/tracing-agent/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/JaegerTracing.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/JaegerTracing.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.tracing.agent;
+
+import io.jaegertracing.Configuration;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Distributed tracing initialization based on Jaeger/OpenTracing
+ */
+public class JaegerTracing implements Tracing {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaegerTracing.class);
+
+    @Override
+    public void initialize() {
+        String serviceName = System.getenv("JAEGER_SERVICE_NAME");
+        if (serviceName != null) {
+            LOGGER.info("Initializing Jaeger tracing with service name {}", serviceName);
+            Tracer tracer = Configuration.fromEnv().getTracer();
+            GlobalTracer.registerIfAbsent(tracer);
+        } else {
+            LOGGER.error("Jaeger tracing cannot be initialized because JAEGER_SERVICE_NAME environment variable is not defined");
+        }
+    }
+}

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.tracing.agent;
+
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Distributed tracing initialization based on OpenTelemetry
+ */
+public class OpenTelemetryTracing implements Tracing {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenTelemetryTracing.class);
+
+    @Override
+    public void initialize() {
+        String serviceName = System.getenv("OTEL_SERVICE_NAME");
+        if (serviceName != null) {
+            LOGGER.info("Initializing OpenTelemetry tracing with service name {}", serviceName);
+            System.setProperty("otel.metrics.exporter", "none"); // disable metrics
+            AutoConfiguredOpenTelemetrySdk.initialize();
+        } else {
+            LOGGER.error("OpenTelemetry tracing cannot be initialized because OTEL_SERVICE_NAME environment variable is not defined");
+        }
+    }
+}

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/Tracing.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/Tracing.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.tracing.agent;
+
+/**
+ * Define an interface for initializing a distributed tracing system
+ */
+public interface Tracing {
+
+    /**
+     * Specific distributed tracing system initialization
+     */
+    void initialize();
+
+    /**
+     * Implementation for having no distributed tracing
+     */
+    class NoTracing implements Tracing {
+
+        @Override
+        public void initialize() {
+            // no distributed tracing enabled
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR fixes #7021 adding the support for OpenTelemetry in the operator by enabling it on Kafka Connect, MM and MM2.
Documentation will be addressed in a different PR.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
