### PR TITLE
Try to fix flaky `KafkaClusterStatefulSetTest.testDefaultSecurityContext` test

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/securityprofiles/PodSecurityProviderFactory.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/securityprofiles/PodSecurityProviderFactory.java
@@ -25,8 +25,7 @@ public class PodSecurityProviderFactory {
     // The default value is set for Unit Tests which might be run without the factory being initialized
     private static PodSecurityProvider provider;
     static {
-        provider = new BaselinePodSecurityProvider();
-        provider.configure(new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION));
+        initialize();
     }
 
     /**
@@ -62,6 +61,15 @@ public class PodSecurityProviderFactory {
         PodSecurityProviderFactory.provider = findProviderOrThrow(providerClass);
         LOGGER.info("Initializing PodSecurityProvider {}", providerClass);
         PodSecurityProviderFactory.provider.configure(platformFeatures);
+    }
+
+    /**
+     * Initializes the PodSecurityProvider factory with the default values. The default values use the Baseline provider
+     * with minimal supported version of Kubernetes.
+     */
+    public static void initialize() {
+        provider = new BaselinePodSecurityProvider();
+        provider.configure(new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -12,8 +12,9 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderFactory;
+import io.strimzi.platform.KubernetesVersion;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.junit5.VertxExtension;
@@ -22,6 +23,7 @@ import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -72,6 +74,11 @@ public class ClusterOperatorTest {
         }
 
         return env;
+    }
+
+    @AfterAll
+    public static void afterAll()   {
+        PodSecurityProviderFactory.initialize();
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -15,6 +15,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderFactory;
 import io.strimzi.platform.KubernetesVersion;
+import io.strimzi.test.annotations.IsolatedSuite;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.junit5.VertxExtension;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@IsolatedSuite
 @ExtendWith(VertxExtension.class)
 public class ClusterOperatorTest {
     private static final Logger LOGGER = LogManager.getLogger(ClusterOperatorTest.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
@@ -552,7 +552,7 @@ public class KafkaClusterStatefulSetTest {
 
     @ParallelTest
     public void testDefaultSecurityContext() {
-        StatefulSet sts = KC.generateStatefulSet(true, null, null, null);
+        StatefulSet sts = KC.generateStatefulSet(false, null, null, null);
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(0L));
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getSecurityContext(), is(nullValue()));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
@@ -198,8 +198,6 @@ public class KafkaClusterStatefulSetTest {
         checkStatefulSet(sts, KAFKA);
         checkOwnerReference(KC.createOwnerReference(), sts);
 
-        System.out.println(sts.getSpec().getTemplate().getSpec().getVolumes());
-
         // Check Volumes
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().size(), is(6));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -553,6 +551,7 @@ public class KafkaClusterStatefulSetTest {
     @ParallelTest
     public void testDefaultSecurityContext() {
         StatefulSet sts = KC.generateStatefulSet(false, null, null, null);
+        assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext(), is(notNullValue()));
         assertThat(sts.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(0L));
         assertThat(sts.getSpec().getTemplate().getSpec().getContainers().get(0).getSecurityContext(), is(nullValue()));
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR tries to fix the `KafkaClusterStatefulSetTest.testDefaultSecurityContext` test which sometimes seems to be flaky on Azure. My assumption is that sometimes, the `ClusterOperatorTest` tests reconfigure the default Pod Security Provider configuration from Kubernetes to OpenShift. This as a result fails the `KafkaClusterStatefulSetTest.testDefaultSecurityContext`. In this PR, we re-initialize the PodSecurityProvider to the default settings which should hopefully fix this. It also marks the `ClusterOperatorTest` tests as isolated to not run in parallel with other tests.

I did not managed to reproduce the issue from Azure locally. So I'm not really sure if this fixes it or not. That remains to be seen from the future Azure test runs. 🤷‍♂️