### PR TITLE
Added a note on how to add keys and keystore certificate when using PEM format

### DIFF
--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -266,7 +266,7 @@ Add as a single-line format.
 Between the `BEGIN CERTIFICATE` and `END CERTIFICATE` delimiters, start with a newline character (`\n`).
 End each line from the original certificate with `\n` too.
 +
-.Example
+.Example keystore configuration
 [source,env,subs="+quotes,attributes"]
 ----
 props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, "-----BEGIN CERTIFICATE----- \n__<user_certificate_content_line_1>__\n__<user_certificate_content_line_n>__\n-----END CERTIFICATE---");


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

_Select the type of your PR_

- Documentation

### Description

This PR adds a note on how to add the key and keystore certificate directly when setting up the client access using listeners
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

