### PR TITLE
Bump Strimzi OAuth library to version 0.11.0

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <cruise-control.version>2.5.103</cruise-control.version>
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <cruise-control.version>2.5.103</cruise-control.version>
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <cruise-control.version>2.5.103</cruise-control.version>
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
-        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <netty.version>4.1.77.Final</netty.version>
         <micrometer.version>1.3.1</micrometer.version>
         <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>


### PR DESCRIPTION
Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>

### Type of change
- Enhancement / new feature

### Description

New version introduces support for 'oauth' authentication / 'keycloak' authorization related metrics, and for password grants.

The integration of additional configuration into CRDs is part of another PR (#7169)

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

