### PR TITLE
[systemtest] Update version of test-clients to 0.4.0

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -170,8 +170,8 @@ public class Environment {
     private static final String RESOURCE_ALLOCATION_STRATEGY_DEFAULT = "SHARE_MEMORY_FOR_ALL_COMPONENTS";
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
-    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.2.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.3.0";
+    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.3.1";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.4.0";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     /**
      * Set values

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaTracingClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaTracingClients.java
@@ -22,11 +22,17 @@ public class KafkaTracingClients  extends KafkaClients {
     private static final String JAEGER_SAMPLER_TYPE =  "const";
     private static final String JAEGER_SAMPLER_PARAM =  "1";
 
+    private static final String OPEN_TELEMETRY = "OpenTelemetry";
+    private static final String OPEN_TRACING = "OpenTracing";
+
     private String jaegerServiceProducerName;
     private String jaegerServiceConsumerName;
     private String jaegerServiceStreamsName;
     private String jaegerServerAgentName;
     private String streamsTopicTargetName;
+    private boolean openTracing = false;
+    private boolean openTelemetry = false;
+    private String tracingType;
 
     public String getJaegerServiceConsumerName() {
         return jaegerServiceConsumerName;
@@ -68,6 +74,38 @@ public class KafkaTracingClients  extends KafkaClients {
         this.streamsTopicTargetName = streamsTopicTargetName;
     }
 
+    public void setOpenTelemetry(boolean openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+
+    public boolean getOpenTelemetry() {
+        return openTelemetry;
+    }
+
+    public void setOpenTracing(boolean openTracing) {
+        this.openTracing = openTracing;
+    }
+
+    public boolean getOpenTracing() {
+        return openTracing;
+    }
+
+    public void setTracingType(String tracingType) {
+        // if `withOpenTelemetry` or `withOpenTracing` is used, this is the only way how to set it also as the tracingType
+        // to remove need of extra check in each client's method
+        if (this.openTelemetry) {
+            this.tracingType = OPEN_TELEMETRY;
+        } else if (this.openTracing) {
+            this.tracingType = OPEN_TRACING;
+        } else {
+            this.tracingType = tracingType;
+        }
+    }
+
+    public String getTracingType() {
+        return tracingType;
+    }
+
     public Job consumerWithTracing() {
         return defaultConsumerStrimzi()
             .editSpec()
@@ -89,6 +127,10 @@ public class KafkaTracingClients  extends KafkaClients {
                             .addNewEnv()
                                 .withName("JAEGER_SAMPLER_PARAM")
                                 .withValue(JAEGER_SAMPLER_PARAM)
+                            .endEnv()
+                            .addNewEnv()
+                                .withName("TRACING_TYPE")
+                                .withValue(tracingType)
                             .endEnv()
                         .endContainer()
                     .endSpec()
@@ -118,6 +160,10 @@ public class KafkaTracingClients  extends KafkaClients {
                             .addNewEnv()
                                 .withName("JAEGER_SAMPLER_PARAM")
                                 .withValue(JAEGER_SAMPLER_PARAM)
+                            .endEnv()
+                            .addNewEnv()
+                                .withName("TRACING_TYPE")
+                                .withValue(tracingType)
                             .endEnv()
                         .endContainer()
                     .endSpec()
@@ -192,6 +238,10 @@ public class KafkaTracingClients  extends KafkaClients {
                             .addNewEnv()
                                 .withName("JAEGER_SAMPLER_PARAM")
                                 .withValue(JAEGER_SAMPLER_PARAM)
+                            .endEnv()
+                            .addNewEnv()
+                                .withName("TRACING_TYPE")
+                                .withValue(tracingType)
                             .endEnv()
                         .endContainer()
                     .endSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingST.java
@@ -583,6 +583,7 @@ public class TracingST extends AbstractST {
             .withJaegerServiceConsumerName(JAEGER_CONSUMER_SERVICE)
             .withJaegerServiceStreamsName(JAEGER_KAFKA_STREAMS_SERVICE)
             .withJaegerServerAgentName(JAEGER_AGENT_NAME)
+            .withOpenTracing()
             .build();
 
         testStorage.addToTestStorage(Constants.KAFKA_TRACING_CLIENT_KEY, kafkaTracingClient);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR updates version of test-clients used in tests to `0.4.0`, which is the latest release of the clients. As part of this, new environment variable had to be added - `TRACING_TYPE` - to use either `OpenTelemetry` or `OpenTracing`.
Also, I added the `withOpenTelemetry` and `withOpenTracing`, which can be used to specify the type without need of using `withTracingType`. 

### Checklist

- [ ] Make sure all tests pass

