### PR TITLE
Fix CC testNewBadGoalsErrorWithSkipHGCheck unit test

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -339,7 +339,7 @@ public class KafkaRebalanceStateMachineTest {
                 .withSkipHardGoalCheck(true)
                 .build();
         kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
-        this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+        this.krNewBadGoalsErrorWithSkipHGCheck(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
 
         rebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withMode(KafkaRebalanceMode.REMOVE_BROKERS)
@@ -348,7 +348,7 @@ public class KafkaRebalanceStateMachineTest {
                 .withSkipHardGoalCheck(true)
                 .build();
         kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
-        this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krNewBadGoalsErrorWithSkipHGCheck(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
     private void krNewBadGoalsErrorWithSkipHGCheck(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Addresses failing unit test KafkaRebalanceStateMachineTest.testNewBadGoalsErrorWithSkipHGCheck

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

