### PR TITLE
Make sure assigned IngressClass name is kept when patching Ingress resources

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
@@ -33,6 +33,52 @@ public class IngressOperator extends AbstractResourceOperator<KubernetesClient, 
     }
 
     /**
+     * Patches the resource with the given namespace and name to match the given desired resource
+     * and completes the given future accordingly.
+     *
+     * IngressOperator needs its own version of this method to patch the Ingress Class name when the default class is
+     * used. When the default IngressClass is used, the class name in the Kafka CR should not be set at all and the
+     * Ingress resources will be created without it. The default Kubernetes Nginx Ingress will then pick up the Ingress
+     * resource and inject the class name into it. So when patching the Ingress resource, we need to set the IngressClass
+     * name in the desired object to match the current. This needs to be done in order to:
+     *     - Avoid unnecessary patching
+     *     - Because if you change the class, the Kubernetes Nginx Ingress controller will not pick it up again, and it
+     *       will stop working
+     *
+     * This is done only when the IngressClass set in Kafka CR is null. If it is set to some specific class, it will be
+     * of course kept.
+     *
+     * @param reconciliation    The reconciliation
+     * @param namespace         Namespace of the Ingress resource
+     * @param name              Name of the Ingress resource
+     * @param current           Current Ingress resource
+     * @param desired           Desired Ingress resource
+     *
+     * @return  Future with reconciliation result
+     */
+    @Override
+    protected Future<ReconcileResult<Ingress>> internalPatch(Reconciliation reconciliation, String namespace, String name, Ingress current, Ingress desired) {
+        patchIngressClassName(current, desired);
+
+        return super.internalPatch(reconciliation, namespace, name, current, desired);
+    }
+
+    /**
+     * Patches the IngressClass name from the current to the desired Ingress resource. The patching is only done if the
+     * desired IngressClass name is not set.
+     *
+     * @param current           Current Ingress resource
+     * @param desired           Desired Ingress resource
+     */
+    /* test */ void patchIngressClassName(Ingress current, Ingress desired) {
+        if (desired.getSpec() != null
+                && current.getSpec() != null
+                && desired.getSpec().getIngressClassName() == null)   {
+            desired.getSpec().setIngressClassName(current.getSpec().getIngressClassName());
+        }
+    }
+
+    /**
      * Succeeds when the Service has an assigned address
      *
      * @param reconciliation The reconciliation


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the default IngressClass is used by Ingress type listeners, Kubernetes Nginx Ingress will pick up the newly created Ingress resources and modify them to inject the class name. That seems to work fine => it assigns the address and the Ingress works fine. But only for few minutes. Because the next reconciliation patches the Ingress resource a reverts the assigned IngressClass name which cause the Nginx Ingress Controller to stop handling the traffic and it all stops working

This PR updates how we patch the Ingress resources. When the IngressClass is not set in Kafka CR, but was injected into the resource in Kubernetes cluster, we will pick the class name and use it in our resource as well. That way, the IngressClass name is not removed and will be set. And thanks to that, the Ingress will keep handling it. This should also minimize the amount of unnecessary patch calls.

This should close #7362 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging