### PR TITLE
Cleanup the `TestUtils` class

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/JmxTransTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JmxTransTest.java
@@ -15,17 +15,14 @@ import static org.hamcrest.Matchers.hasSize;
 public class JmxTransTest {
     @Test
     public void testQueries() {
-        JmxTransSpec opts = TestUtils.fromJson("{" +
-                "\"kafkaQueries\": [{" +
-                        "\"targetMBean\": \"targetMBean1\"," +
-                        "\"attributes\": [\"attribute0\", \"attribute1\"]," +
-                        "\"outputs\": [\"output0\", \"output1\"]" +
-                    "}, {" +
-                        "\"targetMBean\": \"targetMBean2\"," +
-                        "\"attributes\": [\"attribute2\", \"attribute3\"]," +
-                        "\"outputs\": [\"output2\", \"output3\"]" +
-                    "}]" +
-                "}", JmxTransSpec.class);
+        JmxTransSpec opts = TestUtils.fromYamlString("kafkaQueries:\n" +
+                                                     "  - targetMBean: targetMBean1\n" +
+                                                     "    attributes: [attribute0, attribute1]\n" +
+                                                     "    outputs: [output0, output1]\n" +
+                                                     "  - targetMBean: targetMBean2\n" +
+                                                     "    attributes: [attribute2, attribute3]\n" +
+                                                     "    outputs: [output2, output3]",
+                JmxTransSpec.class);
 
         assertThat(opts, is(notNullValue()));
         assertThat(opts.getKafkaQueries(), hasSize(2));
@@ -47,19 +44,16 @@ public class JmxTransTest {
 
     @Test
     public void testOutputDefinition() {
-        JmxTransSpec opts = TestUtils.fromJson("{" +
-                "\"outputDefinitions\": [{" +
-                        "\"outputType\": \"targetOutputType\"," +
-                        "\"host\": \"targetHost\"," +
-                        "\"port\": 9999," +
-                        "\"flushDelayInSeconds\": 1," +
-                        "\"typeNames\": [\"typeName0\", \"typeName1\"]," +
-                        "\"name\": \"targetName\"" +
-                    "}, {" +
-                        "\"outputType\": \"targetOutputType\"," +
-                        "\"name\": \"name1\"" +
-                    "}]" +
-                "}", JmxTransSpec.class);
+        JmxTransSpec opts = TestUtils.fromYamlString("outputDefinitions:\n" +
+                                                     "  - outputType: targetOutputType\n" +
+                                                     "    host: targetHost\n" +
+                                                     "    port: 9999\n" +
+                                                     "    flushDelayInSeconds: 1\n" +
+                                                     "    typeNames: [typeName0, typeName1]\n" +
+                                                     "    name: targetName\n" +
+                                                     "  - outputType: targetOutputType\n" +
+                                                     "    name: name1",
+                JmxTransSpec.class);
 
         assertThat(opts, is(notNullValue()));
         assertThat(opts.getOutputDefinitions(), hasSize(2));
@@ -78,9 +72,7 @@ public class JmxTransTest {
 
     @Test
     public void testUseCustomImage() {
-        JmxTransSpec opts = TestUtils.fromJson("{" +
-                "\"image\": \"testImage\"" +
-                "}", JmxTransSpec.class);
+        JmxTransSpec opts = TestUtils.fromYamlString("image: testImage", JmxTransSpec.class);
 
         assertThat(opts, is(notNullValue()));
         assertThat(opts.getImage(), is("testImage"));

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -12,10 +12,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class JvmOptionsTest {
     @Test
     public void testSetXmxXms() {
-        JvmOptions opts = TestUtils.fromJson("{" +
-                "  \"-Xmx\": \"2g\"," +
-                "  \"-Xms\": \"1g\"" +
-                "}", JvmOptions.class);
+        JvmOptions opts = TestUtils.fromYamlString("-Xmx: 2g\n" +
+                                                   "-Xms: 1g",
+                JvmOptions.class);
 
         assertThat(opts.getXms(), is("1g"));
         assertThat(opts.getXmx(), is("2g"));
@@ -23,7 +22,7 @@ public class JvmOptionsTest {
 
     @Test
     public void testEmptyXmxXms() {
-        JvmOptions opts = TestUtils.fromJson("{}", JvmOptions.class);
+        JvmOptions opts = TestUtils.fromYamlString("{}", JvmOptions.class);
 
         assertThat(opts.getXms(), is(nullValue()));
         assertThat(opts.getXmx(), is(nullValue()));
@@ -31,18 +30,17 @@ public class JvmOptionsTest {
 
     @Test
     public void testXx() {
-        JvmOptions opts = TestUtils.fromJson("{" +
-                "    \"-XX\":" +
-                "            {\"key1\": \"value1\"," +
-                "            \"key2\": \"value2\"," +
-                "            \"key3\": \"true\"," +
-                "            \"key4\": true," +
-                "            \"key5\": 10}" +
-                "}", JvmOptions.class);
+        JvmOptions opts = TestUtils.fromYamlString("-XX:\n" +
+                                                   "  key1: value1\n" +
+                                                   "  key2: value2\n" +
+                                                   "  key3: true\n" +
+                                                   "  key4: true\n" +
+                                                   "  key5: 10\n",
+                JvmOptions.class);
 
         assertThat(opts.getXx(), is(TestUtils.map("key1", "value1", "key2", "value2", "key3", "true", "key4", "true", "key5", "10")));
 
-        opts = TestUtils.fromJson("{}", JvmOptions.class);
+        opts = TestUtils.fromYamlString("{}", JvmOptions.class);
 
         assertThat(opts.getXx(), is(nullValue()));
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaJmxOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaJmxOptionsTest.java
@@ -18,11 +18,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class KafkaJmxOptionsTest {
     @Test
     public void testAuthentication() {
-        KafkaJmxOptions opts = TestUtils.fromJson("{" +
-                "\"authentication\": {" +
-                    "\"type\": \"password\"" +
-                    "}" +
-                "}", KafkaJmxOptions.class);
+        KafkaJmxOptions opts = TestUtils.fromYamlString(
+                "authentication:\n" +
+                "  type: password",
+                KafkaJmxOptions.class);
 
         assertThat(opts.getAuthentication(),  is(notNullValue()));
         assertThat(opts.getAuthentication().getType(),  is(KafkaJmxAuthenticationPassword.TYPE_PASSWORD));
@@ -30,7 +29,7 @@ public class KafkaJmxOptionsTest {
 
     @Test
     public void testNoJmxOpts() {
-        KafkaJmxOptions opts = TestUtils.fromJson("{}", KafkaJmxOptions.class);
+        KafkaJmxOptions opts = TestUtils.fromYamlString("{}", KafkaJmxOptions.class);
 
         assertThat(opts.getAuthentication(),  is(nullValue()));
         assertThat(opts.getAdditionalProperties(),  is(Collections.emptyMap()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -55,17 +55,16 @@ public class AbstractModelTest {
 
     @ParallelTest
     public void testJvmPerformanceOptions() {
-        JvmOptions opts = TestUtils.fromJson("{}", JvmOptions.class);
+        JvmOptions opts = TestUtils.fromYamlString("{}", JvmOptions.class);
 
         assertThat(getPerformanceOptions(opts), is(nullValue()));
 
-        opts = TestUtils.fromJson("{" +
-                "    \"-XX\":" +
-                "            {\"key1\": \"value1\"," +
-                "            \"key2\": \"true\"," +
-                "            \"key3\": false," +
-                "            \"key4\": 10}" +
-                "}", JvmOptions.class);
+        opts = TestUtils.fromYamlString("-XX:\n" +
+                                        "  key1: value1\n" +
+                                        "  key2: true\n" +
+                                        "  key3: false\n" +
+                                        "  key4: 10\n",
+                JvmOptions.class);
 
         assertThat(getPerformanceOptions(opts), is("-XX:key1=value1 -XX:+key2 -XX:-key3 -XX:key4=10"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -117,7 +117,7 @@ public class KafkaConnectClusterTest {
     private final String metricsCMName = "metrics-cm";
     private final ConfigMap metricsCM = io.strimzi.operator.cluster.TestUtils.getJmxMetricsCm(metricsCmJson, metricsCMName, "metrics-config.yml");
     private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics("metrics-config.yml", metricsCMName);
-    private final String configurationJson = "{\"foo\":\"bar\"}";
+    private final String configurationJson = "foo: bar";
     private final String bootstrapServers = "foo-kafka:9092";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
 
@@ -135,7 +135,7 @@ public class KafkaConnectClusterTest {
 
     private final KafkaConnect resource = new KafkaConnectBuilder(ResourceUtils.createEmptyKafkaConnect(namespace, clusterName))
             .withNewSpec()
-                .withConfig((Map<String, Object>) TestUtils.fromJson(configurationJson, Map.class))
+                .withConfig((Map<String, Object>) TestUtils.fromYamlString(configurationJson, Map.class))
                 .withImage(image)
                 .withReplicas(replicas)
                 .withReadinessProbe(new Probe(healthDelay, healthTimeout))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -107,7 +107,7 @@ public class KafkaMirrorMaker2ClusterTest {
     private final String metricsCMName = "metrics-cm";
     private final ConfigMap metricsCM = io.strimzi.operator.cluster.TestUtils.getJmxMetricsCm(metricsCmJson, metricsCMName, "metrics-config.yml");
     private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics("metrics-config.yml", metricsCMName);
-    private final String configurationJson = "{\"foo\":\"bar\"}";
+    private final String configurationJson = "foo: bar";
     private final String bootstrapServers = "foo-kafka:9092";
     private final String targetClusterAlias = "target";
     private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
@@ -130,7 +130,7 @@ public class KafkaMirrorMaker2ClusterTest {
     private final KafkaMirrorMaker2ClusterSpec targetCluster = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(targetClusterAlias)
             .withBootstrapServers(bootstrapServers)
-            .withConfig((Map<String, Object>) TestUtils.fromJson(configurationJson, Map.class))
+            .withConfig((Map<String, Object>) TestUtils.fromYamlString(configurationJson, Map.class))
             .build();
 
     private final KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, clusterName))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -84,8 +84,8 @@ public class KafkaMirrorMakerClusterTest {
     private final ConfigMap metricsCM = io.strimzi.operator.cluster.TestUtils.getJmxMetricsCm(metricsCmJson, metricsCMName, "metrics-config.yml");
     private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics("metrics-config.yml", metricsCMName);
 
-    private final String producerConfigurationJson = "{\"foo\":\"bar\"}";
-    private final String consumerConfigurationJson = "{\"foo\":\"buz\"}";
+    private final String producerConfigurationJson = "foo: bar";
+    private final String consumerConfigurationJson = "foo: buz";
     private final String defaultProducerConfiguration = "";
     private final String defaultConsumerConfiguration = "";
     private final String expectedProducerConfiguration = "foo=bar" + LINE_SEPARATOR;
@@ -102,7 +102,7 @@ public class KafkaMirrorMakerClusterTest {
     private final KafkaMirrorMakerProducerSpec producer = new KafkaMirrorMakerProducerSpecBuilder()
             .withBootstrapServers(producerBootstrapServers)
             .withAbortOnSendFailure(abortOnSendFailure)
-            .withConfig((Map<String, Object>) TestUtils.fromJson(producerConfigurationJson, Map.class))
+            .withConfig((Map<String, Object>) TestUtils.fromYamlString(producerConfigurationJson, Map.class))
             .build();
 
     private final KafkaMirrorMakerConsumerSpec consumer = new KafkaMirrorMakerConsumerSpecBuilder()
@@ -110,7 +110,7 @@ public class KafkaMirrorMakerClusterTest {
             .withGroupId(groupId)
             .withNumStreams(numStreams)
             .withOffsetCommitInterval(offsetCommitInterval)
-            .withConfig((Map<String, Object>) TestUtils.fromJson(consumerConfigurationJson, Map.class))
+            .withConfig((Map<String, Object>) TestUtils.fromYamlString(consumerConfigurationJson, Map.class))
             .build();
 
     private final KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(ResourceUtils.createEmptyKafkaMirrorMaker(namespace, cluster))

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -83,11 +83,6 @@
             <version>${fabric8.kubernetes-model.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-core</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR cleans up the `TestUtils` class. It:
* Removes unused methods
* Fixes some IDE warnings and applies suggestions
* Fixes some typos
* Removes the deprecated `fromJson` method and where it was used it replaces it with `fromYamlString`

### Checklist

- [x] Make sure all tests pass