### PR TITLE
Fixed TracingKafkaClientSupplier documentation

### DIFF
--- a/documentation/modules/tracing/proc-instrumenting-kafka-streams-with-tracers.adoc
+++ b/documentation/modules/tracing/proc-instrumenting-kafka-streams-with-tracers.adoc
@@ -20,32 +20,32 @@ Interceptor instrumentation:: For interceptor instrumentation, add the tracing c
 +
 You enable instrumentation in Kafka Streams applications by adding the tracing JARs as dependencies to your project.
 * To instrument Kafka Streams with OpenTelemetry, you'll need to write a custom `TracingKafkaClientSupplier`.
+* The custom `TracingKafkaClientSupplier` can extend the Kafka provided `DefaultKafkaClientSupplier` but overriding the producer and consumer creation methods in order to wrap the instances with the telemetry related code.
 +
 .Example custom `TracingKafkaClientSupplier`
 [source,java]
 ----
-private static class TracingKafkaClientSupplier implements KafkaClientSupplier {
-    @Override
-    public Admin getAdmin(Map<String, Object> config) {
-        return Admin.create(config);
-    }
+private class TracingKafkaClientSupplier extends DefaultKafkaClientSupplier {
     @Override
     public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
-        KafkaTracing tracing = KafkaTracing.create(GlobalOpenTelemetry.get());
-        return tracing.wrap(new KafkaProducer<>(config));
+        KafkaTelemetry telemetry = KafkaTelemetry.create(GlobalOpenTelemetry.get());
+        return telemetry.wrap(super.getProducer(config));
     }
+
     @Override
     public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
-        KafkaTracing tracing = KafkaTracing.create(GlobalOpenTelemetry.get());
-        return tracing.wrap(new KafkaConsumer<>(config));
+        KafkaTelemetry telemetry = KafkaTelemetry.create(GlobalOpenTelemetry.get());
+        return telemetry.wrap(super.getConsumer(config));
     }
+
     @Override
     public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
-        return getConsumer(config);
+        return this.getConsumer(config);
     }
+
     @Override
     public Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
-        return getConsumer(config);
+        return this.getConsumer(config);
     }
 }
 ----

--- a/documentation/modules/tracing/proc-instrumenting-kafka-streams-with-tracers.adoc
+++ b/documentation/modules/tracing/proc-instrumenting-kafka-streams-with-tracers.adoc
@@ -20,7 +20,7 @@ Interceptor instrumentation:: For interceptor instrumentation, add the tracing c
 +
 You enable instrumentation in Kafka Streams applications by adding the tracing JARs as dependencies to your project.
 * To instrument Kafka Streams with OpenTelemetry, you'll need to write a custom `TracingKafkaClientSupplier`.
-* The custom `TracingKafkaClientSupplier` can extend the Kafka provided `DefaultKafkaClientSupplier` but overriding the producer and consumer creation methods in order to wrap the instances with the telemetry related code.
+* The custom `TracingKafkaClientSupplier` can extend Kafka's `DefaultKafkaClientSupplier`, overriding the producer and consumer creation methods to wrap the instances with the telemetry-related code.
 +
 .Example custom `TracingKafkaClientSupplier`
 [source,java]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The example provided for a custom `TracingKafkaClientSupplier` has a bug, missing to provide the bytes array serializer and deserializer to the consumer and producer creation.
To avoid this, instead of implementing the `KafkaClientSupplier` interface, it's much better to extend the Kafka provided `DefaultKafkaClientSupplier` and overriding methods for adding the tracing logic.

### Checklist

- [x] Update documentation