### PR TITLE
Add all DNS names to the certificate for the to Cluster-IP listener bootstrap service

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -8,6 +8,7 @@ import javax.security.auth.x500.X500Principal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -31,18 +32,44 @@ public class Subject {
             this.commonName = commonName;
             return this;
         }
+
         public Builder withOrganizationName(String organizationName) {
             this.organizationName = organizationName;
             return this;
         }
+
+        /**
+         * Adds the name to the certificate subject as SAN. This creates a list with one item and delegates to the
+         * addDnsNames method.
+         *
+         * @param dnsName   DNS name
+         *
+         * @return  Instance of this builder
+         */
         public Builder addDnsName(String dnsName) {
-            if (!IpAndDnsValidation.isValidDnsNameOrWildcard(dnsName)) {
-                throw new IllegalArgumentException("Invalid DNS name: " + dnsName);
-            }
+            return addDnsNames(List.of(dnsName));
+        }
+
+        /**
+         * Adds one or more DNS names which will be used in the certificate subject for the SANs
+         *
+         * @param newDnsNames   List of DNS names
+         *
+         * @return  Instance of this builder
+         */
+        public Builder addDnsNames(List<String> newDnsNames)  {
             if (dnsNames == null) {
                 dnsNames = new HashSet<>();
             }
-            dnsNames.add(dnsName);
+
+            for (String newDnsName : newDnsNames)   {
+                if (!IpAndDnsValidation.isValidDnsNameOrWildcard(newDnsName)) {
+                    throw new IllegalArgumentException("Invalid DNS name: " + newDnsName);
+                }
+
+                dnsNames.add(newDnsName);
+            }
+
             return this;
         }
 

