### PR TITLE
[systemtest] Collect StrimziPodSets in LogCollector during test failure

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -124,6 +124,7 @@ public interface Constants {
     String NETWORK_POLICY = "NetworkPolicy";
     String JOB = "Job";
     String VALIDATION_WEBHOOK_CONFIG = "ValidatingWebhookConfiguration";
+    String REPLICA_SET = "ReplicaSet";
 
     /**
      * Kafka Bridge JSON encoding with JSON embedded format

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -253,7 +253,6 @@ public class Environment {
     }
 
     public static boolean isStrimziPodSetEnabled() {
-        // REMINDER: this will not work once StrimziPodSet will be moved to beta FG
         return !STRIMZI_FEATURE_GATES.contains(Constants.USE_STRIMZI_STATEFULSETS);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -275,7 +276,8 @@ public class LogCollector {
     }
 
     private void collectAllResourcesFromNamespace(String namespace) {
-        List<String> resources = Arrays.asList(Constants.DEPLOYMENT, Constants.REPLICA_SET);
+        List<String> resources = new ArrayList<>(Arrays.asList(Constants.DEPLOYMENT, Constants.REPLICA_SET));
+
         if (!Environment.isStrimziPodSetEnabled()) {
             resources.add(Constants.STATEFUL_SET);
         } else {

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -27,7 +27,11 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import static io.strimzi.test.TestUtils.writeFile;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -283,7 +287,7 @@ public class LogCollector {
 
     private void collectResource(String kind, String namespace) {
         LOGGER.info("Collecting {} in Namespace {}", kind, namespace);
-        writeFile(String.format("%s/%ss.log", namespaceFile, kind.toLowerCase()), cmdKubeClient(namespace).getResourcesAsYaml(kind.toLowerCase()));
+        writeFile(String.format("%s/%ss.log", namespaceFile, kind.toLowerCase(Locale.ROOT)), cmdKubeClient(namespace).getResourcesAsYaml(kind.toLowerCase(Locale.ROOT)));
     }
 
     private void collectStrimzi(String namespace) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix/Enhancement

### Description

Until now, we were just collecting YAMLs of `StatefulSet` during the test failure. After the `StrimziPodSet`s were added, we never updated the `LogCollector` with this new resource. So when ST fails, we never get additional info about configuration (or status) of SPS. 

This PR fixes this behavior. 

### Checklist

- [ ] Make sure all tests pass

