### PR TITLE
Support multiple operations per ACLRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Using Jaeger exporter by default for backward compatibility
 * Updated JMX Exporter dependency to 0.17.2
 * ZookeeperRoller considers unready pods
+* Support multiple operations per ACLRule
 
 ### Changes, deprecations and removals
 
@@ -26,6 +27,8 @@
   Direct upgrade from Strimzi 0.22 or earlier is not possible anymore.
   You have to upgrade first to one of the Strimzi versions between 0.22 and 0.32 before upgrading to Strimzi 0.32 or newer.
   Please follow the docs for more details.  
+* The `spec.authorization.acls[*].operation` field in the `KafkaUser` resource has been deprecated in favour of the field
+  `spec.authorization.acls[*].operations` which allows to set multiple operations per ACLRule.
 
 ## 0.31.1
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
@@ -6,13 +6,16 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.Example;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,16 +36,17 @@ public class AclRule implements UnknownPropertyPreserving, Serializable {
     private AclRuleResource resource;
     private String host = "*";
     private AclOperation operation;
+    private List<AclOperation> operations;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     public AclRule() {
     }
 
-    public AclRule(AclRuleType type, AclRuleResource resource, String host, AclOperation operation) {
+    public AclRule(AclRuleType type, AclRuleResource resource, String host, List<AclOperation> operations) {
         this.type = type;
         this.resource = resource;
         this.host = host;
-        this.operation = operation;
+        this.operations = operations;
     }
 
     @Description("The type of the rule. " +
@@ -82,13 +86,25 @@ public class AclRule implements UnknownPropertyPreserving, Serializable {
 
     @Description("Operation which will be allowed or denied. " +
             "Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.")
-    @JsonProperty(required = true)
+    @DeprecatedProperty(movedToPath = "spec.authorization.acls[*].operations")
+    @Deprecated
     public AclOperation getOperation() {
         return operation;
     }
 
     public void setOperation(AclOperation operation) {
         this.operation = operation;
+    }
+
+    @Description("List of operations which will be allowed or denied. " +
+            "Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.")
+    @Example("operations: [\"Read\",\"Write\"]")
+    public List<AclOperation> getOperations() {
+        return operations;
+    }
+
+    public void setOperations(List<AclOperation> operations) {
+        this.operations = operations;
     }
 
     @Override

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.out.yaml
@@ -13,18 +13,26 @@ spec:
         type: "topic"
         name: "my-topic"
         patternType: "prefix"
-      operation: "Read"
+      operations:
+      - "Read"
+      - "Write"
     - resource:
         type: "topic"
         name: "my"
         patternType: "prefix"
       host: "127.0.0.1"
-      operation: "Read"
+      operations:
+      - "Read"
+      - "Write"
+      - "Describe"
+      - "Create"
     - resource:
         type: "group"
         name: "my-group"
       host: "127.0.0.1"
-      operation: "Read"
+      operations:
+      - "Read"
     - resource:
         type: "cluster"
-      operation: "Read"
+      operations:
+      - "Read"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUser.yaml
@@ -13,18 +13,26 @@ spec:
           type: topic
           name: my-topic
           patternType: prefix
-        operation: Read
+        operations:
+          - Read
+          - Write
       - resource:
           type: topic
           name: my
           patternType: prefix
-        operation: Read
+        operations:
+          - Read
+          - Write
+          - Describe
+          - Create
         host: 127.0.0.1
       - resource:
           type: group
           name: my-group
-        operation: Read
+        operations:
+          - Read
         host: 127.0.0.1
       - resource:
           type: cluster
-        operation: Read
+        operations:
+          - Read

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUserV1alpha1.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaUserV1alpha1.yaml
@@ -13,17 +13,21 @@ spec:
           type: topic
           name: my-topic
           patternType: prefix
-        operation: Read
+        operations:
+          - Read
+          - Write
       - resource:
           type: topic
           name: my
           patternType: prefix
-        operation: Read
+        operations:
+          - Read
         host: 127.0.0.1
       - resource:
           type: group
           name: my-group
-        operation: Read
+        operations:
+          - Read
         host: 127.0.0.1
       - resource:
           type: cluster

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -78,6 +78,9 @@ structure after everything is said and done should look like `/Library/Java/Java
 doing that run the command at the beginning again and this should link the file and allow you to use maven with OpenJDK
 version 11.
 
+When running the tests, you may encounter `OpenSSL` related errors for parts that you may not have even worked on, in 
+which case you need to make sure you are using `OpenSSL` and not LibreSSL which comes by default with macOS.
+
 ### Kubernetes or OpenShift Cluster
 
 In order to run the integration tests and test any changes made to the operators you will need a functioning Kubernetes

--- a/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
@@ -18,17 +18,15 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Read
+          - Describe
       - resource:
           type: group
           name: my-group
           patternType: prefix
-        operation: Read
+        operations:
+          - Read
 ----
 
 
@@ -63,21 +61,22 @@ When `patternType` is set as `literal`, you can set the name to `*` to indicate 
           type: topic
           name: "*"
           patternType: literal
-        operation: Read
+        operations:
+          - Read
 ----
 
 [id='property-acl-type-{context}']
 === `type`
 
-The `type` of rule, which is to `allow` or `deny` (not currently supported) an operation.
+The `type` of rule, which is to `allow` or `deny` (not currently supported) an operations.
 
 The `type` field is optional.
 If `type` is unspecified, the ACL rule is treated as an `allow` rule.
 
 [id='property-acl-operation-{context}']
-=== `operation`
+=== `operations`
 
-Specify an `operation` for the rule to allow or deny.
+Specify a list of `operations` for the rule to allow or deny.
 
 The following operations are supported:
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2465,14 +2465,16 @@ include::../api/io.strimzi.api.kafka.model.AclRule.adoc[leveloffset=+1]
 
 [options="header"]
 |====
-|Property          |Description
-|host       1.2+<.<a|The host from which the action described in the ACL rule is allowed or denied.
+|Property           |Description
+|host        1.2+<.<a|The host from which the action described in the ACL rule is allowed or denied.
 |string
-|operation  1.2+<.<a|Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.
+|operation   1.2+<.<a|*The `operation` property has been deprecated, and should now be configured using `spec.authorization.acls[*].operations`.* Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.
 |string (one of [Read, Write, Delete, Alter, Describe, All, IdempotentWrite, ClusterAction, Create, AlterConfigs, DescribeConfigs])
-|resource   1.2+<.<a|Indicates the resource for which given ACL rule applies. The type depends on the value of the `resource.type` property within the given object, which must be one of [topic, group, cluster, transactionalId].
+|operations  1.2+<.<a|List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.
+|string (one or more of [Read, Write, Delete, Alter, Describe, All, IdempotentWrite, ClusterAction, Create, AlterConfigs, DescribeConfigs]) array
+|resource    1.2+<.<a|Indicates the resource for which given ACL rule applies. The type depends on the value of the `resource.type` property within the given object, which must be one of [topic, group, cluster, transactionalId].
 |xref:type-AclRuleTopicResource-{context}[`AclRuleTopicResource`], xref:type-AclRuleGroupResource-{context}[`AclRuleGroupResource`], xref:type-AclRuleClusterResource-{context}[`AclRuleClusterResource`], xref:type-AclRuleTransactionalIdResource-{context}[`AclRuleTransactionalIdResource`]
-|type       1.2+<.<a|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+|type        1.2+<.<a|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
 |string (one of [allow, deny])
 |====
 

--- a/packaging/examples/security/tls-auth/bridge.yaml
+++ b/packaging/examples/security/tls-auth/bridge.yaml
@@ -15,23 +15,16 @@ spec:
     - resource:
         type: group
         name: my-group
-      operation: Read
+      operations:
+        - Read
     - resource:
         type: topic
         name: my-topic
-      operation: Read
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Describe
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Write
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Create
+      operations:
+        - Read
+        - Describe
+        - Write
+        - Create
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaBridge

--- a/packaging/examples/security/tls-auth/connect.yaml
+++ b/packaging/examples/security/tls-auth/connect.yaml
@@ -14,77 +14,47 @@ spec:
     - resource:
         type: group
         name: connect-cluster
-      operation: Read
+      operations:
+        - Read
     - resource:
         type: topic
         name: connect-cluster-configs
-      operation: Read
-    - resource:
-        type: topic
-        name: connect-cluster-configs
-      operation: Describe
-    - resource:
-        type: topic
-        name: connect-cluster-configs
-      operation: Write
-    - resource:
-        type: topic
-        name: connect-cluster-configs
-      operation: Create
+      operations:
+        - Read
+        - Describe
+        - Write
+        - Create
     - resource:
         type: topic
         name: connect-cluster-status
-      operation: Read
-    - resource:
-        type: topic
-        name: connect-cluster-status
-      operation: Describe
-    - resource:
-        type: topic
-        name: connect-cluster-status
-      operation: Write
-    - resource:
-        type: topic
-        name: connect-cluster-status
-      operation: Create
+      operations:
+        - Read
+        - Describe
+        - Write
+        - Create
     - resource:
         type: topic
         name: connect-cluster-offsets
-      operation: Read
-    - resource:
-        type: topic
-        name: connect-cluster-offsets
-      operation: Write
-    - resource:
-        type: topic
-        name: connect-cluster-offsets
-      operation: Describe
-    - resource:
-        type: topic
-        name: connect-cluster-offsets
-      operation: Create
-    # Additional topics and groups used by connectors
+      operations:
+        - Read
+        - Describe
+        - Write
+        - Create
+      # Additional topics and groups used by connectors
     # Change to match the topics used by your connectors
     - resource:
         type: group
         name: connect-cluster
-      operation: Read
+      operations:
+        - Read
     - resource:
         type: topic
         name: my-topic
-      operation: Read
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Describe
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Write
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Create
+      operations:
+        - Read
+        - Describe
+        - Write
+        - Create
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnect

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -97,35 +97,27 @@ spec:
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
           name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Create
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: DescribeConfigs
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Write
+        operations:
+          - Read
+          - DescribeConfigs
+          - Write
+          - Create
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Read
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: DescribeConfigs
+        operations:
+          - Read
+          - DescribeConfigs
       # MirrorCheckpointConnector
       - resource:
           type: cluster
-        operation: Describe
+        operations:
+          - Describe
       - resource: # Needed for every group for which offsets are synced
           type: group
           name: "*"
-        operation: Describe
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Read
+        operations:
+          - Describe
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2
@@ -144,125 +136,72 @@ spec:
       - resource:
           type: group
           name: mirrormaker2-cluster
-        operation: Read
+        operations:
+          - Read
       - resource:
           type: topic
           name: mirrormaker2-cluster-configs
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Create
+        operations:
+          - Read
+          - Describe
+          - DescribeConfigs
+          - Write
+          - Create
       - resource:
           type: topic
           name: mirrormaker2-cluster-status
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Create
+        operations:
+          - Read
+          - Describe
+          - DescribeConfigs
+          - Write
+          - Create
       - resource:
           type: topic
           name: mirrormaker2-cluster-offsets
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Create
+        operations:
+          - Read
+          - Describe
+          - DescribeConfigs
+          - Write
+          - Create
       # MirrorSourceConnector
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Create
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Alter
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: AlterConfigs
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Write
+        operations:
+          - Read
+          - Write
+          - AlterConfigs
+          - Alter
+          - Create
       # MirrorCheckpointConnector
       - resource:
           type: cluster
-        operation: Describe
+        operations:
+          - Describe
       - resource:
           type: topic
           name: my-source-cluster.checkpoints.internal
-        operation: Create
-      - resource:
-          type: topic
-          name: my-source-cluster.checkpoints.internal
-        operation: Describe
-      - resource:
-          type: topic
-          name: my-source-cluster.checkpoints.internal
-        operation: Write
+        operations:
+          - Describe
+          - Write
+          - Create
       - resource: # Needed for every group for which the offset is synced
           type: group
           name: "*"
-        operation: Read
-      - resource: # Needed for every group for which the offset is synced
-          type: group
-          name: "*"
-        operation: Describe
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Read
+        operations:
+          - Read
+          - Describe
       # MirrorHeartbeatConnector
       - resource:
           type: topic
           name: heartbeats
-        operation: Create
-      - resource:
-          type: topic
-          name: heartbeats
-        operation: Describe
-      - resource:
-          type: topic
-          name: heartbeats
-        operation: Write
+        operations:
+          - Read
+          - Describe
+          - Write
+          - Create
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2

--- a/packaging/examples/security/tls-auth/user.yaml
+++ b/packaging/examples/security/tls-auth/user.yaml
@@ -10,41 +10,21 @@ spec:
   authorization:
     type: simple
     acls:
-      # Example ACL rules for consuming from my-topic using consumer group my-group
+      # Example ACL rules for creating, describing, consuming and producing from my-topic using consumer group my-group
       - resource:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Read
+          - Describe
+          - Write
+          - Create
         host: "*"
       - resource:
           type: group
           name: my-group
           patternType: literal
-        operation: Read
-        host: "*"
-      # Example ACL rules for producing to topic my-topic
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Read
         host: "*"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -109,6 +109,23 @@ spec:
                               - IdempotentWrite
                               - All
                             description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                          operations:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                                - Read
+                                - Write
+                                - Create
+                                - Delete
+                                - Alter
+                                - Describe
+                                - ClusterAction
+                                - AlterConfigs
+                                - DescribeConfigs
+                                - IdempotentWrite
+                                - All
+                            description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                           resource:
                             type: object
                             properties:
@@ -139,7 +156,6 @@ spec:
                               - deny
                             description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                         required:
-                          - operation
                           - resource
                       description: List of ACL rules which should be applied to this user.
                     type:
@@ -314,6 +330,23 @@ spec:
                               - IdempotentWrite
                               - All
                             description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                          operations:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                                - Read
+                                - Write
+                                - Create
+                                - Delete
+                                - Alter
+                                - Describe
+                                - ClusterAction
+                                - AlterConfigs
+                                - DescribeConfigs
+                                - IdempotentWrite
+                                - All
+                            description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                           resource:
                             type: object
                             properties:
@@ -344,7 +377,6 @@ spec:
                               - deny
                             description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                         required:
-                          - operation
                           - resource
                       description: List of ACL rules which should be applied to this user.
                     type:
@@ -519,6 +551,23 @@ spec:
                               - IdempotentWrite
                               - All
                             description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                          operations:
+                            type: array
+                            items:
+                              type: string
+                              enum:
+                                - Read
+                                - Write
+                                - Create
+                                - Delete
+                                - Alter
+                                - Describe
+                                - ClusterAction
+                                - AlterConfigs
+                                - DescribeConfigs
+                                - IdempotentWrite
+                                - All
+                            description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                           resource:
                             type: object
                             properties:
@@ -549,7 +598,6 @@ spec:
                               - deny
                             description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                         required:
-                          - operation
                           - resource
                       description: List of ACL rules which should be applied to this user.
                     type:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -108,6 +108,23 @@ spec:
                           - IdempotentWrite
                           - All
                           description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                        operations:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - Read
+                            - Write
+                            - Create
+                            - Delete
+                            - Alter
+                            - Describe
+                            - ClusterAction
+                            - AlterConfigs
+                            - DescribeConfigs
+                            - IdempotentWrite
+                            - All
+                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                         resource:
                           type: object
                           properties:
@@ -138,7 +155,6 @@ spec:
                           - deny
                           description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
-                      - operation
                       - resource
                     description: List of ACL rules which should be applied to this user.
                   type:
@@ -313,6 +329,23 @@ spec:
                           - IdempotentWrite
                           - All
                           description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                        operations:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - Read
+                            - Write
+                            - Create
+                            - Delete
+                            - Alter
+                            - Describe
+                            - ClusterAction
+                            - AlterConfigs
+                            - DescribeConfigs
+                            - IdempotentWrite
+                            - All
+                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                         resource:
                           type: object
                           properties:
@@ -343,7 +376,6 @@ spec:
                           - deny
                           description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
-                      - operation
                       - resource
                     description: List of ACL rules which should be applied to this user.
                   type:
@@ -518,6 +550,23 @@ spec:
                           - IdempotentWrite
                           - All
                           description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                        operations:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - Read
+                            - Write
+                            - Create
+                            - Delete
+                            - Alter
+                            - Describe
+                            - ClusterAction
+                            - AlterConfigs
+                            - DescribeConfigs
+                            - IdempotentWrite
+                            - All
+                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                         resource:
                           type: object
                           properties:
@@ -548,7 +597,6 @@ spec:
                           - deny
                           description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
-                      - operation
                       - resource
                     description: List of ACL rules which should be applied to this user.
                   type:

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -108,6 +108,23 @@ spec:
                           - IdempotentWrite
                           - All
                           description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                        operations:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - Read
+                            - Write
+                            - Create
+                            - Delete
+                            - Alter
+                            - Describe
+                            - ClusterAction
+                            - AlterConfigs
+                            - DescribeConfigs
+                            - IdempotentWrite
+                            - All
+                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                         resource:
                           type: object
                           properties:
@@ -138,7 +155,6 @@ spec:
                           - deny
                           description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
-                      - operation
                       - resource
                     description: List of ACL rules which should be applied to this user.
                   type:
@@ -313,6 +329,23 @@ spec:
                           - IdempotentWrite
                           - All
                           description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                        operations:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - Read
+                            - Write
+                            - Create
+                            - Delete
+                            - Alter
+                            - Describe
+                            - ClusterAction
+                            - AlterConfigs
+                            - DescribeConfigs
+                            - IdempotentWrite
+                            - All
+                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                         resource:
                           type: object
                           properties:
@@ -343,7 +376,6 @@ spec:
                           - deny
                           description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
-                      - operation
                       - resource
                     description: List of ACL rules which should be applied to this user.
                   type:
@@ -518,6 +550,23 @@ spec:
                           - IdempotentWrite
                           - All
                           description: "Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                        operations:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - Read
+                            - Write
+                            - Create
+                            - Delete
+                            - Alter
+                            - Describe
+                            - ClusterAction
+                            - AlterConfigs
+                            - DescribeConfigs
+                            - IdempotentWrite
+                            - All
+                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
                         resource:
                           type: object
                           properties:
@@ -548,7 +597,6 @@ spec:
                           - deny
                           description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
-                      - operation
                       - resource
                     description: List of ACL rules which should be applied to this user.
                   type:

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -562,7 +562,7 @@ public class KafkaUserModel {
         Set<SimpleAclRule> simpleAclRules = new HashSet<>();
 
         for (AclRule rule : rules)  {
-            simpleAclRules.add(SimpleAclRule.fromCrd(rule));
+            simpleAclRules.addAll(SimpleAclRule.fromCrd(rule));
         }
 
         this.simpleAclRules = simpleAclRules;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -216,7 +216,7 @@ public class SimpleAclRuleResource {
     }
 
     /**
-     * Creates SimpleAclRuleResource object based on the objects received as part fo the KAfkaUser CR
+     * Creates SimpleAclRuleResource object based on the objects received as part fo the KafkaUser CR
      *
      * @param resource  AclRuleResource as received in KafkaUser CR
      * @return The resource.

--- a/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/ResourceUtils.java
@@ -78,9 +78,8 @@ public class ResourceUtils {
                     .withNewKafkaUserAuthorizationSimple()
                         .addNewAcl()
                             .withNewAclRuleTopicResource()
-                                .withName("my-topic")
-                            .endAclRuleTopicResource()
-                            .withOperation(AclOperation.READ)
+                                .withName("my-topic11").endAclRuleTopicResource()
+                            .withOperations(AclOperation.READ, AclOperation.CREATE, AclOperation.WRITE)
                         .endAcl()
                         .addNewAcl()
                             .withNewAclRuleTopicResource()
@@ -207,14 +206,14 @@ public class ResourceUtils {
     }
 
     public static Set<SimpleAclRule> createExpectedSimpleAclRules(KafkaUser user) {
-        Set<SimpleAclRule> simpleAclRules = new HashSet<SimpleAclRule>();
+        Set<SimpleAclRule> simpleAclRules = new HashSet<>();
 
         if (user.getSpec().getAuthorization() != null && KafkaUserAuthorizationSimple.TYPE_SIMPLE.equals(user.getSpec().getAuthorization().getType())) {
             KafkaUserAuthorizationSimple adapted = (KafkaUserAuthorizationSimple) user.getSpec().getAuthorization();
 
             if (adapted.getAcls() != null) {
                 for (AclRule rule : adapted.getAcls()) {
-                    simpleAclRules.add(SimpleAclRule.fromCrd(rule));
+                    simpleAclRules.addAll(SimpleAclRule.fromCrd(rule));
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: fares.oueslati <oueslati.fares@gmail.com>

### Type of change

- Enhancement / new feature

### Description

Solves https://github.com/strimzi/strimzi-kafka-operator/issues/1671

Currently I need to add a new ACLRule for every operation I want to permit. The KafkaUser CRD is getting very long this way when the user needs read and write access to a lot of topics.

Adding an `operations` and deprecating `operation`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [] Supply screenshots for visual changes, such as Grafana dashboards

