### PR TITLE
System test for cluster role split for cluster wide operator with lim…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -264,8 +264,8 @@ public class SetupClusterOperator {
         // check if namespace is already created
         createCONamespaceIfNeeded();
         prepareEnvForOperator(extensionContext, namespaceInstallTo, bindingsNamespaces);
-        // if a user want to customise one of the Role, ClusterRole, RoleBindings and ClusterRoleBinding he must do it
-        // everything by himself in scope of RBAC permissions otherwise we apply the default one
+        // if we manage directly in the individual test one of the Role, ClusterRole, RoleBindings and ClusterRoleBinding we must do it
+        // everything by ourselves in scope of RBAC permissions otherwise we apply the default one
         if (this.isRolesAndBindingsManagedByAnUser()) {
             final List<HasMetadata> listOfRolesAndBindings = Stream.of(
                     this.roles, this.roleBindings, this.clusterRoles, this.clusterRoleBindings)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -275,6 +275,7 @@ public class SetupClusterOperator {
                 ResourceManager.getInstance().createResource(extensionContext, itemRoleOrBinding);
             }
         } else {
+            LOGGER.info("Install default bindings.");
             this.applyDefaultBindings();
         }
 
@@ -570,7 +571,7 @@ public class SetupClusterOperator {
 
             switch (resourceType) {
                 case Constants.ROLE:
-                    if (this.isRolesAndBindingsManagedByAnUser()) {
+                    if (!this.isRolesAndBindingsManagedByAnUser()) {
                         Role role = TestUtils.configFromYaml(createFile, Role.class);
                         ResourceManager.getInstance().createResource(extensionContext, new RoleBuilder(role)
                             .editMetadata()
@@ -580,7 +581,7 @@ public class SetupClusterOperator {
                     }
                     break;
                 case Constants.CLUSTER_ROLE:
-                    if (this.isRolesAndBindingsManagedByAnUser()) {
+                    if (!this.isRolesAndBindingsManagedByAnUser()) {
                         ClusterRole clusterRole = TestUtils.configFromYaml(changeLeaseNameInResourceIfNeeded(createFile.getAbsolutePath()), ClusterRole.class);
                         ResourceManager.getInstance().createResource(extensionContext, clusterRole);
                     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -274,23 +274,6 @@ public class SetupClusterOperator {
             for (final HasMetadata itemRoleOrBinding : listOfRolesAndBindings) {
                 ResourceManager.getInstance().createResource(extensionContext, itemRoleOrBinding);
             }
-
-//            // a) deploy specific Roles
-//            for (final Role role : this.roles) {
-//                ResourceManager.getInstance().createResource(extensionContext, role);
-//            }
-//            // b) specific ClusterRole
-//            for (final ClusterRole clusterRole : this.clusterRoles) {
-//                ResourceManager.getInstance().createResource(extensionContext, clusterRole);
-//            }
-//            // c) RoleBindings
-//            for (final RoleBinding roleBinding : this.roleBindings) {
-//                ResourceManager.getInstance().createResource(extensionContext, roleBinding);
-//            }
-//            // d) ClusterRoleBindings
-//            for (final ClusterRoleBinding clusterRoleBinding : this.clusterRoleBindings) {
-//                ResourceManager.getInstance().createResource(extensionContext, clusterRoleBinding);
-//            }
         } else {
             this.applyDefaultBindings();
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/ClusterRoleBindingTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/ClusterRoleBindingTemplates.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class ClusterRoleBindingTemplates {
@@ -25,48 +25,55 @@ public class ClusterRoleBindingTemplates {
     public static List<ClusterRoleBinding> clusterRoleBindingsForAllNamespaces(String namespace, String coName) {
         LOGGER.info("Creating ClusterRoleBinding that grant cluster-wide access to all OpenShift projects");
 
-        List<ClusterRoleBinding> kCRBList = new ArrayList<>();
-
-        kCRBList.add(
-            new ClusterRoleBindingBuilder()
-                .withNewMetadata()
-                    .withName(coName + "-namespaced")
-                .endMetadata()
-                .withNewRoleRef()
-                    .withApiGroup("rbac.authorization.k8s.io")
-                    .withKind("ClusterRole")
-                    .withName("strimzi-cluster-operator-namespaced")
-                .endRoleRef()
-                .withSubjects(new SubjectBuilder()
-                    .withKind("ServiceAccount")
-                    .withName("strimzi-cluster-operator")
-                    .withNamespace(namespace)
-                    .build()
-                )
-                .build()
+        final List<ClusterRoleBinding> kCRBList = Arrays.asList(
+            getClusterOperatorNamespacedCrb(coName, namespace),
+            getClusterOperatorEntityOperatorCrb(coName, namespace),
+            getClusterOperatorWatchedCrb(coName, namespace)
         );
 
-        kCRBList.add(
-            new ClusterRoleBindingBuilder()
-                .withNewMetadata()
-                    .withName(coName + "-entity-operator")
-                .endMetadata()
-                .withNewRoleRef()
-                    .withApiGroup("rbac.authorization.k8s.io")
-                    .withKind("ClusterRole")
-                    .withName("strimzi-entity-operator")
-                .endRoleRef()
-                .withSubjects(new SubjectBuilder()
-                    .withKind("ServiceAccount")
-                    .withName("strimzi-cluster-operator")
-                    .withNamespace(namespace)
-                    .build()
-                )
-                .build()
-        );
+        return kCRBList;
+    }
 
-        kCRBList.add(
-            new ClusterRoleBindingBuilder()
+    public static ClusterRoleBinding getClusterOperatorNamespacedCrb(final String coName, final String namespaceName) {
+        return new ClusterRoleBindingBuilder()
+            .withNewMetadata()
+                .withName(coName + "-namespaced")
+            .endMetadata()
+            .withNewRoleRef()
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("ClusterRole")
+                .withName("strimzi-cluster-operator-namespaced")
+            .endRoleRef()
+            .withSubjects(new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName("strimzi-cluster-operator")
+                .withNamespace(namespaceName)
+                .build()
+            )
+            .build();
+    }
+
+    public static ClusterRoleBinding getClusterOperatorEntityOperatorCrb(final String coName, final String namespaceName) {
+        return new ClusterRoleBindingBuilder()
+            .withNewMetadata()
+                .withName(coName + "-entity-operator")
+            .endMetadata()
+            .withNewRoleRef()
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("ClusterRole")
+                .withName("strimzi-entity-operator")
+            .endRoleRef()
+            .withSubjects(new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName("strimzi-cluster-operator")
+                .withNamespace(namespaceName)
+                .build()
+            )
+            .build();
+    }
+
+    public static ClusterRoleBinding getClusterOperatorWatchedCrb(final String coName, final String namespaceName) {
+        return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
                     .withName(coName + "-watched")
                 .endMetadata()
@@ -78,12 +85,9 @@ public class ClusterRoleBindingTemplates {
                 .withSubjects(new SubjectBuilder()
                     .withKind("ServiceAccount")
                     .withName("strimzi-cluster-operator")
-                    .withNamespace(namespace)
+                    .withNamespace(namespaceName)
                     .build()
                 )
-                .build()
-        );
-
-        return kCRBList;
+                .build();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -107,11 +107,6 @@ public class KafkaUtils {
                 List<Condition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
                 for (Condition condition : conditions) {
                     String conditionMessage = condition.getMessage();
-                    LOGGER.error("---=---STATUS");
-                    LOGGER.error(conditionMessage);
-                    LOGGER.error("------EXPECTED");
-                    LOGGER.error(message);
-                    LOGGER.error("---=---");
                     if (conditionMessage.matches(message)) {
                         return true;
                     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -107,6 +107,11 @@ public class KafkaUtils {
                 List<Condition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
                 for (Condition condition : conditions) {
                     String conditionMessage = condition.getMessage();
+                    LOGGER.error("---=---STATUS");
+                    LOGGER.error(conditionMessage);
+                    LOGGER.error("------EXPECTED");
+                    LOGGER.error(message);
+                    LOGGER.error("---=---");
                     if (conditionMessage.matches(message)) {
                         return true;
                     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -101,13 +101,13 @@ public class KafkaUtils {
         });
     }
 
-    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message, long timeout) {
-        TestUtils.waitFor("Kafka Status with message [" + message + "]",
+    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String pattern, long timeout) {
+        TestUtils.waitFor("Kafka Status with message [" + pattern + "]",
             Constants.GLOBAL_POLL_INTERVAL, timeout, () -> {
                 List<Condition> conditions = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getConditions();
                 for (Condition condition : conditions) {
                     String conditionMessage = condition.getMessage();
-                    if (conditionMessage.matches(message)) {
+                    if (conditionMessage.matches(pattern)) {
                         return true;
                     }
                 }
@@ -115,8 +115,8 @@ public class KafkaUtils {
             });
     }
 
-    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String message) {
-        waitUntilKafkaStatusConditionContainsMessage(clusterName, namespace, message, Constants.GLOBAL_STATUS_TIMEOUT);
+    public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String pattern) {
+        waitUntilKafkaStatusConditionContainsMessage(clusterName, namespace, pattern, Constants.GLOBAL_STATUS_TIMEOUT);
     }
 
     public static void waitForZkMntr(String namespaceName, String clusterName, Pattern pattern, int... podIndexes) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
@@ -4,27 +4,41 @@
  */
 package io.strimzi.systemtest.specific;
 
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBrokerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.kafkaclients.externalClients.ExternalKafkaClient;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.kubernetes.ClusterRoleBindingTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.Exec;
+import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -191,6 +205,104 @@ public class SpecificIsolatedST extends AbstractST {
                 newExternalKafkaClient.sendMessagesPlain(),
                 newExternalKafkaClient.receiveMessagesPlain()
             ));
+    }
+
+    // 1. Deploy Cluster Operator with STRIMZI_NAMESPACE set to `*` (i.e., watch all namespaces)
+    // 2. During deployment of ClusterOperator, create ClusterRole (-watched) bound to a cluster-wide configuration
+    // 3. During deployment of ClusterOperator, create ClusterRole (-namespaced) bound to some specific namespace (e.g., example-namespace)
+    // 4. Deploy Kafka cluster into example-namespace
+    // 5. Deploy Kafka cluster into infra-namespace
+    // 6. Check that Kafka CR is present in infra-namespace but fails (it can be checked via CR Status)
+    // 7. Check that Kafka CR is present and successfully deployed in example-namespace
+    @IsolatedTest
+    @Tag(REGRESSION)
+    void testClusterRoleNamespaced(final ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext);
+        final String namespaceWhereCreationOfCustomResourcesIsApproved = "example-1";
+
+        // --- a) defining Role and ClusterRoles
+        final Role strimziClusterOperator020 = TestUtils.configFromYaml(SetupClusterOperator.getInstanceHolder().switchClusterRolesToRolesIfNeeded(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml"), true), Role.class);
+
+        // specify explicit namespace for Role (for ClusterRole we do not specify namespace because ClusterRole is a non-namespaced resource
+        strimziClusterOperator020.getMetadata().setNamespace(namespaceWhereCreationOfCustomResourcesIsApproved);
+
+        final ClusterRole strimziClusterOperator021 = TestUtils.configFromYaml(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator022 = TestUtils.configFromYaml(SetupClusterOperator.getInstanceHolder().changeLeaseNameInResourceIfNeeded(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml").getAbsolutePath()), ClusterRole.class);
+        final ClusterRole strimziClusterOperator023 = TestUtils.configFromYaml(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator030 = TestUtils.configFromYaml(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator031 = TestUtils.configFromYaml(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator033 = TestUtils.configFromYaml(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml"), ClusterRole.class);
+
+        final List<Role> roles = Arrays.asList(strimziClusterOperator020);
+        final List<ClusterRole> clusterRoles = Arrays.asList(strimziClusterOperator021, strimziClusterOperator022,
+                strimziClusterOperator023, strimziClusterOperator030, strimziClusterOperator031, strimziClusterOperator033);
+
+        // ---- b) defining RoleBindings
+        final RoleBinding strimziClusterOperator020Namespaced = TestUtils.configFromYaml(SetupClusterOperator.getInstanceHolder().switchClusterRolesToRolesIfNeeded(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml"), true), RoleBinding.class);
+        final RoleBinding strimziClusterOperator022LeaderElection = TestUtils.configFromYaml(SetupClusterOperator.getInstanceHolder().changeLeaseNameInResourceIfNeeded(new File(Constants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml").getAbsolutePath()), RoleBinding.class);
+
+        // specify explicit namespace for RoleBindings
+        strimziClusterOperator020Namespaced.getMetadata().setNamespace(namespaceWhereCreationOfCustomResourcesIsApproved);
+        strimziClusterOperator022LeaderElection.getMetadata().setNamespace(clusterOperator.getDeploymentNamespace());
+
+        // reference Cluster Operator service account in RoleBindings
+        strimziClusterOperator020Namespaced.getSubjects().stream().findFirst().get().setNamespace(clusterOperator.getDeploymentNamespace());
+        strimziClusterOperator022LeaderElection.getSubjects().stream().findFirst().get().setNamespace(clusterOperator.getDeploymentNamespace());
+
+        final List<RoleBinding> roleBindings = Arrays.asList(
+                strimziClusterOperator020Namespaced,
+                strimziClusterOperator022LeaderElection
+        );
+
+        // ---- c) defining ClusterRoleBindings
+        final List<ClusterRoleBinding> clusterRoleBindings = Arrays.asList(
+            ClusterRoleBindingTemplates.getClusterOperatorWatchedCrb(clusterOperator.getClusterOperatorName(), clusterOperator.getDeploymentNamespace()),
+            ClusterRoleBindingTemplates.getClusterOperatorEntityOperatorCrb(clusterOperator.getClusterOperatorName(), clusterOperator.getDeploymentNamespace())
+        );
+
+        clusterOperator.unInstall();
+        // create namespace, where we will be able to deploy Custom Resources
+        cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()), namespaceWhereCreationOfCustomResourcesIsApproved);
+        clusterOperator = clusterOperator.defaultInstallation()
+            .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
+            // use our pre-defined Roles
+            .withRoles(roles)
+            // use our pre-defined RoleBindings
+            .withRoleBindings(roleBindings)
+            // use our pre-defined ClusterRoles
+            .withClusterRoles(clusterRoles)
+            // use our pre-defined ClusterRoleBindings
+            .withClusterRoleBindings(clusterRoleBindings)
+            .createInstallation()
+            .runBundleInstallation();
+
+        // implicit verification that a user is able to deploy Kafka cluster in namespace <example-1>, where we are allowed
+        // to create Custom Resources because of `*-namespaced Role`
+        resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3)
+            .editMetadata()
+            // this should work
+            .withNamespace(namespaceWhereCreationOfCustomResourcesIsApproved)
+            .endMetadata()
+            .build());
+
+        resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3)
+            .editMetadata()
+                // this should not work
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .build());
+
+        // verify that in `infra-namespace` we are not able to deploy Kafka cluster
+        KafkaUtils.waitForKafkaStatusUpdate(clusterOperator.getDeploymentNamespace(), testStorage.getClusterName());
+
+        final Condition condition = KafkaResource.kafkaClient().inNamespace(clusterOperator.getDeploymentNamespace()).withName(testStorage.getClusterName()).get().getStatus().getConditions().stream().findFirst().get();
+
+        assertThat(condition.getReason(), CoreMatchers.is("KubernetesClientException"));
+        assertThat(condition.getStatus(), CoreMatchers.is("True"));
+        assertThat(condition.getMessage(), CoreMatchers.containsString("Forbidden!Configured service account doesn't have access"));
+
+        // rollback to the default configuration
+        clusterOperator.rollbackToDefaultConfiguration();
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
@@ -207,16 +207,9 @@ public class SpecificIsolatedST extends AbstractST {
             ));
     }
 
-    // 1. Deploy Cluster Operator with STRIMZI_NAMESPACE set to `*` (i.e., watch all namespaces)
-    // 2. During deployment of ClusterOperator, create ClusterRole (-watched) bound to a cluster-wide configuration
-    // 3. During deployment of ClusterOperator, create ClusterRole (-namespaced) bound to some specific namespace (e.g., example-namespace)
-    // 4. Deploy Kafka cluster into example-namespace
-    // 5. Deploy Kafka cluster into infra-namespace
-    // 6. Check that Kafka CR is present in infra-namespace but fails (it can be checked via CR Status)
-    // 7. Check that Kafka CR is present and successfully deployed in example-namespace
     @IsolatedTest
     @Tag(REGRESSION)
-    void testClusterRoleNamespaced(final ExtensionContext extensionContext) {
+    void testClusterWideOperatorWithLimitedAccessToSpecificNamespaceViaRbacRole(final ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
         final String namespaceWhereCreationOfCustomResourcesIsApproved = "example-1";
 


### PR DESCRIPTION
…ited access

Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR aims **(a)** cover https://github.com/strimzi/strimzi-kafka-operator/pull/7390. I have added one test case, which in summary does the following steps:

1. Define our own Roles, ClusterRoles, RoleBindings and ClusterRoleBindings
2. Deploy cluster-wide Cluster Operator
3. During deployment of ClusterOperator, create ClusterRole (-watched) bound to a cluster-wide configuration
4. During deployment of ClusterOperator, create ClusterRole (-namespaced) bound to some specific namespace (i.e., `example-1`)
5. Deploy Kafka cluster into example-namespace
6. Deploy Kafka cluster into infra-namespace
7. Check that Kafka CR is present in infra-namespace but fails (it can be checked via CR Status)
8. Check that Kafka CR is present and successfully deployed in example-namespace 

(b) adding functionality to our SetupClusterOperator (i.e., a user can now add his own Role, RoleBinding, ClusterRole and ClusterRoleBinding resources and pass it via SetupClusterOperator builder. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass