### PR TITLE
Update Jackson Databind to 2.13.4 in operators

### DIFF
--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -7,6 +7,7 @@ package io.strimzi.build.kafka.metadata;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.strimzi.kafka.config.model.ConfigModel;
 import io.strimzi.kafka.config.model.ConfigModels;
 import io.strimzi.kafka.config.model.Scope;
@@ -44,7 +45,7 @@ public class KafkaConfigModelGenerator {
 
         String version = kafkaVersion();
         Map<String, ConfigModel> configs = configs(version);
-        ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT).enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+        ObjectMapper mapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
         ConfigModels root = new ConfigModels();
         root.setVersion(version);
         root.setConfigs(configs);

--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,10 @@
         <fabric8.openshift-client.version>6.1.1</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>6.1.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <fasterxml.jackson-core.version>2.12.6</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.12.6.1</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.12.6</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.12.6</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-core.version>2.13.4</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.13.4</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.13.4</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.13.4</fasterxml.jackson-annotations.version>
         <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
         <snakeyaml.version>1.32</snakeyaml.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Jackson dependency in the operator to 2.13.4. This updates Jackson Databind and addresses CVE-2022-42004.

This updates JAckson only in operators. In the Kafka images, Jackson Databind is direct Kafka dependency. So it would need to be updated in Kafkaitself, it cannot be addressed through Strimzi.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally