### PR TITLE
Update IGNORABLE_PATHS to minimize patching of different Kubernetes resources

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -24,6 +24,10 @@ public class StatefulSetDiff extends AbstractJsonDiff {
 
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
         "^(/metadata/managedFields"
+        + "|/metadata/creationTimestamp"
+        + "|/metadata/resourceVersion"
+        + "|/metadata/generation"
+        + "|/metadata/uid"
         + "|/spec/revisionHistoryLimit"
         + "|/spec/template/metadata/annotations/" + SHORTENED_STRIMZI_DOMAIN + "~1generation"
         + "|/spec/template/spec/initContainers/[0-9]+/resources"

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -41,6 +41,10 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
 
     protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
+                    "|/metadata/creationTimestamp" +
+                    "|/metadata/resourceVersion" +
+                    "|/metadata/generation" +
+                    "|/metadata/uid" +
                     "|/status)$");
 
     protected final Vertx vertx;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -51,6 +51,10 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
 
     protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
+                    "|/metadata/creationTimestamp" +
+                    "|/metadata/resourceVersion" +
+                    "|/metadata/generation" +
+                    "|/metadata/uid" +
                     "|/status)$");
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractResourceOperator.class);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
@@ -16,6 +16,10 @@ import java.util.regex.Pattern;
 public class NetworkPolicyOperator extends AbstractResourceOperator<KubernetesClient, NetworkPolicy, NetworkPolicyList, Resource<NetworkPolicy>> {
     protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
+                    "|/metadata/creationTimestamp" +
+                    "|/metadata/resourceVersion" +
+                    "|/metadata/generation" +
+                    "|/metadata/uid" +
                     "|/spec/policyTypes" +
                     "|/status)$");
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -25,6 +25,10 @@ public class PvcOperator extends AbstractResourceOperator<KubernetesClient, Pers
             "^(/metadata/managedFields" +
                     "|/metadata/annotations/pv.kubernetes.io~1bind-completed" +
                     "|/metadata/finalizers" +
+                    "|/metadata/creationTimestamp" +
+                    "|/metadata/resourceVersion" +
+                    "|/metadata/generation" +
+                    "|/metadata/uid" +
                     "|/status)$");
 
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -31,11 +31,16 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ServiceOperator.class);
     protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
+                    "|/metadata/creationTimestamp" +
+                    "|/metadata/resourceVersion" +
+                    "|/metadata/generation" +
+                    "|/metadata/uid" +
                     "|/spec/sessionAffinity" +
                     "|/spec/clusterIP" +
                     "|/spec/clusterIPs" +
                     "|/spec/ipFamily" + // Legacy field from Kube 1.19 and earlier. We just ignore it, it is not configurable.
                     "|/spec/ipFamilies" + // Immutable field
+                    "|/spec/internalTrafficPolicy" + // Set by Kubernetes to Cluster as default (not configurable through Strimzi as it does nto seem to make much sense for us, so we ignore it)
                     "|/status)$");
 
     private final EndpointOperator endpointOperations;
@@ -73,7 +78,7 @@ public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, 
      * @param reconciliation The reconciliation
      * @param namespace Namespace of the service
      * @param name      Name of the service
-     * @param current   Current servicve
+     * @param current   Current service
      * @param desired   Desired Service
      *
      * @return  Future with reconciliation result


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the `IGNORABLE_PATHS` variable which is used to avoid generating unnecessary patches for various Kubernetes resources. They contain mainly fields automatically set by Kubernetes (which are not in our resources and generate unnecessary diffs). That should help to avoid unnecessary use of the Kubernetes API server.

This should among other things help with the #7442 which is about unnecessary patching of the `internalTrafficPolicy` field.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging