### PR TITLE
Mark tests using MockKube as isolated

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -15,7 +15,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderFactory;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.annotations.IsolatedSuite;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.junit5.VertxExtension;
@@ -25,7 +25,6 @@ import io.vertx.micrometer.VertxPrometheusOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.MalformedURLException;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@IsolatedSuite
 @ExtendWith(VertxExtension.class)
 public class ClusterOperatorTest {
     private static final Logger LOGGER = LogManager.getLogger(ClusterOperatorTest.class);
@@ -83,57 +81,57 @@ public class ClusterOperatorTest {
         PodSecurityProviderFactory.initialize();
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopSingleNamespaceOnOpenShift(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace", true, false, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopMultiNamespaceOnOpenShift(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace1,namespace2", true, false, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopSingleNamespaceOnK8s(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace", false, false, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopMultiNamespaceOnK8s(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace1,namespace2", false, false, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopSingleNamespaceWithPodSets(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace", false, true, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopMultiNamespaceWithPodSets(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace1,namespace2", false, true, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopMultiNamespaceWithPodSetsOnly(VertxTestContext context) throws InterruptedException {
         startStop(context, "namespace1,namespace2", false, true, true);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopAllNamespacesOnOpenShift(VertxTestContext context) throws InterruptedException {
         startStopAllNamespaces(context, "*", true, false, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopAllNamespacesOnK8s(VertxTestContext context) throws InterruptedException {
         startStopAllNamespaces(context, "*", false, false, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopAllNamespacesWithPodSets(VertxTestContext context) throws InterruptedException {
         startStopAllNamespaces(context, "*", false, true, false);
     }
 
-    @Test
+    @IsolatedTest
     public void testStartStopAllNamespacesWithPodSetsOnly(VertxTestContext context) throws InterruptedException {
         startStopAllNamespaces(context, "*", false, true, true);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
@@ -7,7 +7,7 @@ package io.strimzi.operator.cluster.leaderelection;
 import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.Test;
+import io.strimzi.test.annotations.IsolatedTest;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -26,7 +26,7 @@ public class LeaderElectionManagerMockTest {
     @SuppressWarnings("unused")
     private KubernetesClient client;
 
-    @Test
+    @IsolatedTest
     public void testLeaderElectionManager() throws InterruptedException {
         CountDownLatch le1Leader = new CountDownLatch(1);
         CountDownLatch le1NotLeader = new CountDownLatch(1);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -44,6 +44,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -57,7 +58,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
@@ -504,7 +504,7 @@ public class ConnectorMockTest {
                 .endSpec();
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectNotReadyWithoutSpec() {
         String connectName = "cluster";
         KafkaConnect connect = new KafkaConnectBuilder()
@@ -518,7 +518,7 @@ public class ConnectorMockTest {
         waitForConnectNotReady(connectName, "InvalidResourceException", "Spec cannot be null");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorNotReadyWithoutStrimziClusterLabel() {
         String connectorName = "connector";
 
@@ -536,7 +536,7 @@ public class ConnectorMockTest {
                 "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No connect cluster in which to create this connector.");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorNotReadyWhenConnectDoesNotExist() {
         String connectorName = "connector";
 
@@ -552,7 +552,7 @@ public class ConnectorMockTest {
                 "KafkaConnect resource 'cluster' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace ns.");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorNotReadyWithoutSpec() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -581,7 +581,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName, "InvalidResourceException", "spec property is required");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorNotReadyWhenConnectNotConfiguredForConnectors() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -613,7 +613,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, delete connector, delete connect */
-    @Test
+    @IsolatedTest
     public void testConnectConnectorConnectorConnect() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -677,7 +677,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connector, create connect, delete connector, delete connect */
-    @Test
+    @IsolatedTest
     public void testConnectorConnectConnectorConnect() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -740,7 +740,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, delete connect, delete connector */
-    @Test
+    @IsolatedTest
     public void testConnectConnectorConnectConnector() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -804,7 +804,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connector, create connect, delete connect, delete connector */
-    @Test
+    @IsolatedTest
     public void testConnectorConnectConnectConnector() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -871,7 +871,7 @@ public class ConnectorMockTest {
      * check the connector is deleted from the old cluster
      * check the connector is added to the new cluster
      * */
-    @Test
+    @IsolatedTest
     public void testChangeStrimziClusterLabel(VertxTestContext context) {
         String oldConnectClusterName = "cluster1";
         String newConnectClusterName = "cluster2";
@@ -962,7 +962,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, delete connector, delete connect */
-    @Test
+    @IsolatedTest
     public void testConnectorNotReadyWhenExceptionFromConnectRestApi() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1018,7 +1018,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, pause connector, resume connector */
-    @Test
+    @IsolatedTest
     public void testConnectorPauseResume() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1106,7 +1106,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, restart connector */
-    @Test
+    @IsolatedTest
     public void testConnectorRestart() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1182,7 +1182,7 @@ public class ConnectorMockTest {
 
 
     /** Create connect, create connector, add restart annotation, fail to restart connector, check for condition */
-    @Test
+    @IsolatedTest
     public void testConnectorRestartFail() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1262,7 +1262,7 @@ public class ConnectorMockTest {
 
 
     /** Create connect, create connector, restart connector task */
-    @Test
+    @IsolatedTest
     public void testConnectorRestartTask() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1337,7 +1337,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, restart connector task */
-    @Test
+    @IsolatedTest
     public void testConnectorRestartTaskFail() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1417,7 +1417,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, Scale to 0 */
-    @Test
+    @IsolatedTest
     public void testConnectScaleToZero() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1483,7 +1483,7 @@ public class ConnectorMockTest {
     }
 
     /** Create connect, create connector, break the REST API */
-    @Test
+    @IsolatedTest
     public void testConnectRestAPIIssues() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1550,7 +1550,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName, "ConnectTimeoutException", "connection timed out");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorUnknownField() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1592,7 +1592,7 @@ public class ConnectorMockTest {
         waitForConnectorCondition(connectorName, "Warning", "UnknownFields");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorReconciliationPausedUnpaused() {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1640,7 +1640,7 @@ public class ConnectorMockTest {
         waitForConnectorState(connectorName, "RUNNING");
     }
 
-    @Test
+    @IsolatedTest
     public void testConnectorDeleteFailsOnConnectReconciliation() {
         String connectName = "cluster";
 
@@ -1662,7 +1662,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
     }
 
-    @Test
+    @IsolatedTest
     void testConnectorResourceMetrics(VertxTestContext context) {
         String connectName1 = "cluster1";
         String connectName2 = "cluster2";
@@ -1740,7 +1740,7 @@ public class ConnectorMockTest {
         })));
     }
 
-    @Test
+    @IsolatedTest
     void testConnectorResourceMetricsPausedConnect(VertxTestContext context) {
         String connectName = "cluster";
         String connectorName1 = "connector1";
@@ -1799,7 +1799,7 @@ public class ConnectorMockTest {
     }
 
     @Disabled // MockKube2 does not support "In" selector => https://github.com/strimzi/strimzi-kafka-operator/issues/6740
-    @Test
+    @IsolatedTest
     void testConnectorResourceMetricsScaledToZero(VertxTestContext context) {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1847,7 +1847,7 @@ public class ConnectorMockTest {
         })));
     }
 
-    @Test
+    @IsolatedTest
     void testConnectorResourceMetricsStopUseResources(VertxTestContext context) {
         String connectName = "cluster";
         String connectorName = "connector";
@@ -1895,7 +1895,7 @@ public class ConnectorMockTest {
     }
 
     @Disabled // MockKube2 does not support "In" selector => https://github.com/strimzi/strimzi-kafka-operator/issues/6740
-    @Test
+    @IsolatedTest
     void testConnectorResourceMetricsConnectDeletion(VertxTestContext context) {
         String connectName = "cluster";
         String connectorName1 = "connector1";
@@ -1962,7 +1962,7 @@ public class ConnectorMockTest {
     }
 
     @Disabled // MockKube2 does not support "In" selector => https://github.com/strimzi/strimzi-kafka-operator/issues/6740
-    @Test
+    @IsolatedTest
     void testConnectorResourceMetricsMoveConnectToOtherOperator(VertxTestContext context) {
         String connectName1 = "cluster1";
         String connectName2 = "cluster2";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -42,7 +43,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
@@ -154,7 +154,7 @@ public class JbodStorageMockTest {
         mockKube.stop();
     }
 
-    @Test
+    @IsolatedTest
     public void testJbodStorageCreatesPersistentVolumeClaimsMatchingKafkaVolumes(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME))
@@ -187,7 +187,7 @@ public class JbodStorageMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileWithNewVolumeAddedToJbodStorage(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 
@@ -230,7 +230,7 @@ public class JbodStorageMockTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileWithVolumeRemovedFromJbodStorage(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 
@@ -268,7 +268,7 @@ public class JbodStorageMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileWithUpdateVolumeIdJbod(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -174,7 +174,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
         return "{tls=fc4c92a1}";
     }
 
-    @Test
+    @IsolatedTest
     public void testPodPodsRollWhenCustomCertificatesChange(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertStatefulSetMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertStatefulSetMockTest.java
@@ -41,6 +41,7 @@ import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.platform.KubernetesVersion;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -52,7 +53,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Clock;
@@ -225,7 +225,7 @@ public class KafkaAssemblyOperatorCustomCertStatefulSetMockTest {
                 .build();
     }
 
-    @Test
+    @IsolatedTest
     public void testPodToRestartIsEmptyWhenCustomCertAnnotationsHaveMatchingThumbprints(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
@@ -240,7 +240,7 @@ public class KafkaAssemblyOperatorCustomCertStatefulSetMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testPodToRestartNonemptyWhenCustomCertTlsListenerThumbprintAnnotationsNotMatchingThumbprint(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
@@ -266,7 +266,7 @@ public class KafkaAssemblyOperatorCustomCertStatefulSetMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testPodToRestartTrueWhenCustomCertExternalListenerThumbprintAnnotationsNotMatchingThumbprint(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, clusterName), kafka)
@@ -293,7 +293,7 @@ public class KafkaAssemblyOperatorCustomCertStatefulSetMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testPodToRestartIsEmptyAndNoCustomCertAnnotationsWhenNoCustomCertificates(VertxTestContext context) {
         kafka = new KafkaBuilder(createKafka())
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -46,7 +47,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterEach;
@@ -213,7 +213,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Create a cluster from a Kafka */
-    @Test
+    @IsolatedTest
     public void testReconcile(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         initialReconcile(context)
@@ -222,7 +222,7 @@ public class KafkaAssemblyOperatorMockTest {
             .onComplete(context.succeeding(v -> async.flag()));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileReplacesAllDeletedSecrets(VertxTestContext context) {
         initialReconcileThenDeleteSecretsThenReconcile(context,
                 KafkaResources.clientsCaKeySecretName(CLUSTER_NAME),
@@ -283,27 +283,27 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileReplacesDeletedZookeeperServices(VertxTestContext context) {
         initialReconcileThenDeleteServicesThenReconcile(context,
                 KafkaResources.zookeeperServiceName(CLUSTER_NAME),
                 KafkaResources.zookeeperHeadlessServiceName(CLUSTER_NAME));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileReplacesDeletedKafkaServices(VertxTestContext context) {
         initialReconcileThenDeleteServicesThenReconcile(context,
                 KafkaResources.bootstrapServiceName(CLUSTER_NAME),
                 KafkaResources.brokersServiceName(CLUSTER_NAME));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileReplacesDeletedZookeeperPodSet(VertxTestContext context) {
         String podSetName = CLUSTER_NAME + "-zookeeper";
         initialReconcileThenDeletePodSetsThenReconcile(context, podSetName);
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileReplacesDeletedKafkaPodSet(VertxTestContext context) {
         String podSetName = CLUSTER_NAME + "-kafka";
         initialReconcileThenDeletePodSetsThenReconcile(context, podSetName);
@@ -327,7 +327,7 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileUpdatesKafkaPersistentVolumes(VertxTestContext context) {
         assumeTrue(kafkaStorage instanceof PersistentClaimStorage, "Parameterized Test only runs for Params with Kafka Persistent storage");
 
@@ -368,7 +368,7 @@ public class KafkaAssemblyOperatorMockTest {
                 .inNamespace(namespace).withName(name);
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileUpdatesKafkaStorageType(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         initialReconcile(context)
@@ -431,7 +431,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Test that we can change the deleteClaim flag, and that it's honoured */
-    @Test
+    @IsolatedTest
     public void testReconcileUpdatesKafkaWithChangedDeleteClaim(VertxTestContext context) {
         assumeTrue(kafkaStorage instanceof PersistentClaimStorage, "Kafka delete claims do not apply to non-persistent volumes");
 
@@ -492,7 +492,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Create a cluster from a Kafka Cluster CM */
-    @Test
+    @IsolatedTest
     public void testReconcileKafkaScaleDown(VertxTestContext context) {
         int scaleDownTo = KAFKA_REPLICAS - 1;
         // final ordinal will be deleted
@@ -539,7 +539,7 @@ public class KafkaAssemblyOperatorMockTest {
     }
 
     /** Create a cluster from a Kafka Cluster CM */
-    @Test
+    @IsolatedTest
     public void testReconcileKafkaScaleUp(VertxTestContext context) {
         AtomicInteger brokersInternalCertsCount = new AtomicInteger();
 
@@ -583,7 +583,7 @@ public class KafkaAssemblyOperatorMockTest {
             })));
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileResumePartialRoll(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         initialReconcile(context)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -26,6 +26,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -38,7 +39,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
@@ -136,7 +136,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
         return created.future();
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileCreateAndUpdate(VertxTestContext context) {
         setConnectResource(new KafkaConnectBuilder()
                 .withMetadata(new ObjectMetaBuilder()
@@ -163,7 +163,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
     }
 
-    @Test
+    @IsolatedTest
     public void testPauseReconcileUnpause(VertxTestContext context) {
         setConnectResource(new KafkaConnectBuilder()
                 .withMetadata(new ObjectMetaBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -39,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
@@ -141,7 +141,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         return created.future();
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileUpdate(VertxTestContext context) {
         setMirrorMaker2Resource(new KafkaMirrorMaker2Builder()
                 .withMetadata(new ObjectMetaBuilder()
@@ -166,7 +166,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
             .onComplete(context.succeeding(v -> async.flag()));
     }
 
-    @Test
+    @IsolatedTest
     public void testPauseReconcile(VertxTestContext context) {
         setMirrorMaker2Resource(new KafkaMirrorMaker2Builder()
                 .withMetadata(new ObjectMetaBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -26,6 +26,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -37,7 +38,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
@@ -191,7 +191,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests upgrade without the message format and protocol versions configured. In Kafka 3.0 and older, one rolling
     // update should happen => the LMFV field is deprecated and does nto need separate upgrade.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithoutMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
 
@@ -228,7 +228,7 @@ public class KafkaUpgradeDowngradeMockTest {
     // Tests upgrade with the message format and protocol versions changed together with Kafka version change. Two
     // rolling updates should happen => first with the old message and protocol versions and another one which rolls
     // also protocol and message versions.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithNewMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -268,7 +268,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Tests upgrade with the user changing Kafka version, inter.broker.protocol.version and log.message.format.version
     // in separate steps.
-    @Test
+    @IsolatedTest
     public void testUpgradeWithNewMessageAndProtocolVersionsInSeparatePhases(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -311,7 +311,7 @@ public class KafkaUpgradeDowngradeMockTest {
     }
 
     // Tests upgrade without any versions specified in the CR for Kafka 3.0 and higher
-    @Test
+    @IsolatedTest
     public void testUpgradeWithoutAnyVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
 
@@ -351,7 +351,7 @@ public class KafkaUpgradeDowngradeMockTest {
 
     // Test regular downgrade with message and protocol versions defined everywhere and properly rolled out to all brokers.
     // The message and protocol versions used is the same as Kafka version we downgrade to.
-    @Test
+    @IsolatedTest
     public void testDowngradeWithMessageAndProtocolVersions(VertxTestContext context)  {
         Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -29,6 +29,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -40,7 +41,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
@@ -180,7 +180,7 @@ public class PartialRollingUpdateMockTest {
                         .build());
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledKafkaCluster(VertxTestContext context) {
         updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 2), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
         updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 4), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
@@ -213,7 +213,7 @@ public class PartialRollingUpdateMockTest {
         });
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledZookeeperCluster(VertxTestContext context) {
         updatePodAnnotation(KafkaResources.zookeeperPodName(CLUSTER_NAME, 1), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
         updatePodAnnotation(KafkaResources.zookeeperPodName(CLUSTER_NAME, 2), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
@@ -247,7 +247,7 @@ public class PartialRollingUpdateMockTest {
         });
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledClusterForClusterCaCertificate(VertxTestContext context) {
         updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 2), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "-1");
         updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 2), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
@@ -277,7 +277,7 @@ public class PartialRollingUpdateMockTest {
         });
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledClusterForClientsCaCertificate(VertxTestContext context) {
         updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 2), Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "-1");
         updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 2), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialStatefulSetRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialStatefulSetRollingUpdateMockTest.java
@@ -27,6 +27,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.platform.KubernetesVersion;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CountDownLatch;
@@ -196,7 +196,7 @@ public class PartialStatefulSetRollingUpdateMockTest {
                         .build());
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledKafkaCluster(VertxTestContext context) {
         updateStatefulSetGeneration(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME), StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
         updatePodGeneration(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
@@ -219,7 +219,7 @@ public class PartialStatefulSetRollingUpdateMockTest {
         });
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledZookeeperCluster(VertxTestContext context) {
         updateStatefulSetGeneration(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME), StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
         updatePodGeneration(KafkaResources.zookeeperPodName(CLUSTER_NAME, 0), StatefulSetOperator.ANNO_STRIMZI_IO_GENERATION, "3");
@@ -241,7 +241,7 @@ public class PartialStatefulSetRollingUpdateMockTest {
         });
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledClusterForClusterCaCertificate(VertxTestContext context) {
         updateSecretGeneration(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "3");
         updatePodGeneration(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "3");
@@ -274,7 +274,7 @@ public class PartialStatefulSetRollingUpdateMockTest {
         });
     }
 
-    @Test
+    @IsolatedTest
     public void testReconcileOfPartiallyRolledClusterForClientsCaCertificate(VertxTestContext context) {
         updateSecretGeneration(KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "3");
         updatePodGeneration(KafkaResources.kafkaPodName(CLUSTER_NAME, 0), Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "3");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
@@ -36,13 +36,13 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
@@ -222,7 +222,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testPodCreationDeletionAndRecreation(VertxTestContext context) {
         String podSetName = "basic-test";
         String podName = podSetName + "-0";
@@ -293,7 +293,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testScaleUpScaleDown(VertxTestContext context) {
         String podSetName = "scale-up-down";
         String pod1Name = podSetName + "-0";
@@ -386,7 +386,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testPodUpdates(VertxTestContext context) {
         String podSetName = "pod-updates";
         String podName = podSetName + "-0";
@@ -456,7 +456,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testOwnerReferencePatching(VertxTestContext context) {
         String podSetName = "owner-reference";
         String podName = podSetName + "-0";
@@ -504,7 +504,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testCrSelector(VertxTestContext context) {
         String podSetName = "matching-podset";
         String otherPodSetName = "other-podset";
@@ -576,7 +576,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testMetrics(VertxTestContext context) {
         String podSetName = "metrics-test";
         String podName = podSetName + "-0";
@@ -641,7 +641,7 @@ public class StrimziPodSetControllerMockTest {
      *
      * @param context   Test context
      */
-    @Test
+    @IsolatedTest
     public void testFailedPodRecovery(VertxTestContext context) {
         String podSetName = "basic-test";
         String podName = podSetName + "-0";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -53,6 +53,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.strimzi.test.mockkube2.controllers.MockPodController;
 import io.vertx.core.AsyncResult;
@@ -69,7 +70,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Clock;
@@ -181,7 +181,7 @@ public class KubernetesRestartEventsMockTest {
         mockKube.stop();
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenJbodVolumeMembershipAltered(Vertx vertx, VertxTestContext context) {
         //Default Kafka CR has two volumes, so drop to 1
         Kafka kafkaWithLessVolumes = new KafkaBuilder(KAFKA)
@@ -210,7 +210,7 @@ public class KubernetesRestartEventsMockTest {
         lowerVolumes.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_HAS_OLD_REVISION, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenFileSystemResizeRequested(Vertx vertx, VertxTestContext context) {
         // Pretend the resizing process is underway by adding a condition of FileSystemResizePending
         // This will cause the pod to restart to pick up resized PVC
@@ -230,7 +230,7 @@ public class KubernetesRestartEventsMockTest {
         defaultReconciler(vertx).reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(FILE_SYSTEM_RESIZE_NEEDED, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenCaCertHasOldGeneration(Vertx vertx, VertxTestContext context) {
         Secret patched = modifySecretWithAnnotation(clusterCa.caCertSecret(), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "-1");
         ClusterCa oldGenClusterCa = createClusterCaWithSecret(patched);
@@ -250,7 +250,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_HAS_OLD_GENERATION, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenCaCertRemoved(Vertx vertx, VertxTestContext context) {
         ClusterCa ca = new OverridingClusterCa() {
             @Override
@@ -274,7 +274,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_REMOVED, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenCaCertRenewed(Vertx vertx, VertxTestContext context) {
         ClusterCa ca = new OverridingClusterCa() {
             @Override
@@ -298,7 +298,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_RENEWED, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenClientCaCertKeyReplaced(Vertx vertx, VertxTestContext context) {
         // Turn off cert authority generation to cause reconciliation to roll pods
         Kafka kafkaWithoutClientCaGen = new KafkaBuilder(KAFKA)
@@ -316,7 +316,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(Clock.systemUTC()).onComplete(verifyEventPublished(CLIENT_CA_CERT_KEY_REPLACED, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenClusterCaCertKeyReplaced(Vertx vertx, VertxTestContext context) {
         //Turn off cert authority generation to cause reconciliation to roll pods
         Kafka kafkaWithoutClusterCaGen = new KafkaBuilder(KAFKA)
@@ -334,7 +334,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(Clock.systemUTC()).onComplete(verifyEventPublished(CLUSTER_CA_CERT_KEY_REPLACED, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenConfigChangeRequiresRestart(Vertx vertx, VertxTestContext context) {
         // Modify mccked configs call to return a new property to trigger a reconfiguration reconciliation that requires a restart
         Admin adminClient = withChangedBrokerConf(ResourceUtils.adminClientProvider().createAdminClient(null, null, null, null));
@@ -355,7 +355,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CONFIG_CHANGE_REQUIRES_RESTART, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenPodRevisionChanged(Vertx vertx, VertxTestContext context) {
         // Change custom listener cert thumbprint annotation to cause reconciliation requiring restart
         patchKafkaPodWithAnnotation(PodRevision.STRIMZI_REVISION_ANNOTATION, "doesnotmatchthepodset");
@@ -363,14 +363,14 @@ public class KubernetesRestartEventsMockTest {
         defaultReconciler(vertx).reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_HAS_OLD_REVISION, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenPodAnnotatedForManualRollingUpdate(Vertx vertx, VertxTestContext context) {
         patchKafkaPodWithAnnotation(ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true");
 
         defaultReconciler(vertx).reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(MANUAL_ROLLING_UPDATE, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenStrimziPodSetAnnotatedForManualRollingUpdate(Vertx vertx, VertxTestContext context) {
         supplier.strimziPodSetOperator
                 .client()
@@ -385,7 +385,7 @@ public class KubernetesRestartEventsMockTest {
         defaultReconciler(vertx).reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(MANUAL_ROLLING_UPDATE, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenPodIsUnresponsive(Vertx vertx, VertxTestContext context) {
         // Simulate not being able to initiate an initial admin client connection broker at all
         ResourceOperatorSupplier supplierWithModifiedAdmin = supplierWithAdmin(vertx, () -> {
@@ -407,7 +407,7 @@ public class KubernetesRestartEventsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_UNRESPONSIVE, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenPodIsStuck(Vertx vertx, VertxTestContext context) {
         Pod kafkaPod = kafkaPod();
 
@@ -434,7 +434,7 @@ public class KubernetesRestartEventsMockTest {
         defaultReconciler(vertx).reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_STUCK, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenKafkaBrokerCertsChanged(Vertx vertx, VertxTestContext context) {
         // Using the real SSL cert manager (after the cluster was created using the mock cert manager) will cause the desired Kafka broker certs to change,
         // thus the reconciliation will schedule the restart needed to pick them up

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsStatefulSetsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsStatefulSetsMockTest.java
@@ -44,6 +44,7 @@ import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.annotations.IsolatedTest;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.strimzi.test.mockkube2.controllers.MockPodController;
 import io.vertx.core.AsyncResult;
@@ -53,7 +54,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Clock;
@@ -151,7 +151,7 @@ public class KubernetesRestartEventsStatefulSetsMockTest {
         mockKube.stop();
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenPodInStatefulSetHasOldGeneration(Vertx vertx, VertxTestContext context) {
         KafkaReconciler reconciler = new KafkaReconciler(
                 reconciliation,
@@ -174,7 +174,7 @@ public class KubernetesRestartEventsStatefulSetsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_HAS_OLD_GENERATION, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenJbodVolumeMembershipAltered(Vertx vertx, VertxTestContext context) {
         //Default Kafka CR has two volumes, so drop to 1
         Kafka kafkaWithLessVolumes = new KafkaBuilder(KAFKA)
@@ -203,7 +203,7 @@ public class KubernetesRestartEventsStatefulSetsMockTest {
         lowerVolumes.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(JBOD_VOLUMES_CHANGED, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenAnnotatedForManualRollingUpdate(Vertx vertx, VertxTestContext context) {
         StatefulSet kafkaSet = stsOps().withLabel(appName, "kafka").list().getItems().get(0);
         StatefulSet patchedSet = new StatefulSetBuilder(kafkaSet)
@@ -230,7 +230,7 @@ public class KubernetesRestartEventsStatefulSetsMockTest {
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(MANUAL_ROLLING_UPDATE, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenCustomListenerCaCertChanged(Vertx vertx, VertxTestContext context) {
         // Change custom listener cert thumbprint annotation to cause reconciliation requiring restart
         patchKafkaPodWithAnnotation(ANNO_STRIMZI_CUSTOM_LISTENER_CERT_THUMBPRINTS, "1234");
@@ -238,7 +238,7 @@ public class KubernetesRestartEventsStatefulSetsMockTest {
         defaultReconciler(vertx).reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CUSTOM_LISTENER_CA_CERT_CHANGE, context));
     }
 
-    @Test
+    @IsolatedTest
     void testEventEmittedWhenPodIsStuck(Vertx vertx, VertxTestContext context) {
         Pod kafkaPod = kafkaPod();
 

--- a/cluster-operator/src/test/resources/junit-platform.properties
+++ b/cluster-operator/src/test/resources/junit-platform.properties
@@ -1,8 +1,0 @@
-# These are default values if @ParallelTest or @ParallelSuite is not specified
-# junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
-# junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
-junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.default=same_thread
-junit.jupiter.execution.parallel.mode.classes.default=same_thread
-junit.jupiter.execution.parallel.config.strategy=dynamic
-junit.platform.output.capture.maxBuffer=true

--- a/cluster-operator/src/test/resources/junit-platform.properties
+++ b/cluster-operator/src/test/resources/junit-platform.properties
@@ -1,0 +1,8 @@
+# These are default values if @ParallelTest or @ParallelSuite is not specified
+# junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
+# junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=same_thread
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.platform.output.capture.maxBuffer=true


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR tries to fix the flakiness of the Cluster Operator unit tests and get rid of the `Thread limit exceeded replacing blocked worker` error. It marks all tests using the MockKube - which in general use multiple different threads - as isolated to avoid them being run in parallel. 

So far, this seemed to have helped and I had 6 runs without the issue. But as it is not fully reproducible, there is of course a chance that this is just a coincidence.