### PR TITLE
Added the missing ACLs missing the Reassign partitions documentation

### DIFF
--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -76,6 +76,7 @@ spec:
   authorization:
     type: simple <2>
     acls:
+      # access to the topic
       - resource:
           type: topic
           name: my-topic
@@ -85,6 +86,19 @@ spec:
           - Describe
           - Read
           - Write
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: AlterConfigs
+        host: "*"
+      # access to the cluster
+      - resource:
+          type: cluster
+          name: my-cluster
+          patternType: literal
+        operation: AlterConfigs
         host: "*"
       - resource:
           type: cluster
@@ -99,7 +113,6 @@ spec:
 <1> User authentication mechanism defined as mutual `tls`.
 <2> Simple authorization and accompanying list of ACL rules.
 
-NOTE: Permission for a `Describe` operation is required as a minimum for TLS access to a topic.
 --
 
 .Procedure

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -80,32 +80,18 @@ spec:
       - resource:
           type: topic
           name: my-topic
-          patternType: literal
         operations:
           - Create
           - Describe
           - Read
-          - Write
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: AlterConfigs
+          - AlterConfigs
         host: "*"
       # access to the cluster
       - resource:
           type: cluster
-          name: my-cluster
-          patternType: literal
-        operation: AlterConfigs
-        host: "*"
-      - resource:
-          type: cluster
-          name: my-cluster
-          patternType: literal
         operations:
           - Alter
+          - AlterConfigs
         host: "*"
       # ...
   # ...


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Documentation

### Description

This PR is based on the suggestions mentioned in the PR #7411. This PR adds the missing ACLs in the reassign partition documentation and also adds comments to focus on which ACLs are used for topics and which ones are used for cluster

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

