### PR TITLE
Move to Java 17 as the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support for automatically restarting failed Connect or Mirror Maker 2 connectors
 * Redesign of Strimzi User Operator to improve its scalability
+* Use Java 17 as the runtime for all containers
 
 ## 0.32.0
 

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 ARG TARGETPLATFORM
 
 USER root
@@ -11,7 +11,7 @@ RUN microdnf update \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf clean all
 
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 #####
 # Add Tini

--- a/docker-images/jmxtrans/Dockerfile
+++ b/docker-images/jmxtrans/Dockerfile
@@ -1,6 +1,57 @@
-FROM strimzi/base:latest
+######################################################################
+# The JMX Trans image does not use the Strimzi base image because it does not work under Java 17.
+# Instead it starts from the UBI base image and installs everything on its own:
+#     * Java 11
+#     * Tini
+######################################################################
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
+
+ARG JAVA_VERSION=11
+ARG TARGETPLATFORM
+
+USER root
+
+RUN microdnf update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless \
+    && microdnf clean all
+
+ENV JAVA_HOME /usr/lib/jvm/jre-11
+
+#####
+# Add Tini
+#####
+ENV TINI_VERSION v0.19.0
+ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+
+RUN echo $TARGETPLATFORM
+
+RUN set -ex; \
+    if [[ ${TARGETPLATFORM} = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
+        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
+        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ ${TARGETPLATFORM} = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
+        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
+        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    fi
+
+######################################################################
+# This part of the Dockerfile adds the JMXTrans binaries and scripts
+######################################################################
 
 ENV JMXTRANS_HOME /usr/share/jmxtrans
 ENV PATH $JMXTRANS_HOME/bin:$PATH

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 

--- a/docker-images/operator/scripts/launch_java.sh
+++ b/docker-images/operator/scripts/launch_java.sh
@@ -20,9 +20,6 @@ JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp/vertx-cache -Djava.security.eg
 # Enable GC logging for memory tracking
 JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
-# Deny illegal access option is supported only on Java 9 and higher
-JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
-
 # Exit when we run out of heap memory
 JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR moves all of our containers to use Java 17 instead of Java 11. It also removes the `--illegal-access=deny` option whcih is not supported in Java 17 anymore. It does not change the language level used in the actual code and how it is built. That is still using Java 11.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md