### PR TITLE
docs(security context): Adding a pod security label

### DIFF
--- a/documentation/assemblies/configuring/assembly-security-providers.adoc
+++ b/documentation/assemblies/configuring/assembly-security-providers.adoc
@@ -13,7 +13,7 @@ For example, permissions can control runtime operations or access to resources.
 ifdef::Section[]
 //how security context and security providers work
 include::../../modules/configuring/con-config-security-providers.adoc[leveloffset=+1]
-//implementing your own provider
+//enabling the provider
 include::../../modules/configuring/proc-config-restricted-security-provider.adoc[leveloffset=+1]
 //implementing your own provider
 include::../../modules/configuring/con-config-custom-security-providers.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-config-custom-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-custom-security-providers.adoc
@@ -11,12 +11,11 @@ If Strimzi's Baseline Provider and Restricted Provider don't quite match your ne
 Implement a custom pod security provider to apply your own security context profile.
 You can decide what applications and privileges to include in the profile.
 
-Your custom pod security provider can implement the `PodSecurityProvider.java` interface that gets the security context for pods and containers. 
-Or it can extend the Baseline Provider or Restricted Provider classes. 
+Your custom pod security provider can implement the `PodSecurityProvider.java` interface that gets the security context for pods and containers; or it can extend the Baseline Provider or Restricted Provider classes. 
 
 The pod security provider plugins use the Java Service Provider Interface, so your custom pod security provider also requires a provider configuration file for service discovery. 
 
-To implement your own provider, the general steps are as follows:
+To implement your own provider, the general steps include the following:
 
 . Build the JAR file for the provider.
 . Add the JAR file to the Cluster Operator image.

--- a/documentation/modules/configuring/con-config-platform-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-platform-security-providers.adoc
@@ -13,6 +13,6 @@ SCCs are the settings and strategies that control the security features a pod ha
 
 By default, OpenShift injects security context configuration automatically.
 In most cases, this means you don't need to configure security context for the pods and containers created by the Cluster Operator.  
-Although it is possible to create and manage your own SCCs.
+Although you can still create and manage your own SCCs.
 
 For more information, see the {OpenShiftDocs}. 

--- a/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
+++ b/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
@@ -15,7 +15,7 @@ To make the required changes, configure the `060-Deployment-strimzi-cluster-oper
 By enabling a new pod security provider, any pods or containers created by the Cluster Operator are subject to the limitations it imposes.
 Pods and containers that are already running are restarted for the changes to take affect.
 
-.Prerequsites
+.Prerequisites
 
 * You need an account with permission to create and manage `CustomResourceDefinition` and RBAC (`ClusterRole`, and `RoleBinding`) resources.
 

--- a/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
+++ b/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
@@ -60,3 +60,16 @@ template:
 ----
 +
 If you apply specific security context for a component using `template` configuration, it takes priority over the general configuration provided by the pod security provider.
+
+. (Optional) Add a `pod-security` label to ensure that all pods created in a namespace must have a `restricted` security context.     
++
+Add the label to the namespace watched by the Cluster Operator.
++
+[source,yaml]
+.Adding a pod security label to a namespace
+----
+kubectl label --overwrite ns myproject \
+  pod-security.kubernetes.io/enforce=restricted
+----
++
+The label serves as a check, prohibiting the creation of pods in the namespace without a restricted security profile. 

--- a/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
+++ b/documentation/modules/configuring/proc-config-restricted-security-provider.adoc
@@ -60,16 +60,3 @@ template:
 ----
 +
 If you apply specific security context for a component using `template` configuration, it takes priority over the general configuration provided by the pod security provider.
-
-. (Optional) Add a `pod-security` label to ensure that all pods created in a namespace must have a `restricted` security context.     
-+
-Add the label to the namespace watched by the Cluster Operator.
-+
-[source,yaml]
-.Adding a pod security label to a namespace
-----
-kubectl label --overwrite ns myproject \
-  pod-security.kubernetes.io/enforce=restricted
-----
-+
-The label serves as a check, prohibiting the creation of pods in the namespace without a restricted security profile. 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Adds an optional step to add the `pod-security` label to a namespace as an added check when using the `restricted` security context.
Plus some minor edits from peer review

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

