### PR TITLE
Avoid suggesting a relationship between the custom listener certificate and Clients CA

### DIFF
--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -68,7 +68,7 @@ Contains the private and public keys for encrypting communication between the Us
 `_<cluster_name>_-cruise-control-certs`:: Contains the private and public keys for encrypting communication between Cruise Control and Kafka or ZooKeeper.
 `_<cluster_name>_-kafka-exporter-certs`:: Contains the private and public keys for encrypting communication between Kafka Exporter and Kafka or ZooKeeper.
 
-NOTE: You can xref:kafka-listener-certificates-str[provide your own server certificates and private keys] to connect to to Kafka brokers using _Kafka listener certificates_ rather than certificates signed by the cluster CA or clients CA.
+NOTE: You can xref:kafka-listener-certificates-str[provide your own server certificates and private keys] to connect to to Kafka brokers using _Kafka listener certificates_ rather than certificates signed by the cluster CA.
 
 == Cluster CA secrets
 

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -68,7 +68,7 @@ Contains the private and public keys for encrypting communication between the Us
 `_<cluster_name>_-cruise-control-certs`:: Contains the private and public keys for encrypting communication between Cruise Control and Kafka or ZooKeeper.
 `_<cluster_name>_-kafka-exporter-certs`:: Contains the private and public keys for encrypting communication between Kafka Exporter and Kafka or ZooKeeper.
 
-NOTE: You can xref:kafka-listener-certificates-str[provide your own server certificates and private keys] to connect to to Kafka brokers using _Kafka listener certificates_ rather than certificates signed by the cluster CA.
+NOTE: You can xref:kafka-listener-certificates-str[provide your own server certificates and private keys] to connect to Kafka brokers using _Kafka listener certificates_ rather than certificates signed by the cluster CA.
 
 == Cluster CA secrets
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

We should avoid suggesting any relationship between the custom listener certificates and the Clients CA. There isn't any - the listener certificate has no impact on the client authentication and had nothing to do with it.