### PR TITLE
Use the new operations field for ACLs in the docs and examples

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect-user-authorization.adoc
@@ -89,82 +89,41 @@ spec:
           type: topic
           name: connect-cluster-offsets
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-offsets
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-offsets
-          patternType: literal
-        operation: Describe
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-offsets
-          patternType: literal
-        operation: Read
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
         host: "*"
       # access to status.storage.topic
       - resource:
           type: topic
           name: connect-cluster-status
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-status
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-status
-          patternType: literal
-        operation: Describe
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-status
-          patternType: literal
-        operation: Read
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
         host: "*"
       # access to config.storage.topic
       - resource:
           type: topic
           name: connect-cluster-configs
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-configs
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-configs
-          patternType: literal
-        operation: Describe
-        host: "*"
-      - resource:
-          type: topic
-          name: connect-cluster-configs
-          patternType: literal
-        operation: Read
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
         host: "*"
       # consumer group
       - resource:
           type: group
           name: connect-cluster
           patternType: literal
-        operation: Read
+        operations:
+          - Read
         host: "*"
 ----
 

--- a/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
@@ -181,35 +181,32 @@ spec:
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
           name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Create
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: DescribeConfigs
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Write
+        operations:
+          - Create
+          - DescribeConfigs
+          - Read
+          - Write
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Read
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: DescribeConfigs
+        operations:
+          - DescribeConfigs
+          - Read
       # MirrorCheckpointConnector
       - resource:
           type: cluster
-        operation: Describe
+        operations:
+          - Describe
       - resource: # Needed for every group for which offsets are synced
           type: group
           name: "*"
-        operation: Describe
+        operations:
+          - Describe
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
           name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Read
+        operations:
+          - Read
 ----
 +
 .Example target user configuration for TLS client authentication
@@ -231,125 +228,71 @@ spec:
       - resource:
           type: group
           name: mirrormaker2-cluster
-        operation: Read
+        operations:
+          - Read
       - resource:
           type: topic
           name: mirrormaker2-cluster-configs
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Create
+        operations:
+          - Create
+          - Describe
+          - DescribeConfigs
+          - Read
+          - Write
       - resource:
           type: topic
           name: mirrormaker2-cluster-status
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Create
+        operations:
+          - Create
+          - Describe
+          - DescribeConfigs
+          - Read
+          - Write
       - resource:
           type: topic
           name: mirrormaker2-cluster-offsets
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Create
+        operations:
+          - Create
+          - Describe
+          - DescribeConfigs
+          - Read
+          - Write
       # MirrorSourceConnector
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Create
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Alter
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: AlterConfigs
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Write
+        operations:
+          - Create
+          - Alter
+          - AlterConfigs
+          - Write
       # MirrorCheckpointConnector
       - resource:
           type: cluster
-        operation: Describe
+        operations:
+          - Describe
       - resource:
           type: topic
           name: my-source-cluster.checkpoints.internal
-        operation: Create
-      - resource:
-          type: topic
-          name: my-source-cluster.checkpoints.internal
-        operation: Describe
-      - resource:
-          type: topic
-          name: my-source-cluster.checkpoints.internal
-        operation: Write
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
       - resource: # Needed for every group for which the offset is synced
           type: group
           name: "*"
-        operation: Read
-      - resource: # Needed for every group for which the offset is synced
-          type: group
-          name: "*"
-        operation: Describe
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Read
+        operations:
+          - Read
+          - Describe
       # MirrorHeartbeatConnector
       - resource:
           type: topic
           name: heartbeats
-        operation: Create
-      - resource:
-          type: topic
-          name: heartbeats
-        operation: Describe
-      - resource:
-          type: topic
-          name: heartbeats
-        operation: Write
+        operations:
+          - Create
+          - Describe
+          - Write
 ----
 +
 NOTE: You can use a certificate issued outside the User Operator by setting `type` to `tls-external`.

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -80,25 +80,18 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
         host: "*"
       - resource:
           type: cluster
           name: my-cluster
           patternType: literal
