### PR TITLE
[TopicOperator IT tests] -> make sure that AdmiClient and KafkaCluste…

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -59,14 +59,17 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
     @AfterAll
     public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
-        teardown(true);
-        teardownKubeCluster();
-        adminClient.close();
-        kafkaCluster.stop();
+        try {
+            teardown(true);
+        } finally {
+            teardownKubeCluster();
+            adminClient.close();
+            kafkaCluster.stop();
+        }
     }
 
     @AfterEach
-    void afterEach() throws InterruptedException, ExecutionException, TimeoutException {
+    void afterEach() throws InterruptedException, TimeoutException {
         // clean-up KafkaTopic resources in Kubernetes
         clearKafkaTopics(true);
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorReplicationIT.java
@@ -46,10 +46,13 @@ public class TopicOperatorReplicationIT extends TopicOperatorBaseIT {
 
     @AfterAll
     public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
-        teardown(true);
-        teardownKubeCluster();
-        adminClient.close();
-        kafkaCluster.stop();
+        try {
+            teardown(true);
+        } finally {
+            teardownKubeCluster();
+            adminClient.close();
+            kafkaCluster.stop();
+        }
     }
 
     @AfterEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTopicDeletionDisabledIT.java
@@ -33,10 +33,13 @@ public class TopicOperatorTopicDeletionDisabledIT extends TopicOperatorBaseIT {
 
     @AfterAll
     public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
-        teardown(false);
-        teardownKubeCluster();
-        adminClient.close();
-        kafkaCluster.stop();
+        try {
+            teardown(false);
+        } finally {
+            teardownKubeCluster();
+            adminClient.close();
+            kafkaCluster.stop();
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
…r always tearndown

Signed-off-by: morsak <maros.orsak159@gmail.com>

### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR fixes a potential problem in the `@AfterAll` scope in the TopicOperatorITs suites. Specifically the `teardown(true)` could throw an exception, which might lead to non-executing following code.

```java
@AfterAll
public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
            teardown(true);  <--- potential exception thrown
            ...
            teardownKubeCluster(); <--- this code is not executed at all
            adminClient.close();
            kafkaCluster.stop();
}
``` 

This also causes no closed connections of AdminClient to the KafkaBrokers and runs unnecessary Kafka clusters. With this change, we will eliminate such issues:

```java
@AfterAll
    public void afterAll() throws InterruptedException, ExecutionException, TimeoutException {
        try {
            teardown(true);
        } finally {
            teardownKubeCluster();
            adminClient.close();
            kafkaCluster.stop();
        }
    }
``` 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass