### PR TITLE
Upgrade Fabric8 Kubernetes client to 6.2.0

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1266,10 +1266,18 @@ spec:
                                       matchLabels:
                                         x-kubernetes-preserve-unknown-fields: true
                                         type: object
+                                  matchLabelKeys:
+                                    type: array
+                                    items:
+                                      type: string
                                   maxSkew:
                                     type: integer
                                   minDomains:
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:
@@ -2385,10 +2393,18 @@ spec:
                                       matchLabels:
                                         x-kubernetes-preserve-unknown-fields: true
                                         type: object
+                                  matchLabelKeys:
+                                    type: array
+                                    items:
+                                      type: string
                                   maxSkew:
                                     type: integer
                                   minDomains:
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:
@@ -3461,10 +3477,18 @@ spec:
                                       matchLabels:
                                         x-kubernetes-preserve-unknown-fields: true
                                         type: object
+                                  matchLabelKeys:
+                                    type: array
+                                    items:
+                                      type: string
                                   maxSkew:
                                     type: integer
                                   minDomains:
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:
@@ -4417,10 +4441,18 @@ spec:
                                       matchLabels:
                                         x-kubernetes-preserve-unknown-fields: true
                                         type: object
+                                  matchLabelKeys:
+                                    type: array
+                                    items:
+                                      type: string
                                   maxSkew:
                                     type: integer
                                   minDomains:
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:
@@ -5251,10 +5283,18 @@ spec:
                                       matchLabels:
                                         x-kubernetes-preserve-unknown-fields: true
                                         type: object
+                                  matchLabelKeys:
+                                    type: array
+                                    items:
+                                      type: string
                                   maxSkew:
                                     type: integer
                                   minDomains:
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:
@@ -5840,10 +5880,18 @@ spec:
                                       matchLabels:
                                         x-kubernetes-preserve-unknown-fields: true
                                         type: object
+                                  matchLabelKeys:
+                                    type: array
+                                    items:
+                                      type: string
                                   maxSkew:
                                     type: integer
                                   minDomains:
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
                                   topologyKey:
                                     type: string
                                   whenUnsatisfiable:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -831,10 +831,18 @@ spec:
                                   matchLabels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
                               maxSkew:
                                 type: integer
                               minDomains:
                                 type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
                               topologyKey:
                                 type: string
                               whenUnsatisfiable:
@@ -1509,10 +1517,18 @@ spec:
                                   matchLabels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
                               maxSkew:
                                 type: integer
                               minDomains:
                                 type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
                               topologyKey:
                                 type: string
                               whenUnsatisfiable:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -979,10 +979,18 @@ spec:
                                   matchLabels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
                               maxSkew:
                                 type: integer
                               minDomains:
                                 type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
                               topologyKey:
                                 type: string
                               whenUnsatisfiable:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -855,10 +855,18 @@ spec:
                                   matchLabels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
                               maxSkew:
                                 type: integer
                               minDomains:
                                 type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
                               topologyKey:
                                 type: string
                               whenUnsatisfiable:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -925,10 +925,18 @@ spec:
                                   matchLabels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
                               maxSkew:
                                 type: integer
                               minDomains:
                                 type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
                               topologyKey:
                                 type: string
                               whenUnsatisfiable:
@@ -1603,10 +1611,18 @@ spec:
                                   matchLabels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
                               maxSkew:
                                 type: integer
                               minDomains:
                                 type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
                               topologyKey:
                                 type: string
                               whenUnsatisfiable:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1265,10 +1265,18 @@ spec:
                                     matchLabels:
                                       x-kubernetes-preserve-unknown-fields: true
                                       type: object
+                                matchLabelKeys:
+                                  type: array
+                                  items:
+                                    type: string
                                 maxSkew:
                                   type: integer
                                 minDomains:
                                   type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
                                 topologyKey:
                                   type: string
                                 whenUnsatisfiable:
@@ -2384,10 +2392,18 @@ spec:
                                     matchLabels:
                                       x-kubernetes-preserve-unknown-fields: true
                                       type: object
+                                matchLabelKeys:
+                                  type: array
+                                  items:
+                                    type: string
                                 maxSkew:
                                   type: integer
                                 minDomains:
                                   type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
                                 topologyKey:
                                   type: string
                                 whenUnsatisfiable:
@@ -3460,10 +3476,18 @@ spec:
                                     matchLabels:
                                       x-kubernetes-preserve-unknown-fields: true
                                       type: object
+                                matchLabelKeys:
+                                  type: array
+                                  items:
+                                    type: string
                                 maxSkew:
                                   type: integer
                                 minDomains:
                                   type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
                                 topologyKey:
                                   type: string
                                 whenUnsatisfiable:
@@ -4416,10 +4440,18 @@ spec:
                                     matchLabels:
                                       x-kubernetes-preserve-unknown-fields: true
                                       type: object
+                                matchLabelKeys:
+                                  type: array
+                                  items:
+                                    type: string
                                 maxSkew:
                                   type: integer
                                 minDomains:
                                   type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
                                 topologyKey:
                                   type: string
                                 whenUnsatisfiable:
@@ -5250,10 +5282,18 @@ spec:
                                     matchLabels:
                                       x-kubernetes-preserve-unknown-fields: true
                                       type: object
+                                matchLabelKeys:
+                                  type: array
+                                  items:
+                                    type: string
                                 maxSkew:
                                   type: integer
                                 minDomains:
                                   type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
                                 topologyKey:
                                   type: string
                                 whenUnsatisfiable:
@@ -5839,10 +5879,18 @@ spec:
                                     matchLabels:
                                       x-kubernetes-preserve-unknown-fields: true
                                       type: object
+                                matchLabelKeys:
+                                  type: array
+                                  items:
+                                    type: string
                                 maxSkew:
                                   type: integer
                                 minDomains:
                                   type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
                                 topologyKey:
                                   type: string
                                 whenUnsatisfiable:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -830,10 +830,18 @@ spec:
                                 matchLabels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             maxSkew:
                               type: integer
                             minDomains:
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:
@@ -1508,10 +1516,18 @@ spec:
                                 matchLabels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             maxSkew:
                               type: integer
                             minDomains:
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -978,10 +978,18 @@ spec:
                                 matchLabels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             maxSkew:
                               type: integer
                             minDomains:
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -854,10 +854,18 @@ spec:
                                 matchLabels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             maxSkew:
                               type: integer
                             minDomains:
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -924,10 +924,18 @@ spec:
                                 matchLabels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             maxSkew:
                               type: integer
                             minDomains:
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:
@@ -1602,10 +1610,18 @@ spec:
                                 matchLabels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             maxSkew:
                               type: integer
                             minDomains:
                               type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
                             topologyKey:
                               type: string
                             whenUnsatisfiable:

--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
         <lombok.version>1.18.4</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.1.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.1.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.1.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.2.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.2.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.2.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.13.4</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.13.4.1</fasterxml.jackson-databind.version>

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -57,7 +57,7 @@ public class KafkaResource implements ResourceType<Kafka> {
     @Override
     public void delete(Kafka resource) {
         final String namespaceName = resource.getMetadata().getNamespace();
-        final String clusterName = resource.getMetadata().getClusterName();
+        final String clusterName = resource.getMetadata().getName();
 
         Preconditions.notNull(namespaceName, "Kafka namespace name is null!");
         Preconditions.notNull(clusterName, "Kafka cluster name is null!");

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaBridgeTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaBridgeTemplates.java
@@ -66,7 +66,6 @@ public class KafkaBridgeTemplates {
             .withNewMetadata()
                 .withName(name)
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
-                .withClusterName(kafkaClusterName)
             .endMetadata()
             .editSpec()
                 .withBootstrapServers(bootstrap)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -57,7 +57,6 @@ public class KafkaConnectTemplates {
             .withNewMetadata()
                 .withName(name)
                 .withNamespace(namespaceName)
-                .withClusterName(kafkaClusterName)
             .endMetadata()
             .editOrNewSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -77,7 +77,6 @@ public class KafkaMirrorMaker2Templates {
             .withNewMetadata()
                 .withName(name)
                 .withNamespace(ResourceManager.kubeClient().getNamespace())
-                .withClusterName(kafkaTargetClusterName)
             .endMetadata()
             .editOrNewSpec()
                 .withVersion(Environment.ST_KAFKA_VERSION)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -146,7 +146,6 @@ public class KafkaTemplates {
         KafkaBuilder kb = new KafkaBuilder(kafka)
             .withNewMetadata()
                 .withName(name)
-                .withClusterName(name)
                 .withNamespace(kubeClient().getNamespace())
             .endMetadata()
             .editSpec()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaUserTemplates.java
@@ -48,7 +48,6 @@ public class KafkaUserTemplates {
     public static KafkaUserBuilder defaultUser(String namespaceName, String clusterName, String name) {
         return new KafkaUserBuilder()
             .withNewMetadata()
-                .withClusterName(clusterName)
                 .withName(name)
                 .withNamespace(namespaceName)
                 .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, clusterName)


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 to 6.2.0 which brings some improvements and bugfixes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally