### PR TITLE
Disable parallel unit test execution in Cluster Operator

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -15,7 +15,6 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderFactory;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.annotations.IsolatedSuite;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.junit5.VertxExtension;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@IsolatedSuite
 @ExtendWith(VertxExtension.class)
 public class ClusterOperatorTest {
     private static final Logger LOGGER = LogManager.getLogger(ClusterOperatorTest.class);

--- a/cluster-operator/src/test/resources/junit-platform.properties
+++ b/cluster-operator/src/test/resources/junit-platform.properties
@@ -1,8 +1,0 @@
-# These are default values if @ParallelTest or @ParallelSuite is not specified
-# junit.jupiter.execution.parallel.mode.default <==> ParallelTest = concurrent
-# junit.jupiter.execution.parallel.mode.classes.default <==> ParallelSuite = concurrent
-junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.default=same_thread
-junit.jupiter.execution.parallel.mode.classes.default=same_thread
-junit.jupiter.execution.parallel.config.strategy=dynamic
-junit.platform.output.capture.maxBuffer=true


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Cluster Operator unit tests seem to be flaky lately with the following errors:
```
RejectedExecution java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
```

This seems to be related to the parallel execution. This PR disables the parallel execution which anyway does nto bring any significant time savings. It also removes the `@IsolatedSuite` annotation from `ClusterOperatorTest` which should not be needed anymore.