### PR TITLE
[systemtest] Use correct version of Bridge inside Helm tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
@@ -75,7 +75,7 @@ public class HelmResource implements SpecificResourceType {
 
         // image tags config
         values.put("defaultImageTag", Environment.STRIMZI_TAG);
-        values.put("kafkaBridge.image.tag", Environment.useLatestReleasedBridge() ? "latest" : BridgeUtils.getBridgeVersion());
+        values.put("kafkaBridge.image.tag", BridgeUtils.getBridgeVersion());
 
         // Additional config
         values.put("image.imagePullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

Currently, we have a "typo" in our `HelmResource`, where we are getting, if the latest released version of Bridge should be used, or the version from main branch.
We, in the Helm STs, will always need to test Bridge with version, which is currently supported by Strimzi.
This PR fixes this "bug".

### Checklist

- [ ] Make sure all tests pass
