### PR TITLE
Update minimal supported Kubernetes version to 1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changes, deprecations and removals
 
+* **From 0.32.0 on, Strimzi supports only Kubernetes version 1.19 and newer.**
 * A connector or task failing triggers a 'NotReady' condition to be added to the KafkaConnector CR status. This is different from previous versions where the CR would report 'Ready' even if the connector or a task had failed.
 * The `ClusterRole` from file `020-ClusterRole-strimzi-cluster-operator-role.yaml` was split into two separate roles:
   * The original `strimzi-cluster-operator-namespaced` `ClusterRole` in the file `020-ClusterRole-strimzi-cluster-operator-role.yaml` contains the rights related to the resources created based on some Strimzi custom resources.

--- a/api/src/main/java/io/strimzi/platform/KubernetesVersion.java
+++ b/api/src/main/java/io/strimzi/platform/KubernetesVersion.java
@@ -8,16 +8,13 @@ package io.strimzi.platform;
  * Represents Kubernetes version which Strimzi runs on
  */
 public class KubernetesVersion implements Comparable<KubernetesVersion> {
-    private int major;
-    private int minor;
+    private final int major;
+    private final int minor;
 
     // unsupported versions
     public static final KubernetesVersion V1_15 = new KubernetesVersion(1, 15);
 
     // supported versions
-    public static final KubernetesVersion V1_16 = new KubernetesVersion(1, 16);
-    public static final KubernetesVersion V1_17 = new KubernetesVersion(1, 17);
-    public static final KubernetesVersion V1_18 = new KubernetesVersion(1, 18);
     public static final KubernetesVersion V1_19 = new KubernetesVersion(1, 19);
     public static final KubernetesVersion V1_20 = new KubernetesVersion(1, 20);
     public static final KubernetesVersion V1_21 = new KubernetesVersion(1, 21);
@@ -26,7 +23,7 @@ public class KubernetesVersion implements Comparable<KubernetesVersion> {
     public static final KubernetesVersion V1_24 = new KubernetesVersion(1, 24);
     public static final KubernetesVersion V1_25 = new KubernetesVersion(1, 25);
 
-    public static final KubernetesVersion MINIMAL_SUPPORTED_VERSION = V1_16;
+    public static final KubernetesVersion MINIMAL_SUPPORTED_VERSION = V1_19;
     public static final int MINIMAL_SUPPORTED_MAJOR = MINIMAL_SUPPORTED_VERSION.major;
     public static final int MINIMAL_SUPPORTED_MINOR = MINIMAL_SUPPORTED_VERSION.minor;
 

--- a/api/src/test/java/io/strimzi/platform/KubernetesVersionTest.java
+++ b/api/src/test/java/io/strimzi/platform/KubernetesVersionTest.java
@@ -13,34 +13,30 @@ import static org.hamcrest.Matchers.lessThan;
 public class KubernetesVersionTest {
     @Test
     public void versionTest() {
-        KubernetesVersion kv1p16 = new KubernetesVersion(1, 5);
-        assertThat(kv1p16.compareTo(KubernetesVersion.V1_15), lessThan(0));
-        assertThat(kv1p16.compareTo(KubernetesVersion.V1_16), lessThan(0));
-        assertThat(kv1p16.compareTo(KubernetesVersion.V1_17), lessThan(0));
-        assertThat(kv1p16.compareTo(KubernetesVersion.V1_18), lessThan(0));
+        KubernetesVersion kv1p5 = new KubernetesVersion(1, 5);
+        assertThat(kv1p5.compareTo(KubernetesVersion.V1_15), lessThan(0));
+        assertThat(kv1p5.compareTo(KubernetesVersion.V1_19), lessThan(0));
+        assertThat(kv1p5.compareTo(KubernetesVersion.V1_25), lessThan(0));
 
         assertThat(KubernetesVersion.V1_15.compareTo(KubernetesVersion.V1_15), is(0));
-        assertThat(KubernetesVersion.V1_15.compareTo(KubernetesVersion.V1_16), lessThan(0));
-        assertThat(KubernetesVersion.V1_15.compareTo(KubernetesVersion.V1_17), lessThan(0));
-        assertThat(KubernetesVersion.V1_15.compareTo(KubernetesVersion.V1_18), lessThan(0));
+        assertThat(KubernetesVersion.V1_15.compareTo(KubernetesVersion.V1_19), lessThan(0));
+        assertThat(KubernetesVersion.V1_15.compareTo(KubernetesVersion.V1_25), lessThan(0));
 
 
-        assertThat(KubernetesVersion.V1_19.compareTo(KubernetesVersion.V1_15), greaterThan(0));
-        assertThat(KubernetesVersion.V1_19.compareTo(KubernetesVersion.V1_16), greaterThan(0));
-        assertThat(KubernetesVersion.V1_19.compareTo(KubernetesVersion.V1_17), greaterThan(0));
-        assertThat(KubernetesVersion.V1_19.compareTo(KubernetesVersion.V1_18), greaterThan(0));
-        assertThat(KubernetesVersion.V1_19.compareTo(KubernetesVersion.V1_19), is(0));
+        assertThat(KubernetesVersion.V1_22.compareTo(KubernetesVersion.V1_15), greaterThan(0));
+        assertThat(KubernetesVersion.V1_22.compareTo(KubernetesVersion.V1_19), greaterThan(0));
+        assertThat(KubernetesVersion.V1_22.compareTo(KubernetesVersion.V1_22), is(0));
 
-        KubernetesVersion kv2p16 = new KubernetesVersion(2, 16);
-        assertThat(kv2p16.compareTo(KubernetesVersion.V1_15), greaterThan(0));
-        assertThat(kv2p16.compareTo(KubernetesVersion.V1_16), greaterThan(0));
-        assertThat(kv2p16.compareTo(KubernetesVersion.V1_17), greaterThan(0));
-        assertThat(kv2p16.compareTo(KubernetesVersion.V1_18), greaterThan(0));
+        KubernetesVersion kv2p22 = new KubernetesVersion(2, 22);
+        assertThat(kv2p22.compareTo(KubernetesVersion.V1_15), greaterThan(0));
+        assertThat(kv2p22.compareTo(KubernetesVersion.V1_19), greaterThan(0));
+        assertThat(kv2p22.compareTo(KubernetesVersion.V1_20), greaterThan(0));
+        assertThat(kv2p22.compareTo(KubernetesVersion.V1_21), greaterThan(0));
     }
 
     @Test
     public void versionsEqualTest() {
-        KubernetesVersion kv1p16 = new KubernetesVersion(1, 16);
-        assertThat(kv1p16, is(KubernetesVersion.V1_16));
+        KubernetesVersion kv1p25 = new KubernetesVersion(1, 25);
+        assertThat(kv1p25, is(KubernetesVersion.V1_25));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -211,7 +211,7 @@ public class ClusterOperatorTest {
 
         CountDownLatch latch = new CountDownLatch(namespaceList.size() + 1);
 
-        Main.deployClusterOperatorVerticles(VERTX, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_16),
+        Main.deployClusterOperatorVerticles(VERTX, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(openShift, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                     ClusterOperatorConfig.fromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", VERTX.deploymentIDs(), hasSize(namespaceList.size()));
@@ -309,7 +309,7 @@ public class ClusterOperatorTest {
         Map<String, String> env = buildEnv(namespaces, strimziPodSets, podSetsOnly);
 
         CountDownLatch latch = new CountDownLatch(2);
-        Main.deployClusterOperatorVerticles(VERTX, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(openShift, KubernetesVersion.V1_16),
+        Main.deployClusterOperatorVerticles(VERTX, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(openShift, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 ClusterOperatorConfig.fromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", VERTX.deploymentIDs(), hasSize(1));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -150,7 +150,7 @@ public class CertificateRenewalTest {
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), certManager, passwordGenerator,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(1L));
 
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -157,7 +157,7 @@ public class ConnectorMockTest {
                 .build();
         mockKube.start();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_18);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         setupMockConnectAPI();
 
         metricsProvider = ResourceUtils.metricsProvider();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -132,7 +132,7 @@ public class JbodStorageMockTest {
                 .build();
         mockKube.start();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         // creating the Kafka operator
         ResourceOperatorSupplier ros =
                 new ResourceOperatorSupplier(JbodStorageMockTest.vertx, this.client,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -81,7 +81,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
                 .build();
         mockKube.start();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         supplier = supplier(client, pfa);
 
         podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertStatefulSetMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertStatefulSetMockTest.java
@@ -71,7 +71,7 @@ import static org.hamcrest.Matchers.not;
 @EnableKubernetesMockClient(crud = true)
 @ExtendWith(VertxExtension.class)
 public class KafkaAssemblyOperatorCustomCertStatefulSetMockTest {
-    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_18;
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
     private final MockCertManager certManager = new MockCertManager();
     private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
     private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS, "-UseStrimziPodSets");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaAssemblyOperatorManualRollingUpdatesTest {
-    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.V1_18;
+    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
     private static final MockCertManager CERT_MANAGER = new MockCertManager();
     private static final PasswordGenerator PASSWORD_GENERATOR = new PasswordGenerator(10, "a", "a");
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -84,8 +84,6 @@ public class KafkaAssemblyOperatorMockTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static Vertx vertx;
 
-    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
-
     private static final int KAFKA_REPLICAS = 3;
     private Storage kafkaStorage;
 
@@ -164,7 +162,7 @@ public class KafkaAssemblyOperatorMockTest {
                 .build();
         mockKube.start();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, kubernetesVersion);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         supplier = supplierWithMocks();
         podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
@@ -177,7 +175,7 @@ public class KafkaAssemblyOperatorMockTest {
     private ResourceOperatorSupplier supplierWithMocks() {
         return new ResourceOperatorSupplier(vertx, client, ResourceUtils.zookeeperLeaderFinder(vertx, client),
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
-                ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, kubernetesVersion), 2_000);
+                ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), 2_000);
     }
 
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNonParametrizedTest.java
@@ -136,7 +136,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), certManager, passwordGenerator,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 
@@ -221,7 +221,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), certManager, passwordGenerator,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 
@@ -300,7 +300,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), certManager, passwordGenerator,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 
@@ -337,7 +337,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
         ArgumentCaptor<ClusterRoleBinding> desiredCrb = ArgumentCaptor.forClass(ClusterRoleBinding.class);
         when(mockCrbOps.reconcile(any(), eq(KafkaResources.initContainerClusterRoleBindingName(NAME, NAMESPACE)), desiredCrb.capture())).thenReturn(Future.succeededFuture());
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16), certManager, passwordGenerator,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), certManager, passwordGenerator,
                 supplier, ResourceUtils.dummyClusterOperatorConfig(1L));
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 
@@ -403,7 +403,7 @@ public class KafkaAssemblyOperatorNonParametrizedTest {
                 "cluster-operator-name",
                 ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS, null);
 
-        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.V1_19), certManager, passwordGenerator,
+        KafkaAssemblyOperator op = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION), certManager, passwordGenerator,
                 supplier, config);
         Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -78,7 +78,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(VertxExtension.class)
 public class KafkaAssemblyOperatorPodSetTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
-    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.V1_18;
+    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
     private static final MockCertManager CERT_MANAGER = new MockCertManager();
     private static final PasswordGenerator PASSWORD_GENERATOR = new PasswordGenerator(10, "a", "a");
     private final static KafkaVersionChange VERSION_CHANGE = new KafkaVersionChange(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -86,7 +86,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
     private static final String OUTPUT_IMAGE_HASH_STUB = Util.hashStub(OUTPUT_IMAGE);
 
     protected static Vertx vertx;
-    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
 
     @BeforeAll
     public static void before() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -85,7 +85,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
     private static final String OUTPUT_IMAGE_HASH_STUB = Util.hashStub(OUTPUT_IMAGE);
 
     protected static Vertx vertx;
-    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_16;
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
 
     @BeforeAll
     public static void before() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerSkipBootstrapLoadBalancerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerSkipBootstrapLoadBalancerTest.java
@@ -98,7 +98,7 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
         MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
                 new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
                 kafkaCluster,
-                new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16),
+                new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
@@ -172,7 +172,7 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
         MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
                 new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
                 kafkaCluster,
-                new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16),
+                new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,
@@ -240,7 +240,7 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
         MockKafkaListenersReconciler reconciler = new MockKafkaListenersReconciler(
                 new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
                 kafkaCluster,
-                new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16),
+                new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
                 supplier.secretOperations,
                 supplier.serviceOperations,
                 supplier.routeOperations,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -106,7 +106,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
 
     private Future<Void> createMirrorMaker2Cluster(VertxTestContext context, KafkaConnectApi kafkaConnectApi, boolean reconciliationPaused) {
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(vertx, client,
                 new ZookeeperLeaderFinder(vertx,
                     // Retry up to 3 times (4 attempts), with overall max delay of 35000ms

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 @ExtendWith(VertxExtension.class)
 public class KafkaStatusTest {
-    private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_18;
+    private final KubernetesVersion kubernetesVersion = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
     private final MockCertManager certManager = new MockCertManager();
     private final PasswordGenerator passwordGenerator = new PasswordGenerator(10, "a", "a");
     private final ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -53,7 +53,7 @@ public class KafkaUpgradeDowngradeMockTest {
     private static final String NAMESPACE = "my-namespace";
     private static final String CLUSTER_NAME = "my-cluster";
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
-    private static final PlatformFeaturesAvailability PFA = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
+    private static final PlatformFeaturesAvailability PFA = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
     private static final Kafka KAFKA = new KafkaBuilder()
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -130,7 +130,7 @@ public class PartialRollingUpdateMockTest {
                 .build();
         mockKube.start();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         supplier = supplier(client, pfa);
 
         podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialStatefulSetRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialStatefulSetRollingUpdateMockTest.java
@@ -125,7 +125,7 @@ public class PartialStatefulSetRollingUpdateMockTest {
                 .build();
         mockKube.start();
 
-        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.V1_16);
+        PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         ResourceOperatorSupplier supplier = supplier(client, pfa);
 
         kco = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"), supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS, 2_000, "-UseStrimziPodSets"));

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -70,7 +70,7 @@ public class CrdGeneratorTest {
 
     @Test
     public void versionedTest() throws IOException {
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.parseRange("1.16+"), ApiVersion.V1BETA1);
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1BETA1);
         StringWriter w = new StringWriter();
         crdGenerator.generate(VersionedExampleCrd.class, w);
         String s = w.toString();

--- a/documentation/modules/configuring/ref-affinity.adoc
+++ b/documentation/modules/configuring/ref-affinity.adoc
@@ -22,9 +22,6 @@ The affinity configuration can include different types of affinity:
 * Pod affinity and anti-affinity
 * Node affinity
 
-NOTE: On Kubernetes 1.16 and 1.17, the support for `topologySpreadConstraint` is disabled by default.
-In order to use `topologySpreadConstraint`, you have to enable the `EvenPodsSpread` feature gate in Kubernetes API server and scheduler.
-
 [role="_additional-resources"]
 .Additional resources
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractCustomResourceOperatorIT.java
@@ -124,7 +124,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
         PlatformFeaturesAvailability.create(vertx, client)
                 .onComplete(context.succeeding(pfa -> context.verify(() -> {
                     assertThat("Kubernetes version : " + pfa.getKubernetesVersion() + " is too old",
-                            pfa.getKubernetesVersion().compareTo(KubernetesVersion.V1_16), CoreMatchers.is(not(lessThan(0))));
+                            pfa.getKubernetesVersion().compareTo(KubernetesVersion.MINIMAL_SUPPORTED_VERSION), CoreMatchers.is(not(lessThan(0))));
                 })))
 
                 .compose(pfa -> {
@@ -172,7 +172,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
         PlatformFeaturesAvailability.create(vertx, client)
                 .onComplete(context.succeeding(pfa -> context.verify(() -> {
                     assertThat("Kubernetes version : " + pfa.getKubernetesVersion() + " is too old",
-                            pfa.getKubernetesVersion().compareTo(KubernetesVersion.V1_16), CoreMatchers.is(not(lessThan(0))));
+                            pfa.getKubernetesVersion().compareTo(KubernetesVersion.MINIMAL_SUPPORTED_VERSION), CoreMatchers.is(not(lessThan(0))));
                 })))
                 .compose(pfa -> {
                     LOGGER.info("Creating resource");
@@ -220,7 +220,7 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
         PlatformFeaturesAvailability.create(vertx, client)
                 .onComplete(context.succeeding(pfa -> context.verify(() -> {
                     assertThat("Kubernetes version : " + pfa.getKubernetesVersion() + " is too old",
-                            pfa.getKubernetesVersion().compareTo(KubernetesVersion.V1_16), CoreMatchers.is(not(lessThan(0))));
+                            pfa.getKubernetesVersion().compareTo(KubernetesVersion.MINIMAL_SUPPORTED_VERSION), CoreMatchers.is(not(lessThan(0))));
                 })))
                 .compose(pfa -> {
                     LOGGER.info("Creating resource");

--- a/tools/cold-backup/README.md
+++ b/tools/cold-backup/README.md
@@ -18,7 +18,7 @@ Consumer group offsets are included, but not Kafka Connect, MirrorMaker and Kafk
 
 - bash 5+ (GNU)
 - tar 1.33+ (GNU)
-- kubectl 1.16+ (K8s CLI)
+- kubectl 1.19+ (K8s CLI)
 - yq 4.6+ (YAML processor)
 - enough disk space
 

--- a/tools/log-dump/README.md
+++ b/tools/log-dump/README.md
@@ -11,7 +11,7 @@ Partition dumps can be useful to troubleshoot Kafka issues. For example, we can 
 ## Requirements
 
 - bash 5+ (GNU)
-- kubectl 1.16+ (K8s CLI)
+- kubectl 1.19+ (K8s CLI)
 - yq 4.6+ (YAML processor)
 - jshell (JDK 9+)
 

--- a/tools/olm-bundle/csv-template/bases/strimzi-cluster-operator.clusterserviceversion.yaml
+++ b/tools/olm-bundle/csv-template/bases/strimzi-cluster-operator.clusterserviceversion.yaml
@@ -336,7 +336,7 @@ metadata:
   name: strimzi-cluster-operator.v # placeholder
   namespace: placeholder
 spec:
-  MinKubeVersion: 1.16.0
+  MinKubeVersion: 1.19.0
   customresourcedefinitions:
     owned:
     - description: Represents a Kafka cluster


### PR DESCRIPTION
### Type of change

- Task

### Description

As agreed, Strimzi 0.32 should support only Kubernetes 1.19 and newer. This PRe updates the minimal supported version and sets it to 1.19 and updates some related docs and tests.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally