### PR TITLE
docs(upgrade): Updates the prereqs for the kafka upgrade and downgrade procedures

### DIFF
--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -7,16 +7,16 @@
 = Downgrading Kafka brokers and client applications
 
 [role="_abstract"]
-This procedure describes how you can downgrade a Strimzi Kafka cluster to a lower (previous) version of Kafka, such as downgrading from {KafkaVersionHigher} to {KafkaVersionLower}.
+Downgrade a Strimzi Kafka cluster to a lower (previous) version of Kafka, such as downgrading from {KafkaVersionHigher} to {KafkaVersionLower}.
 
 .Prerequisites
 
-Before you downgrade the Strimzi Kafka cluster, check the following for the `Kafka` resource:
+* The Cluster Operator is up and running.
+* Before you downgrade the Strimzi Kafka cluster, check the following for the `Kafka` resource:
 
-* IMPORTANT: xref:con-target-downgrade-version-{context}[Compatibility of Kafka versions].
-* The Cluster Operator, which supports both versions of Kafka, is up and running.
-* The `Kafka.spec.kafka.config` does not contain options that are not supported by the Kafka version being downgraded to.
-* The `Kafka.spec.kafka.config` has a `log.message.format.version` and `inter.broker.protocol.version` that is supported by the Kafka version being downgraded to.
+** IMPORTANT: xref:con-target-downgrade-version-{context}[Compatibility of Kafka versions].
+** `Kafka.spec.kafka.config` does not contain options that are not supported by the Kafka version being downgraded to.
+** `Kafka.spec.kafka.config` has a `log.message.format.version` and `inter.broker.protocol.version` that is supported by the Kafka version being downgraded to.
 +
 From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to `3.0` or higher, the `log.message.format.version` option is ignored and doesn't need to be set.
 

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -6,21 +6,16 @@
 
 = Upgrading Kafka brokers and client applications
 
-This procedure describes how to upgrade a Strimzi Kafka cluster to the latest supported Kafka version.
-
-Compared to your current Kafka version, the new version might support a higher _log message format version_ or _inter-broker protocol version_, or both.
-Follow the steps to upgrade these versions, if required.
-For more information, see xref:ref-kafka-versions-{context}[].
+[role="_abstract"]
+Upgrade a Strimzi Kafka cluster to the latest supported Kafka version and _inter-broker protocol version_.
 
 You should also choose a xref:con-strategies-for-upgrading-clients-{context}[strategy for upgrading clients].
 Kafka clients are upgraded in step 6 of this procedure.
 
 .Prerequisites
 
-For the `Kafka` resource to be upgraded, check that:
-
-* The Cluster Operator, which supports both versions of Kafka, is up and running.
-* The `Kafka.spec.kafka.config` does _not_ contain options that are not supported in the new Kafka version.
+* The Cluster Operator is up and running.
+* Before you upgrade the Strimzi Kafka cluster, check that the `Kafka.spec.kafka.config` properties of the `Kafka` resource do _not_ contain configuration options that are not supported in the new Kafka version.
 
 .Procedure
 
@@ -151,6 +146,4 @@ IMPORTANT: From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to 
 * The Kafka cluster and clients are now using the new Kafka version.
 * The brokers are configured to send messages using the inter-broker protocol version and message format version of the new version of Kafka.
 
-Following the Kafka upgrade, if required, you can:
-
-* xref:proc-upgrading-consumers-streams-cooperative-rebalancing_{context}[Upgrade consumers to use the incremental cooperative rebalance protocol]
+Following the Kafka upgrade, if required, you can xref:proc-upgrading-consumers-streams-cooperative-rebalancing_{context}[upgrade consumers to use the incremental cooperative rebalance protocol].


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Removes the misleading sentence _"The Cluster Operator, which supports both versions of Kafka, is up and running."_ from the prereqs of [Upgrading Kafka brokers and client applications](https://strimzi.io/docs/operators/in-development/deploying.html#proc-upgrading-brokers-newer-kafka-str) and [Downgrading Kafka brokers and client applications](https://strimzi.io/docs/operators/in-development/deploying.html#proc-downgrading-brokers-older-kafka-str). 

Minor edits to the abstracts or each procedure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

