### PR TITLE
Internal Kafka clients should do TLS hostname verification except Nodeports

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -419,7 +419,6 @@ public class KafkaClients extends BaseClients {
 
         this.setAdditionalConfig(this.getAdditionalConfig() +
             // scram-sha
-            "ssl.endpoint.identification.algorithm=\n" +
             "sasl.mechanism=SCRAM-SHA-512\n" +
             "security.protocol=" + securityProtocol + "\n" +
             "sasl.jaas.config=" + saslJaasConfigDecrypted);
@@ -427,7 +426,6 @@ public class KafkaClients extends BaseClients {
 
     final protected void configureTls() {
         this.setAdditionalConfig(this.getAdditionalConfig() +
-            "ssl.endpoint.identification.algorithm=\n" +
             "sasl.mechanism=GSSAPI\n" +
             "security.protocol=" + SecurityProtocol.SSL + "\n");
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -100,9 +100,26 @@ public class SystemTestCertManager {
                 .withSubjectDn(STRIMZI_INTERMEDIATE_CA)
                 .build();
     }
+
+    public static SystemTestCertAndKey generateIntermediateCaCertAndKey(final SystemTestCertAndKey rootCert,
+                                                                        final ASN1Encodable[] sanDnsNames) {
+        return intermediateCaCertBuilder(rootCert)
+                .withSubjectDn(STRIMZI_INTERMEDIATE_CA)
+                .withSanDnsNames(sanDnsNames)
+                .build();
+    }
+
     public static SystemTestCertAndKey generateStrimziCaCertAndKey(SystemTestCertAndKey rootCert, String subjectDn) {
         return strimziCaCertBuilder(rootCert)
                 .withSubjectDn(subjectDn)
+                .build();
+    }
+
+    public static SystemTestCertAndKey generateEndEntityCertAndKey(final SystemTestCertAndKey intermediateCert,
+                                                                   final ASN1Encodable[] sansNames) {
+        return endEntityCertBuilder(intermediateCert)
+                .withSubjectDn(STRIMZI_END_SUBJECT)
+                .withSanDnsNames(sansNames)
                 .build();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -101,14 +101,6 @@ public class SystemTestCertManager {
                 .build();
     }
 
-    public static SystemTestCertAndKey generateIntermediateCaCertAndKey(final SystemTestCertAndKey rootCert,
-                                                                        final ASN1Encodable[] sanDnsNames) {
-        return intermediateCaCertBuilder(rootCert)
-                .withSubjectDn(STRIMZI_INTERMEDIATE_CA)
-                .withSanDnsNames(sanDnsNames)
-                .build();
-    }
-
     public static SystemTestCertAndKey generateStrimziCaCertAndKey(SystemTestCertAndKey rootCert, String subjectDn) {
         return strimziCaCertBuilder(rootCert)
                 .withSubjectDn(subjectDn)

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
@@ -155,9 +155,6 @@ public class HttpBridgeKafkaExternalListenersST extends AbstractST {
             .withMessageCount(MESSAGE_COUNT)
             .withPort(Constants.HTTP_BRIDGE_DEFAULT_PORT)
             .withNamespaceName(namespace)
-            // we disable ssl.endpoint.identification.algorithm for external listener (i.e., Nodeport),
-            // because TLS hostname verification is not supported on such listener type.
-            .withAdditionalConfig("ssl.endpoint.identification.algorithm=\n")
             .build();
 
         // Create topic
@@ -216,7 +213,7 @@ public class HttpBridgeKafkaExternalListenersST extends AbstractST {
             .withTopicName(topicName)
             .withMessageCount(MESSAGE_COUNT)
             .withUserName(weirdUserName)
-            // we disable ssl.endpoint.identification.algorithm for external listener (i.e., Nodeport),
+            // we disable ssl.endpoint.identification.algorithm for external listener (i.e., NodePort),
             // because TLS hostname verification is not supported on such listener type.
             .withAdditionalConfig("ssl.endpoint.identification.algorithm=\n")
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
@@ -155,6 +155,9 @@ public class HttpBridgeKafkaExternalListenersST extends AbstractST {
             .withMessageCount(MESSAGE_COUNT)
             .withPort(Constants.HTTP_BRIDGE_DEFAULT_PORT)
             .withNamespaceName(namespace)
+            // we disable ssl.endpoint.identification.algorithm for external listener (i.e., Nodeport),
+            // because TLS hostname verification is not supported on such listener type.
+            .withAdditionalConfig("ssl.endpoint.identification.algorithm=\n")
             .build();
 
         // Create topic
@@ -213,6 +216,9 @@ public class HttpBridgeKafkaExternalListenersST extends AbstractST {
             .withTopicName(topicName)
             .withMessageCount(MESSAGE_COUNT)
             .withUserName(weirdUserName)
+            // we disable ssl.endpoint.identification.algorithm for external listener (i.e., Nodeport),
+            // because TLS hostname verification is not supported on such listener type.
+            .withAdditionalConfig("ssl.endpoint.identification.algorithm=\n")
             .build();
 
         if (auth.getType().equals(Constants.TLS_LISTENER_DEFAULT_NAME)) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1587,7 +1587,7 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        int expectedMessageCountForNewGroup = testStorage.getMessageCount();
+        int expectedMessageCountForNewGroup = testStorage.getMessageCount() * 3;
 
         KafkaClients kafkaClients = new KafkaClientsBuilder()
             .withNamespaceName(testStorage.getNamespaceName())
@@ -1611,7 +1611,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResource(extensionContext, kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount() * 3);
 
         SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
         SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1587,7 +1587,7 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        int expectedMessageCountForNewGroup = testStorage.getMessageCount() * 3;
+        int expectedMessageCountForNewGroup = testStorage.getMessageCount();
 
         KafkaClients kafkaClients = new KafkaClientsBuilder()
             .withNamespaceName(testStorage.getNamespaceName())
@@ -1611,10 +1611,10 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResource(extensionContext, kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount() * 3);
+        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
-        SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), STRIMZI_CERT_AND_KEY_2);
-        SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), STRIMZI_CERT_AND_KEY_1);
+        SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
+        SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);
 
         kafkaSnapshot = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaSnapshot);
 


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Bugfix

### Description

Currently, our internal Kafka clients do not perform TLS hostname verification on all possible Kubernetes listeners. This PR  solves https://github.com/strimzi/strimzi-kafka-operator/issues/7518 and enables TLS hostname verification and also disables it in situations where we do not want to execute it (e.g., when we use Nodeport listener, because it does not support TLS hostname verification on ports).  

### Checklist

- [x] Make sure all tests pass