### PR TITLE
Fix JMX port not added to KafkaCluster

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1321,6 +1321,10 @@ public class KafkaCluster extends AbstractModel {
             ports.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
         }
 
+        if (isJmxEnabled) {
+            ports.add(createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP"));
+        }
+
         return ports;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -567,6 +567,10 @@ public class ZookeeperCluster extends AbstractModel {
             portList.add(createContainerPort(METRICS_PORT_NAME, METRICS_PORT, "TCP"));
         }
 
+        if (isJmxEnabled) {
+            portList.add(createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP"));
+        }
+
         return portList;
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -456,10 +456,11 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
+
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        ContainerPort jmxContainerPort = kc.createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP");
         List<Container> containers = kc.getContainers(ImagePullPolicy.IFNOTPRESENT);
 
+        ContainerPort jmxContainerPort = kc.createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP");
         assertThat(containers.get(0).getPorts().contains(jmxContainerPort), is(true));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -94,6 +94,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.strimzi.operator.cluster.model.AbstractModel.JMX_PORT;
+import static io.strimzi.operator.cluster.model.AbstractModel.JMX_PORT_NAME;
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -443,6 +445,22 @@ public class KafkaClusterTest {
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
 
         checkOwnerReference(kc.createOwnerReference(), headless);
+    }
+
+    @ParallelTest
+    public void testExposesJmxContainerPortWhenJmxEnabled() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withJmxOptions(new KafkaJmxOptionsBuilder().build())
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
+        ContainerPort jmxContainerPort = kc.createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP");
+        List<Container> containers = kc.getContainers(ImagePullPolicy.IFNOTPRESENT);
+
+        assertThat(containers.get(0).getPorts().contains(jmxContainerPort), is(true));
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -274,10 +274,11 @@ public class ZookeeperClusterTest {
                     .endZookeeper()
                 .endSpec()
                 .build();
+
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        ContainerPort jmxContainerPort = zc.createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP");
         List<Container> containers = zc.getContainers(ImagePullPolicy.IFNOTPRESENT);
 
+        ContainerPort jmxContainerPort = zc.createContainerPort(JMX_PORT_NAME, JMX_PORT, "TCP");
         assertThat(containers.get(0).getPorts().contains(jmxContainerPort), is(true));
     }
 


### PR DESCRIPTION
Add the JXM port to the list of container ports when JMX is enabled on a KafkaCluster.

### Type of change

- Bugfix

### Description

When setting `jmxOptions: {}` on a KafkaCluster, the JMX port is not exposed. I noticed on t[he PR to add JMX to KafkaConnectCluster](https://github.com/strimzi/strimzi-kafka-operator/pull/4096/files#diff-9401e8484d93180261dbb8e40efde42a935698119bb824142ad87594ad9a0620R354) that the JMX port is add to the list of container ports. I believe this may need to be added to KafkaCluster as well so that the JMX port is exposed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

