### PR TITLE
Docs: Super users require full cert subject w/o User Operator

### DIFF
--- a/documentation/modules/security/con-securing-kafka-authorization.adoc
+++ b/documentation/modules/security/con-securing-kafka-authorization.adoc
@@ -27,6 +27,7 @@ and are supported by all authorization mechanisms.
 
 To designate super users for a Kafka cluster, add a list of user principals to the `superUsers` property.
 If a user uses TLS client authentication, their username is the common name from their certificate subject prefixed with `CN=`.
+Otherwise, if not using the User Operator and using your own certificates for TLS client authentication, their username is their full certificate subject, which uses the form `CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown`.
 
 .An example configuration with super users
 [source,yaml,subs="attributes+"]
@@ -45,5 +46,6 @@ spec:
         - CN=client_1
         - user_2
         - CN=client_3
+        - CN=client_4,OU=my_ou,O=my_org,L=my_location,ST=my_state,C=US
     # ...
 ----

--- a/documentation/modules/security/con-securing-kafka-authorization.adoc
+++ b/documentation/modules/security/con-securing-kafka-authorization.adoc
@@ -18,7 +18,7 @@ Supported authorization options:
 * xref:type-KafkaAuthorizationCustom-reference[Custom authorization]
 
 .Kafka cluster authorization options
-image::kafka-authorization-config-options.png[options for kafks authorization configuration]
+image::kafka-authorization-config-options.png[options for kafka authorization configuration]
 
 == Super users
 
@@ -27,7 +27,7 @@ and are supported by all authorization mechanisms.
 
 To designate super users for a Kafka cluster, add a list of user principals to the `superUsers` property.
 If a user uses TLS client authentication, their username is the common name from their certificate subject prefixed with `CN=`.
-Otherwise, if not using the User Operator and using your own certificates for TLS client authentication, their username is their full certificate subject, which uses the form `CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown`.
+Otherwise, if not using the User Operator and using your own certificates for TLS client authentication, their username is their full certificate subject, with the fields formatted as: `CN=user,OU=my_ou,O=my_org,L=my_location,ST=my_state,C=my_country_code`. Note that some fields may not be present in the certificate's subject, and thus should be omitted.
 
 .An example configuration with super users
 [source,yaml,subs="attributes+"]
@@ -47,5 +47,7 @@ spec:
         - user_2
         - CN=client_3
         - CN=client_4,OU=my_ou,O=my_org,L=my_location,ST=my_state,C=US
+        - CN=client_5,OU=my_ou,O=my_org,C=GB
+        - CN=client_6,O=my_org
     # ...
 ----


### PR DESCRIPTION
Resolves #7427

### Type of change

- Documentation

### Description

The current documentation on adding super users with TLS client auth assumes the User Operator is used to provision client certs. When using custom client certs without the User Operator, the entire cert subject is required, as per https://docs.confluent.io/platform/current/kafka/authorization.html#tls-ssl-principal-user-names

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards