### PR TITLE
docs(tracing): Moves the tracing content

### DIFF
--- a/documentation/assemblies/metrics/assembly-metrics.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics.adoc
@@ -3,7 +3,7 @@
 // deploying/deploying.adoc
 
 [id='assembly-metrics-{context}']
-= Introducing metrics to Kafka
+= Introducing metrics
 
 [role="_abstract"]
 You can use Prometheus and Grafana to monitor your Strimzi deployment.

--- a/documentation/assemblies/tracing/assembly-distributed-tracing.adoc
+++ b/documentation/assemblies/tracing/assembly-distributed-tracing.adoc
@@ -3,7 +3,7 @@
 // configuring/configuring.adoc
 
 [id='assembly-distributed-tracing-{context}']
-= Distributed tracing
+= Introducing distributed tracing
 
 Distributed tracing allows you to track the progress of transactions between applications in a distributed system. In a microservices architecture, tracing tracks the progress of transactions between services. Trace data is useful for monitoring application performance and investigating issues with target systems and end-user applications.
 

--- a/documentation/assemblies/tracing/assembly-setting-up-tracing-mirror-maker-connect-bridge.adoc
+++ b/documentation/assemblies/tracing/assembly-setting-up-tracing-mirror-maker-connect-bridge.adoc
@@ -12,7 +12,7 @@ For MirrorMaker and MirrorMaker 2.0, messages are traced from the source cluster
 
 .Tracing in Kafka Connect
 
-Only messages produced and consumed by Kafka Connect itself are traced. To trace messages sent between Kafka Connect and external systems, you must configure tracing in the connectors for those systems. For more information, see xref:proc-kafka-connect-config-{context}[].
+Only messages produced and consumed by Kafka Connect itself are traced. To trace messages sent between Kafka Connect and external systems, you must configure tracing in the connectors for those systems.
 
 .Tracing in the Kafka Bridge
 

--- a/documentation/configuring/configuring.adoc
+++ b/documentation/configuring/configuring.adoc
@@ -24,8 +24,6 @@ include::assemblies/operators/assembly-operators.adoc[leveloffset=+1]
 
 include::assemblies/cruise-control/assembly-cruise-control-concepts.adoc[leveloffset=+1]
 
-include::assemblies/tracing/assembly-distributed-tracing.adoc[leveloffset=+1]
-
 include::assemblies/security/assembly-security.adoc[leveloffset=+1]
 
 include::assemblies/managing/assembly-management-tasks.adoc[leveloffset=+1]

--- a/documentation/deploying/deploying.adoc
+++ b/documentation/deploying/deploying.adoc
@@ -24,6 +24,8 @@ include::modules/deploying/proc-deploy-cluster-operator-helm-chart.adoc[leveloff
 include::assemblies/deploying/assembly-deploy-verify.adoc[leveloffset=+1]
 //Introduce metrics and monitoring to your deployment
 include::assemblies/metrics/assembly-metrics.adoc[leveloffset=+1]
+//Introduce tracing to your deployment
+include::assemblies/tracing/assembly-distributed-tracing.adoc[leveloffset=+1]
 //Upgrading the deployment
 include::assemblies/upgrading/assembly-upgrade.adoc[leveloffset=+1]
 //Downgrading the deployment

--- a/documentation/modules/configuring/proc-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-bridge.adoc
@@ -122,7 +122,7 @@ By default, the Kafka Bridge connects to Kafka brokers without authentication.
 <12> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <13> Optional: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
 <14> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<15> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<15> Environment variables are set for distributed tracing.
 
 . Create or update the resource:
 +
@@ -133,3 +133,4 @@ kubectl apply -f _KAFKA-BRIDGE-CONFIG-FILE_
 .Additional resources
 
 * link:{BookURLBridge}[Using the Strimzi Kafka Bridge^]
+* link:{BookURLDeploying}#assembly-distributed-tracing-str[Introducing distributed tracing^]

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -181,7 +181,7 @@ You can also use _configuration provider plugins_ to xref:assembly-loading-confi
 <17> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
 <18> SPECIALIZED OPTION: xref:type-Rack-reference[Rack awareness] configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
 <19> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<20> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
+<20> Environment variables are set for distributed tracing.
 
 . Create or update the resource:
 +
@@ -189,3 +189,8 @@ You can also use _configuration provider plugins_ to xref:assembly-loading-confi
 kubectl apply -f _KAFKA-CONNECT-CONFIG-FILE_
 
 . If authorization is enabled for Kafka Connect, xref:proc-configuring-kafka-connect-user-authorization-{context}[configure Kafka Connect users to enable access to the Kafka Connect consumer group and topics].
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:{BookURLDeploying}#assembly-distributed-tracing-str[Introducing distributed tracing^]

--- a/documentation/modules/configuring/proc-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker.adoc
@@ -146,8 +146,8 @@ spec:
 <19> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
 <20> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
 <21> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<22> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<23> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<22> Environment variables are set for distributed tracing.
+<23> Distributed tracing is enabled for Jaeger.
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.
 
@@ -155,3 +155,8 @@ WARNING: With the `abortOnSendFailure` property set to `false`, the producer att
 +
 [source,shell,subs=+quotes]
 kubectl apply -f _<your-file>_
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:{BookURLDeploying}#assembly-distributed-tracing-str[Introducing distributed tracing^]

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -242,8 +242,8 @@ To configure topic offset synchronization, this property must also be set for th
 <41> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
 <42> SPECIALIZED OPTION: xref:type-Rack-reference[Rack awareness] configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
 <43> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<44> Environment variables are also xref:ref-tracing-environment-variables-str[set for distributed tracing using Jaeger].
-<45> xref:assembly-distributed-tracing-str[Distributed tracing is enabled for Jaeger].
+<44> Environment variables are set for distributed tracing.
+<45> Distributed tracing is enabled for Jaeger.
 <46> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 You can also use _configuration provider plugins_ to xref:assembly-loading-config-with-providers-str[load configuration values from external sources].
 
@@ -251,3 +251,8 @@ You can also use _configuration provider plugins_ to xref:assembly-loading-confi
 +
 [source,shell,subs=+quotes]
 kubectl apply -f _MIRRORMAKER-CONFIGURATION-FILE_
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:{BookURLDeploying}#assembly-distributed-tracing-str[Introducing distributed tracing^]

--- a/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
+++ b/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
@@ -121,9 +121,3 @@ spec:
 ----
 kubectl apply -f your-file
 ----
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:type-ContainerTemplate-reference[]
-* xref:assembly-customizing-kubernetes-resources-{context}[]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Moves _distributed tracing_ content so that it is in the deploying guide with the metrics content.
So you can deploy and then introduce metrics and/or distributed tracing.

This PR does not change the content for the open telemetry changes
The updates to the content will be made in a separate PR

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

