### PR TITLE
Update Cruise Control to 2.5.103 and re-enable CC system tests

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.100</cruise-control.version>
+        <cruise-control.version>2.5.103</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.100</cruise-control.version>
+        <cruise-control.version>2.5.103</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.100</cruise-control.version>
+        <cruise-control.version>2.5.103</cruise-control.version>
         <opa-authorizer.version>1.4.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.100</cruise-control.version>
+        <cruise-control.version>2.5.103</cruise-control.version>
     </properties>
 
     <repositories>

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -20,7 +20,6 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.specific.CruiseControlUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -35,8 +34,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-// Disabled due to https://github.com/strimzi/strimzi-kafka-operator/issues/7408
-@Disabled
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
 @Tag(ACCEPTANCE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -46,7 +46,6 @@ import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -70,8 +69,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-// Disabled due to https://github.com/strimzi/strimzi-kafka-operator/issues/7408
-@Disabled
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
 @ParallelSuite

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.Logger;
 
 import static org.hamcrest.CoreMatchers.is;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -160,8 +159,6 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world - 99");
     }
 
-    // Disabled due to https://github.com/strimzi/strimzi-kafka-operator/issues/7408
-    @Disabled
     @IsolatedTest
     @Tag(CRUISE_CONTROL)
     void testKafkaCCAndRebalanceWithMultipleCOs(ExtensionContext extensionContext) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -42,7 +42,6 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -132,8 +131,6 @@ public class ReconciliationST extends AbstractST {
         KafkaConnectorUtils.waitForConnectorsTaskMaxChangeViaAPI(namespaceName, connectPodName, clusterName, SCALE_TO);
     }
 
-    // Disabled due to https://github.com/strimzi/strimzi-kafka-operator/issues/7408
-    @Disabled
     @ParallelNamespaceTest
     @Tag(CRUISE_CONTROL)
     @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test class")


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr updates Cruise Control to 2.5.103 which adds support for Kafka 3.3. That allows us to re-enable the system tests which were disabled before.

This should close #7408.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging