### PR TITLE
[systemtest] Better regex for the StrimziPodSet reconciliation failure

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -83,7 +83,9 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
 
         // error that pods already exist when doing reconciliation of StrimziPodSets
         // connected to https://github.com/strimzi/strimzi-kafka-operator/issues/7529 - remove this once the issue will be fixed
-        RECONCILIATION_PODSET_ALREADY_EXISTS("ERROR StrimziPodSetController:[0-9]+ - Reconciliation.*[fF]ailed.*already exists.*");
+        RECONCILIATION_PODSET_ALREADY_EXISTS("ERROR StrimziPodSetController:[0-9]+ - Reconciliation.*[fF]ailed"
+            + "(?s)(.*?)"
+            + "io.fabric8.kubernetes.client.KubernetesClientException.*already exists");
 
         final String name;
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In #7527 I added `StrimziPodSet` reconciliation failure when pods already exists into the ST whitelist. It seems that this regex works for few cases, other cases with new lines etc. are still taken, so the tests are still failing.

This PR tries to fix this issue and tries to cover all possible possibilities.

### Checklist

- [ ] Make sure all tests pass
