### PR TITLE
docs(downgrade): Note on OLM and downgrade constraints

### DIFF
--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -9,7 +9,7 @@
 If you are encountering issues with the version of Strimzi you upgraded to,
 you can revert your installation to the previous version.
 
-If you used the installation artifacts to install Strimzi, you can use the same artifacts to perform the following downgrade procedures:
+If you used the YAML installation files to install Strimzi, you can use the YAML installation files from the previous release to perform the following downgrade procedures:
 
 . xref:proc-downgrade-cluster-operator-{context}[]
 . xref:assembly-downgrade-kafka-versions-{context}[]

--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -5,6 +5,7 @@
 [id='assembly-downgrade-{context}']
 = Downgrading Strimzi
 
+[role="_abstract"]
 If you are encountering issues with the version of Strimzi you upgraded to,
 you can revert your installation to the previous version.
 
@@ -18,6 +19,8 @@ You can perform a downgrade to:
 
 If the previous version of Strimzi does not support the version of Kafka you are using,
 you can also downgrade Kafka as long as the log message format versions appended to messages match.
+
+WARNING: The downgrade steps use the installation artifacts provided with Strimzi. The Operator Lifecycle Manager (OLM) does not support downgrades. If you installed Strimzi using the OLM, and wish to retain a subscription, you can try reinstalling an earlier version of Strimzi. Otherwise, if you use these downgrade instructions, your deployment will no longer be managed by the OLM.   
 
 //steps to downgrade the operators
 include::../../modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -9,18 +9,17 @@
 If you are encountering issues with the version of Strimzi you upgraded to,
 you can revert your installation to the previous version.
 
-You can perform a downgrade to:
+If you used the installation artifacts to install Strimzi, you can use the same artifacts to perform the following downgrade procedures:
 
-. Revert your Cluster Operator to the previous Strimzi version.
-** xref:proc-downgrade-cluster-operator-{context}[]
-
-. Downgrade all Kafka brokers and client applications to the previous Kafka version.
-** xref:assembly-downgrade-kafka-versions-{context}[]
+. xref:proc-downgrade-cluster-operator-{context}[]
+. xref:assembly-downgrade-kafka-versions-{context}[]
 
 If the previous version of Strimzi does not support the version of Kafka you are using,
 you can also downgrade Kafka as long as the log message format versions appended to messages match.
 
-WARNING: The downgrade steps use the installation artifacts provided with Strimzi. The Operator Lifecycle Manager (OLM) does not support downgrades. If you installed Strimzi using the OLM, and wish to retain a subscription, you can try reinstalling an earlier version of Strimzi. Otherwise, if you use these downgrade instructions, your deployment will no longer be managed by the OLM.   
+WARNING: If you deployed Strimzi using another installation method, use a supported approach to downgrade Strimzi.
+Do not use the downgrade instructions provided here. 
+For example, if you installed Strimzi using the Operator Lifecycle Manager (OLM), you can downgrade by changing the deployment channel to an earlier version of Strimzi. 
 
 //steps to downgrade the operators
 include::../../modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Adds a note to [Downgrading Strimzi](https://strimzi.io/docs/operators/in-development/deploying.html#assembly-downgrade-str) to clarify that the downgrade steps use the install artifacts. And downgrading using the OLM is not possible. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

