### PR TITLE
docs(format fix): Format fix for internal listener ref

### DIFF
--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -10,7 +10,7 @@ Configure client authentication for Kafka brokers by creating listeners.
 Specify the listener authentication type using the `Kafka.spec.kafka.listeners.authentication` property in the `Kafka` resource.
 
 For clients inside the Kubernetes cluster, you can create `plain` (without encryption) or `tls` _internal_ listeners.
-`The internal` listener type use a headless service and the DNS names given to the broker pods. 
+The `internal` listener type use a headless service and the DNS names given to the broker pods. 
 As an alternative to the headless service, you can also create a `cluster-ip` type of internal listener to expose Kafka using per-broker `ClusterIP` services.
 For clients outside the Kubernetes cluster, you create _external_ listeners and specify a connection mechanism,
 which can be `nodeport`, `loadbalancer`, `ingress`, or `route` (on OpenShift).


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Format fix for `internal` listener type reference in the docs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

