### PR TITLE
Fix the `RoleBinding` creation in the Quickstart guide

### DIFF
--- a/documentation/modules/quickstart/proc-installing-product.adoc
+++ b/documentation/modules/quickstart/proc-installing-product.adoc
@@ -85,6 +85,10 @@ kubectl create -f install/cluster-operator/020-RoleBinding-strimzi-cluster-opera
 ----
 [source, shell, subs=+quotes]
 ----
+kubectl create -f install/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml -n my-kafka-project
+----
+[source, shell, subs=+quotes]
+----
 kubectl create -f install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml -n my-kafka-project
 ----
 --


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #7390 I missed to update the Quickstart docs which now doesn't work because the new Role Binding is not created. Luckily it was noticed by @devguyio. This PR should fix it.