### PR TITLE
Set the OwnerReference in Pods managed by StrimziPodSets as controllers

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -675,19 +675,19 @@ public class ModelUtils {
      * Creates the OwnerReference based on the resource passed as parameter
      *
      * @param owner         The resource which should be the owner
-     * @param controller    Indicates whether the owner acts also as the controller. This value is used in the
+     * @param isController  Indicates whether the owner acts also as the controller. This value is used in the
      *                      controller flag which is part of the OwnerReference object.
      *
      * @return          The new OwnerReference
      */
-    public static OwnerReference createOwnerReference(HasMetadata owner, boolean controller)   {
+    public static OwnerReference createOwnerReference(HasMetadata owner, boolean isController)   {
         return new OwnerReferenceBuilder()
                 .withApiVersion(owner.getApiVersion())
                 .withKind(owner.getKind())
                 .withName(owner.getMetadata().getName())
                 .withUid(owner.getMetadata().getUid())
                 .withBlockOwnerDeletion(false)
-                .withController(controller)
+                .withController(isController)
                 .build();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -674,18 +674,20 @@ public class ModelUtils {
     /**
      * Creates the OwnerReference based on the resource passed as parameter
      *
-     * @param owner     The resource which should be the owner
+     * @param owner         The resource which should be the owner
+     * @param controller    Indicates whether the owner acts also as the controller. This value is used in the
+     *                      controller flag which is part of the OwnerReference object.
      *
      * @return          The new OwnerReference
      */
-    public static OwnerReference createOwnerReference(HasMetadata owner)   {
+    public static OwnerReference createOwnerReference(HasMetadata owner, boolean controller)   {
         return new OwnerReferenceBuilder()
                 .withApiVersion(owner.getApiVersion())
                 .withKind(owner.getKind())
                 .withName(owner.getMetadata().getName())
                 .withUid(owner.getMetadata().getUid())
                 .withBlockOwnerDeletion(false)
-                .withController(false)
+                .withController(controller)
                 .build();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -717,7 +717,7 @@ public class KafkaRebalanceAssemblyOperator
                     .withNamespace(kafkaRebalance.getMetadata().getNamespace())
                     .withName(kafkaRebalance.getMetadata().getName())
                     .withLabels(Collections.singletonMap("app", "strimzi"))
-                    .withOwnerReferences(ModelUtils.createOwnerReference(kafkaRebalance))
+                    .withOwnerReferences(ModelUtils.createOwnerReference(kafkaRebalance, false))
                 .endMetadata()
                 .withData(Collections.singletonMap(BROKER_LOAD_KEY, beforeAndAfterBrokerLoad.encode()))
                 .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -309,7 +309,7 @@ public class StrimziPodSetController implements Runnable {
                         Pod pod = PodSetUtils.mapToPod(desiredPod);
                         desiredPods.add(pod.getMetadata().getName());
 
-                        maybeCreateOrPatchPod(reconciliation, pod, ModelUtils.createOwnerReference(podSet), podCounter);
+                        maybeCreateOrPatchPod(reconciliation, pod, ModelUtils.createOwnerReference(podSet, true), podCounter);
                     }
 
                     // Check if any pods needs to be deleted

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -29,6 +29,8 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
@@ -569,7 +571,7 @@ public class ModelUtilsTest {
                 .endMetadata()
                 .build();
 
-        OwnerReference ref = ModelUtils.createOwnerReference(owner);
+        OwnerReference ref = ModelUtils.createOwnerReference(owner, false);
 
         assertThat(ref.getApiVersion(), is(owner.getApiVersion()));
         assertThat(ref.getKind(), is(owner.getKind()));
@@ -577,6 +579,25 @@ public class ModelUtilsTest {
         assertThat(ref.getUid(), is(owner.getMetadata().getUid()));
         assertThat(ref.getBlockOwnerDeletion(), is(false));
         assertThat(ref.getController(), is(false));
+    }
+
+    @ParallelTest
+    public void testCreateControllerOwnerReference()   {
+        StrimziPodSet owner = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-cluster-kafka")
+                    .withUid("some-uid")
+                .endMetadata()
+                .build();
+
+        OwnerReference ref = ModelUtils.createOwnerReference(owner, true);
+
+        assertThat(ref.getApiVersion(), is(owner.getApiVersion()));
+        assertThat(ref.getKind(), is(owner.getKind()));
+        assertThat(ref.getName(), is(owner.getMetadata().getName()));
+        assertThat(ref.getUid(), is(owner.getMetadata().getUid()));
+        assertThat(ref.getBlockOwnerDeletion(), is(false));
+        assertThat(ref.getController(), is(true));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The StrimziPodSet controller currently sets the StrimziPodSet as the owner of the Pod resources. But it does not configure itself as controller there. The issue with that is that `kubectl drain` does not like it when draining the nodes:

```
kubectl drain ip-10-0-142-210.ec2.internal --delete-emptydir-data --ignore-daemonsets --timeout=6000s
node/ip-10-0-142-210.ec2.internal cordoned
error: unable to drain node "ip-10-0-142-210.ec2.internal" due to error:cannot delete Pods declare no controller (use --force to override): myproject/my-cluster-kafka-0, myproject/my-cluster-zookeeper-2, continuing command...
There are pending nodes to be drained:
 ip-10-0-142-210.ec2.internal
cannot delete Pods declare no controller (use --force to override): myproject/my-cluster-kafka-0, myproject/my-cluster-zookeeper-2
```

This is not a major issue -> it can be overridden by adding the `--force` flag. But it should not be needed, since the pods have controller. This PR changes the owner reference used for the Pods managed by the StrimziPodSets to mark itself as controller. That allows the node draining even without the `--force` flag. That should make it easier to drain nodes through various autoscalers which might not use the `--force` flag or for the Strimzi Pods to coexist with other applications using bare pods (so that the `--force` flag needed for Strimzi does not have to kick out other pods where it might not be desired).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally