### PR TITLE
Removed unused Vert.x components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,16 +526,6 @@
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
-                <artifactId>vertx-web-common</artifactId>
-                <version>${vertx.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-web-client</artifactId>
-                <version>${vertx.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.vertx</groupId>
                 <artifactId>vertx-micrometer-metrics</artifactId>
                 <version>${vertx.version}</version>
             </dependency>


### PR DESCRIPTION
It seems that `vertx-web-common` and `vertx-web-client` are not referenced (so not used) in any of the projects.
This PR removes them from the principal pom.xml.