### PR TITLE
Try to find better balance between OOM killer and being out of heap space

### DIFF
--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -28,7 +28,7 @@ JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
 
 # Default memory options used when the user didn't configured any of these options, we set the defaults
 if [[ "$JAVA_OPTS" != *"MinRAMPercentage"* && "$JAVA_OPTS" != *"MaxRAMPercentage"* ]]; then
-  JAVA_OPTS="${JAVA_OPTS} -XX:MinRAMPercentage=10 -XX:MaxRAMPercentage=20"
+  JAVA_OPTS="${JAVA_OPTS} -XX:MinRAMPercentage=15 -XX:MaxRAMPercentage=20"
 fi
 
 # Disable FIPS if needed


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR continues to try to find the right balance between the container memory and heap space. Originally, the operator was very often running over the container memory limits and was being killed by OOM killer in Kubernetes. Then we limited more the available heap memory using the `-XX:MinRAMPercentage`. That from my experience helped to reduce the OOM kills (I haven't seen any in my environments). But it introduced very frequent crashes because Java cannot allocate memory on the heap. Lately, this seems to be happening very often even with just one Kafka cluster and one Connect cluter.

This PR continues the tuning attempts and changes the `-XX:MinRAMPercentage` from 10% to 15% to see if it helps. My tests so far show that it helped to minimize the OutOfHeap issues I had very commonly during a regular work. It also does not seem to introduce any frequent OOM kills (but that might require longer observation after the next release). So hopefully this PR helps to bring in a bit more stability.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally