### PR TITLE
docs(k8s): Updates the Kubernetes version attribute

### DIFF
--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -22,9 +22,6 @@ The affinity configuration can include different types of affinity:
 * Pod affinity and anti-affinity
 * Node affinity
 
-NOTE: On Kubernetes 1.16 and 1.17, the support for `topologySpreadConstraint` is disabled by default.
-In order to use `topologySpreadConstraint`, you have to enable the `EvenPodsSpread` feature gate in Kubernetes API server and scheduler.
-
 [role="_additional-resources"]
 .Additional resources
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -20,7 +20,7 @@
 :UpgradeGuide: link:https://strimzi.io/docs/operators/0.24.0/deploying.html#assembly-upgrade-resources-str[Strimzi 0.24.0 upgrade documentation^]
 
 // Kubernetes versions
-:KubernetesVersion: 1.16 and later
+:KubernetesVersion: 1.19 and later
 
 // Kafka upgrade attributes used in kafka upgrades section
 :DefaultKafkaVersion: 3.3.1


### PR DESCRIPTION
…related to older versions

Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates the Kubernetes version attriubute used in the docs.
Also removes a note related to using Strimzi with older Kubernetes versions. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

