### PR TITLE
Add optional --out-dir parameter to the report script

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -14,7 +14,7 @@ MM2=""
 KUBECTL_INSTALLED=false
 OC_INSTALLED=false
 KUBE_CLIENT="kubectl"
-OUT_DIR="$(mktemp -d)"
+OUT_DIR=""
 SECRETS_OPT="hidden"
 
 # sed non-printable text delimiter
@@ -97,6 +97,10 @@ shift $((OPTIND-1))
 
 if [[ -z $NAMESPACE || -z $CLUSTER ]]; then
   error "$USAGE"
+fi
+
+if [[ -z $OUT_DIR ]]; then
+  OUT_DIR="$(mktemp -d)"
 fi
 
 if [[ "$SECRETS_OPT" != "all" && "$SECRETS_OPT" != "off" && "$SECRETS_OPT" != "hidden" ]]; then

--- a/tools/report.sh
+++ b/tools/report.sh
@@ -8,9 +8,13 @@ fi
 { # this ensures the entire script is downloaded #
 NAMESPACE=""
 CLUSTER=""
+BRIDGE=""
+CONNECT=""
+MM2=""
 KUBECTL_INSTALLED=false
 OC_INSTALLED=false
 KUBE_CLIENT="kubectl"
+OUT_DIR="$(mktemp -d)"
 SECRETS_OPT="hidden"
 
 # sed non-printable text delimiter
@@ -37,19 +41,24 @@ if [[ $OC_INSTALLED = false && $KUBECTL_INSTALLED = false ]]; then
 fi
 
 # check kube connectivity
-$KUBE_CLIENT version --request-timeout=10s 1>/dev/null
+$KUBE_CLIENT version -o yaml --request-timeout=5s 1>/dev/null
 
 readonly USAGE="
-Usage: ${0} --namespace=<string> --cluster=<string> [--bridge=<string>] [--connect=<string>] [--mm2=<string>] [--secrets=(off|hidden|all)]
-Bridge, connect and mm2 are optional, specify the component name if you want to get logs.
+Usage: report.sh [required] [optional]
+
+Required:
+  --namespace=<string>
+  --cluster=<string>
+
+Optional:
+  --bridge=<string>
+  --connect=<string>
+  --mm2=<string>
+  --out-dir=<string>
+  --secrets=(off|hidden|all)]
+
 Default level of secret verbosity is 'hidden' (only secret key will be reported).
 "
-
-NAMESPACE=""
-CLUSTER=""
-BRIDGE=""
-CONNECT=""
-MM2=""
 
 OPTSPEC=":-:"
 while getopts "$OPTSPEC" optchar; do
@@ -58,6 +67,10 @@ while getopts "$OPTSPEC" optchar; do
       case "${OPTARG}" in
         namespace=*)
           NAMESPACE=${OPTARG#*=} && readonly NAMESPACE
+          ;;
+        out-dir=*)
+          OUT_DIR=${OPTARG#*=}
+          OUT_DIR=${OUT_DIR//\~/$HOME} && readonly OUT_DIR
           ;;
         cluster=*)
           CLUSTER=${OPTARG#*=} && readonly CLUSTER
@@ -82,13 +95,8 @@ while getopts "$OPTSPEC" optchar; do
 done
 shift $((OPTIND-1))
 
-if [[ -z $NAMESPACE && -z $CLUSTER ]]; then
-  echo "--namespace and --cluster are mandatory options."
+if [[ -z $NAMESPACE || -z $CLUSTER ]]; then
   error "$USAGE"
-fi
-
-if [[ -z $SECRETS_OPT ]]; then
-  SECRETS_OPT="hidden"
 fi
 
 if [[ "$SECRETS_OPT" != "all" && "$SECRETS_OPT" != "off" && "$SECRETS_OPT" != "hidden" ]]; then
@@ -118,7 +126,6 @@ if [[ -z $($KUBE_CLIENT get kafkas.kafka.strimzi.io "$CLUSTER" -o name -n "$NAME
   error "Kafka cluster $CLUSTER in namespace $NAMESPACE not found! Exiting"
 fi
 
-TMP="$(mktemp -d)" && readonly TMP
 RESOURCES=(
   "deployments"
   "statefulsets"
@@ -146,23 +153,23 @@ fi
 
 get_masked_secrets() {
   echo "secrets"
-  mkdir -p "$TMP"/reports/secrets
+  mkdir -p "$OUT_DIR"/reports/secrets
   local resources && resources=$($KUBE_CLIENT get secrets -l strimzi.io/cluster="$CLUSTER" -o name -n "$NAMESPACE")
   for res in $resources; do
     local filename && filename=$(echo "$res" | cut -f 2 -d "/")
     echo "    $res"
     local secret && secret=$($KUBE_CLIENT get "$res" -o yaml -n "$NAMESPACE")
     if [[ "$SECRETS_OPT" == "all" ]]; then
-      echo "$secret" > "$TMP"/reports/secrets/"$filename".yaml
+      echo "$secret" > "$OUT_DIR"/reports/secrets/"$filename".yaml
     else
-      echo "$secret" | sed "$SE" > "$TMP"/reports/secrets/"$filename".yaml
+      echo "$secret" | sed "$SE" > "$OUT_DIR"/reports/secrets/"$filename".yaml
     fi
   done
 }
 
 get_namespaced_yamls() {
   local type="$1"
-  mkdir -p "$TMP"/reports/"$type"
+  mkdir -p "$OUT_DIR"/reports/"$type"
   local resources
   resources=$($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$CLUSTER" -o name -n "$NAMESPACE" 2>/dev/null ||true)
   resources="$resources $($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$BRIDGE" -o name -n "$BRIDGE" 2>/dev/null ||true)"
@@ -174,9 +181,9 @@ get_namespaced_yamls() {
       local filename && filename=$(echo "$res" | cut -f 2 -d "/")
       echo "    $res"
       if [[ "$SECRETS_OPT" == "all" ]]; then
-        $KUBE_CLIENT get "$res" -o yaml -n "$NAMESPACE" > "$TMP"/reports/"$type"/"$filename".yaml
+        $KUBE_CLIENT get "$res" -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/"$type"/"$filename".yaml
       else
-        $KUBE_CLIENT get "$res" -o yaml -n "$NAMESPACE" | sed "$SE" > "$TMP"/reports/"$type"/"$filename".yaml
+        $KUBE_CLIENT get "$res" -o yaml -n "$NAMESPACE" | sed "$SE" > "$OUT_DIR"/reports/"$type"/"$filename".yaml
       fi
     done
   fi
@@ -190,7 +197,7 @@ done
 
 get_nonnamespaced_yamls() {
   local type="$1"
-  mkdir -p "$TMP"/reports/"$type"
+  mkdir -p "$OUT_DIR"/reports/"$type"
   local resources && resources=$($KUBE_CLIENT get "$type" -l app=strimzi -o name -n "$NAMESPACE")
   echo "$type"
   for res in $resources; do
@@ -214,22 +221,22 @@ get_pod_logs() {
     local logs
     if [[ "$count" -eq 1 ]]; then
       logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$TMP"/reports/podlogs/"$pod".log; fi
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log; fi
       logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -p 2>/dev/null ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$TMP"/reports/podlogs/"$pod".log.0; fi
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log.0; fi
     fi
     if [[ "$count" -gt 1 && -n "$con" && "$names" == *"$con"* ]]; then
       logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -c "$con" ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$TMP"/reports/podlogs/"$pod"-"$con".log; fi
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod"-"$con".log; fi
       logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -p -c "$con" 2>/dev/null ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$TMP"/reports/podlogs/"$pod"-"$con".log.0; fi
-    fi 
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod"-"$con".log.0; fi
+    fi
   fi
 }
 
 echo "podlogs"
-mkdir -p "$TMP"/reports/podlogs
-mkdir -p "$TMP"/reports/configs
+mkdir -p "$OUT_DIR"/reports/podlogs
+mkdir -p "$OUT_DIR"/reports/configs
 PODS=$($KUBE_CLIENT get po -l strimzi.io/cluster="$CLUSTER" -o name -n "$NAMESPACE" | cut -d "/" -f 2)
 PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$BRIDGE" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
 PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$CONNECT" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
@@ -241,12 +248,12 @@ for POD in $PODS; do
     get_pod_logs "$POD" zookeeper
     get_pod_logs "$POD" tls-sidecar
     $KUBE_CLIENT exec -i "$POD" -n "$NAMESPACE" -c zookeeper -- \
-      cat /tmp/zookeeper.properties > "$TMP"/reports/configs/"$POD".cfg
+      cat /tmp/zookeeper.properties > "$OUT_DIR"/reports/configs/"$POD".cfg
   elif [[ "$POD" =~ .*-kafka-[0-9]+ ]]; then
     get_pod_logs "$POD" kafka
     get_pod_logs "$POD" tls-sidecar
     $KUBE_CLIENT exec -i "$POD" -n "$NAMESPACE" -c kafka -- \
-      cat /tmp/strimzi.properties > "$TMP"/reports/configs/"$POD".cfg
+      cat /tmp/strimzi.properties > "$OUT_DIR"/reports/configs/"$POD".cfg
   elif [[ "$POD" == *"-entity-operator-"* ]]; then
     get_pod_logs "$POD" topic-operator
     get_pod_logs "$POD" user-operator
@@ -269,8 +276,8 @@ echo "clusteroperator"
 CO_DEPLOY=$($KUBE_CLIENT get deploy strimzi-cluster-operator -o name -n "$NAMESPACE" --ignore-not-found) && readonly CO_DEPLOY
 if [[ -n $CO_DEPLOY ]]; then
   echo "    $CO_DEPLOY"
-  $KUBE_CLIENT get deploy strimzi-cluster-operator -o yaml -n "$NAMESPACE" > "$TMP"/reports/deployments/cluster-operator.yaml
-  $KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o yaml -n "$NAMESPACE" > "$TMP"/reports/pods/cluster-operator.yaml
+  $KUBE_CLIENT get deploy strimzi-cluster-operator -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/deployments/cluster-operator.yaml
+  $KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/pods/cluster-operator.yaml
   CO_POD=$($KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o name -n "$NAMESPACE" --ignore-not-found)
   if [[ -n $CO_POD ]]; then
     echo "    $CO_POD"
@@ -284,15 +291,15 @@ if [[ -n $CO_RS ]]; then
   echo "    $CO_RS"
   CO_RS=$(echo "$CO_RS" | tail -n1) && echo "    $CO_RS"
   CO_RS=$(echo "$CO_RS" | cut -d "/" -f 2) && readonly CO_RS
-  $KUBE_CLIENT get rs "$CO_RS" -n "$NAMESPACE" > "$TMP"/reports/replicasets/"$CO_RS".yaml
+  $KUBE_CLIENT get rs "$CO_RS" -n "$NAMESPACE" > "$OUT_DIR"/reports/replicasets/"$CO_RS".yaml
 fi
 
 echo "draincleaner"
 DC_DEPLOY=$($KUBE_CLIENT get deploy strimzi-drain-cleaner -o name -n "$NAMESPACE" --ignore-not-found) && readonly DC_DEPLOY
 if [[ -n $DC_DEPLOY ]]; then
   echo "    $DC_DEPLOY"
-  $KUBE_CLIENT get deploy strimzi-drain-cleaner -o yaml -n "$NAMESPACE" > "$TMP"/reports/deployments/drain-cleaner.yaml
-  $KUBE_CLIENT get po -l app=strimzi-drain-cleaner -o yaml -n "$NAMESPACE" > "$TMP"/reports/pods/drain-cleaner.yaml
+  $KUBE_CLIENT get deploy strimzi-drain-cleaner -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/deployments/drain-cleaner.yaml
+  $KUBE_CLIENT get po -l app=strimzi-drain-cleaner -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/pods/drain-cleaner.yaml
   DC_POD=$($KUBE_CLIENT get po -l app=strimzi-drain-cleaner -o name -n "$NAMESPACE" --ignore-not-found)
   if [[ -n $DC_POD ]]; then
     echo "    $DC_POD"
@@ -302,7 +309,7 @@ if [[ -n $DC_DEPLOY ]]; then
 fi
 
 echo "customresources"
-mkdir -p "$TMP"/reports/crs
+mkdir -p "$OUT_DIR"/reports/crs
 CRS=$($KUBE_CLIENT get crd -o name | cut -d "/" -f 2) && readonly CRS
 for CR in $CRS; do
   if [[ $CR == *".strimzi.io" ]]; then
@@ -311,7 +318,7 @@ for CR in $CRS; do
       echo "    $CR"
       for j in $RES; do
         RES=$(echo "$j" | cut -f 1 -d " ")
-        $KUBE_CLIENT get "$CR" "$RES" -n "$NAMESPACE" -o yaml > "$TMP"/reports/crs/"$CR"-"$RES".yaml
+        $KUBE_CLIENT get "$CR" "$RES" -n "$NAMESPACE" -o yaml > "$OUT_DIR"/reports/crs/"$CR"-"$RES".yaml
         echo "        $RES"
       done
     fi
@@ -319,28 +326,31 @@ for CR in $CRS; do
 done
 
 echo "customresourcedefinitions"
-mkdir -p "$TMP"/reports/crds
+mkdir -p "$OUT_DIR"/reports/crds
 CRDS=$($KUBE_CLIENT get crd -o name) && readonly CRDS
 for CRD in $CRDS; do
   CRD=$(echo "$CRD" | cut -d "/" -f 2)
   if [[ "$CRD" == *".strimzi.io" ]]; then
     echo "    $CRD"
-    $KUBE_CLIENT get crd "$CRD" -o yaml > "$TMP"/reports/crds/"$CRD".yaml
+    $KUBE_CLIENT get crd "$CRD" -o yaml > "$OUT_DIR"/reports/crds/"$CRD".yaml
   fi
 done
 
 echo "events"
 EVENTS=$($KUBE_CLIENT get event -n "$NAMESPACE" --ignore-not-found) && readonly EVENTS
 if [[ -n $EVENTS ]]; then
-  mkdir -p "$TMP"/reports/events
-  echo "$EVENTS" > "$TMP"/reports/events/events.txt
+  mkdir -p "$OUT_DIR"/reports/events
+  echo "$EVENTS" > "$OUT_DIR"/reports/events/events.txt
 fi
 
-FILENAME="report-$(date +"%d-%m-%Y_%H-%M-%S")" && readonly FILENAME
-OLD_DIR="$(pwd)" && readonly OLD_DIR
-cd "$TMP" || exit
+FILENAME="report-$(date +"%d-%m-%Y_%H-%M-%S")"
+OLD_DIR="$(pwd)"
+cd "$OUT_DIR" || exit
 zip -qr "$FILENAME".zip ./reports/
 cd "$OLD_DIR" || exit
-mv "$TMP"/"$FILENAME".zip ./
+if [[ $OUT_DIR == *"tmp."* ]]; then
+  # let's keep the old behavior when --out-dir is not specified
+  mv "$OUT_DIR"/"$FILENAME".zip ./
+fi
 echo "Report file $FILENAME.zip created"
 } # this ensures the entire script is downloaded #


### PR DESCRIPTION
This is useful if you don't have enough /tmp space and you want to use a different dir. If you don't specify the out dir, then the current behavior is maintained.