### PR TITLE
Fix the error message when `ipFamilyPolicy` or `ipFamilies` are set on a `type=internal` listener

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -222,7 +222,7 @@ public class ListenersValidator {
     private static void validateIpFamilyPolicy(Set<String> errors, GenericKafkaListener listener) {
         if (KafkaListenerType.INTERNAL == listener.getType()
                 && listener.getConfiguration().getIpFamilyPolicy() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure ipFamilyPolicy because it is not internal listener");
+            errors.add("listener " + listener.getName() + " cannot configure ipFamilyPolicy because it is internal listener");
         }
     }
 
@@ -235,7 +235,7 @@ public class ListenersValidator {
     private static void validateIpFamilies(Set<String> errors, GenericKafkaListener listener) {
         if (KafkaListenerType.INTERNAL == listener.getType()
                 && listener.getConfiguration().getIpFamilies() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure ipFamilies because it is not internal listener");
+            errors.add("listener " + listener.getName() + " cannot configure ipFamilies because it is internal listener");
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -271,8 +271,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, or Ingress based listener",
-                "listener " + name + " cannot configure ipFamilyPolicy because it is not internal listener",
-                "listener " + name + " cannot configure ipFamilies because it is not internal listener"
+                "listener " + name + " cannot configure ipFamilyPolicy because it is internal listener",
+                "listener " + name + " cannot configure ipFamilies because it is internal listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `ipFamilyPolicy` or `ipFamilies` cannot be used on `type=internal` listeners because these listeners do not have their own services. The services are shared with replication and control plane listeners. These fields can be only changed through the `template` section. However, the error message is wrong and suggests these options can be used only on internal listeners => so actually the opposite of what it should say. This Pr fixes the error message.

This should close #7524.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging