### PR TITLE
[systemtest] Enable KafkaStreams checks for OpenTelemetry and enable both `OpenTracingST` and `OpenTelemetryST` suites after fixes 

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -26,7 +25,6 @@ import static io.strimzi.systemtest.Constants.TRACING;
 @Tag(TRACING)
 @Tag(INTERNAL_CLIENTS_USED)
 @ParallelSuite
-@Disabled("because of https://github.com/strimzi/strimzi-kafka-operator/issues/7622")
 public class OpenTelemetryST extends TracingAbstractST {
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTracingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTracingST.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -32,7 +31,6 @@ import static io.strimzi.systemtest.Constants.TRACING;
 @Tag(TRACING)
 @Tag(INTERNAL_CLIENTS_USED)
 @ParallelSuite
-@Disabled("because of https://github.com/strimzi/strimzi-kafka-operator/issues/7622")
 public class OpenTracingST extends TracingAbstractST {
     @Override
     protected Tracing tracing() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingAbstractST.java
@@ -134,11 +134,13 @@ public abstract class TracingAbstractST extends AbstractST {
 
         resourceManager.createResource(extensionContext, ((KafkaTracingClients) storageMap.get(extensionContext).retrieveFromTestStorage(KAFKA_TRACING_CLIENT_KEY)).kafkaStreamsWithTracing());
 
-//        TODO: Disabled because of issue with Streams API and tracing. Uncomment this after fix. https://github.com/strimzi/strimzi-kafka-operator/issues/5680
-//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
-//            JAEGER_KAFKA_STREAMS_SERVICE,
-//            storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(),
-//            JAEGER_QUERY_SERVICE);
+        // Disabled for OpenTracing, because of issue with Streams API and tracing https://github.com/strimzi/strimzi-kafka-operator/issues/5680
+        if (this.getClass().getSimpleName().contains(TracingConstants.OPEN_TELEMETRY)) {
+            TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(),
+                JAEGER_KAFKA_STREAMS_SERVICE,
+                storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(),
+                JAEGER_QUERY_SERVICE);
+        }
     }
 
     void doTestProducerConsumerMirrorMaker2Service(final ExtensionContext extensionContext) {
@@ -410,6 +412,7 @@ public abstract class TracingAbstractST extends AbstractST {
 
         resourceManager.createResource(extensionContext, ((KafkaTracingClients) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(KAFKA_TRACING_CLIENT_KEY)).producerWithTracing());
         resourceManager.createResource(extensionContext, ((KafkaTracingClients) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(KAFKA_TRACING_CLIENT_KEY)).consumerWithTracing());
+        resourceManager.createResource(extensionContext, ((KafkaTracingClients) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(KAFKA_TRACING_CLIENT_KEY)).kafkaStreamsWithTracing());
 
         ClientUtils.waitForClientsSuccess(
             storageMap.get(extensionContext).getProducerName(),
@@ -419,9 +422,11 @@ public abstract class TracingAbstractST extends AbstractST {
         TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_PRODUCER_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "To_" + storageMap.get(extensionContext).getTopicName(), JAEGER_QUERY_SERVICE);
         TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_CONSUMER_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "From_" + storageMap.get(extensionContext).getTopicName(), JAEGER_QUERY_SERVICE);
         TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_KAFKA_CONNECT_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "From_" + storageMap.get(extensionContext).getTopicName(), JAEGER_QUERY_SERVICE);
-        // TODO: Disabled because of issue with Streams API and tracing. Uncomment this after fix. https://github.com/strimzi/strimzi-kafka-operator/issues/5680
-//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_KAFKA_STREAMS_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "From_" + storageMap.get(extensionContext).getTopicName(), JAEGER_QUERY_SERVICE);
-//        TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_KAFKA_STREAMS_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "To_" + storageMap.get(extensionContext).retrieveFromTestStorage(Constants.STREAM_TOPIC_KEY).toString(), JAEGER_QUERY_SERVICE);
+        // Disabled for OpenTracing, because of issue with Streams API and tracing https://github.com/strimzi/strimzi-kafka-operator/issues/5680
+        if (this.getClass().getSimpleName().contains(TracingConstants.OPEN_TELEMETRY)) {
+            TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_KAFKA_STREAMS_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "From_" + storageMap.get(extensionContext).getTopicName(), JAEGER_QUERY_SERVICE);
+            TracingUtils.verify(storageMap.get(extensionContext).getNamespaceName(), JAEGER_KAFKA_STREAMS_SERVICE, storageMap.get(extensionContext).retrieveFromTestStorage(Constants.SCRAPER_POD_KEY).toString(), "To_" + storageMap.get(extensionContext).retrieveFromTestStorage(Constants.STREAM_TOPIC_KEY).toString(), JAEGER_QUERY_SERVICE);
+        }
     }
 
     void doTestKafkaBridgeService(final ExtensionContext extensionContext) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement 

### Description

Until now, we were skipping checks for `KafkaStreams` in the tracing tests, because of #5680 . This is still the issue, but we can enable those checks for `OpenTelemetry`.

Also, I'm enabling back the `OpenTelemetryST` and `OpenTracingST`. The issue was in deletion of Cert-manager and it's namespace - there were some leftover webhooks from previous instance of Jaeger operator and we didn't delete them (neither the webhook or whole namespace). But, in #7631 I added the whole namespace to our `Stack`, which is being deleted after all tests. This should fix the issues we saw in AZP (and everywhere else).

### Checklist

- [ ] Make sure all tests pass

