### PR TITLE
Bump micrometer from 1.3.1 to 1.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
         <netty.version>4.1.77.Final</netty.version>
-        <micrometer.version>1.3.1</micrometer.version>
+        <micrometer.version>1.9.5</micrometer.version>
         <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>


### PR DESCRIPTION

### Type of change


- Enhancement / new feature

### Description

Micrometer no longer maintains 1.3 (https://micrometer.io/docs/support) so it is time to move on to a newer release.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