--- a/certificate-manager/src/test/java/io/strimzi/certs/SubjectTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SubjectTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.certs;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -39,6 +40,7 @@ public class SubjectTest {
                 .withOrganizationName("MyOrg")
                 .addDnsName("example.com")
                 .addDnsName("example.org")
+                .addDnsNames(List.of("example.cz", "example.co.uk"))
                 .addIpAddress("123.123.123.123")
                 .addIpAddress("127.0.0.1")
                 .build();
@@ -46,7 +48,9 @@ public class SubjectTest {
                 "IP.0", "123.123.123.123",
                 "IP.1", "127.0.0.1",
                 "DNS.0", "example.org",
-                "DNS.1", "example.com"),
+                "DNS.1", "example.co.uk",
+                "DNS.2", "example.com",
+                "DNS.3", "example.cz"),
                 subject.subjectAltNames());
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -177,22 +177,14 @@ public class ClusterCa extends Ca {
 
     public Map<String, CertAndKey> generateBrokerCerts(String namespace, String cluster, int replicas, Set<String> externalBootstrapAddresses,
                                                        Map<Integer, Set<String>> externalAddresses, boolean isMaintenanceTimeWindowsSatisfied) throws IOException {
-        DnsNameGenerator kafkaDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.bootstrapServiceName(cluster));
-        DnsNameGenerator kafkaHeadlessDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.brokersServiceName(cluster));
-
         Function<Integer, Subject> subjectFn = i -> {
             Subject.Builder subject = new Subject.Builder()
                     .withOrganizationName("io.strimzi")
                     .withCommonName(KafkaResources.kafkaStatefulSetName(cluster));
 
-            subject.addDnsName(KafkaResources.bootstrapServiceName(cluster));
-            subject.addDnsName(String.format("%s.%s", KafkaResources.bootstrapServiceName(cluster), namespace));
-            subject.addDnsName(kafkaDnsGenerator.serviceDnsNameWithoutClusterDomain());
-            subject.addDnsName(kafkaDnsGenerator.serviceDnsName());
-            subject.addDnsName(KafkaResources.brokersServiceName(cluster));
-            subject.addDnsName(String.format("%s.%s", KafkaResources.brokersServiceName(cluster), namespace));
-            subject.addDnsName(kafkaHeadlessDnsGenerator.serviceDnsNameWithoutClusterDomain());
-            subject.addDnsName(kafkaHeadlessDnsGenerator.serviceDnsName());
+            subject.addDnsNames(ModelUtils.generateAllServiceDnsNames(namespace, KafkaResources.bootstrapServiceName(cluster)));
+            subject.addDnsNames(ModelUtils.generateAllServiceDnsNames(namespace, KafkaResources.brokersServiceName(cluster)));
+
             subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), KafkaResources.kafkaPodName(cluster, i)));
             subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(cluster), KafkaResources.kafkaPodName(cluster, i)));
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -733,4 +733,29 @@ public class ModelUtils {
     public static int idOfPod(String podName)  {
         return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
     }
+
+    /**
+     * Generates all possible DNS names for a Kubernetes service:
+     *     - service-name
+     *     - service-name.namespace
+     *     - service-name.namespace.svc
+     *     - service-name.namespace.svc.dns.suffix
+     *
+     * @param namespace     Namespace of the service
+     * @param serviceName   Name of the service
+     *
+     * @return  List with all possible DNS names
+     */
+    public static List<String> generateAllServiceDnsNames(String namespace, String serviceName)    {
+        DnsNameGenerator kafkaDnsGenerator = DnsNameGenerator.of(namespace, serviceName);
+
+        List<String> dnsNames = new ArrayList<>(4);
+
+        dnsNames.add(serviceName);
+        dnsNames.add(String.format("%s.%s", serviceName, namespace));
+        dnsNames.add(kafkaDnsGenerator.serviceDnsNameWithoutClusterDomain());
+        dnsNames.add(kafkaDnsGenerator.serviceDnsName());
+
+        return dnsNames;
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -23,6 +23,7 @@ import io.strimzi.operator.cluster.model.DnsNameGenerator;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.ListenersUtils;
+import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
@@ -403,7 +404,8 @@ public class KafkaListenersReconciler {
             String bootstrapAddress = getInternalServiceHostname(reconciliation.namespace(), ListenersUtils.backwardsCompatibleBootstrapServiceName(reconciliation.name(), listener), useServiceDnsDomain);
 
             if (listener.isTls()) {
-                result.bootstrapDnsNames.add(bootstrapAddress);
+                ModelUtils.generateAllServiceDnsNames(reconciliation.namespace(), ListenersUtils.backwardsCompatibleBootstrapServiceName(reconciliation.name(), listener))
+                                .forEach(dnsName -> result.bootstrapDnsNames.add(dnsName));
             }
 
             ListenerStatus ls = new ListenerStatusBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -65,6 +65,7 @@ import static io.strimzi.operator.common.Util.parseMap;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -719,6 +720,14 @@ public class ModelUtilsTest {
         assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is("70"));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is("10000000000"));
+    }
+
+    @ParallelTest
+    public void testServiceDnsNames() {
+        List<String> dnsNames = ModelUtils.generateAllServiceDnsNames("my-namespace", "my-service");
+
+        assertThat(dnsNames.size(), is(4));
+        assertThat(dnsNames, hasItems("my-service", "my-service.my-namespace", "my-service.my-namespace.svc", "my-service.my-namespace.svc.cluster.local"));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerClusterIPTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerClusterIPTest.java
@@ -200,8 +200,8 @@ public class KafkaListenerReconcilerClusterIPTest {
                     assertThat(listenerStatus.getAddresses().get(0).getPort(), is(LISTENER_PORT));
 
                     //check hostnames
-                    assertThat(res.bootstrapDnsNames.size(), is(1));
-                    assertThat(res.bootstrapDnsNames, hasItems("my-kafka-kafka-external-bootstrap.test.svc"));
+                    assertThat(res.bootstrapDnsNames.size(), is(4));
+                    assertThat(res.bootstrapDnsNames, hasItems("my-kafka-kafka-external-bootstrap", "my-kafka-kafka-external-bootstrap.test", "my-kafka-kafka-external-bootstrap.test.svc", "my-kafka-kafka-external-bootstrap.test.svc.cluster.local"));
                     Set<String> allBrokersDnsNames = res.brokerDnsNames.values().stream().flatMap(s -> s.stream()).collect(Collectors.toSet());
                     assertThat(allBrokersDnsNames.size(), is(3));
                     assertThat(allBrokersDnsNames, hasItems("my-kafka-kafka-1.test.svc", "my-kafka-kafka-2.test.svc", "my-kafka-kafka-0.test.svc"));
@@ -300,8 +300,8 @@ public class KafkaListenerReconcilerClusterIPTest {
                     assertThat(listenerStatus.getAddresses().get(0).getPort(), is(LISTENER_PORT));
 
                     //check hostnames
-                    assertThat(res.bootstrapDnsNames.size(), is(1));
-                    assertThat(res.bootstrapDnsNames, hasItems("my-kafka-kafka-external-bootstrap.test.svc"));
+                    assertThat(res.bootstrapDnsNames.size(), is(4));
+                    assertThat(res.bootstrapDnsNames, hasItems("my-kafka-kafka-external-bootstrap", "my-kafka-kafka-external-bootstrap.test", "my-kafka-kafka-external-bootstrap.test.svc", "my-kafka-kafka-external-bootstrap.test.svc.cluster.local"));
                     Set<String> allBrokersDnsNames = res.brokerDnsNames.values().stream().flatMap(s -> s.stream()).collect(Collectors.toSet());
                     assertThat(allBrokersDnsNames.size(), is(6));
                     assertThat(allBrokersDnsNames, hasItems("my-address-0", "my-address-1", "my-address-2", "my-kafka-kafka-1.test.svc", "my-kafka-kafka-2.test.svc", "my-kafka-kafka-0.test.svc"));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The PR #7365 added a new listener type `cluster-ip` which is an internal listener based on per-broker services instead of an headless service and its DNS names. The original PR adds only the `<service-name>.<namespace>.svc` DNS name to the server certificate SANs. So when a user tried to use one of the other DNS names available for the service (e.g. `<service-name>.<namespace>` or just `<service-name>`), then the TLS hostname verification fails.

This PR adds all the possible DNS names of the service to the certificate so that users can use any format for the bootstrap service. Since this is done also om the `ClusterCa` class for the regular services used for `type: internal` listeners or for the replication and control plane listeners, it also refactors the code to have these service name generated in one place instead of many.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally