### PR TITLE
docs(upgrade) clarification of current protocol and message versions

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth.adoc
@@ -30,7 +30,7 @@ Optionally, `scope` and `audience` can be specified if needed.
 You can configure the address of your OAuth server in the `tokenEndpointUri` property together with the OAuth client ID and refresh token.
 The OAuth client will connect to the OAuth server, authenticate using the client ID and refresh token and get an access token which it will use to authenticate with the Kafka broker.
 In the `refreshToken` property, specify a link to a `Secret` containing the refresh token.
-+
+
 .An example of OAuth client authentication using client ID and refresh token
 [source,yaml,subs=attributes+]
 ----

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -59,7 +59,7 @@ NOTE: The value of `log.message.format.version` and `inter.broker.protocol.versi
 ====
 Changing the `kafka.version` ensures that all brokers in the cluster will be upgraded to start using the new broker binaries.
 During this process, some brokers are using the old binaries while others have already upgraded to the new ones.
-Leaving the `inter.broker.protocol.version` set to the current version ensures that the brokers can continue to communicate with each other throughout the upgrade.
+Leaving the `inter.broker.protocol.version` unchanged at the current setting ensures that the brokers can continue to communicate with each other throughout the upgrade.
 ====
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -33,7 +33,7 @@ kubectl edit kafka _my-cluster_
 
 . If configured, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` and `inter.broker.protocol.version` set to the defaults for the _current_ Kafka version.
 +
-For example, if upgrading from Kafka version {KafkaVersionLower} to {KafkaVersionHigher}:
+For example, the current version is {KafkaVersionLower} if upgrading from Kafka version {KafkaVersionLower} to {KafkaVersionHigher}:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -59,7 +59,7 @@ NOTE: The value of `log.message.format.version` and `inter.broker.protocol.versi
 ====
 Changing the `kafka.version` ensures that all brokers in the cluster will be upgraded to start using the new broker binaries.
 During this process, some brokers are using the old binaries while others have already upgraded to the new ones.
-Leaving the `inter.broker.protocol.version` unchanged ensures that the brokers can continue to communicate with each other throughout the upgrade.
+Leaving the `inter.broker.protocol.version` set to the current version ensures that the brokers can continue to communicate with each other throughout the upgrade.
 ====
 +
 For example, if upgrading from Kafka {KafkaVersionLower} to {KafkaVersionHigher}:

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -28,12 +28,12 @@ For the `Kafka` resource to be upgraded, check that:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl edit kafka _my-cluster_
+kubectl edit kafka _<my_cluster>_
 ----
 
-. If configured, ensure that `Kafka.spec.kafka.config` has the `log.message.format.version` and `inter.broker.protocol.version` set to the defaults for the _current_ Kafka version.
+. If configured, check that the `inter.broker.protocol.version` and `log.message.format.version` properties are set to the _current_ version.
 +
-For example, the current version is {KafkaVersionLower} if upgrading from Kafka version {KafkaVersionLower} to {KafkaVersionHigher}:
+For example, the current version is {InterBrokerVersionLower} if upgrading from Kafka version {KafkaVersionLower} to {KafkaVersionHigher}:
 +
 [source,yaml,subs=attributes+]
 ----


### PR DESCRIPTION
### Type of change

**Documentation**

Updates [Upgrading Kafka brokers and client applications](https://strimzi.io/docs/operators/in-development/deploying.html#proc-upgrading-brokers-newer-kafka-str) to make it clear what _current_ version means in terms of protocol and log message versions.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

