### PR TITLE
Fix flaky `StrimziPodSetControllerMockTest.testFailedPodRecovery` unit test

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
@@ -686,7 +686,9 @@ public class StrimziPodSetControllerMockTest {
                     10_000,
                     () -> {
                         Pod p = client.pods().inNamespace(NAMESPACE).withName(podName).get();
-                        return p != null && !resourceVersion.equals(p.getMetadata().getResourceVersion());
+                        return p != null
+                                && !resourceVersion.equals(p.getMetadata().getResourceVersion())
+                                && p.getStatus() != null; // We need to also wait for the Pod status to be set to avoid NullPointerExceptions
                     },
                     () -> context.failNow("Test timed out waiting for pod recreation!"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
@@ -686,9 +686,13 @@ public class StrimziPodSetControllerMockTest {
                     10_000,
                     () -> {
                         Pod p = client.pods().inNamespace(NAMESPACE).withName(podName).get();
+                        // Waits for the Pod to be re-created by the StrimziPodSetController and for its status to be
+                        // updated by MockKube (and its MockPodController). Waiting for the status of the Pod to be
+                        // updated is important to avoid any Null Pointer Exceptions in the asserts done after
+                        // the wait is complete
                         return p != null
                                 && !resourceVersion.equals(p.getMetadata().getResourceVersion())
-                                && p.getStatus() != null; // We need to also wait for the Pod status to be set to avoid NullPointerExceptions
+                                && p.getStatus() != null;
                     },
                     () -> context.failNow("Test timed out waiting for pod recreation!"));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `StrimziPodSetControllerMockTest.testFailedPodRecovery` unit test is sometimes flaky on Azure. This PR tries to fix the NPE which is happening due to a race condition when the status of the pod is not yet set by the _mock pod controller_.

### Checklist

- [x] Make sure all tests pass