### PR TITLE
Update Jacoco version to 0.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven.jar.version>3.1.0</maven.jar.version>
         <sonatype.nexus.staging.version>1.6.3</sonatype.nexus.staging.version>
         <maven.spotbugs.version>4.5.3.0</maven.spotbugs.version>
-        <maven.jacoco.version>0.7.9</maven.jacoco.version>
+        <maven.jacoco.version>0.8.8</maven.jacoco.version>
         <maven.exec.version>1.6.0</maven.exec.version>
         <maven.resources.version>3.1.0</maven.resources.version>
 


### PR DESCRIPTION
Signed-off-by: michaelcullen <michael.cullen@est.tech>

### Type of change

- Enhancement


### Description

The current version of Jacoco is not supported by Java 11 and has been updated to support this.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

