### PR TITLE
[systemtest] Refactor metrics tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
@@ -39,6 +39,8 @@ public class MetricsCollector {
 
     private static final Logger LOGGER = LogManager.getLogger(MetricsCollector.class);
 
+    private static final Object LOCK = new Object();
+
     private String namespaceName;
     private String scraperPodName;
     private ComponentType componentType;
@@ -46,6 +48,7 @@ public class MetricsCollector {
     private int metricsPort;
     private String metricsPath;
     private LabelSelector componentLabelSelector;
+    private Map<String, String> collectedData;
 
     public static class Builder {
         private String namespaceName;
@@ -112,6 +115,10 @@ public class MetricsCollector {
 
     public int getMetricsPort() {
         return metricsPort;
+    }
+
+    public Map<String, String> getCollectedData() {
+        return collectedData;
     }
 
     protected MetricsCollector.Builder newBuilder() {
@@ -208,19 +215,49 @@ public class MetricsCollector {
     /**
      * Parse out specific metric from whole metrics file
      * @param pattern regex pattern for specific metric
-     * @param data all metrics data
      * @return list of parsed values
      */
-    public static ArrayList<Double> collectSpecificMetric(Pattern pattern, Map<String, String> data) {
+    public ArrayList<Double> collectSpecificMetric(Pattern pattern) {
         ArrayList<Double> values = new ArrayList<>();
 
-        for (Map.Entry<String, String> entry : data.entrySet()) {
-            Matcher t = pattern.matcher(entry.getValue());
-            if (t.find()) {
-                values.add(Double.parseDouble(t.group(1)));
+        if (collectedData != null && !collectedData.isEmpty()) {
+            for (Map.Entry<String, String> entry : collectedData.entrySet()) {
+                Matcher t = pattern.matcher(entry.getValue());
+                if (t.find()) {
+                    values.add(Double.parseDouble(t.group(1)));
+                }
             }
         }
+
         return values;
+    }
+
+    /**
+     * Method checks already collected metrics data, if
+     * @param pattern Pattern of metric which is desired
+     *
+     * @return ArrayList of values collected from the metrics
+     */
+    public ArrayList<Double> waitForSpecificMetricAndCollect(Pattern pattern) {
+        synchronized (LOCK) {
+            ArrayList<Double> values = collectSpecificMetric(pattern);
+
+            if (values.isEmpty()) {
+                TestUtils.waitFor(String.format("metrics contain pattern: %s", pattern.toString()), Constants.GLOBAL_POLL_INTERVAL_MEDIUM, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+                    this.collectMetricsFromPods();
+                    ArrayList<Double> vals = this.collectSpecificMetric(pattern);
+
+                    if (!vals.isEmpty()) {
+                        values.addAll(vals);
+                        return true;
+                    }
+
+                    return false;
+                });
+            }
+
+            return values;
+        }
     }
 
     /**
@@ -237,16 +274,14 @@ public class MetricsCollector {
         int ret = exec.execute(null, executableCommand, 20_000);
 
         LOGGER.info("Metrics collection for PodIp {} from Pod {} finished with return code: {}", metricsPodIp, scraperPodName, ret);
-
         return exec.out();
     }
 
     /**
      * Collect metrics from all pods with specific selector with wait
-     * @return map with metrics {podName, metrics}
      */
     @SuppressWarnings("unchecked")
-    public Map<String, String> collectMetricsFromPods() {
+    public void collectMetricsFromPods() {
         Map<String, String>[] metricsData = (Map<String, String>[]) new HashMap[1];
         TestUtils.waitFor("metrics has data", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
             () -> {
@@ -265,7 +300,7 @@ public class MetricsCollector {
                 return true;
             });
 
-        return metricsData[0];
+        collectedData = metricsData[0];
     }
 
     public Map<String, String> collectMetricsFromPodsWithoutWait() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
@@ -233,7 +233,7 @@ public class MetricsCollector {
     }
 
     /**
-     * Method checks already collected metrics data, if
+     * Method checks already collected metrics data for Pattern containing desired metric
      * @param pattern Pattern of metric which is desired
      *
      * @return ArrayList of values collected from the metrics

--- a/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
@@ -238,26 +238,24 @@ public class MetricsCollector {
      *
      * @return ArrayList of values collected from the metrics
      */
-    public ArrayList<Double> waitForSpecificMetricAndCollect(Pattern pattern) {
-        synchronized (LOCK) {
-            ArrayList<Double> values = collectSpecificMetric(pattern);
+    public synchronized ArrayList<Double> waitForSpecificMetricAndCollect(Pattern pattern) {
+        ArrayList<Double> values = collectSpecificMetric(pattern);
 
-            if (values.isEmpty()) {
-                TestUtils.waitFor(String.format("metrics contain pattern: %s", pattern.toString()), Constants.GLOBAL_POLL_INTERVAL_MEDIUM, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-                    this.collectMetricsFromPods();
-                    ArrayList<Double> vals = this.collectSpecificMetric(pattern);
+        if (values.isEmpty()) {
+            TestUtils.waitFor(String.format("metrics contain pattern: %s", pattern.toString()), Constants.GLOBAL_POLL_INTERVAL_MEDIUM, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+                this.collectMetricsFromPods();
+                ArrayList<Double> vals = this.collectSpecificMetric(pattern);
 
-                    if (!vals.isEmpty()) {
-                        values.addAll(vals);
-                        return true;
-                    }
+                if (!vals.isEmpty()) {
+                    values.addAll(vals);
+                    return true;
+                }
 
-                    return false;
-                });
-            }
-
-            return values;
+                return false;
+            });
         }
+
+        return values;
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -747,14 +747,16 @@ class RollingUpdateST extends AbstractST {
             .build();
 
         LOGGER.info("Check if metrics are present in pod of Kafka and Zookeeper");
-        Map<String, String> kafkaMetricsOutput = metricsCollector.collectMetricsFromPods();
-        Map<String, String> zkMetricsOutput = metricsCollector.toBuilder()
+        metricsCollector.collectMetricsFromPods();
+
+        assertThat(metricsCollector.getCollectedData().values().toString().contains("kafka_"), is(true));
+
+        metricsCollector.toBuilder()
             .withComponentType(ComponentType.Zookeeper)
             .build()
             .collectMetricsFromPods();
 
-        assertThat(kafkaMetricsOutput.values().toString().contains("kafka_"), is(true));
-        assertThat(zkMetricsOutput.values().toString().contains("replicaId"), is(true));
+        assertThat(metricsCollector.getCollectedData().values().toString().contains("replicaId"), is(true));
 
         LOGGER.info("Changing metrics to something else");
 
@@ -811,14 +813,16 @@ class RollingUpdateST extends AbstractST {
 
         LOGGER.info("Check if metrics are present in pod of Kafka and Zookeeper");
 
-        kafkaMetricsOutput = metricsCollector.collectMetricsFromPods();
-        zkMetricsOutput = metricsCollector.toBuilder()
+        metricsCollector.collectMetricsFromPods();
+
+        assertThat(metricsCollector.getCollectedData().values().toString().contains("kafka_"), is(true));
+
+        metricsCollector.toBuilder()
             .withComponentType(ComponentType.Zookeeper)
             .build()
             .collectMetricsFromPods();
 
-        assertThat(kafkaMetricsOutput.values().toString().contains("kafka_"), is(true));
-        assertThat(zkMetricsOutput.values().toString().contains("replicaId"), is(true));
+        assertThat(metricsCollector.getCollectedData().values().toString().contains("replicaId"), is(true));
 
         LOGGER.info("Removing metrics from Kafka and Zookeeper and setting them to null");
 
@@ -833,8 +837,8 @@ class RollingUpdateST extends AbstractST {
 
         LOGGER.info("Check if metrics are not existing in pods");
 
-        kafkaMetricsOutput = metricsCollector.collectMetricsFromPodsWithoutWait();
-        zkMetricsOutput = metricsCollector.toBuilder()
+        Map<String, String> kafkaMetricsOutput = metricsCollector.collectMetricsFromPodsWithoutWait();
+        Map<String, String> zkMetricsOutput = metricsCollector.toBuilder()
             .withComponentType(ComponentType.Zookeeper)
             .build()
             .collectMetricsFromPodsWithoutWait();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesIsolatedST.java
@@ -153,9 +153,9 @@ public class NetworkPoliciesIsolatedST extends AbstractST {
             .withComponentType(ComponentType.KafkaExporter)
             .build();
 
-        Map<String, String> kafkaExporterMetricsData = metricsCollector.collectMetricsFromPods();
-        assertThat("Kafka Exporter metrics should be non-empty", kafkaExporterMetricsData.size() > 0);
-        for (Map.Entry<String, String> entry : kafkaExporterMetricsData.entrySet()) {
+        metricsCollector.collectMetricsFromPods();
+        assertThat("Kafka Exporter metrics should be non-empty", metricsCollector.getCollectedData().size() > 0);
+        for (Map.Entry<String, String> entry : metricsCollector.getCollectedData().entrySet()) {
             assertThat("Value from collected metric should be non-empty", !entry.getValue().isEmpty());
             assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_consumergroup_current_offset"));
             assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_topic_partitions{topic=\"" + topic0 + "\"} 1"));


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix
- Refactoring

### Description

This PR completely refactors the whole `MetricsIsolatedST` suite, which is flaky. As part of this refactoring, I added `collectedData` into the `MetricsCollector`, so each instance holds latest version of metrics get from each `resource` or `pod`. When the `collectedData` doesn't contain specific pattern, the `waitFor` is used here for specific metric to appear. For each poll, `collectedData` is updated with new value. This way I removed flakiness in case the metric wasn't present just in the moment of assert.

Also, this PR removes some checks, which weren't working before - for example checking metrics of resources, which doesn't exist.

As part of this PR, I removed few metrics, which were not relevant (because it depended or environment or resource and it's state):

`system_cpu_count`
`strimzi_reconciliations_locked_total`
`strimzi_reconciliations_failed_total` - if reconciliation doesn't fail, this metric is not present in metrics
`strimzi_reconciliations_periodical_total` for KafkaConnector, which is not present

Fixes #7544 

### Checklist

- [ ] Make sure all tests pass
