### PR TITLE
Adapt tests to recent kubectl versions

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -116,6 +116,7 @@ public abstract class AbstractCrdIT implements TestSeparator {
             assertThat("Could not find" + requiredProperty + " in message: " + message, message, anyOf(
                     containsStringIgnoringCase(requiredProperty + " in body is required"),
                     containsStringIgnoringCase(requiredProperty + ": Required value"),
+                    containsStringIgnoringCase(requiredProperty.substring(requiredProperty.lastIndexOf(".") + 1) + ": Required value"),
                     containsStringIgnoringCase("missing required field \"" + requiredProperty + "\""),
                     containsStringIgnoringCase("missing required field \"" + requiredProperty.substring(requiredProperty.lastIndexOf(".") + 1) + "\"")
             ));

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaCrdIT.java
@@ -41,7 +41,10 @@ public class KafkaCrdIT extends AbstractCrdIT {
             KubeClusterException.class,
             () -> createDeleteCustomResource("Kafka-with-extra-property.yaml"));
 
-        assertThat(exception.getMessage(), containsString("unknown field \"thisPropertyIsNotInTheSchema\""));
+        assertThat(exception.getMessage(), anyOf(
+                containsString("unknown field \"thisPropertyIsNotInTheSchema\""),
+                containsString("unknown field \"spec.thisPropertyIsNotInTheSchema\"")
+        ));
     }
 
     @Test
@@ -74,6 +77,7 @@ public class KafkaCrdIT extends AbstractCrdIT {
         assertThat(exception.getMessage(),
                 anyOf(
                         containsStringIgnoringCase("invalid: spec.maintenanceTimeWindows: Invalid value: \"null\": spec.maintenanceTimeWindows in body must be of type string: \"null\""),
+                        containsStringIgnoringCase("invalid: spec.maintenanceTimeWindows[0]: Invalid value: \"null\": spec.maintenanceTimeWindows[0] in body must be of type string: \"null\""),
                         containsStringIgnoringCase("unknown object type \"nil\" in Kafka.spec.maintenanceTimeWindows[0]")
                 ));
     }
@@ -99,7 +103,8 @@ public class KafkaCrdIT extends AbstractCrdIT {
         assertThat(exception.getMessage(), anyOf(
                 containsStringIgnoringCase("spec.zookeeper.storage.type in body should be one of [ephemeral persistent-claim]"),
                 containsStringIgnoringCase("spec.zookeeper.storage.type: Unsupported value: \"jbod\": supported values: \"ephemeral\", \"persistent-claim\""),
-                containsStringIgnoringCase("unknown field \"volumes\" in io.strimzi.kafka.v1beta2.Kafka.spec.zookeeper.storage")));
+                containsStringIgnoringCase("unknown field \"volumes\" in io.strimzi.kafka.v1beta2.Kafka.spec.zookeeper.storage"),
+                containsStringIgnoringCase("unknown field \"spec.zookeeper.storage.volumes\"")));
     }
 
     @Test
@@ -161,7 +166,6 @@ public class KafkaCrdIT extends AbstractCrdIT {
             });
 
         assertMissingRequiredPropertiesMessage(exception.getMessage(),
-                "targetMBean",
                 "attributes",
                 "outputs");
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaUserCrdIT.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -49,7 +50,10 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
             KubeClusterException.class,
             () -> createDeleteCustomResource("KafkaUser-with-extra-property.yaml"));
 
-        assertThat(exception.getMessage(), containsString("unknown field \"thisPropertyIsNotInTheSchema\""));
+        assertThat(exception.getMessage(), anyOf(
+                containsString("unknown field \"thisPropertyIsNotInTheSchema\""),
+                containsString("unknown field \"spec.thisPropertyIsNotInTheSchema\"")
+        ));
     }
 
     @BeforeAll

--- a/api/src/test/resources/io/strimzi/api/kafka/model/JmxTrans-output-definition-with-missing-required-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/JmxTrans-output-definition-with-missing-required-property.yaml
@@ -9,9 +9,6 @@ spec:
     storage:
       type: persistent-claim
       size: 500Gi
-    listeners:
-      plain: {}
-      tls: {}
   jmxTrans:
     outputDefinitions:
       - host: "wont matter about the host"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/JmxTrans-queries-with-missing-required-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/JmxTrans-queries-with-missing-required-property.yaml
@@ -10,14 +10,16 @@ spec:
       type: persistent-claim
       size: 500Gi
     listeners:
-      plain: {}
-      tls: {}
+      - type: internal
+        tls: false
+        port: 9092
+        name: test
   jmxTrans:
     outputDefinitions:
       - outputType: "wont matter about type"
         name: "won't matter"
     kafkaQueries:
-      - empty: "object"
+      - targetMBean: ""
   zookeeper:
     replicas: 1
     storage:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-missing-required-property.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-with-missing-required-property.yaml
@@ -3,7 +3,9 @@ kind: Kafka
 metadata:
   name: missing-required-property
 spec:
-  topicOperator:
-    watchedNamespace: my-ns
-  someUnsupportedFields: sdfsa
-
+  cruiseControl:
+    template:
+      pod:
+        metadata:
+          annotations:
+            app: kafka

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls-auth-with-missing-required.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnect-with-tls-auth-with-missing-required.yaml
@@ -8,15 +8,6 @@ spec:
   bootstrapServers: kafka:9092
   config:
     name: bar
-  tolerations:
-    - key: "key1"
-      operator: "Equal"
-      value: "value1"
-      effect: "NoSchedule"
-    - key: "key2"
-      operator: "Equal"
-      value: "value2"
-      effect: "NoSchedule"
   tls:
     trustedCertificates:
       - secretName: my-secret


### PR DESCRIPTION
Signed-off-by: fares.oueslati <fares.oueslati@blablacar.com>

### Type of change

- Bugfix

### Description

Adapt tests to recent kubectl versions, here is [the discussion ](https://github.com/strimzi/strimzi-kafka-operator/pull/7414/files#r987093614)that led me to open this PR.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

