### PR TITLE
Update Scala in operators to 2.13.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <vertx-junit5.version>4.2.4</vertx-junit5.version>
         <kafka.version>3.2.3</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
-        <scala-library.version>2.13.6</scala-library.version>
+        <scala-library.version>2.13.9</scala-library.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <zkclient.version>0.11</zkclient.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Scala version used by the operators to 2.13.9. Strimzi Operators use it only for tests and for building the configuration models, not at runtime. So we should not be really affected by CVE-2022-36944. But this should silence the alerts.

Kafka uses Scala as well. It might not be affected by the CVE because it does nto use the affected functionality. But the Scala version needs to be addressed in Kafka.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally