### PR TITLE
Update Jackson Databind to 2.13.4.1 in operators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <fabric8.kubernetes-model.version>6.1.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.13.4</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.13.4</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-databind.version>2.13.4.1</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.13.4</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.13.4</fasterxml.jackson-annotations.version>
         <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Jackson dependency in the operator to 2.13.4.1. This updates Jackson Databind and addresses CVE-2022-42003 (see https://github.com/FasterXML/jackson-databind/issues/3590#issue-1362567066 for more details).

This updates Jackson only in operators. In the Kafka images, Jackson Databind is direct Kafka dependency. So it would need to be updated in Kafka itself, it cannot be addressed through Strimzi.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally