### PR TITLE
[systemtest] Enable multiple COs in one namespace in our tests after LeaderElection feature

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest;
 import io.strimzi.test.TestUtils;
 
 import java.time.Duration;
+import java.util.Map;
 
 /**
  * Interface for keep global constants used across system tests.
@@ -400,4 +401,17 @@ public interface Constants {
     String KAFKA_SELECTOR = "KAFKA_SELECTOR";
     String ZOOKEEPER_SELECTOR = "ZOOKEEPER_SELECTOR";
     String ENTITY_OPERATOR_NAME = "ENTITY_OPERATOR_NAME";
+
+    /**
+     * Lease related resources - ClusterRole, Role, RoleBinding
+     */
+    String PATH_TO_LEASE_CLUSTER_ROLE = PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml";
+    // Path after change of ClusterRole -> Role in our SetupClusterOperator class
+    String PATH_TO_LEASE_ROLE = PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-Role-strimzi-cluster-operator-role.yaml";
+    String PATH_TO_LEASE_ROLE_BINDING = PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml";
+    Map<String, String> LEASE_FILES_AND_RESOURCES = Map.of(
+        CLUSTER_ROLE, PATH_TO_LEASE_CLUSTER_ROLE,
+        ROLE, PATH_TO_LEASE_ROLE,
+        ROLE_BINDING, PATH_TO_LEASE_ROLE_BINDING
+    );
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -13,7 +13,10 @@ import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.Constants;
@@ -462,6 +465,63 @@ public class SetupClusterOperator {
         prepareEnvForOperator(extensionContext, clientNamespace, Collections.singletonList(clientNamespace));
     }
 
+    private String changeLeaseNameInResourceIfNeeded(String yamlPath) {
+        final EnvVar leaseEnvVar = extraEnvVars.stream().filter(envVar -> envVar.getName().equals("STRIMZI_LEADER_ELECTION_LEASE_NAME")).findFirst().orElse(null);
+        if (leaseEnvVar != null && yamlPath.contains("022-")) {
+            try {
+                File tmpFile = File.createTempFile(yamlPath.replace(Constants.STRIMZI_DEPLOYMENT_NAME + ".yaml", leaseEnvVar.getValue()), "yaml");
+                String tmpFileContent = "";
+                final String resourceName = leaseEnvVar.getValue() + "-leader-election";
+                final String resourceType = yamlPath.replace(TestUtils.USER_PATH + "/../packaging/install/cluster-operator/", "").split("-")[1];
+
+                switch (resourceType) {
+                    case Constants.ROLE:
+                        RoleBuilder roleBuilder = new RoleBuilder(TestUtils.configFromYaml(yamlPath, Role.class))
+                            .editMetadata()
+                                .withName(resourceName)
+                            .endMetadata()
+                            .editMatchingRule(rule -> rule.getFirstResourceName().equals(Constants.STRIMZI_DEPLOYMENT_NAME))
+                                .withResourceNames(leaseEnvVar.getValue())
+                            .endRule();
+
+                        tmpFileContent = TestUtils.toYamlString(roleBuilder.build());
+                        break;
+                    case Constants.CLUSTER_ROLE:
+                        ClusterRoleBuilder clusterRoleBuilder = new ClusterRoleBuilder(TestUtils.configFromYaml(yamlPath, ClusterRole.class))
+                            .editMetadata()
+                                .withName(resourceName)
+                            .endMetadata()
+                            .editMatchingRule(rule -> rule.getResourceNames().stream().findAny().orElse("").equals(Constants.STRIMZI_DEPLOYMENT_NAME))
+                                .withResourceNames(leaseEnvVar.getValue())
+                            .endRule();
+
+                        tmpFileContent = TestUtils.toYamlString(clusterRoleBuilder.build());
+                        break;
+                    case Constants.ROLE_BINDING:
+                        RoleBindingBuilder roleBindingBuilder = new RoleBindingBuilder(TestUtils.configFromYaml(yamlPath, RoleBinding.class))
+                            .editMetadata()
+                                .withName(resourceName)
+                            .endMetadata()
+                            .editRoleRef()
+                                .withName(resourceName)
+                            .endRoleRef();
+
+                        tmpFileContent = TestUtils.toYamlString(roleBindingBuilder.build());
+                        break;
+                    default:
+                        return yamlPath;
+                }
+
+                TestUtils.writeFile(tmpFile.getAbsolutePath(), tmpFileContent);
+                return tmpFile.getAbsolutePath();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return yamlPath;
+        }
+    }
+
     /**
      * Perform application of ServiceAccount, Roles and CRDs needed for proper cluster operator deployment.
      * Configuration files are loaded from packaging/install/cluster-operator directory.
@@ -493,7 +553,7 @@ public class SetupClusterOperator {
                         .build());
                     break;
                 case Constants.CLUSTER_ROLE:
-                    ClusterRole clusterRole = TestUtils.configFromYaml(createFile, ClusterRole.class);
+                    ClusterRole clusterRole = TestUtils.configFromYaml(changeLeaseNameInResourceIfNeeded(createFile.getAbsolutePath()), ClusterRole.class);
                     ResourceManager.getInstance().createResource(extensionContext, clusterRole);
                     break;
                 case Constants.SERVICE_ACCOUNT:
@@ -558,12 +618,16 @@ public class SetupClusterOperator {
         // 020-RoleBinding => Cluster Operator rights for managing operands
         File roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
+
         // 022-RoleBinding => Leader election RoleBinding (is only in the operator namespace)
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml");
-        RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, namespace);
+        roleFile = switchClusterRolesToRolesIfNeeded(roleFile);
+        RoleBindingResource.roleBinding(extensionContext, changeLeaseNameInResourceIfNeeded(roleFile.getAbsolutePath()), namespace, namespace);
+
         // 023-RoleBinding => Leader election RoleBinding (is only in the operator namespace)
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
+
         // 031-RoleBinding => Entity Operator delegation
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml");
         RoleBindingResource.roleBinding(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace, bindingsNamespace);
@@ -577,7 +641,8 @@ public class SetupClusterOperator {
         RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
 
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml");
-        RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);
+        roleFile = switchClusterRolesToRolesIfNeeded(roleFile);
+        RoleResource.role(extensionContext, changeLeaseNameInResourceIfNeeded(roleFile.getAbsolutePath()), namespace);
 
         roleFile = new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml");
         RoleResource.role(extensionContext, switchClusterRolesToRolesIfNeeded(roleFile).getAbsolutePath(), namespace);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -467,14 +467,15 @@ public class SetupClusterOperator {
 
     private String changeLeaseNameInResourceIfNeeded(String yamlPath) {
         final EnvVar leaseEnvVar = extraEnvVars.stream().filter(envVar -> envVar.getName().equals("STRIMZI_LEADER_ELECTION_LEASE_NAME")).findFirst().orElse(null);
-        if (leaseEnvVar != null && yamlPath.contains("022-")) {
+        Map.Entry<String, String> resourceEntry = Constants.LEASE_FILES_AND_RESOURCES.entrySet().stream().filter(entry -> yamlPath.equals(entry.getValue())).findFirst().orElse(null);
+
+        if (leaseEnvVar != null && resourceEntry != null) {
             try {
                 File tmpFile = File.createTempFile(yamlPath.replace(Constants.STRIMZI_DEPLOYMENT_NAME + ".yaml", leaseEnvVar.getValue()), "yaml");
-                String tmpFileContent = "";
+                String tmpFileContent;
                 final String resourceName = leaseEnvVar.getValue() + "-leader-election";
-                final String resourceType = yamlPath.replace(TestUtils.USER_PATH + "/../packaging/install/cluster-operator/", "").split("-")[1];
 
-                switch (resourceType) {
+                switch (resourceEntry.getKey()) {
                     case Constants.ROLE:
                         RoleBuilder roleBuilder = new RoleBuilder(TestUtils.configFromYaml(yamlPath, Role.class))
                             .editMetadata()


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- "Bugfix"

### Description

After the LeaderElection feature was introduced, one of our tests - `MultipleClusterOperatorsIsolatedST#testKafkaCCAndRebalanceWithMultipleCOs` - had to be changed to run two COs in different namespaces - because of the `ClusterRole`, `Role` and `RoleBinding` which wasn't configured to allow us to edit it with different lease name.

This PR enables these resources to be configurable and changes back `MultipleClusterOperatorsIsolatedST#testKafkaCCAndRebalanceWithMultipleCOs` to run COs in one namespace (which was intention).

### Checklist

- [ ] Make sure all tests pass

