### PR TITLE
Fix the condition whether the kubectl/oc command exists or not

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -27,10 +27,10 @@ error() {
   exit 1
 }
 
-if [[ $(kubectl &>/dev/null) -eq 0 ]]; then
+if [[ -x "$(command -v kubectl)" ]]; then
   KUBECTL_INSTALLED=true
 else
-  if [[ $(oc &>/dev/null) -eq 0 ]]; then
+  if [[ -x "$(command -v oc)" ]]; then
     OC_INSTALLED=true
     KUBE_CLIENT="oc"
   fi


### PR DESCRIPTION
Signed-off-by: Tomonari Yamashita <tyamashi.oss@gmail.com>

### Type of change

- Bugfix

### Description

Fix the condition whether the kubectl/oc command exists or not, in tools/report.sh

[Problem]
- report.sh tries to use kubectl command even though kubectl does not exist in PATH.
    -  So “./report.sh: line 44: kubectl: command not found” error occurs when to execute report.sh.
    - This issue reproduced on “Red Hat Enterprise Linux release 8.5 (Ootpa)”, and I saw several users who report the same issue, It can be inconvenient to identify user problems.

[Problem cause]
- [[ $(kubectl &>/dev/null) -eq 0 ]] can be evaluated to be true even if the kubectl command does not exist.

[Solution]
- Use “command -v” to check whether the kubectl command exists.
    - ”command -v” is a built-in function in all POSIX and bash since POSIX 2008 standard. 
    - For details, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html#tag_20_22

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

No automatic testing for the tools/report.sh to dump Strimzi project. 
- The following tests were performed manually:
    - If there is only oc command.
    - If there is only kubectl command.
    - If there are oc and kubectl commands.
    - If there is no oc command and kubectl command.
