### PR TITLE
Add option to change default image for docker registry deployed inside minikube

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -4,8 +4,8 @@ set -xe
 rm -rf ~/.kube
 
 KUBE_VERSION=${KUBE_VERSION:-1.19.0}
-REGISTRY_IMAGE=${REGISTRY_IMAGE:-"registry"}
-REGISTRY_IMAGE_S390X=${REGISTRY_IMAGE_S390X:-"s390x/registry:2.8.0-beta.1"}
+MINIKUBE_REGISTRY_IMAGE=${REGISTRY_IMAGE:-"registry"}
+MINIKUBE_REGISTRY_IMAGE_S390X=${REGISTRY_IMAGE_S390X:-"s390x/registry:2.8.0-beta.1"}
 COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
 
 DEFAULT_MINIKUBE_MEMORY=$(free -m | grep "Mem" | awk '{print $2}')
@@ -63,9 +63,9 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     touch $HOME/.kube/config
 
     if [ "$ARCH" = "s390x" ]; then
-        docker run -d -p 5000:5000 --name s390x-registry ${REGISTRY_IMAGE_S390X}
+        docker run -d -p 5000:5000 --name s390x-registry ${MINIKUBE_REGISTRY_IMAGE_S390X}
     else
-        docker run -d -p 5000:5000 ${REGISTRY_IMAGE}
+        docker run -d -p 5000:5000 ${MINIKUBE_REGISTRY_IMAGE}
     fi
 
     export KUBECONFIG=$HOME/.kube/config

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -5,7 +5,6 @@ rm -rf ~/.kube
 
 KUBE_VERSION=${KUBE_VERSION:-1.19.0}
 MINIKUBE_REGISTRY_IMAGE=${REGISTRY_IMAGE:-"registry"}
-MINIKUBE_REGISTRY_IMAGE_S390X=${REGISTRY_IMAGE_S390X:-"s390x/registry:2.8.0-beta.1"}
 COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
 
 DEFAULT_MINIKUBE_MEMORY=$(free -m | grep "Mem" | awk '{print $2}')
@@ -62,11 +61,7 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     mkdir $HOME/.kube || true
     touch $HOME/.kube/config
 
-    if [ "$ARCH" = "s390x" ]; then
-        docker run -d -p 5000:5000 --name s390x-registry ${MINIKUBE_REGISTRY_IMAGE_S390X}
-    else
-        docker run -d -p 5000:5000 ${MINIKUBE_REGISTRY_IMAGE}
-    fi
+	docker run -d -p 5000:5000 ${MINIKUBE_REGISTRY_IMAGE}
 
     export KUBECONFIG=$HOME/.kube/config
     # We can turn on network polices support by adding the following options --network-plugin=cni --cni=calico

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -4,6 +4,8 @@ set -xe
 rm -rf ~/.kube
 
 KUBE_VERSION=${KUBE_VERSION:-1.19.0}
+REGISTRY_IMAGE=${REGISTRY_IMAGE:-"registry"}
+REGISTRY_IMAGE_S390X=${REGISTRY_IMAGE_S390X:-"s390x/registry:2.8.0-beta.1"}
 COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
 
 DEFAULT_MINIKUBE_MEMORY=$(free -m | grep "Mem" | awk '{print $2}')
@@ -61,9 +63,9 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
     touch $HOME/.kube/config
 
     if [ "$ARCH" = "s390x" ]; then
-        docker run -d -p 5000:5000 --name s390x-registry s390x/registry:2.8.0-beta.1
+        docker run -d -p 5000:5000 --name s390x-registry ${REGISTRY_IMAGE_S390X}
     else
-        docker run -d -p 5000:5000 registry
+        docker run -d -p 5000:5000 ${REGISTRY_IMAGE}
     fi
 
     export KUBECONFIG=$HOME/.kube/config


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

### Type of change

- Enhancement / new feature

### Description

From time to time we face the issue that we are not able to pull image `registry` from dockerhub due to pull rate limits. This PR introduces an option that allows us to pull different image from our private registry. The image will be specified via env variable `MINIKUBE_REGISTRY_IMAGE`. The default value will remain the same (`registry`) so this change shouldn't affect any pipeline on Strimzi azure.

I also added the same option for s390x with env var name `MINIKUBE_REGISTRY_IMAGE_S390X` .

### Checklist

- [x] Make sure all tests pass

