### PR TITLE
[systemtest] Collect logs from `cert-manager` namespace

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -205,7 +205,7 @@ public class LogCollector {
                     containerStatus -> scrapeAndCreateLogs(namespaceFile, pod.getMetadata().getName(), containerStatus, pod.getMetadata().getNamespace()));
             }
         // Tracing pods (they can't be labeled because CR of the Jaeger does not propagate labels to the Pods )
-        } else if (pod.getMetadata().getName().contains("jaeger")) {
+        } else if (pod.getMetadata().getName().contains("jaeger") || pod.getMetadata().getName().contains("cert-manager")) {
             LOGGER.debug("Collecting logs for TestSuite: {}, and Jaeger Pods: {}", this.collectorElement.getTestClassName(), pod.getMetadata().getName());
             pod.getStatus().getContainerStatuses().forEach(
                 containerStatus -> scrapeAndCreateLogs(namespaceFile, pod.getMetadata().getName(), containerStatus, pod.getMetadata().getNamespace()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingAbstractST.java
@@ -36,6 +36,7 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.TracingUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -555,6 +556,9 @@ public abstract class TracingAbstractST extends AbstractST {
 
     private void deployJaegerContent(ExtensionContext extensionContext) throws IOException {
         ResourceManager.STORED_RESOURCES.computeIfAbsent(extensionContext.getDisplayName(), k -> new Stack<>());
+
+        // create namespace `cert-manager` and add it to stack, to collect logs from it
+        cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), CERT_MANAGER_NAMESPACE);
 
         LOGGER.info("Deploying CertManager from {}", certManagerPath);
         // because we don't want to apply CertManager's file to specific namespace, passing the empty String will do the trick


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

After #7599 we are using `cert-manager` as a prerequisite for running Jaeger operator. This manager is deployed in `cert-manager` namespace. But when the deployment phase fails, we are not getting any logs from the `cert-manager` namespace.

This PR fixes this issue.

### Checklist

- [ ] Make sure all tests pass
