### PR TITLE
docs(resource config): Makes intros to resource config sections consistent

### DIFF
--- a/documentation/assemblies/configuring/assembly-config-kafka-bridge.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-bridge.adoc
@@ -5,13 +5,11 @@
 [id='assembly-config-kafka-bridge-{context}']
 = Kafka Bridge cluster configuration
 
-This section describes how to configure a Kafka Bridge deployment in your Strimzi cluster.
-
+[role="_abstract"]
+Configure a Kafka Bridge deployment using the `KafkaBridge` resource.
 Kafka Bridge provides an API for integrating HTTP-based clients with a Kafka cluster.
 
-If you are using the Kafka Bridge, you configure the `KafkaBridge` resource.
-
-The full schema of the `KafkaBridge` resource is described in xref:type-KafkaBridge-reference[].
+xref:type-KafkaBridge-reference[] describes the full schema of the `KafkaBridge` resource.
 
 //procedure to configure Kafka Bridge
 include::../../modules/configuring/proc-config-kafka-bridge.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka-connect.adoc
@@ -6,12 +6,12 @@
 = Kafka Connect cluster configuration
 
 [role="_abstract"]
-This section describes how to configure a Kafka Connect deployment in your Strimzi cluster.
-
+Configure a Kafka Connect deployment using the `KafkaConnect` resource.
 Kafka Connect is an integration toolkit for streaming data between Kafka brokers and other systems using connector plugins.
 Kafka Connect provides a framework for integrating Kafka with an external data source or target, such as a database, for import or export of data using connectors.
 Connectors are plugins that provide the connection configuration needed.
-The full schema of the `KafkaConnect` resource is described in xref:type-KafkaConnect-reference[].
+
+xref:type-KafkaConnect-reference[] describes the full schema of the `KafkaConnect` resource.
 
 For more information on deploying connector plugins, see link:{BookURLDeploying}#using-kafka-connect-with-plug-ins-str[Extending Kafka Connect with connector plugins^].
 

--- a/documentation/assemblies/configuring/assembly-config-kafka.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka.adoc
@@ -6,14 +6,14 @@
 = Kafka cluster configuration
 
 [role="_abstract"]
-This section describes how to configure a Kafka deployment in your Strimzi cluster.
-A Kafka cluster is deployed with a ZooKeeper cluster. The deployment can also include the Topic Operator and User Operator, which manage Kafka topics and users.
-
-You configure Kafka using the `Kafka` resource.
-Configuration options are also available for ZooKeeper and the Entity Operator within the `Kafka` resource.
+Configure a Kafka deployment using the `Kafka` resource.
+A Kafka cluster is deployed with a ZooKeeper cluster. 
+A deployment can also include the Topic Operator and User Operator, which manage Kafka topics and users.
+Configuration options are available for ZooKeeper and the Entity Operator within the `Kafka` resource.
 The Entity Operator comprises the Topic Operator and User Operator.
 
-The full schema of the `Kafka` resource is described in the xref:type-Kafka-reference[].
+xref:type-Kafka-reference[] describes the full schema of the `Kafka` resource.
+
 For more information about Apache Kafka, see the {kafkaDoc}.
 
 .Listener configuration

--- a/documentation/assemblies/configuring/assembly-config-kafka.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka.adoc
@@ -7,10 +7,9 @@
 
 [role="_abstract"]
 Configure a Kafka deployment using the `Kafka` resource.
-A Kafka cluster is deployed with a ZooKeeper cluster. 
-A deployment can also include the Topic Operator and User Operator, which manage Kafka topics and users.
-Configuration options are available for ZooKeeper and the Entity Operator within the `Kafka` resource.
+A Kafka cluster is deployed with a ZooKeeper cluster, so configuration options are also available for ZooKeeper within the `Kafka` resource.
 The Entity Operator comprises the Topic Operator and User Operator.
+You can also configure `entityOperator` properties in the `Kafka` resource to include the Topic Operator and User Operator in the deployment. 
 
 xref:type-Kafka-reference[] describes the full schema of the `Kafka` resource.
 

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
@@ -5,23 +5,19 @@
 [id='assembly-deployment-configuration-kafka-mirror-maker-{context}']
 = Kafka MirrorMaker cluster configuration
 
-This chapter describes how to configure a Kafka MirrorMaker deployment in your Strimzi cluster to replicate data between Kafka clusters.
+[role="_abstract"]
+Configure a Kafka MirrorMaker deployment using the `KafkaMirrorMaker` resource.
+KafkaMirrorMaker replicates data between Kafka clusters.
+
+xref:type-KafkaMirrorMaker-reference[] describes the full schema of the `KafkaMirrorMaker` resource.
 
 You can use Strimzi with MirrorMaker or xref:assembly-mirrormaker-str[MirrorMaker 2.0].
 MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror data between Kafka clusters.
-
-If you are using MirrorMaker, you configure the `KafkaMirrorMaker` resource.
 
 IMPORTANT: Kafka MirrorMaker 1 (referred to as just _MirrorMaker_ in the documentation) has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.  
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.
 The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apache Kafka 4.0.0.
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the xref:unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
-
-The following procedure shows how the resource is configured:
-
-* xref:configuring-kafka-mirror-maker-{context}[Configuring Kafka MirrorMaker]
-
-The full schema of the `KafkaMirrorMaker` resource is described in the xref:type-KafkaMirrorMaker-reference[KafkaMirrorMaker schema reference].
 
 include::../../modules/configuring/proc-config-mirrormaker.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
@@ -6,10 +6,10 @@
 = Kafka MirrorMaker 2.0 cluster configuration
 
 [role="_abstract"]
-MirrorMaker 2.0 replicates data between two or more active Kafka clusters, within or across data centers.
+Configure a Kafka MirrorMaker 2.0 deployment using the `KafkaMirrorMaker2` resource.
+MirrorMaker 2.0 replicates data between two or more Kafka clusters, within or across data centers.
 
-If you are using MirrorMaker 2.0, you configure the `KafkaMirrorMaker2` resource.
-The full schema of the `KafkaMirrorMaker2` resource is described in the xref:type-KafkaMirrorMaker2-reference[KafkaMirrorMaker2 schema reference].
+xref:type-KafkaMirrorMaker2-reference[] describes the full schema of the `KafkaMirrorMaker2` resource.
 
 MirrorMaker 2.0 resource configuration differs from the previous version of MirrorMaker.
 If you choose to use MirrorMaker 2.0, there is currently no legacy support, so any resources must be manually converted into the new format.

--- a/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-deployment-configuration.adoc
@@ -21,9 +21,9 @@ include::assembly-config-kafka.adoc[leveloffset=+1]
 
 include::assembly-config-kafka-connect.adoc[leveloffset=+1]
 
-include::assembly-config-mirrormaker.adoc[leveloffset=+1]
-
 include::assembly-config-mirrormaker2.adoc[leveloffset=+1]
+
+include::assembly-config-mirrormaker.adoc[leveloffset=+1]
 
 include::assembly-config-kafka-bridge.adoc[leveloffset=+1]
 

--- a/documentation/modules/overview/con-overview-mirrormaker2.adoc
+++ b/documentation/modules/overview/con-overview-mirrormaker2.adoc
@@ -15,7 +15,7 @@ MirrorMaker 2.0 uses:
 
 MirrorMaker 2.0 is based on the Kafka Connect framework, _connectors_ managing the transfer of data between clusters.
 
-You configure a `KafkaMirrorMaker2` custom resource to define the Kafka Connect deployment, including the connection details of the source and target clusters, and then run a set of MirrorMaker 2.0 connectors to make the connection.
+You configure MirrorMaker 2.0 to define the Kafka Connect deployment, including the connection details of the source and target clusters, and then run a set of MirrorMaker 2.0 connectors to make the connection.
 
 MirrorMaker 2.0 consists of the following connectors:
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Makes the abstracts in the resource config sections of [Configuring a Strimzi deployment](https://strimzi.io/docs/operators/in-development/configuring.html#assembly-deployment-configuration-str) consistent.

Also prioritizes MM2 over old MM in the order.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

