### PR TITLE
Stop using the `Recreate` strategy in the Cluster Operator `Deployment` as it should not be needed anymore

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -173,5 +173,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-  strategy:
-    type: Recreate

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -128,5 +128,3 @@ spec:
             requests:
               cpu: 200m
               memory: 384Mi
-  strategy:
-    type: Recreate


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In the past, when the Cluster Operator didn't support the leader election, we use the `Recreate` strategy in its deployment. That means that the old operator pods were first deleted before the new pod was started. This was needed in order to avoid multiple operator instances operating the same resources.

In some cases, this might not create the smoothest rollout - for example if the starting of the new pod gets stuck for some reason. And we should not need it anymore, since the Leader Election support should make sure that only one of the Pods running in parallel will actually operate the resources. So we can remove this and move back to the default `RollingUpdate` strategy which will first start the new pod and only when it is ready and running it will stop the old one.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally