### PR TITLE
Disabled bridge metrics test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -60,6 +60,7 @@ import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -431,6 +432,7 @@ public class MetricsIsolatedST extends AbstractST {
         assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 1));
     }
 
+    @Disabled("Started to fail on the system_cpu_count metric check which is different depending on the environment")
     @ParallelTest
     @Tag(BRIDGE)
     void testKafkaBridgeMetrics(ExtensionContext extensionContext) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -432,7 +432,8 @@ public class MetricsIsolatedST extends AbstractST {
         assertThat(values.stream().mapToDouble(i -> i).sum(), is((double) 1));
     }
 
-    @Disabled("Started to fail on the system_cpu_count metric check which is different depending on the environment")
+    @Disabled("Started to fail on the system_cpu_count metric check which is different depending on the environment. " +
+            "Test has to be re-enabled as per https://github.com/strimzi/strimzi-kafka-operator/issues/7544")
     @ParallelTest
     @Tag(BRIDGE)
     void testKafkaBridgeMetrics(ExtensionContext extensionContext) {


### PR DESCRIPTION
The `MetricsIsolatedST.testKafkaBridgeMetrics` started to fail on checking the `system_cpu_count` metric which gets a different value depending on the platform (i.e. in AZP fails with 1 != 2, on my laptop 1 != 12, ...)
Waiting for investigating why it's now failing but moving forward with the next release, this PR disables the test for now.