### PR TITLE
Split the cluster roles to allow cluster-wide operators with only limited access to some namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@
 * The `ControlPlaneListener` feature gate moves to GA
 * Add client rack-awareness support to Strimzi Bridge pods
 
-### Deprecations and removals
+### Changes, deprecations and removals
 
 * A connector or task failing triggers a 'NotReady' condition to be added to the KafkaConnector CR status. This is different from previous versions where the CR would report 'Ready' even if the connector or a task had failed.
+* The `ClusterRole` from file `020-ClusterRole-strimzi-cluster-operator-role.yaml` was split into two separate roles:
+  * The original `strimzi-cluster-operator-namespaced` `ClusterRole` in the file `020-ClusterRole-strimzi-cluster-operator-role.yaml` contains the rights related to the resources created based on some Strimzi custom resources.
+  * The new `strimzi-cluster-operator-watched` `ClusterRole` in the file `023-ClusterRole-strimzi-cluster-operator-role.yaml` contains the rights required to watch and manage the Strimzi custom resources.
+  
+  When deploying the Strimzi Cluster Operator as cluster-wide, the `strimzi-cluster-operator-watched` `ClusterRole` needs to be always granted at the cluster level.
+  But the `strimzi-cluster-operator-namespaced` `ClusterRole` might be granted only for the namespaces where any custom resources are created.
 * The `ControlPlaneListener` feature gate moves to GA. 
   Direct upgrade from Strimzi 0.22 or earlier is not possible anymore.
   You have to upgrade first to one of the Strimzi versions between 0.22 and 0.32 before upgrading to Strimzi 0.32 or newer.

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app: strimzi
 rules:
+  # Resources in this role are used by the operator based on an operand being deployed in some namespace. When needed, you
+  # can deploy the operator as a cluster-wide operator. But grant the rights listed in this role only on the namespaces
+  # where the operands will be deployed. That way, you can limit the access the operator has to other namespaces where it
+  # does not manage any clusters.
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
@@ -47,52 +51,6 @@ rules:
       - secrets
       # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
       - persistentvolumeclaims
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "kafka.strimzi.io"
-    resources:
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
-      - kafkas
-      - kafkas/status
-      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
-      - kafkaconnects
-      - kafkaconnects/status
-      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
-      - kafkaconnectors
-      - kafkaconnectors/status
-      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
-      - kafkamirrormakers
-      - kafkamirrormakers/status
-      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
-      - kafkabridges
-      - kafkabridges/status
-      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
-      - kafkamirrormaker2s
-      - kafkamirrormaker2s/status
-      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
-      - kafkarebalances
-      - kafkarebalances/status
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "core.strimzi.io"
-    resources:
-      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-      - strimzipodsets
-      - strimzipodsets/status
     verbs:
       - get
       - list

--- a/cluster-operator/src/main/resources/cluster-roles/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,65 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-watched
+  labels:
+    app: strimzi
+rules:
+  # Resources in this role are being watched by the operator. When operator is deployed as cluster-wide, these permissions
+  # need to be granted to the operator on a cluster wide level as well, even if the operands will be deployed only in
+  # few of the namespaces in given cluster. This is required to set up the Kubernetes watches and informers.
+  # Note: The rights included in this role might change in the future
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+      - pods
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      - kafkas
+      - kafkas/status
+      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+      - kafkaconnects
+      - kafkaconnects/status
+      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+      - kafkaconnectors
+      - kafkaconnectors/status
+      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+      - kafkamirrormakers
+      - kafkamirrormakers/status
+      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+      - kafkabridges
+      - kafkabridges/status
+      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+      - kafkamirrormaker2s
+      - kafkamirrormaker2s/status
+      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+      - kafkarebalances
+      - kafkarebalances/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+      - strimzipodsets
+      - strimzipodsets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-multiple-namespaces.adoc
@@ -50,6 +50,7 @@ repeating them for `watched-namespace-1`, `watched-namespace-2`, `watched-namesp
 +
 [source,shell,subs="+quotes,attributes+"]
 kubectl create -f install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml -n _<watched_namespace>_
+kubectl create -f install/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml -n _<watched_namespace>_
 kubectl create -f install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n _<watched_namespace>_
 
 . Deploy the Cluster Operator:

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-watch-whole-cluster.adoc
@@ -48,6 +48,7 @@ spec:
 +
 [source,shell,subs="+quotes,attributes+"]
 kubectl create clusterrolebinding strimzi-cluster-operator-namespaced --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount my-cluster-operator-namespace:strimzi-cluster-operator
+kubectl create clusterrolebinding strimzi-cluster-operator-watched --clusterrole=strimzi-cluster-operator-watched --serviceaccount my-cluster-operator-namespace:strimzi-cluster-operator
 kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation --clusterrole=strimzi-entity-operator --serviceaccount my-cluster-operator-namespace:strimzi-cluster-operator
 
 . Deploy the Cluster Operator to your Kubernetes cluster.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -10,6 +10,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+# Resources in this role are used by the operator based on an operand being deployed in some namespace. When needed, you
+# can deploy the operator as a cluster-wide operator. But grant the rights listed in this role only on the namespaces
+# where the operands will be deployed. That way, you can limit the access the operator has to other namespaces where it
+# does not manage any clusters.
 - apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
@@ -52,52 +56,6 @@ rules:
   - secrets
     # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
   - persistentvolumeclaims
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "kafka.strimzi.io"
-  resources:
-    # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
-  - kafkas
-  - kafkas/status
-    # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
-  - kafkaconnects
-  - kafkaconnects/status
-    # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
-  - kafkaconnectors
-  - kafkaconnectors/status
-    # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
-  - kafkamirrormakers
-  - kafkamirrormakers/status
-    # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
-  - kafkabridges
-  - kafkabridges/status
-    # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
-  - kafkamirrormaker2s
-  - kafkamirrormaker2s/status
-    # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
-  - kafkarebalances
-  - kafkarebalances/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - "core.strimzi.io"
-  resources:
-    # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-  - strimzipodsets
-  - strimzipodsets/status
   verbs:
   - get
   - list

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.createGlobalResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-watched
+  labels:
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: role
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Resources in this role are being watched by the operator. When operator is deployed as cluster-wide, these permissions
+# need to be granted to the operator on a cluster wide level as well, even if the operands will be deployed only in
+# few of the namespaces in given cluster. This is required to set up the Kubernetes watches and informers.
+# Note: The rights included in this role might change in the future
+- apiGroups:
+  - ""
+  resources:
+    # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+  - pods
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+  - kafkas
+  - kafkas/status
+  # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+  - kafkaconnects
+  - kafkaconnects/status
+  # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+  - kafkaconnectors
+  - kafkaconnectors/status
+  # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+  - kafkamirrormakers
+  - kafkamirrormakers/status
+  # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+  - kafkabridges
+  - kafkabridges/status
+  # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+  - kafkamirrormaker2s
+  - kafkamirrormaker2s/status
+  # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+  - kafkarebalances
+  - kafkarebalances/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - "core.strimzi.io"
+  resources:
+  # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+  - strimzipodsets
+  - strimzipodsets/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+{{- end -}}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,0 +1,31 @@
+{{- $root := . -}}
+{{- range append .Values.watchNamespaces .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if $root.Values.watchAnyNamespace }}
+kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
+metadata:
+  {{- if $root.Values.watchAnyNamespace }}
+  name: strimzi-cluster-operator-watched
+  {{- else }}
+  name: strimzi-cluster-operator-watched
+  {{- end }}
+  namespace: {{ . }}
+  labels:
+    app: {{ template "strimzi.name" $root }}
+    chart: {{ template "strimzi.chart" $root }}
+    component: role-binding
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: {{ $root.Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-watched
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app: strimzi
 rules:
+  # Resources in this role are used by the operator based on an operand being deployed in some namespace. When needed, you
+  # can deploy the operator as a cluster-wide operator. But grant the rights listed in this role only on the namespaces
+  # where the operands will be deployed. That way, you can limit the access the operator has to other namespaces where it
+  # does not manage any clusters.
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
@@ -47,52 +51,6 @@ rules:
       - secrets
       # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
       - persistentvolumeclaims
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "kafka.strimzi.io"
-    resources:
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
-      - kafkas
-      - kafkas/status
-      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
-      - kafkaconnects
-      - kafkaconnects/status
-      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
-      - kafkaconnectors
-      - kafkaconnectors/status
-      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
-      - kafkamirrormakers
-      - kafkamirrormakers/status
-      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
-      - kafkabridges
-      - kafkabridges/status
-      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
-      - kafkamirrormaker2s
-      - kafkamirrormaker2s/status
-      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
-      - kafkarebalances
-      - kafkarebalances/status
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "core.strimzi.io"
-    resources:
-      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-      - strimzipodsets
-      - strimzipodsets/status
     verbs:
       - get
       - list

--- a/packaging/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,65 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-watched
+  labels:
+    app: strimzi
+rules:
+  # Resources in this role are being watched by the operator. When operator is deployed as cluster-wide, these permissions
+  # need to be granted to the operator on a cluster wide level as well, even if the operands will be deployed only in
+  # few of the namespaces in given cluster. This is required to set up the Kubernetes watches and informers.
+  # Note: The rights included in this role might change in the future
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+      - pods
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      - kafkas
+      - kafkas/status
+      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+      - kafkaconnects
+      - kafkaconnects/status
+      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+      - kafkaconnectors
+      - kafkaconnectors/status
+      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+      - kafkamirrormakers
+      - kafkamirrormakers/status
+      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+      - kafkabridges
+      - kafkabridges/status
+      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+      - kafkamirrormaker2s
+      - kafkamirrormaker2s/status
+      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+      - kafkarebalances
+      - kafkarebalances/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+      - strimzipodsets
+      - strimzipodsets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update

--- a/packaging/install/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-watched
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-watched
+  apiGroup: rbac.authorization.k8s.io

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -552,6 +552,9 @@ public class SetupClusterOperator {
         // 022-RoleBinding => Leader election RoleBinding (is only in the operator namespace)
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, namespace);
+        // 023-RoleBinding => Leader election RoleBinding (is only in the operator namespace)
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml");
+        RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
         // 031-RoleBinding => Entity Operator delegation
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
@@ -565,6 +568,9 @@ public class SetupClusterOperator {
         RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
 
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml");
+        RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+
+        roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml");
         RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
 
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml");

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/ClusterRoleBindingTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/ClusterRoleBindingTemplates.java
@@ -65,6 +65,25 @@ public class ClusterRoleBindingTemplates {
                 .build()
         );
 
+        kCRBList.add(
+            new ClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName(coName + "-watched")
+                .endMetadata()
+                .withNewRoleRef()
+                    .withApiGroup("rbac.authorization.k8s.io")
+                    .withKind("ClusterRole")
+                    .withName("strimzi-cluster-operator-watched")
+                .endRoleRef()
+                .withSubjects(new SubjectBuilder()
+                    .withKind("ServiceAccount")
+                    .withName("strimzi-cluster-operator")
+                    .withNamespace(namespace)
+                    .build()
+                )
+                .build()
+        );
+
         return kCRBList;
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, Strimzi can be installed in two different modes:
* **Watching one or more individual namespaces.** In this case, most of the RBAC resources need to be set-up only for the namespaces the operator watches. Only the RBAC rights for the cluster-wide resources such as reading the nodes or storage classes or managing cluster role bindings need to be _cluster-wide_. This works fine in general. But given how the Kubernetes API is designed, the operator here deployes a separate _verticle_ per namespaces with its own watches etc. Due to this, this mode can consume a lot of resources when you want too many namespaces and does not scale well.
* **Watching the whole cluster.** In this mode, the operator is watching the whole cluster and has access to the whole cluster. All RBAC resources are set-up as cluster wide. This mode works well and does not have any scalability issues related to the number of namespaces in the cluster. This is because it uses only a single operator _verticle_ and only one set watches for the whole cluster. However, in this mode, the operator has also access tot he whole cluster and in theory, it can for example read the secrets in all namespaces. This is something users sometimes wnat to avoid for security reasons.

This PR tries to make it easier for users to install the operator as cluster-wide but limit the RBAC rights the operator has. It splits the existing role `strimzi-cluster-operator-namespaced` into too roles:
* The original `strimzi-cluster-operator-namespaced`
* The new `strimzi-cluster-operator-watched`

The original role now covers the RBAC rights which are needed only in the namespaces where some custom resource is created. The new role contains the RBAC rights which are required as cluster wide for the watches and informers and also to do some basic management of the custom resources (get them, update their status etc.).

Thanks to this split, the users can do the following:
* Deploy the CO as cluster-wide
* Bind the new role `strimzi-cluster-operator-watched` as cluster-wide
* Bind the `strimzi-cluster-operator-namespaced` role with role-binding onl for the namespaces, where the user plans to have some operands.

This adds additional complexities for users who want to take this effort. They will be resonsible for managing the RBAC rights and creating the required `RoleBindings` for the `strimzi-cluster-operator-namespaced` role. If the user fails to do it, the operator will run into RBAC errors (which will be reflected in the state of the CR in the namespace with missing RBAC). But at the same time, the operator will have less access rights to completely unrelated namespaces, so it might be more secure.

This option does not replace the regular cluster-wide installation. It will be only an _expert_ option for those who want to use this. There will be no special tolling provided for such installation as it is expected the users using this will deal with this in their own way. The split of the cluster roles just makes it much easier for them to install the operator this way.

This should fix #7378 

### Checklist

- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md