### PR TITLE
[doc] Standalone UO: fix two values in `STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION`

### DIFF
--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -86,8 +86,8 @@ spec:
               value: '* * 8-10 * * ?;* * 14-15 * * ?'
             - name: STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION <16>
               value: |
-                default.api.timeout.ms=60000
-                request.timeout.ms=120000
+                default.api.timeout.ms=120000
+                request.timeout.ms=60000
 ----
 <1> The Kubernetes namespace for the User Operator to watch for `KafkaUser` resources. Only one namespace can be specified.
 <2>  The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

When I tried deployment of standalone UO with configured Admin client, I used configuration from our documentation:

```
            - name: STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION <16>
              value: |
                default.api.timeout.ms=60000
                request.timeout.ms=120000
```

UO then just throws error that `default.api.timeout.ms` should be no lower than `request.timeout.ms`. This PR just changes the values of these two configurations, to fix possible confusion when users will try to deploy standalone UO via documentation.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

