### PR TITLE
Feat/auto restart connectors

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -34,6 +34,8 @@ public abstract class AbstractConnectorSpec extends Spec {
     private Boolean pause;
     private Map<String, Object> config = new HashMap<>(0);
 
+    private AutoRestart autoRestart;
+
     @Description("The maximum number of tasks for the Kafka Connector")
     @Minimum(1)
     public Integer getTasksMax() {
@@ -60,5 +62,15 @@ public abstract class AbstractConnectorSpec extends Spec {
 
     public void setPause(Boolean pause) {
         this.pause = pause;
+    }
+
+    @Description("Automatic restart of connector and tasks configuration")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public AutoRestart getAutoRestart() {
+        return autoRestart;
+    }
+
+    public void setAutoRestart(AutoRestart autoRestart) {
+        this.autoRestart = autoRestart;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -23,7 +23,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"pause", "tasksMax", "config"})
+@JsonPropertyOrder({"pause", "tasksMax", "autoRestart", "config"})
 @EqualsAndHashCode
 public abstract class AbstractConnectorSpec extends Spec {
     private static final long serialVersionUID = 1L;
@@ -32,6 +32,8 @@ public abstract class AbstractConnectorSpec extends Spec {
 
     private Integer tasksMax;
     private Boolean pause;
+
+    private AutoRestart autoRestart = new AutoRestart();
     private Map<String, Object> config = new HashMap<>(0);
 
     @Description("The maximum number of tasks for the Kafka Connector")
@@ -60,5 +62,15 @@ public abstract class AbstractConnectorSpec extends Spec {
 
     public void setPause(Boolean pause) {
         this.pause = pause;
+    }
+
+    @Description("Whether the connector should restart when tasks fail ")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public AutoRestart getAutoRestart() {
+        return autoRestart;
+    }
+
+    public void setAutoRestart(AutoRestart autoRestart) {
+        this.autoRestart = autoRestart;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -23,7 +23,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"pause", "tasksMax", "autoRestart", "config"})
+@JsonPropertyOrder({"pause", "tasksMax", "config"})
 @EqualsAndHashCode
 public abstract class AbstractConnectorSpec extends Spec {
     private static final long serialVersionUID = 1L;
@@ -32,8 +32,6 @@ public abstract class AbstractConnectorSpec extends Spec {
 
     private Integer tasksMax;
     private Boolean pause;
-
-
     private Map<String, Object> config = new HashMap<>(0);
 
     @Description("The maximum number of tasks for the Kafka Connector")
@@ -63,6 +61,4 @@ public abstract class AbstractConnectorSpec extends Spec {
     public void setPause(Boolean pause) {
         this.pause = pause;
     }
-
-
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -33,7 +33,7 @@ public abstract class AbstractConnectorSpec extends Spec {
     private Integer tasksMax;
     private Boolean pause;
 
-    private AutoRestart autoRestart = new AutoRestart();
+
     private Map<String, Object> config = new HashMap<>(0);
 
     @Description("The maximum number of tasks for the Kafka Connector")
@@ -64,13 +64,5 @@ public abstract class AbstractConnectorSpec extends Spec {
         this.pause = pause;
     }
 
-    @Description("Whether the connector should restart when tasks fail ")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public AutoRestart getAutoRestart() {
-        return autoRestart;
-    }
 
-    public void setAutoRestart(AutoRestart autoRestart) {
-        this.autoRestart = autoRestart;
-    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -26,11 +26,10 @@ import java.util.Map;
 @EqualsAndHashCode
 public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
-    private boolean enabled = false;
+    private boolean enabled;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false")
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled")
     public boolean isEnabled() {
         return enabled;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the AutoRestart configuration.
+ */
+@DescriptionFile
+@Buildable(
+    editableEnabled = false,
+    builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+public class AutoRestart implements UnknownPropertyPreserving, Serializable {
+    private static final long serialVersionUID = 1L;
+    private boolean enabled = true;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+
+    @Description("Enable/Disable auto restart, default to true")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @EqualsAndHashCode
 public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
-    private boolean enabled;
+    private boolean enabled = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled")

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -29,7 +29,7 @@ public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private boolean enabled = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Whether automatic restart should be enabled or disabled, default to true")
+    @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to true")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isEnabled() {
         return enabled;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -29,7 +29,7 @@ public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private boolean enabled = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Whether automatic restart should be enable or disable, default to true")
+    @Description("Whether automatic restart should be enabled or disabled, default to true")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isEnabled() {
         return enabled;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -29,8 +29,7 @@ public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private boolean enabled = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-
-    @Description("Enable/Disable auto restart, default to true")
+    @Description("Whether automatic restart should be enable or disable, default to true")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isEnabled() {
         return enabled;

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -26,10 +26,10 @@ import java.util.Map;
 @EqualsAndHashCode
 public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
-    private boolean enabled = true;
+    private boolean enabled = false;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to true")
+    @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isEnabled() {
         return enabled;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -23,8 +23,6 @@ public class KafkaConnectorSpec extends AbstractConnectorSpec {
 
     private String className;
 
-    private AutoRestart autoRestart = new AutoRestart();
-
     @Description("The Class for the Kafka Connector")
     @JsonProperty("class")
     public String getClassName() {
@@ -35,13 +33,4 @@ public class KafkaConnectorSpec extends AbstractConnectorSpec {
         this.className = className;
     }
 
-    @Description("Automatic restart of connector and tasks configuration")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public AutoRestart getAutoRestart() {
-        return autoRestart;
-    }
-
-    public void setAutoRestart(AutoRestart autoRestart) {
-        this.autoRestart = autoRestart;
-    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -16,12 +16,14 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"class", "tasksMax", "config"})
+@JsonPropertyOrder({"class", "tasksMax", "autoRestart", "config"})
 @EqualsAndHashCode(callSuper = true)
 public class KafkaConnectorSpec extends AbstractConnectorSpec {
     private static final long serialVersionUID = 1L;
 
     private String className;
+
+    private AutoRestart autoRestart = new AutoRestart();
 
     @Description("The Class for the Kafka Connector")
     @JsonProperty("class")
@@ -31,5 +33,15 @@ public class KafkaConnectorSpec extends AbstractConnectorSpec {
 
     public void setClassName(String className) {
         this.className = className;
+    }
+
+    @Description("Whether the connector should restart when tasks fail ")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public AutoRestart getAutoRestart() {
+        return autoRestart;
+    }
+
+    public void setAutoRestart(AutoRestart autoRestart) {
+        this.autoRestart = autoRestart;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -32,5 +32,4 @@ public class KafkaConnectorSpec extends AbstractConnectorSpec {
     public void setClassName(String className) {
         this.className = className;
     }
-
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnectorSpec.java
@@ -35,7 +35,7 @@ public class KafkaConnectorSpec extends AbstractConnectorSpec {
         this.className = className;
     }
 
-    @Description("Whether the connector should restart when tasks fail ")
+    @Description("Automatic restart of connector and tasks configuration")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public AutoRestart getAutoRestart() {
         return autoRestart;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -14,8 +15,20 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"tasksMax", "config"})
+@JsonPropertyOrder({"tasksMax", "autoRestartConnectorsAndTasks", "config"})
 @EqualsAndHashCode(callSuper = true)
 public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {
     private static final long serialVersionUID = 1L;
+
+    private AutoRestart autoRestartConnectorsAndTasks = new AutoRestart();
+
+    @Description("Whether the connector should restart when tasks fail ")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public AutoRestart getAutoRestartConnectorsAndTasks() {
+        return autoRestartConnectorsAndTasks;
+    }
+
+    public void setAutoRestartConnectorsAndTasks(AutoRestart autoRestart) {
+        this.autoRestartConnectorsAndTasks = autoRestart;
+    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
@@ -14,7 +14,7 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"tasksMax", "autoRestartConnectorsAndTasks", "config"})
+@JsonPropertyOrder({"tasksMax", "config"})
 @EqualsAndHashCode(callSuper = true)
 public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 
@@ -19,16 +18,4 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {
     private static final long serialVersionUID = 1L;
-
-    private AutoRestart autoRestartConnectorsAndTasks = new AutoRestart();
-
-    @Description("Automatic restart of connectors and tasks configuration")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public AutoRestart getAutoRestartConnectorsAndTasks() {
-        return autoRestartConnectorsAndTasks;
-    }
-
-    public void setAutoRestartConnectorsAndTasks(AutoRestart autoRestart) {
-        this.autoRestartConnectorsAndTasks = autoRestart;
-    }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ConnectorSpec.java
@@ -22,7 +22,7 @@ public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {
 
     private AutoRestart autoRestartConnectorsAndTasks = new AutoRestart();
 
-    @Description("Whether the connector should restart when tasks fail ")
+    @Description("Automatic restart of connectors and tasks configuration")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public AutoRestart getAutoRestartConnectorsAndTasks() {
         return autoRestartConnectorsAndTasks;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
@@ -24,13 +24,16 @@ import static java.util.Collections.emptyMap;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "count", "lastRestartTimestamp"})
+@JsonPropertyOrder({ "count", "connectorName", "lastRestartTimestamp"})
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class AutoRestartStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private int count;
+
+    private String connectorName;
+
     private String lastRestartTimestamp;
     private Map<String, Object> additionalProperties;
 
@@ -42,6 +45,15 @@ public class AutoRestartStatus implements UnknownPropertyPreserving, Serializabl
 
     public void setCount(int count) {
         this.count = count;
+    }
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The name of the connector that is getting restarted")
+    public String getConnectorName() {
+        return connectorName;
+    }
+
+    public void setConnectorName(String connectorName) {
+        this.connectorName = connectorName;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+@Buildable(
+    editableEnabled = false,
+    builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "count", "lastRestartTimestamp"})
+@EqualsAndHashCode
+@ToString(callSuper = true)
+public class AutoRestartStatus implements UnknownPropertyPreserving, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private int count;
+    private String lastRestartTimestamp;
+    private Map<String, Object> additionalProperties;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The number of time the element restarted.")
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("Last time the  auto restart was attempted. " +
+        "The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone")
+    public String getLastRestartTimestamp() {
+        return lastRestartTimestamp;
+    }
+
+    public void setLastRestartTimestamp(String lastRestartTimestamp) {
+        this.lastRestartTimestamp = lastRestartTimestamp;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : emptyMap();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(1);
+        }
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
@@ -38,7 +38,7 @@ public class AutoRestartStatus implements UnknownPropertyPreserving, Serializabl
     private Map<String, Object> additionalProperties;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("The number of times the element restarted.")
+    @Description("The number of times the connector or task is restarted.")
     public int getCount() {
         return count;
     }
@@ -47,7 +47,7 @@ public class AutoRestartStatus implements UnknownPropertyPreserving, Serializabl
         this.count = count;
     }
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("The name of the connector that is getting restarted")
+    @Description("The name of the connector being restarted.")
     public String getConnectorName() {
         return connectorName;
     }
@@ -57,8 +57,8 @@ public class AutoRestartStatus implements UnknownPropertyPreserving, Serializabl
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("Last time the  auto restart was attempted. " +
-        "The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone")
+    @Description("The last time the automatic restart was attempted. " +
+        "The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.")
     public String getLastRestartTimestamp() {
         return lastRestartTimestamp;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/AutoRestartStatus.java
@@ -38,7 +38,7 @@ public class AutoRestartStatus implements UnknownPropertyPreserving, Serializabl
     private Map<String, Object> additionalProperties;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Description("The number of time the element restarted.")
+    @Description("The number of times the element restarted.")
     public int getCount() {
         return count;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaConnectorStatus.java
@@ -23,7 +23,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "connectorStatus", "tasksMax", "topics" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "autoRestart", "connectorStatus", "tasksMax", "topics" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaConnectorStatus extends Status {
@@ -32,6 +32,7 @@ public class KafkaConnectorStatus extends Status {
     private Map<String, Object> connectorStatus;
     private int tasksMax;
     private List<String> topics;
+    private AutoRestartStatus autoRestart;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Description("The connector status, as reported by the Kafka Connect REST API.")
@@ -61,5 +62,15 @@ public class KafkaConnectorStatus extends Status {
 
     public void setTopics(List<String> topics) {
         this.topics = topics;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("The auto restart status")
+    public AutoRestartStatus getAutoRestart() {
+        return autoRestart;
+    }
+
+    public void setAutoRestart(AutoRestartStatus autoRestart) {
+        this.autoRestart = autoRestart;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
@@ -33,6 +33,8 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
 
     private List<Map<String, Object>> connectors = new ArrayList<>(3);
 
+    private List<AutoRestartStatus> autoRestartStatuses = new ArrayList<>();
+
     @Description("List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<Map<String, Object>> getConnectors() {
@@ -41,5 +43,15 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
 
     public void setConnectors(List<Map<String, Object>> connectors) {
         this.connectors = connectors;
-    } 
+    }
+
+    @Description("List of MirrorMaker 2.0 connector auto restart statuses")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<AutoRestartStatus> getAutoRestartStatuses() {
+        return autoRestartStatuses;
+    }
+
+    public void setAutoRestartStatuses(List<AutoRestartStatus> autoRestartStatuses) {
+        this.autoRestartStatuses = autoRestartStatuses;
+    }
 }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
@@ -11,6 +11,8 @@ spec:
   config:
     file: "/home/source/test.source.txt"
     topic: "test.topic"
+  autoRestart:
+    enabled: true
 status:
   observedGeneration: 0
   connectorStatus:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.out.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   class: "org.apache.kafka.connect.file.FileStreamSourceConnector"
   tasksMax: 2
+  autoRestart:
+    enabled: true
   config:
     file: "/home/source/test.source.txt"
     topic: "test.topic"
-  autoRestart:
-    enabled: true
 status:
   observedGeneration: 0
   connectorStatus:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaConnector.yaml
@@ -11,6 +11,8 @@ spec:
   config:
     file: "/home/source/test.source.txt"
     topic: "test.topic"
+  autoRestart:
+    enabled: true
 status:
   observedGeneration: 0
   connectorStatus:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -17,21 +17,15 @@ spec:
     targetCluster: "target"
     sourceConnector:
       tasksMax: 2
-      autoRestartConnectorsAndTasks:
-        enabled: true
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
     heartbeatConnector:
       tasksMax: 2
-      autoRestartConnectorsAndTasks:
-        enabled: true
       config:
         heartbeats.topic.replication.factor: 1
     checkpointConnector:
       tasksMax: 2
-      autoRestartConnectorsAndTasks:
-        enabled: true
       config:
         checkpoints.topic.replication.factor: 1
     topicsPattern: "my-topic"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -17,23 +17,23 @@ spec:
     targetCluster: "target"
     sourceConnector:
       tasksMax: 2
+      autoRestartConnectorsAndTasks:
+        enabled: true
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
-      autoRestart:
-        enabled: true
     heartbeatConnector:
       tasksMax: 2
+      autoRestartConnectorsAndTasks:
+        enabled: true
       config:
         heartbeats.topic.replication.factor: 1
-      autoRestart:
-        enabled: true
     checkpointConnector:
       tasksMax: 2
+      autoRestartConnectorsAndTasks:
+        enabled: true
       config:
         checkpoints.topic.replication.factor: 1
-      autoRestart:
-        enabled: true
     topicsPattern: "my-topic"
     groupsPattern: "my-group"
   template:

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaMirrorMaker2.out.yaml
@@ -20,14 +20,20 @@ spec:
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
+      autoRestart:
+        enabled: true
     heartbeatConnector:
       tasksMax: 2
       config:
         heartbeats.topic.replication.factor: 1
+      autoRestart:
+        enabled: true
     checkpointConnector:
       tasksMax: 2
       config:
         checkpoints.topic.replication.factor: 1
+      autoRestart:
+        enabled: true
     topicsPattern: "my-topic"
     groupsPattern: "my-group"
   template:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -624,7 +624,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param autoRestartStatus
      * @return true if the connector
      */
-    protected boolean shouldAutoRestart(AutoRestartStatus autoRestartStatus, JsonObject statusResult) {
+    boolean shouldAutoRestart(AutoRestartStatus autoRestartStatus, JsonObject statusResult) {
         if (connectorHasFailed(statusResult) || failedTaskIds(statusResult).size() > 0) {
             if (autoRestartStatus == null) {
                 return true;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -38,6 +38,7 @@ import io.strimzi.api.kafka.model.status.AutoRestartStatus;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
+import io.strimzi.api.kafka.model.status.KafkaMirrorMaker2Status;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -76,7 +76,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -630,7 +629,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 return true;
             }
             var count =  autoRestartStatus.getCount();
-            var minutesSinceLastRestart = StatusUtils.unitDifferenceUntilNow(StatusUtils.iso8601(autoRestartStatus.getLastRestartTimestamp()), ChronoUnit.MINUTES);
+            var minutesSinceLastRestart = StatusUtils.minutesDifferenceUntilNow(StatusUtils.isoUtcDatetime(autoRestartStatus.getLastRestartTimestamp()));
 
             // n^2 + n
             var nextRestart = count * count + count;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -164,9 +164,11 @@ public interface KafkaConnectApi {
      * @param host The host to make the request to.
      * @param port The port to make the request to.
      * @param connectorName The name of the connector to restart.
+     * @param includeTasks Whether to restart the connector instance and task instances or just the connector.
+     * @param onlyFailed Specifies whether to restart just the instances with a FAILED status or all instances.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> restart(String host, int port, String connectorName);
+    Future<Void> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/tasks/${taskID}/restart}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -161,14 +161,15 @@ public interface KafkaConnectApi {
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/restart}.
-     * @param host The host to make the request to.
-     * @param port The port to make the request to.
+     *
+     * @param host          The host to make the request to.
+     * @param port          The port to make the request to.
      * @param connectorName The name of the connector to restart.
-     * @param includeTasks Whether to restart the connector instance and task instances or just the connector.
-     * @param onlyFailed Specifies whether to restart just the instances with a FAILED status or all instances.
-     * @return A Future which completes with the result of the request.
+     * @param includeTasks  Whether to restart the connector instance and task instances or just the connector.
+     * @param onlyFailed    Specifies whether to restart just the instances with a FAILED status or all instances.
+     * @return A Future which completes with the result of the request and the new status of the connector
      */
-    Future<Void> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
+    Future<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/tasks/${taskID}/restart}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -554,8 +554,8 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<Void> restart(String host, int port, String connectorName) {
-        return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/restart");
+    public Future<Void> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
+        return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/restart?includeTasks=" + includeTasks + "&onlyFailed=" + onlyFailed);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -554,16 +554,17 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<Void> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
+    public Future<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
         return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/restart?includeTasks=" + includeTasks + "&onlyFailed=" + onlyFailed);
     }
 
     @Override
     public Future<Void> restartTask(String host, int port, String connectorName, int taskID) {
-        return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/tasks/" + taskID + "/restart");
+        return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/tasks/" + taskID + "/restart")
+            .compose(result -> Future.succeededFuture());
     }
 
-    private Future<Void> restartConnectorOrTask(String host, int port, String path) {
+    private Future<Map<String, Object>> restartConnectorOrTask(String host, int port, String path) {
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
             httpClient.request(HttpMethod.POST, port, host, path, request -> {
                 if (request.succeeded()) {
@@ -571,9 +572,18 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                             .putHeader("Accept", "application/json");
                     request.result().send(response -> {
                         if (response.succeeded()) {
-                            if (response.result().statusCode() == 204) {
+                            if (response.result().statusCode() == 202) {
                                 response.result().bodyHandler(body -> {
-                                    result.complete();
+                                    try {
+                                        var status = mapper.readValue(body.getBytes(), TREE_TYPE);
+                                        result.complete(status);
+                                    } catch (IOException e) {
+                                        result.fail(new ConnectRestException(response.result(), "Failed to parse restart status response", e));
+                                    }
+                                });
+                            } else if (response.result().statusCode() == 204) {
+                                response.result().bodyHandler(body -> {
+                                    result.complete(null);
                                 });
                             } else {
                                 result.fail("Unexpected status code " + response.result().statusCode()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Spec;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha256;
+import io.strimzi.api.kafka.model.status.AutoRestartStatus;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
@@ -489,6 +490,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         if (autoRestart != null) {
                             autoRestart.setConnectorName(connectorName);
                             mirrorMaker2Status.getAutoRestartStatuses().add(autoRestart);
+                            mirrorMaker2Status.getAutoRestartStatuses().sort(Comparator.comparing(AutoRestartStatus::getConnectorName));
                         }
                     } else {
                         maybeUpdateMirrorMaker2Status(reconciliation, mirrorMaker2, result.cause());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -485,6 +485,11 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         mirrorMaker2Status.addConditions(result.result().conditions);
                         mirrorMaker2Status.getConnectors().add(result.result().statusResult);
                         mirrorMaker2Status.getConnectors().sort(new ConnectorsComparatorByName());
+                        var autoRestart = result.result().autoRestart;
+                        if (autoRestart != null) {
+                            autoRestart.setConnectorName(connectorName);
+                            mirrorMaker2Status.getAutoRestartStatuses().add(autoRestart);
+                        }
                     } else {
                         maybeUpdateMirrorMaker2Status(reconciliation, mirrorMaker2, result.cause());
                     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -82,6 +82,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -297,7 +298,7 @@ public class ConnectorMockTest {
             }
             return Future.succeededFuture();
         });
-        when(api.restart(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+        when(api.restart(any(), anyInt(), anyString(), anyBoolean(), anyBoolean())).thenAnswer(invocation -> {
             String host = invocation.getArgument(0);
             String connectorName = invocation.getArgument(2);
             ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
@@ -1157,7 +1158,9 @@ public class ConnectorMockTest {
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, never()).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1174,7 +1177,9 @@ public class ConnectorMockTest {
 
         verify(api, times(1)).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, never()).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1187,7 +1192,7 @@ public class ConnectorMockTest {
         String connectName = "cluster";
         String connectorName = "connector";
 
-        when(api.restart(anyString(), anyInt(), anyString()))
+        when(api.restart(anyString(), anyInt(), anyString(), anyBoolean(), anyBoolean()))
             .thenAnswer(invocation -> Future.failedFuture(new ConnectRestException("GET", "/foo", 500, "Internal server error", "Bad stuff happened")));
 
         // Create KafkaConnect cluster and wait till it's ready
@@ -1236,7 +1241,9 @@ public class ConnectorMockTest {
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, never()).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1254,7 +1261,9 @@ public class ConnectorMockTest {
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
         verify(api, atLeastOnce()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, never()).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1313,7 +1322,9 @@ public class ConnectorMockTest {
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, never()).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1330,7 +1341,9 @@ public class ConnectorMockTest {
 
         verify(api, times(0)).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, times(1)).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1391,7 +1404,9 @@ public class ConnectorMockTest {
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            eq(false),
+            eq(false));
         verify(api, never()).restartTask(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), eq(0));
@@ -1408,7 +1423,9 @@ public class ConnectorMockTest {
 
         verify(api, times(0)).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
-            eq(connectorName));
+            eq(connectorName),
+            any(),
+            any());
         // Might be triggered twice (on annotation and on status update), but the second hit is sometimes only after
         // this check depending on the timing
         verify(api, atLeastOnce()).restartTask(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -1424,8 +1424,8 @@ public class ConnectorMockTest {
         verify(api, times(0)).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName),
-            any(),
-            any());
+            eq(false),
+            eq(false));
         // Might be triggered twice (on annotation and on status update), but the second hit is sometimes only after
         // this check depending on the timing
         verify(api, atLeastOnce()).restartTask(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -178,7 +178,7 @@ public class KafkaConnectApiIT {
             .compose(ignored -> client.resume("localhost", port, "test"))
             .onComplete(context.succeedingThenComplete())
 
-            .compose(ignored -> client.restart("localhost", port, "test"))
+            .compose(ignored -> client.restart("localhost", port, "test", true, true))
             .onComplete(context.succeedingThenComplete())
 
             .compose(ignored -> client.restartTask("localhost", port, "test", 0))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -353,7 +353,7 @@ public class KafkaConnectorIT {
                 connector);
             })
             .onComplete(context.succeeding(v -> {
-                assertConnectorIsAutoRestarted(1, context, client, namespace, connectorName);
+                assertConnectorIsAutoRestarted(2, context, client, namespace, connectorName);
                 context.completeNow();
             }));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -46,10 +46,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -347,7 +343,6 @@ public class KafkaConnectorIT {
                 assertConnectorIsAutoRestarted(1, context, client, namespace, connectorName);
             }))
             .compose(ignored -> {
-                Instant.now(Clock.fixed(Instant.now().plus(2, ChronoUnit.MINUTES), ZoneOffset.UTC));
                 return operator.reconcileConnectorAndHandleResult(new Reconciliation("test", "KafkaConnect", namespace, "bogus"),
                 "localhost", connectClient, true, connectorName,
                 connector);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TestingConnector.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TestingConnector.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -72,7 +73,7 @@ public class TestingConnector extends SourceConnector {
             sleep(taskStartTime);
             if (getBoolean(map, TASK_FAIL_ON_START)) {
                 LOGGER.infoOp("Failing task {}", this);
-                throw new RuntimeException("Task failed to start");
+                throw new ConnectException("Task failed to start");
             }
             LOGGER.infoOp("Started task {}", this);
         }

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,0 +1,1 @@
+Specify whether the auto restart should be enabled on a Connector

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,15 +1,19 @@
-Connectors and tasks that are in the FAILED state are automatically restarted.
+Configures automatic restarts for connectors and tasks that are in a `FAILED` state.
 
-A back-off algorithm is applied to automatic restarts of each connector and it's tasks.
-When a connector is failing an auto restart attempt will happen at first and second reconcile then attempts will be delayed,
-incrementing the time between automatic restarts by 2 minutes up to a maximum of 30 minutes, at which point no further
-automatic restarts are attempted, and the connector or tasks are left in the FAILED state.
+A back-off algorithm applies the automatic restart to each failed connector and its tasks.
+
+The operator attempts an automatic restart on reconciliation. 
+If the first attempt fails, the operator makes up to six more attempts. 
+The duration between each restart attempt increases from 2 to 30 minutes. 
+If the restart fails after the final attempt, there is likely to be a problem with the connector configuration. 
+The connector and tasks remain in a `FAILED` state.  
 
 
-If you are using a Kafka version <3.0.0, only the connector will be restarted not failed tasks.
+If you are using Kafka 3.0.0 or later, only the failed connector is restarted not failed tasks.
 
 To disable the automatic restarting of the connector and it's tasks when they are in the FAILED state on a KafkaConnector resource:
 
+.Disabling automatic restarts of failed connectors for Kafka Connect
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: strimzi.io/v1alpha1
@@ -21,8 +25,9 @@ spec:
         enabled: false
 ----
 
-Similarly, a new field in the KafkaMirrorMaker2 spec named autoRestartConnectorsAndTasks with an enabled field value of false can be applied, to disable auto-restarting connectors and tasks.
+For MirrorMaker 2.0, use the `autoRestartConnectorsAndTasks` property of the `KafkaMirrorMaker2` resource to disable automatic restarts of failed connectors and tasks.
 
+.Disabling automatic restarts of failed connectors for MirrorMaker 2.0
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: strimzi.io/v1alpha1

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,19 +1,21 @@
 Configures automatic restarts for connectors and tasks that are in a `FAILED` state.
 
-A back-off algorithm applies the automatic restart to each failed connector and its tasks.
+Once enabled, a back-off algorithm applies the automatic restart to each failed connector and its tasks.
 
 The operator attempts an automatic restart on reconciliation. 
 If the first attempt fails, the operator makes up to six more attempts. 
-The duration between each restart attempt increases from 2 to 30 minutes. 
+The duration between each restart attempt increases from 2 to 30 minutes.
+After each restart failed connectors and tasks transit from `FAILED` to `RESTARTING`.
 If the restart fails after the final attempt, there is likely to be a problem with the connector configuration. 
-The connector and tasks remain in a `FAILED` state.  
+The connector and tasks remain in a `FAILED` state.
+It means that you will have to restart connector/tasks manually, for example by annotating KafKaConnector CR with `strimzi.io/restart: "true"`
 
 
-If you are using Kafka 3.0.0 or later, only the failed connector is restarted not failed tasks.
+If you are using a Kafka version earlier than 3.0.0, only the failed connector is restarted not failed tasks.
 
-To disable the automatic restarting of the connector and it's tasks when they are in the FAILED state on a KafkaConnector resource:
+For Kafka Connect connectors, use the `autoRestart` property of the `KafkaConnector` resource to enable automatic restarts of failed connectors and tasks.
 
-.Disabling automatic restarts of failed connectors for Kafka Connect
+.Enabling automatic restarts of failed connectors for Kafka Connect
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: strimzi.io/v1alpha1
@@ -22,12 +24,12 @@ metadata:
     name: my-source-connector
 spec:
     autoRestart:
-        enabled: false
+        enabled: true
 ----
 
-For MirrorMaker 2.0, use the `autoRestartConnectorsAndTasks` property of the `KafkaMirrorMaker2` resource to disable automatic restarts of failed connectors and tasks.
+For MirrorMaker 2.0, use the `autoRestartConnectorsAndTasks` property of the `KafkaMirrorMaker2` resource to enable automatic restarts of failed connectors and tasks.
 
-.Disabling automatic restarts of failed connectors for MirrorMaker 2.0
+.Enabling automatic restarts of failed connectors for MirrorMaker 2.0
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: strimzi.io/v1alpha1
@@ -35,6 +37,6 @@ kind: KafkaMirrorMaker2
 metadata:
   name: my-mm2-cluster
 spec:
-  autoRestartConnectorsAndTasks:
-    enabled: false
+  autoRestart:
+    enabled: true
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,12 +1,12 @@
 Connectors and tasks that are in the FAILED state are automatically restarted.
 
 A back-off algorithm is applied to automatic restarts of each connector and it's tasks.
-When a connector is failing an auto restart attempt will happen at first and second reconcile then attempts while be delayed
+When a connector is failing an auto restart attempt will happen at first and second reconcile then attempts will be delayed,
 incrementing the time between automatic restarts by 2 minutes up to a maximum of 30 minutes, at which point no further
 automatic restarts are attempted, and the connector or tasks are left in the FAILED state.
 
 
-If you are using a kafka version <3.0.0, only the connector will be restarted not failed tasks.
+If you are using a Kafka version <3.0.0, only the connector will be restarted not failed tasks.
 
 To disable the automatic restarting of the connector and it's tasks when they are in the FAILED state on a KafkaConnector resource:
 

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,1 +1,35 @@
-Specify whether the auto restart should be enabled on a Connector
+Connectors and tasks that are in the FAILED state are automatically restarted.
+
+A back-off algorithm is applied to automatic restarts of each connector and it's tasks.
+When a connector is failing an auto restart attempt will happen at first and second reconcile then attempts while be delayed
+incrementing the time between automatic restarts by 2 minutes up to a maximum of 30 minutes, at which point no further
+automatic restarts are attempted, and the connector or tasks are left in the FAILED state.
+
+
+If you are using a kafka version <3.0.0, only the connector will be restarted not failed tasks.
+
+To disable the automatic restarting of the connector and it's tasks when they are in the FAILED state on a KafkaConnector resource:
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: strimzi.io/v1alpha1
+kind: KafkaConnector
+metadata:
+    name: my-source-connector
+spec:
+    autoRestart:
+        enabled: false
+----
+
+Similarly, a new field in the KafkaMirrorMaker2 spec named autoRestartConnectorsAndTasks with an enabled field value of false can be applied, to disable auto-restarting connectors and tasks.
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: strimzi.io/v1alpha1
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mm2-cluster
+spec:
+  autoRestartConnectorsAndTasks:
+    enabled: false
+----

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -27,7 +27,7 @@ spec:
         enabled: true
 ----
 
-For MirrorMaker 2.0, use the `autoRestartConnectorsAndTasks` property of the `KafkaMirrorMaker2` resource to enable automatic restarts of failed connectors and tasks.
+For MirrorMaker 2.0, use the `autoRestart` property of connectors in the `KafkaMirrorMaker2` resource to enable automatic restarts of failed connectors and tasks.
 
 .Enabling automatic restarts of failed connectors for MirrorMaker 2.0
 [source,yaml,subs="attributes+"]
@@ -37,6 +37,17 @@ kind: KafkaMirrorMaker2
 metadata:
   name: my-mm2-cluster
 spec:
-  autoRestart:
-    enabled: true
+  mirrors:
+  - sourceConnector:
+      autoRestart:
+        enabled: true
+      # ...
+    heartbeatConnector:
+      autoRestart:
+        enabled: true
+      # ...
+    checkpointConnector:
+      autoRestart:
+        enabled: true
+      # ...
 ----

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3038,7 +3038,7 @@ include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property        |Description
-|enabled  1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+|enabled  1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3014,10 +3014,10 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |string
 |tasksMax     1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
-|map
 |autoRestart  1.2+<.<a|Whether the connector should restart when tasks fail .
 |xref:type-AutoRestart-{context}[`AutoRestart`]
+|config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|map
 |pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
 |boolean
 |====
@@ -3068,7 +3068,7 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 [id='type-AutoRestartStatus-{context}']
 ### `AutoRestartStatus` schema reference
 
-Used in: xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`]
+Used in: xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaMirrorMaker2Status-{context}[`KafkaMirrorMaker2Status`]
 
 
 [options="header"]
@@ -3076,6 +3076,8 @@ Used in: xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`]
 |Property                     |Description
 |count                 1.2+<.<a|The number of time the element restarted.
 |integer
+|connectorName         1.2+<.<a|The name of the connector that is getting restarted.
+|string
 |lastRestartTimestamp  1.2+<.<a|Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
 |string
 |====
@@ -3211,14 +3213,14 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 
 [options="header"]
 |====
-|Property            |Description
-|tasksMax     1.2+<.<a|The maximum number of tasks for the Kafka Connector.
+|Property                              |Description
+|tasksMax                       1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
-|map
-|autoRestart  1.2+<.<a|Whether the connector should restart when tasks fail .
+|autoRestartConnectorsAndTasks  1.2+<.<a|Whether the connector should restart when tasks fail .
 |xref:type-AutoRestart-{context}[`AutoRestart`]
-|pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|config                         1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|map
+|pause                          1.2+<.<a|Whether the connector should be paused. Defaults to false.
 |boolean
 |====
 
@@ -3230,20 +3232,22 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 
 [options="header"]
 |====
-|Property                   |Description
-|conditions          1.2+<.<a|List of status conditions.
+|Property                    |Description
+|conditions           1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration   1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|url                 1.2+<.<a|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+|url                  1.2+<.<a|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
-|connectorPlugins    1.2+<.<a|The list of connector plugins available in this Kafka Connect deployment.
+|autoRestartStatuses  1.2+<.<a|List of MirrorMaker 2.0 connector auto restart statuses.
+|xref:type-AutoRestartStatus-{context}[`AutoRestartStatus`] array
+|connectorPlugins     1.2+<.<a|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
-|connectors          1.2+<.<a|List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
+|connectors           1.2+<.<a|List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
 |map array
-|labelSelector       1.2+<.<a|Label selector for pods providing this resource.
+|labelSelector        1.2+<.<a|Label selector for pods providing this resource.
 |string
-|replicas            1.2+<.<a|The current number of pods being used to provide this resource.
+|replicas             1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3038,7 +3038,7 @@ include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property        |Description
-|enabled  1.2+<.<a|Whether automatic restart should be enable or disable, default to true.
+|enabled  1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
 |boolean
 |====
 
@@ -3074,11 +3074,11 @@ Used in: xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:
 [options="header"]
 |====
 |Property                     |Description
-|count                 1.2+<.<a|The number of time the element restarted.
+|count                 1.2+<.<a|The number of times the connector or task is restarted.
 |integer
-|connectorName         1.2+<.<a|The name of the connector that is getting restarted.
+|connectorName         1.2+<.<a|The name of the connector being restarted.
 |string
-|lastRestartTimestamp  1.2+<.<a|Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
+|lastRestartTimestamp  1.2+<.<a|The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
 |string
 |====
 
@@ -3213,14 +3213,14 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 
 [options="header"]
 |====
-|Property                              |Description
-|tasksMax                       1.2+<.<a|The maximum number of tasks for the Kafka Connector.
+|Property            |Description
+|tasksMax     1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|autoRestartConnectorsAndTasks  1.2+<.<a|Automatic restart of connectors and tasks configuration.
-|xref:type-AutoRestart-{context}[`AutoRestart`]
-|config                         1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
-|pause                          1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|autoRestart  1.2+<.<a|Automatic restart of connector and tasks configuration.
+|xref:type-AutoRestart-{context}[`AutoRestart`]
+|pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3009,14 +3009,36 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 
 [options="header"]
 |====
-|Property         |Description
-|class     1.2+<.<a|The Class for the Kafka Connector.
+|Property            |Description
+|class        1.2+<.<a|The Class for the Kafka Connector.
 |string
-|tasksMax  1.2+<.<a|The maximum number of tasks for the Kafka Connector.
+|tasksMax     1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|config    1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
-|pause     1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|autoRestart  1.2+<.<a|Whether the connector should restart when tasks fail .
+|xref:type-AutoRestart-{context}[`AutoRestart`]
+|pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|boolean
+|====
+
+[id='type-AutoRestart-{context}']
+### `AutoRestart` schema reference
+
+Used in: xref:type-KafkaConnectorSpec-{context}[`KafkaConnectorSpec`], xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
+
+xref:type-AutoRestart-schema-{context}[Full list of `AutoRestart` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
+
+[id='type-AutoRestart-schema-{context}']
+==== `AutoRestart` schema properties
+
+
+[options="header"]
+|====
+|Property        |Description
+|enabled  1.2+<.<a|Enable/Disable auto restart, default to true.
 |boolean
 |====
 
@@ -3033,12 +3055,29 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
+|autoRestart         1.2+<.<a|The auto restart status.
+|xref:type-AutoRestartStatus-{context}[`AutoRestartStatus`]
 |connectorStatus     1.2+<.<a|The connector status, as reported by the Kafka Connect REST API.
 |map
 |tasksMax            1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
 |topics              1.2+<.<a|The list of topics used by the Kafka Connector.
 |string array
+|====
+
+[id='type-AutoRestartStatus-{context}']
+### `AutoRestartStatus` schema reference
+
+Used in: xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`]
+
+
+[options="header"]
+|====
+|Property                     |Description
+|count                 1.2+<.<a|The number of time the element restarted.
+|integer
+|lastRestartTimestamp  1.2+<.<a|Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.
+|string
 |====
 
 [id='type-KafkaMirrorMaker2-{context}']
@@ -3172,12 +3211,14 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 
 [options="header"]
 |====
-|Property         |Description
-|tasksMax  1.2+<.<a|The maximum number of tasks for the Kafka Connector.
+|Property            |Description
+|tasksMax     1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|config    1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
-|pause     1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|autoRestart  1.2+<.<a|Whether the connector should restart when tasks fail .
+|xref:type-AutoRestart-{context}[`AutoRestart`]
+|pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3014,7 +3014,7 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |string
 |tasksMax     1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|autoRestart  1.2+<.<a|Whether the connector should restart when tasks fail .
+|autoRestart  1.2+<.<a|Automatic restart of connector and tasks configuration.
 |xref:type-AutoRestart-{context}[`AutoRestart`]
 |config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
@@ -3038,7 +3038,7 @@ include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property        |Description
-|enabled  1.2+<.<a|Enable/Disable auto restart, default to true.
+|enabled  1.2+<.<a|Whether automatic restart should be enable or disable, default to true.
 |boolean
 |====
 
@@ -3216,7 +3216,7 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 |Property                              |Description
 |tasksMax                       1.2+<.<a|The maximum number of tasks for the Kafka Connector.
 |integer
-|autoRestartConnectorsAndTasks  1.2+<.<a|Whether the connector should restart when tasks fail .
+|autoRestartConnectorsAndTasks  1.2+<.<a|Automatic restart of connectors and tasks configuration.
 |xref:type-AutoRestart-{context}[`AutoRestart`]
 |config                         1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -51,22 +51,21 @@ public class StatusUtils {
     }
 
     /**
-     *  Returns an Instant from a string date in ISO 8601 format
+     * Returns an Instant from a string date in ISO 8601 format
      * @param date a string representing a date, for example "2019-07-23T09:08:12.356Z"
      * @return an Instant
      */
-    public static Instant iso8601(String date)  {
+    public static Instant isoUtcDatetime(String date)  {
         return Instant.parse(date);
     }
 
     /**
-     * Get an amount of time unit between a date and now
+     * Get an amount of minutes between a date and now
      * @param date the date to start from
-     * @param unit the time unit of the interval, for example ChronoUnit.MINUTES
      * @return long amount of time
      */
-    public static long unitDifferenceUntilNow(Instant date,  ChronoUnit unit) {
-        return unit.between(date, ZonedDateTime.now(ZoneOffset.UTC));
+    public static long minutesDifferenceUntilNow(Instant date) {
+        return ChronoUnit.MINUTES.between(date, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     public static Condition buildConditionFromException(String type, String status, Throwable error) {

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -60,6 +60,13 @@ spec:
                   type: integer
                   minimum: 1
                   description: The maximum number of tasks for the Kafka Connector.
+                autoRestart:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: "Whether automatic restart should be enable or disable, default to true."
+                  description: Automatic restart of connector and tasks configuration.
                 config:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -95,6 +102,19 @@ spec:
                 observedGeneration:
                   type: integer
                   description: The generation of the CRD that was last reconciled by the operator.
+                autoRestart:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                      description: The number of time the element restarted.
+                    connectorName:
+                      type: string
+                      description: The name of the connector that is getting restarted.
+                    lastRestartTimestamp:
+                      type: string
+                      description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                  description: The auto restart status.
                 connectorStatus:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -65,7 +65,7 @@ spec:
                   properties:
                     enabled:
                       type: boolean
-                      description: "Whether automatic restart should be enable or disable, default to true."
+                      description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                   description: Automatic restart of connector and tasks configuration.
                 config:
                   x-kubernetes-preserve-unknown-fields: true
@@ -107,13 +107,13 @@ spec:
                   properties:
                     count:
                       type: integer
-                      description: The number of time the element restarted.
+                      description: The number of times the connector or task is restarted.
                     connectorName:
                       type: string
-                      description: The name of the connector that is getting restarted.
+                      description: The name of the connector being restarted.
                     lastRestartTimestamp:
                       type: string
-                      description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                      description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
                   description: The auto restart status.
                 connectorStatus:
                   x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -244,17 +244,17 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
-                          autoRestartConnectorsAndTasks:
-                            type: object
-                            properties:
-                              enabled:
-                                type: boolean
-                                description: "Whether automatic restart should be enable or disable, default to true."
-                            description: Automatic restart of connectors and tasks configuration.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                             description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          autoRestart:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                                description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
@@ -266,17 +266,17 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
-                          autoRestartConnectorsAndTasks:
-                            type: object
-                            properties:
-                              enabled:
-                                type: boolean
-                                description: "Whether automatic restart should be enable or disable, default to true."
-                            description: Automatic restart of connectors and tasks configuration.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                             description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          autoRestart:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                                description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
@@ -288,17 +288,17 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
-                          autoRestartConnectorsAndTasks:
-                            type: object
-                            properties:
-                              enabled:
-                                type: boolean
-                                description: "Whether automatic restart should be enable or disable, default to true."
-                            description: Automatic restart of connectors and tasks configuration.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                             description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          autoRestart:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                                description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
@@ -1919,13 +1919,13 @@ spec:
                     properties:
                       count:
                         type: integer
-                        description: The number of time the element restarted.
+                        description: The number of times the connector or task is restarted.
                       connectorName:
                         type: string
-                        description: The name of the connector that is getting restarted.
+                        description: The name of the connector being restarted.
                       lastRestartTimestamp:
                         type: string
-                        description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                        description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
                   description: List of MirrorMaker 2.0 connector auto restart statuses.
                 connectorPlugins:
                   type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -244,6 +244,13 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
+                          autoRestartConnectorsAndTasks:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                                description: "Whether automatic restart should be enable or disable, default to true."
+                            description: Automatic restart of connectors and tasks configuration.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
@@ -259,6 +266,13 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
+                          autoRestartConnectorsAndTasks:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                                description: "Whether automatic restart should be enable or disable, default to true."
+                            description: Automatic restart of connectors and tasks configuration.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
@@ -274,6 +288,13 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
+                          autoRestartConnectorsAndTasks:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                                description: "Whether automatic restart should be enable or disable, default to true."
+                            description: Automatic restart of connectors and tasks configuration.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
@@ -1891,6 +1912,21 @@ spec:
                 url:
                   type: string
                   description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+                autoRestartStatuses:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      count:
+                        type: integer
+                        description: The number of time the element restarted.
+                      connectorName:
+                        type: string
+                        description: The name of the connector that is getting restarted.
+                      lastRestartTimestamp:
+                        type: string
+                        description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                  description: List of MirrorMaker 2.0 connector auto restart statuses.
                 connectorPlugins:
                   type: array
                   items:

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -64,8 +64,8 @@ spec:
                 properties:
                   enabled:
                     type: boolean
-                    description: "Enable/Disable auto restart, default to true."
-                description: Whether the connector should restart when tasks fail .
+                    description: "Whether automatic restart should be enable or disable, default to true."
+                description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -63,6 +63,13 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+              autoRestart:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                    description: "Enable/Disable auto restart, default to true."
+                description: Whether the connector should restart when tasks fail .
               pause:
                 type: boolean
                 description: Whether the connector should be paused. Defaults to false.
@@ -94,6 +101,16 @@ spec:
               observedGeneration:
                 type: integer
                 description: The generation of the CRD that was last reconciled by the operator.
+              autoRestart:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: The number of time the element restarted.
+                  lastRestartTimestamp:
+                    type: string
+                    description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                description: The auto restart status.
               connectorStatus:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -64,7 +64,7 @@ spec:
                 properties:
                   enabled:
                     type: boolean
-                    description: "Whether automatic restart should be enable or disable, default to true."
+                    description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
                 description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true
@@ -106,13 +106,13 @@ spec:
                 properties:
                   count:
                     type: integer
-                    description: The number of time the element restarted.
+                    description: The number of times the connector or task is restarted.
                   connectorName:
                     type: string
-                    description: The name of the connector that is getting restarted.
+                    description: The name of the connector being restarted.
                   lastRestartTimestamp:
                     type: string
-                    description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
                 description: The auto restart status.
               connectorStatus:
                 x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -64,7 +64,7 @@ spec:
                 properties:
                   enabled:
                     type: boolean
-                    description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                    description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                 description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -59,10 +59,6 @@ spec:
                 type: integer
                 minimum: 1
                 description: The maximum number of tasks for the Kafka Connector.
-              config:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
               autoRestart:
                 type: object
                 properties:
@@ -70,6 +66,10 @@ spec:
                     type: boolean
                     description: "Enable/Disable auto restart, default to true."
                 description: Whether the connector should restart when tasks fail .
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
               pause:
                 type: boolean
                 description: Whether the connector should be paused. Defaults to false.
@@ -107,6 +107,9 @@ spec:
                   count:
                     type: integer
                     description: The number of time the element restarted.
+                  connectorName:
+                    type: string
+                    description: The name of the connector that is getting restarted.
                   lastRestartTimestamp:
                     type: string
                     description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -243,17 +243,17 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
-                        autoRestartConnectorsAndTasks:
-                          type: object
-                          properties:
-                            enabled:
-                              type: boolean
-                              description: "Whether automatic restart should be enable or disable, default to true."
-                          description: Automatic restart of connectors and tasks configuration.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                          description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -265,17 +265,17 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
-                        autoRestartConnectorsAndTasks:
-                          type: object
-                          properties:
-                            enabled:
-                              type: boolean
-                              description: "Whether automatic restart should be enable or disable, default to true."
-                          description: Automatic restart of connectors and tasks configuration.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                          description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -287,17 +287,17 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
-                        autoRestartConnectorsAndTasks:
-                          type: object
-                          properties:
-                            enabled:
-                              type: boolean
-                              description: "Whether automatic restart should be enable or disable, default to true."
-                          description: Automatic restart of connectors and tasks configuration.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                          description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -1918,13 +1918,13 @@ spec:
                   properties:
                     count:
                       type: integer
-                      description: The number of time the element restarted.
+                      description: The number of times the connector or task is restarted.
                     connectorName:
                       type: string
-                      description: The name of the connector that is getting restarted.
+                      description: The name of the connector being restarted.
                     lastRestartTimestamp:
                       type: string
-                      description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                      description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
                 description: List of MirrorMaker 2.0 connector auto restart statuses.
               connectorPlugins:
                 type: array

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -243,17 +243,17 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
-                        config:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-                        autoRestart:
+                        autoRestartConnectorsAndTasks:
                           type: object
                           properties:
                             enabled:
                               type: boolean
                               description: "Enable/Disable auto restart, default to true."
                           description: Whether the connector should restart when tasks fail .
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -265,17 +265,17 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
-                        config:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-                        autoRestart:
+                        autoRestartConnectorsAndTasks:
                           type: object
                           properties:
                             enabled:
                               type: boolean
                               description: "Enable/Disable auto restart, default to true."
                           description: Whether the connector should restart when tasks fail .
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -287,17 +287,17 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
-                        config:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-                        autoRestart:
+                        autoRestartConnectorsAndTasks:
                           type: object
                           properties:
                             enabled:
                               type: boolean
                               description: "Enable/Disable auto restart, default to true."
                           description: Whether the connector should restart when tasks fail .
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -1911,6 +1911,21 @@ spec:
               url:
                 type: string
                 description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+              autoRestartStatuses:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                      description: The number of time the element restarted.
+                    connectorName:
+                      type: string
+                      description: The name of the connector that is getting restarted.
+                    lastRestartTimestamp:
+                      type: string
+                      description: "Last time the  auto restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                description: List of MirrorMaker 2.0 connector auto restart statuses.
               connectorPlugins:
                 type: array
                 items:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -252,7 +252,7 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -274,7 +274,7 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -296,7 +296,7 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled. Defaults to false.
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -247,6 +247,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: "Enable/Disable auto restart, default to true."
+                          description: Whether the connector should restart when tasks fail .
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -262,6 +269,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: "Enable/Disable auto restart, default to true."
+                          description: Whether the connector should restart when tasks fail .
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
@@ -277,6 +291,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: "Enable/Disable auto restart, default to true."
+                          description: Whether the connector should restart when tasks fail .
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -248,8 +248,8 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                              description: "Enable/Disable auto restart, default to true."
-                          description: Whether the connector should restart when tasks fail .
+                              description: "Whether automatic restart should be enable or disable, default to true."
+                          description: Automatic restart of connectors and tasks configuration.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
@@ -270,8 +270,8 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                              description: "Enable/Disable auto restart, default to true."
-                          description: Whether the connector should restart when tasks fail .
+                              description: "Whether automatic restart should be enable or disable, default to true."
+                          description: Automatic restart of connectors and tasks configuration.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
@@ -292,8 +292,8 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                              description: "Enable/Disable auto restart, default to true."
-                          description: Whether the connector should restart when tasks fail .
+                              description: "Whether automatic restart should be enable or disable, default to true."
+                          description: Automatic restart of connectors and tasks configuration.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Implements [Automatically restarting FAILED connectors and tasks -  proposal 007](https://github.com/strimzi/proposals/blob/main/007-restarting-kafka-connect-connectors-and-tasks.md#automatically-restarting-failed-connectors-and-tasks)

Related issue : #2621 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