-        operation: Alter
+        operations:
+          - Alter
         host: "*"
       # ...
   # ...

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -167,17 +167,15 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Describe
+          - Read
       - resource:
           type: group
           name: my-group
           patternType: literal
-        operation: Read
+        operations:
+          - Read
 ----
 <1> The label must match the label of the Kafka cluster.
 <2> Authentication specified as `tls`.

--- a/documentation/modules/operators/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-user.adoc
@@ -51,38 +51,26 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Describe
+          - Read
         host: "*"
       - resource:
           type: group
           name: my-group
           patternType: literal
-        operation: Read
+        operations:
+          - Read
         host: "*"
       # Example Producer Acls for topic my-topic
       - resource:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Create
+          - Describe
+          - Write
         host: "*"
 ----
 

--- a/documentation/modules/security/proc-configuring-secure-kafka-user.adoc
+++ b/documentation/modules/security/proc-configuring-secure-kafka-user.adoc
@@ -52,17 +52,15 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Describe
+          - Read
       - resource:
           type: group
           name: my-group
           patternType: literal
-        operation: Read
+        operations:
+          - Read
 ----
 <1> User authentication mechanism, defined as mutual `tls` or `scram-sha-512`.
 <2> Simple authorization, which requires an accompanying list of ACL rules.

--- a/packaging/examples/security/scram-sha-512-auth/bridge.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/bridge.yaml
@@ -15,23 +15,16 @@ spec:
     - resource:
         type: group
         name: my-group
-      operation: Read
+      operations:
+        - Read
     - resource:
         type: topic
         name: my-topic
-      operation: Read
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Describe
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Write
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Create
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaBridge

--- a/packaging/examples/security/scram-sha-512-auth/connect.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/connect.yaml
@@ -14,77 +14,47 @@ spec:
     - resource:
         type: group
         name: connect-cluster
-      operation: Read
+      operations:
+        - Read
     - resource:
         type: topic
         name: connect-cluster-configs
-      operation: Read
-    - resource:
-        type: topic
-        name: connect-cluster-configs
-      operation: Describe
-    - resource:
-        type: topic
-        name: connect-cluster-configs
-      operation: Write
-    - resource:
-        type: topic
-        name: connect-cluster-configs
-      operation: Create
+      operations:
+        - Create
+        - Describe
+        - Read
+        - Write
     - resource:
         type: topic
         name: connect-cluster-status
-      operation: Read
-    - resource:
-        type: topic
-        name: connect-cluster-status
-      operation: Describe
-    - resource:
-        type: topic
-        name: connect-cluster-status
-      operation: Write
-    - resource:
-        type: topic
-        name: connect-cluster-status
-      operation: Create
+      operations:
+        - Create
+        - Describe
+        - Read
+        - Write
     - resource:
         type: topic
         name: connect-cluster-offsets
-      operation: Read
-    - resource:
-        type: topic
-        name: connect-cluster-offsets
-      operation: Write
-    - resource:
-        type: topic
-        name: connect-cluster-offsets
-      operation: Describe
-    - resource:
-        type: topic
-        name: connect-cluster-offsets
-      operation: Create
+      operations:
+        - Create
+        - Describe
+        - Read
+        - Write
     # Additional topics and groups used by connectors
     # Change to match the topics used by your connectors
     - resource:
         type: group
         name: connect-cluster
-      operation: Read
+      operations:
+       - Read
     - resource:
         type: topic
         name: my-topic
-      operation: Read
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Describe
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Write
-    - resource:
-        type: topic
-        name: my-topic
-      operation: Create
+      operations:
+        - Create
+        - Describe
+        - Read
+        - Write
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnect

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -97,35 +97,32 @@ spec:
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
           name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Create
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: DescribeConfigs
-      - resource: # Not needed if offset-syncs.topic.location=target
-          type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Write
+        operations:
+          - Create
+          - DescribeConfigs
+          - Read
+          - Write
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Read
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: DescribeConfigs
+        operations:
+          - Read
+          - DescribeConfigs
       # MirrorCheckpointConnector
       - resource:
           type: cluster
-        operation: Describe
+        operations:
+          - Describe
       - resource: # Needed for every group for which offsets are synced
           type: group
           name: "*"
-        operation: Describe
+        operations:
+          - Describe
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
           name: mm2-offset-syncs.my-target-cluster.internal
-        operation: Read
+        operations:
+          - Read
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2
@@ -144,125 +141,75 @@ spec:
       - resource:
           type: group
           name: mirrormaker2-cluster
-        operation: Read
+        operations:
+          - Read
       - resource:
           type: topic
           name: mirrormaker2-cluster-configs
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-configs
-        operation: Create
+        operations:
+          - Create
+          - Describe
+          - DescribeConfigs
+          - Read
+          - Write
       - resource:
           type: topic
           name: mirrormaker2-cluster-status
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-status
-        operation: Create
+        operations:
+          - Create
+          - Describe
+          - DescribeConfigs
+          - Read
+          - Write
       - resource:
           type: topic
           name: mirrormaker2-cluster-offsets
-        operation: Read
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Write
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Describe
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: DescribeConfigs
-      - resource:
-          type: topic
-          name: mirrormaker2-cluster-offsets
-        operation: Create
+        operations:
+          - Create
+          - Describe
+          - DescribeConfigs
+          - Read
+          - Write
       # MirrorSourceConnector
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Create
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Alter
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: AlterConfigs
-      - resource: # Needed for every topic which is mirrored
-          type: topic
-          name: "*"
-        operation: Write
+        operations:
+          - Create
+          - Alter
+          - AlterConfigs
+          - Write
       # MirrorCheckpointConnector
       - resource:
           type: cluster
-        operation: Describe
+        operations:
+          - Describe
       - resource:
           type: topic
           name: my-source-cluster.checkpoints.internal
-        operation: Create
-      - resource:
-          type: topic
-          name: my-source-cluster.checkpoints.internal
-        operation: Describe
-      - resource:
-          type: topic
-          name: my-source-cluster.checkpoints.internal
-        operation: Write
+        operations:
+          - Create
+          - Describe
+          - Write
       - resource: # Needed for every group for which the offset is synced
           type: group
           name: "*"
-        operation: Read
-      - resource: # Needed for every group for which the offset is synced
-          type: group
-          name: "*"
-        operation: Describe
+        operations:
+          - Read
+          - Decribe
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
-        operation: Read
+        operations:
+          - Read
       # MirrorHeartbeatConnector
       - resource:
           type: topic
           name: heartbeats
-        operation: Create
-      - resource:
-          type: topic
-          name: heartbeats
-        operation: Describe
-      - resource:
-          type: topic
-          name: heartbeats
-        operation: Write
+        operations:
+          - Create
+          - Describe
+          - Write
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2

--- a/packaging/examples/security/scram-sha-512-auth/user.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/user.yaml
@@ -15,36 +15,24 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Describe
+          - Read
         host: "*"
       - resource:
           type: group
           name: my-group
           patternType: literal
-        operation: Read
+        operations:
+          - Read
         host: "*"
       # Example ACL rules for producing to topic my-topic
       - resource:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Create
+          - Describe
+          - Write
         host: "*"

--- a/packaging/examples/user/kafka-user.yaml
+++ b/packaging/examples/user/kafka-user.yaml
@@ -15,36 +15,24 @@ spec:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Read
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Describe
+          - Read
         host: "*"
       - resource:
           type: group
           name: my-group
           patternType: literal
-        operation: Read
+        operations:
+          - Read
         host: "*"
       # Example Producer Acls for topic my-topic
       - resource:
           type: topic
           name: my-topic
           patternType: literal
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: my-topic
-          patternType: literal
-        operation: Describe
+        operations:
+          - Create
+          - Describe
+          - Write
         host: "*"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like #7414 updates only some of the ACL examples from the old deprecated `operation` field to the new `operations` format. This PR updates the remaining examples and docs.

### Checklist

- [x] Update documentation