### PR TITLE
ZookeeperRoller considers unready pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Kafka Connect, Mirror Maker, Mirror Maker 2 and Strimzi Bridge can be configured to use OpenTelemetry
   * Using Jaeger exporter by default for backward compatibility
 * Updated JMX Exporter dependency to 0.17.2
+* ZookeeperRoller considers unready pods
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -89,12 +89,12 @@ public class ZooKeeperRoller {
                             for (ZookeeperPodContext podContext : clusterRollContext.getPodContextsWithNonReadyFirst())  {
                                 final String podName = podContext.getPodName();
                                 if (podContext.requiresRestart() && !podName.equals(leader)) {
-                                        LOGGER.debugCr(reconciliation, "Restarting non-leader pod {}", podName);
-                                        // roll the pod and wait until it is ready
-                                        // this prevents rolling into faulty state (note: this applies just for ZK pods)
-                                        fut = fut.compose(ignore -> restartPod(reconciliation, podName, podContext.reasonsToRestart));
+                                    LOGGER.debugCr(reconciliation, "Restarting non-leader pod {}", podName);
+                                    // roll the pod and wait until it is ready
+                                    // this prevents rolling into faulty state (note: this applies just for ZK pods)
+                                    fut = fut.compose(ignore -> restartPod(reconciliation, podName, podContext.reasonsToRestart));
                                 } else {
-                                    if(podContext.requiresRestart()) {
+                                    if (podContext.requiresRestart()) {
                                         LOGGER.debugCr(reconciliation, "Deferring restart of leader {}", podName);
                                     }
                                     LOGGER.debugCr(reconciliation, "Pod {} does not need to be restarted", podName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -88,16 +88,16 @@ public class ZooKeeperRoller {
                             // Then roll each non-leader pod => the leader is rolled last
                             for (ZookeeperPodContext podContext : clusterRollContext.getPodContextsWithNonReadyFirst())  {
                                 if (podContext.requiresRestart() && !podContext.getPodName().equals(leader)) {
-                                    LOGGER.debugCr(reconciliation, "Restarting non-leader pod {}", podContext.getPodName());
+                                    LOGGER.debugCr(reconciliation, "Pod {} needs to be restarted", podContext.getPodName());
                                     // roll the pod and wait until it is ready
                                     // this prevents rolling into faulty state (note: this applies just for ZK pods)
                                     fut = fut.compose(ignore -> restartPod(reconciliation, podContext.getPodName(), podContext.reasonsToRestart));
                                 } else {
                                     if (podContext.requiresRestart()) {
                                         LOGGER.debugCr(reconciliation, "Deferring restart of leader {}", podContext.getPodName());
+                                    } else {
+                                        LOGGER.debugCr(reconciliation, "Pod {} does not need to be restarted", podContext.getPodName());
                                     }
-                                    LOGGER.debugCr(reconciliation, "Pod {} does not need to be restarted", podContext.getPodName());
-                                    LOGGER.debugCr(reconciliation, "Waiting for non-restarted pod {} to become ready", podContext.getPodName());
                                     fut = fut.compose(ignore -> podOperator.readiness(reconciliation, reconciliation.namespace(), podContext.getPodName(), READINESS_POLLING_INTERVAL_MS, operationTimeoutMs));
                                 }
                             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -13,16 +13,20 @@ import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * ZooKeeperRoller helps to roll ZooKeeper cluster. It uses the ZooKeeperLeaderFinder to find the leader which is
- * rolled first.
+ * rolled last.
  */
 public class ZooKeeperRoller {
+
+    private static final long READINESS_POLLING_INTERVAL_MS = 1_000;
+
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ZooKeeperRoller.class.getName());
 
     private final PodOperator podOperator;
@@ -53,60 +57,63 @@ public class ZooKeeperRoller {
 
         return podOperator.listAsync(namespace, selectorLabels)
                 .compose(pods -> {
-                    Map<String, List<String>> podsToRoll = new HashMap<>(pods.size());
-                    boolean needsRolling = false;
+                    ZookeeperClusterRollContext clusterRollContext = new ZookeeperClusterRollContext();
 
                     for (Pod pod : pods)    {
                         List<String> restartReasons = podRestart.apply(pod);
-                        String podName = pod.getMetadata().getName();
-
+                        final boolean ready = podOperator.isReady(namespace, pod.getMetadata().getName());
+                        ZookeeperPodContext podContext = new ZookeeperPodContext(pod, restartReasons, ready);
                         if (restartReasons != null && !restartReasons.isEmpty())    {
-                            LOGGER.debugCr(reconciliation, "Pod {} should be rolled due to {}", podName, restartReasons);
-                            podsToRoll.put(podName, restartReasons);
-                            needsRolling = true;
+                            LOGGER.debugCr(reconciliation, "Pod {} should be rolled due to {}", podContext.getPodName(), restartReasons);
                         } else {
-                            LOGGER.debugCr(reconciliation, "Pod {} does not need to be rolled", podName);
-                            podsToRoll.put(podName, null);
+                            LOGGER.debugCr(reconciliation, "Pod {} does not need to be rolled", podContext.getPodName());
                         }
+                        clusterRollContext.add(podContext);
                     }
 
-                    if (needsRolling)   {
-                        return Future.succeededFuture(podsToRoll);
+                    if (clusterRollContext.requiresRestart())   {
+                        return Future.succeededFuture(clusterRollContext);
                     } else {
                         return Future.succeededFuture(null);
                     }
-                }).compose(podsToRoll -> {
-                    if (podsToRoll != null)  {
+                }).compose(clusterRollContext -> {
+                    if (clusterRollContext != null)  {
                         Promise<Void> promise = Promise.promise();
-                        Future<String> leaderFuture = leaderFinder.findZookeeperLeader(reconciliation, podsToRoll.keySet(), clusterCaSecret, coKeySecret);
+                        Future<String> leaderFuture = leaderFinder.findZookeeperLeader(reconciliation, clusterRollContext.podNames(), clusterCaSecret, coKeySecret);
 
                         leaderFuture.compose(leader -> {
                             LOGGER.debugCr(reconciliation, "Zookeeper leader is " + (ZookeeperLeaderFinder.UNKNOWN_LEADER.equals(leader) ? "unknown" : "pod " + leader));
                             Future<Void> fut = Future.succeededFuture();
 
                             // Then roll each non-leader pod => the leader is rolled last
-                            for (Map.Entry<String, List<String>> podEntry : podsToRoll.entrySet())  {
-                                if (podEntry.getValue() != null && !podEntry.getValue().isEmpty()) {
-                                    if (!podEntry.getKey().equals(leader)) {
-                                        LOGGER.debugCr(reconciliation, "Restarting non-leader pod {}", podEntry.getKey());
+                            for (ZookeeperPodContext podContext : clusterRollContext.getPodContextsWithNonReadyFirst())  {
+                                if (podContext.requiresRestart()) {
+                                    final String podName = podContext.getPodName();
+                                    if (!podName.equals(leader)) {
+                                        LOGGER.debugCr(reconciliation, "Restarting non-leader pod {}", podName);
                                         // roll the pod and wait until it is ready
                                         // this prevents rolling into faulty state (note: this applies just for ZK pods)
-                                        fut = fut.compose(ignore -> restartPod(reconciliation, podEntry.getKey(), podEntry.getValue()));
+                                        fut = fut.compose(ignore -> restartPod(reconciliation, podName, podContext.reasonsToRestart));
                                     } else {
-                                        LOGGER.debugCr(reconciliation, "Deferring restart of leader {}", podEntry.getKey());
+                                        LOGGER.debugCr(reconciliation, "Deferring restart of leader {}", podName);
                                     }
+                                } else {
+                                    final String podName = podContext.getPodName();
+                                    LOGGER.debugCr(reconciliation, "Pod {} does not need to be restarted", podName);
+                                    LOGGER.debugCr(reconciliation, "Waiting for non-restarted pod {} to become ready", podName);
+                                    fut = fut.compose(ignore -> podOperator.readiness(reconciliation, reconciliation.namespace(), podName, READINESS_POLLING_INTERVAL_MS, operationTimeoutMs));
                                 }
                             }
 
                             // Check if we have a leader and if it needs rolling
-                            if (ZookeeperLeaderFinder.UNKNOWN_LEADER.equals(leader) || podsToRoll.get(leader) == null || podsToRoll.get(leader).isEmpty()) {
+                            if (ZookeeperLeaderFinder.UNKNOWN_LEADER.equals(leader) || clusterRollContext.get(leader) == null || !clusterRollContext.get(leader).requiresRestart()) {
                                 return fut;
                             } else {
                                 // Roll the leader pod
                                 return fut.compose(ar -> {
                                     // the leader is rolled as the last
                                     LOGGER.debugCr(reconciliation, "Restarting leader pod (previously deferred) {}", leader);
-                                    return restartPod(reconciliation, leader, podsToRoll.get(leader));
+                                    return restartPod(reconciliation, leader, clusterRollContext.get(leader).reasonsToRestart);
                                 });
                             }
                         }).onComplete(promise);
@@ -128,14 +135,76 @@ public class ZooKeeperRoller {
      * @return a Future which completes when the given (possibly recreated) pod is ready.
      */
     Future<Void> restartPod(Reconciliation reconciliation, String podName, List<String> reasons) {
-        long pollingIntervalMs = 1_000;
-
         LOGGER.infoCr(reconciliation, "Rolling pod {} due to {}", podName, reasons);
         return podOperator.getAsync(reconciliation.namespace(), podName)
                 .compose(pod -> podOperator.restart(reconciliation, pod, operationTimeoutMs))
                 .compose(ignore -> {
                     LOGGER.debugCr(reconciliation, "Waiting for readiness of pod {}", podName);
-                    return podOperator.readiness(reconciliation, reconciliation.namespace(), podName, pollingIntervalMs, operationTimeoutMs);
+                    return podOperator.readiness(reconciliation, reconciliation.namespace(), podName, READINESS_POLLING_INTERVAL_MS, operationTimeoutMs);
                 });
+    }
+
+
+    private static class ZookeeperClusterRollContext {
+
+        private final List<ZookeeperPodContext> podContexts = new ArrayList<>();
+
+
+        private ZookeeperClusterRollContext() {
+        }
+
+
+        public List<ZookeeperPodContext> getPodContextsWithNonReadyFirst() {
+            return podContexts.stream().sorted((contextA, contextB) -> Boolean.compare(contextA.ready, contextB.ready)).collect(Collectors.toList());
+        }
+
+
+        public void add(final ZookeeperPodContext podContext) {
+            podContexts.add(podContext);
+        }
+
+
+        public boolean requiresRestart() {
+            return podContexts.stream().anyMatch(ZookeeperPodContext::requiresRestart);
+        }
+
+
+        public Set<String> podNames() {
+            return podContexts.stream().map(ZookeeperPodContext::getPodName).collect(Collectors.toSet());
+        }
+
+
+        public ZookeeperPodContext get(final String podName) {
+            return podContexts.stream().filter(podContext -> podContext.getPodName().equals(podName)).findAny().orElse(null);
+        }
+    }
+
+    private static class ZookeeperPodContext {
+
+        private final Pod pod;
+
+        private final boolean ready;
+
+        private final List<String> reasonsToRestart = new ArrayList<>();
+
+
+        private ZookeeperPodContext(final Pod pod, final List<String> reasonsToRestart, final boolean ready) {
+            this.pod = pod;
+            this.ready = ready;
+            if (reasonsToRestart != null) {
+                this.reasonsToRestart.addAll(reasonsToRestart);
+            }
+        }
+
+
+        String getPodName() {
+            return pod.getMetadata().getName();
+        }
+
+
+        boolean requiresRestart() {
+            return !reasonsToRestart.isEmpty();
+        }
+
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
@@ -108,7 +108,7 @@ public class ZooKeeperRollerTest {
     }
 
     @Test
-    public void testReadinessOfNonRestartedPodCanPreventFurtherRestarts(VertxTestContext context)  {
+    public void testNonReadinessOfPodCanPreventAllPodRestarts(VertxTestContext context)  {
         final String followerPodNonReady = "my-cluster-zookeeper-1";
         final String leaderPodNeedsRestart = "my-cluster-zookeeper-2";
         final String followerPodNeedsRestart = "my-cluster-zookeeper-0";
@@ -141,7 +141,7 @@ public class ZooKeeperRollerTest {
     }
 
     @Test
-    public void testReadinessOfLeaderPodCanPreventFurtherRestarts(VertxTestContext context)  {
+    public void testNonReadinessOfLeaderCanPreventAllPodRestarts(VertxTestContext context)  {
         final String followerPod1NeedsRestart = "my-cluster-zookeeper-1";
         final String leaderPodNeedsRestartNonReady = "my-cluster-zookeeper-2";
         final String followerPod2NeedsRestart = "my-cluster-zookeeper-0";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -100,9 +101,7 @@ public class ZooKeeperRollerTest {
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, shouldRoll, new Secret(), new Secret())
               .onComplete(context.succeeding(v -> context.verify(() -> {
                   assertThat(roller.podRestarts.size(), is(3));
-                  assertThat(roller.podRestarts.pollFirst(), is("my-cluster-zookeeper-1"));
-                  assertThat(roller.podRestarts.pollFirst(), is("my-cluster-zookeeper-0"));
-                  assertThat(roller.podRestarts.pollFirst(), is("my-cluster-zookeeper-2"));
+                  assertThat(roller.podRestarts, contains("my-cluster-zookeeper-1", "my-cluster-zookeeper-0", "my-cluster-zookeeper-2"));
                   async.flag();
               })));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRollerTest.java
@@ -11,7 +11,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.vertx.core.Future;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
@@ -69,7 +68,6 @@ public class ZooKeeperRollerTest {
 
         MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
 
-        Checkpoint async = context.checkpoint();
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, pod -> List.of("Should restart"), new Secret(), new Secret())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertThat(roller.podRestarts.size(), is(3));
@@ -77,7 +75,7 @@ public class ZooKeeperRollerTest {
                     assertThat(roller.podRestarts.contains("my-cluster-zookeeper-1"), is(true));
                     assertThat(roller.podRestarts.contains("my-cluster-zookeeper-2"), is(true));
 
-                    async.flag();
+                    context.completeNow();
                 })));
     }
 
@@ -97,12 +95,11 @@ public class ZooKeeperRollerTest {
 
         MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
 
-        Checkpoint async = context.checkpoint();
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, shouldRoll, new Secret(), new Secret())
               .onComplete(context.succeeding(v -> context.verify(() -> {
                   assertThat(roller.podRestarts.size(), is(3));
                   assertThat(roller.podRestarts, contains("my-cluster-zookeeper-1", "my-cluster-zookeeper-0", "my-cluster-zookeeper-2"));
-                  async.flag();
+                  context.completeNow();
               })));
     }
 
@@ -128,11 +125,10 @@ public class ZooKeeperRollerTest {
 
         MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
 
-        Checkpoint async = context.checkpoint();
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, shouldRoll, new Secret(), new Secret())
               .onComplete(context.failing(v -> context.verify(() -> {
                   assertThat(roller.podRestarts.size(), is(0));
-                  async.flag();
+                  context.completeNow();
               })));
     }
 
@@ -146,12 +142,11 @@ public class ZooKeeperRollerTest {
 
         MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
 
-        Checkpoint async = context.checkpoint();
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, pod -> null, new Secret(), new Secret())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertThat(roller.podRestarts.size(), is(0));
 
-                    async.flag();
+                    context.completeNow();
                 })));
     }
 
@@ -165,7 +160,6 @@ public class ZooKeeperRollerTest {
 
         MockZooKeeperRoller roller = new MockZooKeeperRoller(podOperator, leaderFinder, 300_00L);
 
-        Checkpoint async = context.checkpoint();
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, pod -> List.of("Should restart"), new Secret(), new Secret())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertThat(roller.podRestarts.size(), is(3));
@@ -173,7 +167,7 @@ public class ZooKeeperRollerTest {
                     assertThat(roller.podRestarts.contains("my-cluster-zookeeper-2"), is(true));
                     assertThat(roller.podRestarts.contains("my-cluster-zookeeper-0"), is(true));
 
-                    async.flag();
+                    context.completeNow();
                 })));
     }
 
@@ -196,14 +190,13 @@ public class ZooKeeperRollerTest {
             }
         };
 
-        Checkpoint async = context.checkpoint();
         roller.maybeRollingUpdate(Reconciliation.DUMMY_RECONCILIATION, DUMMY_SELECTOR, shouldRoll, new Secret(), new Secret())
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertThat(roller.podRestarts.size(), is(2));
                     assertThat(roller.podRestarts.contains("my-cluster-zookeeper-0"), is(true));
                     assertThat(roller.podRestarts.contains("my-cluster-zookeeper-2"), is(true));
 
-                    async.flag();
+                    context.completeNow();
                 })));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This fix makes the ZookeeperRoller:
1. re-order the pods so that non-ready pods are evaluated first
2. wait for pods that do not require a restart to become ready

This means that in the a scenario with a pod stuck in a non-ready state it will evaluate the non-ready pod first on each run and await readiness. Likely ending in an exception.

Why:
Previously a bad pattern could occur where ZookeeperRoller restarted a pod and it did not become ready. This eventually hit a timeout that failed the roll but on the next periodic reconciliation that pod would not be eligible for a restart and the roller would then restart the next node. This would eventually take the whole Zookeeper cluster offline if, for example, the pods couldn't be scheduled.

Note:
There are further specialisations in the KafkaRoller that we could add/share with the ZookeeperRoller, like a short-circuit for pods that are stuck in pending due to them being unschedulable.

Fixes #1001

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md