### PR TITLE
Enhance KafkaRoller log for ForceableProblems

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -620,7 +620,11 @@ public class KafkaRoller {
 
         @Override
         public String toString() {
-            var name = getClass().getSimpleName();
+            /**
+             * This is a static nested class, so we want to prevent the Outer$Nested
+             * name returned by getSimpleName()
+             */
+            var name = "ForeseeableProblem";
             var message = getMessage();
             return ( message != null) ? (name + ": " + message) : name;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -324,13 +324,8 @@ public class KafkaRoller {
                             e);
                 } else {
                     long delay1 = ctx.backOff.delayMs();
-                    if (e instanceof ForeseeableProblem) {
-                        LOGGER.debugCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
-                                podRef, e.getMessage(), delay1);
-                    } else {
-                        LOGGER.infoCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
-                                podRef, e, delay1);
-                    }
+                    LOGGER.infoCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
+                            podRef, e, delay1);
                     schedule(podRef, delay1, TimeUnit.MILLISECONDS);
                 }
             }
@@ -622,6 +617,13 @@ public class KafkaRoller {
             super(msg, cause);
             this.forceNow = forceNow;
         }
+
+        @Override
+        public String toString() {
+            var name = getClass().getSimpleName();
+            var message = getMessage();
+            return ( message != null) ? (name + ": " + message) : name;
+        }
     }
 
     /** Exceptions which we're prepared to ignore in the final attempt */
@@ -869,9 +871,7 @@ public class KafkaRoller {
 
         @Override
         public String toString() {
-            return "{" +
-                    podName +
-                    '}';
+            return podName;
         }
 
         @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -368,8 +368,8 @@ public class KafkaRoller {
             checkReconfigurability(podRef, pod, restartContext);
             if (restartContext.forceRestart || restartContext.needsRestart || restartContext.needsReconfig) {
                 if (!restartContext.forceRestart && deferController(podRef, restartContext)) {
-                    LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to verify. Will favor trying to verify non-controller pods first", podRef);
-                    throw new ForceableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to verify.");
+                    LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to verify. Verify non-controller pods first will be prioritized.", podRef);
+                    throw new ForceableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to verify");
                 } else {
                     if (restartContext.forceRestart || canRoll(podRef, 60_000, TimeUnit.MILLISECONDS, false, restartContext)) {
                         // Check for rollability before trying a dynamic update so that if the dynamic update fails we can go to a full restart

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -300,7 +300,7 @@ public class KafkaRoller {
         RestartContext ctx = podToContext.computeIfAbsent(podRef.getPodName(),
             k -> new RestartContext(backoffSupplier));
         singleExecutor.schedule(() -> {
-            LOGGER.debugCr(reconciliation, "Considering updating pod {} after delay of {} {}", podRef, delay, unit);
+            LOGGER.debugCr(reconciliation, "Considering updating pod {} after a delay of {} {}", podRef, delay, unit);
             try {
                 restartIfNecessary(podRef, ctx);
                 ctx.promise.complete();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -197,7 +197,7 @@ public class KafkaRoller {
         if (this.allClient == null) {
             try {
                 this.allClient = adminClient(IntStream.range(0, podList.size()).boxed().collect(Collectors.toList()), false);
-            } catch (ForceableProblem | FatalProblem e) {
+            } catch (ForeseeableProblem | FatalProblem e) {
                 LOGGER.warnCr(reconciliation, "Failed to create adminClient.", e);
                 return false;
             }
@@ -324,7 +324,7 @@ public class KafkaRoller {
                             e);
                 } else {
                     long delay1 = ctx.backOff.delayMs();
-                    if (e instanceof ForceableProblem) {
+                    if (e instanceof ForeseeableProblem) {
                         LOGGER.debugCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
                                 podRef, e.getMessage(), delay1);
                     } else {
@@ -344,7 +344,7 @@ public class KafkaRoller {
      * @param podRef Reference of pod to roll.
      * @param restartContext
      * @throws InterruptedException Interrupted while waiting.
-     * @throws ForceableProblem Some error. Not thrown when finalAttempt==true.
+     * @throws ForeseeableProblem Some error. Not thrown when finalAttempt==true.
      * @throws UnforceableProblem Some error, still thrown when finalAttempt==true.
      */
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
@@ -369,7 +369,7 @@ public class KafkaRoller {
             if (restartContext.forceRestart || restartContext.needsRestart || restartContext.needsReconfig) {
                 if (!restartContext.forceRestart && deferController(podRef, restartContext)) {
                     LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to verify. Verify non-controller pods first will be prioritized.", podRef);
-                    throw new ForceableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to verify");
+                    throw new ForeseeableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to verify");
                 } else {
                     if (restartContext.forceRestart || canRoll(podRef, 60_000, TimeUnit.MILLISECONDS, false, restartContext)) {
                         // Check for rollability before trying a dynamic update so that if the dynamic update fails we can go to a full restart
@@ -393,7 +393,7 @@ public class KafkaRoller {
                 await(isReady(namespace, podRef.getPodName()), operationTimeoutMs, TimeUnit.MILLISECONDS, e -> new FatalProblem("Error while waiting for non-restarted pod " + podRef.getPodName() + " to become ready", e));
                 LOGGER.debugCr(reconciliation, "Pod {} is now ready", podRef);
             }
-        } catch (ForceableProblem e) {
+        } catch (ForeseeableProblem e) {
             if (isPodStuck(pod) || restartContext.backOff.done() || e.forceNow) {
                 if (canRoll(podRef, 60_000, TimeUnit.MILLISECONDS, true, restartContext)) {
                     LOGGER.warnCr(reconciliation, "Pod {} will be force-rolled, due to error: {}", podRef, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
@@ -449,7 +449,7 @@ public class KafkaRoller {
             try {
                 dynamicUpdateBrokerConfig(podRef, allClient, restartContext.diff, restartContext.logDiff);
                 updatedDynamically = true;
-            } catch (ForceableProblem e) {
+            } catch (ForeseeableProblem e) {
                 LOGGER.debugCr(reconciliation, "Pod {} could not be updated dynamically ({}), will restart", podRef, e);
                 updatedDynamically = false;
             }
@@ -463,7 +463,7 @@ public class KafkaRoller {
      * Determine whether the pod should be restarted, or the broker reconfigured.
      */
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
-    private void checkReconfigurability(PodRef podRef, Pod pod, RestartContext restartContext) throws ForceableProblem, InterruptedException, FatalProblem {
+    private void checkReconfigurability(PodRef podRef, Pod pod, RestartContext restartContext) throws ForeseeableProblem, InterruptedException, FatalProblem {
 
         RestartReasons reasonToRestartPod = restartContext.restartReasons;
         boolean podStuck = pod != null
@@ -506,7 +506,7 @@ public class KafkaRoller {
         Config brokerConfig;
         try {
             brokerConfig = brokerConfig(podRef);
-        } catch (ForceableProblem e) {
+        } catch (ForeseeableProblem e) {
             if (restartContext.backOff.done()) {
                 needsRestart = true;
                 brokerConfig = null;
@@ -552,11 +552,11 @@ public class KafkaRoller {
      * @param podRef The reference of the broker.
      * @return a Future which completes with the config of the given broker.
      */
-    protected Config brokerConfig(PodRef podRef) throws ForceableProblem, InterruptedException {
+    protected Config brokerConfig(PodRef podRef) throws ForeseeableProblem, InterruptedException {
         ConfigResource resource = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(podRef.getPodId()));
         return await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, allClient.describeConfigs(singletonList(resource)).values().get(resource)),
             30, TimeUnit.SECONDS,
-            error -> new ForceableProblem("Error getting broker config", error)
+            error -> new ForeseeableProblem("Error getting broker config", error)
         );
     }
 
@@ -565,16 +565,16 @@ public class KafkaRoller {
      * @param brokerId The id of the broker.
      * @return a Future which completes with the logging of the given broker.
      */
-    protected Config brokerLogging(int brokerId) throws ForceableProblem, InterruptedException {
+    protected Config brokerLogging(int brokerId) throws ForeseeableProblem, InterruptedException {
         ConfigResource resource = Util.getBrokersLogging(brokerId);
         return await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, allClient.describeConfigs(singletonList(resource)).values().get(resource)),
                 30, TimeUnit.SECONDS,
-            error -> new ForceableProblem("Error getting broker logging", error)
+            error -> new ForeseeableProblem("Error getting broker logging", error)
         );
     }
 
     protected void dynamicUpdateBrokerConfig(PodRef podRef, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff)
-            throws ForceableProblem, InterruptedException {
+            throws ForeseeableProblem, InterruptedException {
         Map<ConfigResource, Collection<AlterConfigOp>> updatedConfig = new HashMap<>(2);
         var podId = podRef.podId;
         updatedConfig.put(Util.getBrokersConfig(podId), configurationDiff.getConfigDiff());
@@ -589,36 +589,36 @@ public class KafkaRoller {
         await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, brokerConfigFuture), 30, TimeUnit.SECONDS,
             error -> {
                 LOGGER.errorCr(reconciliation, "Error doing dynamic config update", error);
-                return new ForceableProblem("Error doing dynamic update", error);
+                return new ForeseeableProblem("Error doing dynamic update", error);
             });
         await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, brokerLoggingConfigFuture), 30, TimeUnit.SECONDS,
             error -> {
                 LOGGER.errorCr(reconciliation, "Error performing dynamic logging update for pod {}", podRef, error);
-                return new ForceableProblem("Error performing dynamic logging update for pod " + podRef, error);
+                return new ForeseeableProblem("Error performing dynamic logging update for pod " + podRef, error);
             });
 
         LOGGER.infoCr(reconciliation, "Dynamic update of pod {} was successful.", podRef);
     }
 
     private KafkaBrokerLoggingConfigurationDiff logging(PodRef podRef)
-            throws ForceableProblem, InterruptedException {
+            throws ForeseeableProblem, InterruptedException {
         Config brokerLogging = brokerLogging(podRef.getPodId());
         LOGGER.traceCr(reconciliation, "Pod {}: logging description {}", podRef, brokerLogging);
         return new KafkaBrokerLoggingConfigurationDiff(reconciliation, brokerLogging, kafkaLogging);
     }
 
     /** Exceptions which we're prepared to ignore (thus forcing a restart) in some circumstances. */
-    static final class ForceableProblem extends Exception {
+    static final class ForeseeableProblem extends Exception {
         final boolean forceNow;
-        ForceableProblem(String msg) {
+        ForeseeableProblem(String msg) {
             this(msg, null);
         }
 
-        ForceableProblem(String msg, Throwable cause) {
+        ForeseeableProblem(String msg, Throwable cause) {
             this(msg, cause, false);
         }
 
-        ForceableProblem(String msg, Throwable cause, boolean forceNow) {
+        ForeseeableProblem(String msg, Throwable cause, boolean forceNow) {
             super(msg, cause);
             this.forceNow = forceNow;
         }
@@ -646,11 +646,11 @@ public class KafkaRoller {
     }
 
     private boolean canRoll(PodRef podRef, long timeout, TimeUnit unit, boolean ignoreSslError, RestartContext restartContext)
-            throws ForceableProblem, InterruptedException {
+            throws ForeseeableProblem, InterruptedException {
         try {
             return await(availability(allClient).canRoll(podRef.getPodId()), timeout, unit,
-                t -> new ForceableProblem("An error while trying to determine the possibility of updating Kafka pods", t));
-        } catch (ForceableProblem e) {
+                t -> new ForeseeableProblem("An error while trying to determine the possibility of updating Kafka pods", t));
+        } catch (ForeseeableProblem e) {
             // If we're not able to connect then roll
             if (ignoreSslError && e.getCause() instanceof SslAuthenticationException) {
                 restartContext.restartReasons.add(RestartReason.POD_UNRESPONSIVE);
@@ -734,7 +734,7 @@ public class KafkaRoller {
     /**
      * Returns an AdminClient instance bootstrapped from the given pod.
      */
-    protected Admin adminClient(List<Integer> bootstrapPods, boolean ceShouldBeFatal) throws ForceableProblem, FatalProblem {
+    protected Admin adminClient(List<Integer> bootstrapPods, boolean ceShouldBeFatal) throws ForeseeableProblem, FatalProblem {
         List<String> podNames = bootstrapPods.stream().map(this::podName).collect(Collectors.toList());
         try {
             String bootstrapHostnames = podNames.stream().map(podName -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), podName) + ":" + KafkaCluster.REPLICATION_PORT).collect(Collectors.joining(","));
@@ -745,10 +745,10 @@ public class KafkaRoller {
                     || e.getCause() instanceof ConfigException)) {
                 throw new FatalProblem("An error while try to create an admin client with bootstrap brokers " + podNames, e);
             } else {
-                throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + podNames, e);
+                throw new ForeseeableProblem("An error while try to create an admin client with bootstrap brokers " + podNames, e);
             }
         } catch (RuntimeException e) {
-            throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + podNames, e);
+            throw new ForeseeableProblem("An error while try to create an admin client with bootstrap brokers " + podNames, e);
         }
     }
 
@@ -798,7 +798,7 @@ public class KafkaRoller {
 
     /**
      * If we've already had trouble connecting to this broker try to probe whether the connection is
-     * open on the broker; if it's not then maybe throw a ForceableProblem to immediately force a restart.
+     * open on the broker; if it's not then maybe throw a ForeseeableProblem to immediately force a restart.
      * This is an optimization for brokers which don't seem to be running.
      */
     private void maybeTcpProbe(PodRef podRef, Exception executionException, RestartContext restartContext) throws Exception {
@@ -808,12 +808,12 @@ public class KafkaRoller {
                 // do a tcp connect and close (with a short connect timeout)
                 tcpProbe(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), podRef.getPodName()), KafkaCluster.REPLICATION_PORT);
             } catch (IOException connectionException) {
-                throw new ForceableProblem("Unable to connect to " + podRef.getPodName() + ":" + KafkaCluster.REPLICATION_PORT, executionException.getCause(), true);
+                throw new ForeseeableProblem("Unable to connect to " + podRef.getPodName() + ":" + KafkaCluster.REPLICATION_PORT, executionException.getCause(), true);
             }
             throw executionException;
         } else {
             restartContext.noteConnectionError();
-            throw new ForceableProblem("Error while trying to determine the cluster controller from pod " + podRef.getPodName(), executionException.getCause());
+            throw new ForeseeableProblem("Error while trying to determine the cluster controller from pod " + podRef.getPodName(), executionException.getCause());
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -326,7 +326,7 @@ public class KafkaRoller {
                     long delay1 = ctx.backOff.delayMs();
                     if (e instanceof ForceableProblem) {
                         LOGGER.debugCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
-                                podRef, e, delay1);
+                                podRef, e.getMessage(), delay1);
                     } else {
                         LOGGER.infoCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
                                 podRef, e, delay1);
@@ -368,7 +368,7 @@ public class KafkaRoller {
             checkReconfigurability(podRef, pod, restartContext);
             if (restartContext.forceRestart || restartContext.needsRestart || restartContext.needsReconfig) {
                 if (!restartContext.forceRestart && deferController(podRef, restartContext)) {
-                    LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to verify. Will favor trying to verify non-controller pods first.", podRef);
+                    LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to verify. Will favor trying to verify non-controller pods first", podRef);
                     throw new ForceableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to verify.");
                 } else {
                     if (restartContext.forceRestart || canRoll(podRef, 60_000, TimeUnit.MILLISECONDS, false, restartContext)) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -626,7 +626,7 @@ public class KafkaRoller {
              */
             var name = "ForeseeableProblem";
             var message = getMessage();
-            return ( message != null) ? (name + ": " + message) : name;
+            return (message != null) ? (name + ": " + message) : name;
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -217,6 +217,7 @@ public class KafkaRoller {
         this.podNeedsRestart = podNeedsRestart;
         Promise<Void> result = Promise.promise();
         singleExecutor.submit(() -> {
+            LOGGER.infoCr(reconciliation, "Verifying cluster pods are up-to-date.");
             List<PodRef> pods = new ArrayList<>(podList.size());
 
             for (int podIndex = 0; podIndex < podList.size(); podIndex++) {
@@ -224,8 +225,7 @@ public class KafkaRoller {
                 // only for it not to become ready and thus drive the cluster to a worse state.
                 pods.add(podOperations.isReady(namespace, podList.get(podIndex)) ? pods.size() : 0, new PodRef(podList.get(podIndex), ModelUtils.idOfPod(podList.get(podIndex))));
             }
-
-            LOGGER.debugCr(reconciliation, "Initial order for rolling restart {}", pods);
+            LOGGER.debugCr(reconciliation, "Initial order for updating pods (rolling restart or dynamic update) is {}", pods);
             List<Future> futures = new ArrayList<>(podList.size());
             for (PodRef podRef: pods) {
                 futures.add(schedule(podRef, 0, TimeUnit.MILLISECONDS));
@@ -300,7 +300,7 @@ public class KafkaRoller {
         RestartContext ctx = podToContext.computeIfAbsent(podRef.getPodName(),
             k -> new RestartContext(backoffSupplier));
         singleExecutor.schedule(() -> {
-            LOGGER.debugCr(reconciliation, "Considering restart of pod {} after delay of {} {}", podRef, delay, unit);
+            LOGGER.debugCr(reconciliation, "Considering updating pod {} after delay of {} {}", podRef, delay, unit);
             try {
                 restartIfNecessary(podRef, ctx);
                 ctx.promise.complete();
@@ -308,7 +308,7 @@ public class KafkaRoller {
                 // Let the executor deal with interruption.
                 Thread.currentThread().interrupt();
             } catch (FatalProblem e) {
-                LOGGER.infoCr(reconciliation, "Could not restart pod {}, giving up after {} attempts. Total delay between attempts {}ms",
+                LOGGER.infoCr(reconciliation, "Could not verify pod {} is up-to-date, giving up after {} attempts. Total delay between attempts {}ms",
                         podRef, ctx.backOff.maxAttempts(), ctx.backOff.totalDelayMs(), e);
                 ctx.promise.fail(e);
                 singleExecutor.shutdownNow();
@@ -317,15 +317,20 @@ public class KafkaRoller {
                 });
             } catch (Exception e) {
                 if (ctx.backOff.done()) {
-                    LOGGER.infoCr(reconciliation, "Could not roll pod {}, giving up after {} attempts. Total delay between attempts {}ms",
+                    LOGGER.infoCr(reconciliation, "Could not verify pod {} is up-to-date, giving up after {} attempts. Total delay between attempts {}ms",
                             podRef, ctx.backOff.maxAttempts(), ctx.backOff.totalDelayMs(), e);
                     ctx.promise.fail(e instanceof TimeoutException ?
                             new io.strimzi.operator.common.operator.resource.TimeoutException() :
                             e);
                 } else {
                     long delay1 = ctx.backOff.delayMs();
-                    LOGGER.infoCr(reconciliation, "Could not roll pod {} due to {}, retrying after at least {}ms",
-                            podRef, e, delay1);
+                    if (e instanceof ForceableProblem) {
+                        LOGGER.debugCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
+                                podRef, e, delay1);
+                    } else {
+                        LOGGER.infoCr(reconciliation, "Will temporarily skip verifying pod {} is up-to-date due to {}, retrying after at least {}ms",
+                                podRef, e, delay1);
+                    }
                     schedule(podRef, delay1, TimeUnit.MILLISECONDS);
                 }
             }
@@ -363,8 +368,8 @@ public class KafkaRoller {
             checkReconfigurability(podRef, pod, restartContext);
             if (restartContext.forceRestart || restartContext.needsRestart || restartContext.needsReconfig) {
                 if (!restartContext.forceRestart && deferController(podRef, restartContext)) {
-                    LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to roll", podRef);
-                    throw new ForceableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to roll");
+                    LOGGER.debugCr(reconciliation, "Pod {} is controller and there are other pods to verify. Will favor trying to verify non-controller pods first.", podRef);
+                    throw new ForceableProblem("Pod " + podRef.getPodName() + " is currently the controller and there are other pods still to verify.");
                 } else {
                     if (restartContext.forceRestart || canRoll(podRef, 60_000, TimeUnit.MILLISECONDS, false, restartContext)) {
                         // Check for rollability before trying a dynamic update so that if the dynamic update fails we can go to a full restart
@@ -375,8 +380,8 @@ public class KafkaRoller {
                             awaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS);
                         }
                     } else {
-                        LOGGER.debugCr(reconciliation, "Pod {} cannot be rolled right now", podRef);
-                        throw new UnforceableProblem("Pod " + podRef.getPodName() + " is currently not rollable");
+                        LOGGER.debugCr(reconciliation, "Pod {} cannot be updated right now", podRef);
+                        throw new UnforceableProblem("Pod " + podRef.getPodName() + " cannot be updated right now.");
                     }
                 }
             } else {
@@ -511,7 +516,7 @@ public class KafkaRoller {
         }
 
         if (!needsRestart && allowReconfiguration) {
-            LOGGER.traceCr(reconciliation, "Broker {}: description {}", podRef, brokerConfig);
+            LOGGER.traceCr(reconciliation, "Pod {}: description {}", podRef, brokerConfig);
             diff = new KafkaBrokerConfigurationDiff(reconciliation, brokerConfig, kafkaConfigProvider.apply(podRef.getPodId()), kafkaVersion, podRef.getPodId());
             loggingDiff = logging(podRef);
 
@@ -520,7 +525,7 @@ public class KafkaRoller {
                     LOGGER.debugCr(reconciliation, "Pod {} needs to be reconfigured.", podRef);
                     needsReconfig = true;
                 } else {
-                    LOGGER.infoCr(reconciliation, "Pod {} needs to be restarted, because reconfiguration cannot be done dynamically", podRef);
+                    LOGGER.infoCr(reconciliation, "Pod {} needs to be restarted, dynamic update cannot be done.", podRef);
                     restartContext.restartReasons.add(RestartReason.CONFIG_CHANGE_REQUIRES_RESTART);
                     needsRestart = true;
                 }
@@ -592,7 +597,7 @@ public class KafkaRoller {
                 return new ForceableProblem("Error performing dynamic logging update for pod " + podRef, error);
             });
 
-        LOGGER.infoCr(reconciliation, "Dynamic reconfiguration for broker {} was successful.", podRef);
+        LOGGER.infoCr(reconciliation, "Dynamic update of pod {} was successful.", podRef);
     }
 
     private KafkaBrokerLoggingConfigurationDiff logging(PodRef podRef)
@@ -644,7 +649,7 @@ public class KafkaRoller {
             throws ForceableProblem, InterruptedException {
         try {
             return await(availability(allClient).canRoll(podRef.getPodId()), timeout, unit,
-                t -> new ForceableProblem("An error while trying to determine rollability", t));
+                t -> new ForceableProblem("An error while trying to determine the possibility of updating Kafka pods", t));
         } catch (ForceableProblem e) {
             // If we're not able to connect then roll
             if (ignoreSslError && e.getCause() instanceof SslAuthenticationException) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -217,7 +217,7 @@ public class KafkaRoller {
         this.podNeedsRestart = podNeedsRestart;
         Promise<Void> result = Promise.promise();
         singleExecutor.submit(() -> {
-            LOGGER.infoCr(reconciliation, "Verifying cluster pods are up-to-date.");
+            LOGGER.debugCr(reconciliation, "Verifying cluster pods are up-to-date.");
             List<PodRef> pods = new ArrayList<>(podList.size());
 
             for (int podIndex = 0; podIndex < podList.size(); podIndex++) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -390,7 +390,7 @@ public class KafkaRollerTest {
                 false, new DefaultAdminClientProvider(), false, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
-                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 is currently not rollable",
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
                 // Controller last, broker 1 never restarted
                 asList(0, 3, 4, 2));
         // TODO assert subsequent rolls
@@ -401,7 +401,7 @@ public class KafkaRollerTest {
         clearRestarted();
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(1),
-                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 is currently not rollable",
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-1 cannot be updated right now.",
                 // Controller last, broker 1 never restarted
                 emptyList());
     }
@@ -418,7 +418,7 @@ public class KafkaRollerTest {
                 false, new DefaultAdminClientProvider(), false, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4),
-                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 is currently not rollable",
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
                 // We expect all non-controller pods to be rolled
                 asList(0, 1, 3, 4));
         clearRestarted();
@@ -429,7 +429,7 @@ public class KafkaRollerTest {
                 false, new DefaultAdminClientProvider(), false, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
                 singletonList(2),
-                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 is currently not rollable",
+                KafkaRoller.UnforceableProblem.class, "Pod c-kafka-2 cannot be updated right now.",
                 // We expect all non-controller pods to be rolled
                 emptyList());
     }
@@ -496,7 +496,7 @@ public class KafkaRollerTest {
                 false, new DefaultAdminClientProvider(), false, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
             asList(0, 1, 2, 3, 4),
-            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to roll",
+            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to verify.",
             // We expect all non-controller pods to be rolled
             asList(0, 1, 4));
     }
@@ -756,8 +756,8 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected void dynamicUpdateBrokerConfig(int podId, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff) throws ForceableProblem {
-            ForceableProblem problem = alterConfigsException.apply(podId);
+        protected void dynamicUpdateBrokerConfig(PodRef podRef, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff) throws ForceableProblem {
+            ForceableProblem problem = alterConfigsException.apply(podRef.getPodId());
             if (problem != null) {
                 throw problem;
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -496,7 +496,7 @@ public class KafkaRollerTest {
                 false, new DefaultAdminClientProvider(), false, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
             asList(0, 1, 2, 3, 4),
-            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to verify",
+            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is controller and there are other pods to verify. Non-controller pods will be verified first",
             // We expect all non-controller pods to be rolled
             asList(0, 1, 4));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -439,7 +439,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(null, null, addPodNames(REPLICAS), podOps,
                 noException(), null,
-                noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
+                noException(), noException(), podId -> podId == 1 ? new KafkaRoller.ForeseeableProblem("could not get config exception") : null,
             brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), false, 2);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -453,7 +453,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(null, null, addPodNames(REPLICAS), podOps,
             noException(), null,
-            noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForceableProblem("could not get config exception") : null,
+            noException(), noException(), podId -> podId == controller ? new KafkaRoller.ForeseeableProblem("could not get config exception") : null,
             brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), false, controller);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -466,7 +466,7 @@ public class KafkaRollerTest {
         PodOperator podOps = mockPodOps(podId -> succeededFuture());
         TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(null, null, addPodNames(REPLICAS), podOps,
                 noException(), null,
-                noException(), podId -> new KafkaRoller.ForceableProblem("could not get alter exception"), noException(),
+                noException(), podId -> new KafkaRoller.ForeseeableProblem("could not get alter exception"), noException(),
             brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), false, 2);
         // The algorithm should carry on rolling the pods
         doSuccessfulRollingRestart(testContext, kafkaRoller,
@@ -496,7 +496,7 @@ public class KafkaRollerTest {
                 false, new DefaultAdminClientProvider(), false, 2);
         doFailingRollingRestart(testContext, kafkaRoller,
             asList(0, 1, 2, 3, 4),
-            KafkaRoller.ForceableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to verify.",
+            KafkaRoller.ForeseeableProblem.class, "Pod c-kafka-2 is currently the controller and there are other pods still to verify",
             // We expect all non-controller pods to be rolled
             asList(0, 1, 4));
     }
@@ -628,8 +628,8 @@ public class KafkaRollerTest {
         private final Throwable acCloseException;
         private final Function<Integer, Future<Boolean>> canRollFn;
         private final Function<Integer, Throwable> controllerException;
-        private final Function<Integer, ForceableProblem> alterConfigsException;
-        private final Function<Integer, ForceableProblem> getConfigsException;
+        private final Function<Integer, ForeseeableProblem> alterConfigsException;
+        private final Function<Integer, ForeseeableProblem> getConfigsException;
         private boolean delegateControllerCall;
         private boolean delegateAdminClientCall;
         private final int[] controllers;
@@ -641,8 +641,8 @@ public class KafkaRollerTest {
                                    Function<List<Integer>, RuntimeException> acOpenException,
                                    Throwable acCloseException,
                                    Function<Integer, Throwable> controllerException,
-                                   Function<Integer, ForceableProblem> alterConfigsException,
-                                   Function<Integer, ForceableProblem> getConfigsException,
+                                   Function<Integer, ForeseeableProblem> alterConfigsException,
+                                   Function<Integer, ForeseeableProblem> getConfigsException,
                                    Function<Integer, Future<Boolean>> canRollFn,
                                    boolean delegateControllerCall,
                                    AdminClientProvider adminClientProvider,
@@ -679,13 +679,13 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected Admin adminClient(List<Integer> bootstrapBrokers, boolean b) throws ForceableProblem, FatalProblem {
+        protected Admin adminClient(List<Integer> bootstrapBrokers, boolean b) throws ForeseeableProblem, FatalProblem {
             if (delegateAdminClientCall) {
                 return super.adminClient(bootstrapBrokers, b);
             }
             RuntimeException exception = acOpenException.apply(bootstrapBrokers);
             if (exception != null) {
-                throw new ForceableProblem("An error while try to create the admin client", exception);
+                throw new ForeseeableProblem("An error while try to create the admin client", exception);
             }
             Admin ac = mock(AdminClient.class, invocation -> {
                 if ("close".equals(invocation.getMethod().getName())) {
@@ -729,7 +729,7 @@ public class KafkaRollerTest {
             }
             Throwable throwable = controllerException.apply(podRef.getPodId());
             if (throwable != null) {
-                throw new ForceableProblem("An error while trying to determine the cluster controller from pod " + podRef.getPodName(), throwable);
+                throw new ForeseeableProblem("An error while trying to determine the cluster controller from pod " + podRef.getPodName(), throwable);
             } else {
                 int index;
                 if (controllerCall < controllers.length) {
@@ -743,8 +743,8 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected Config brokerConfig(PodRef podRef) throws ForceableProblem {
-            ForceableProblem problem = getConfigsException.apply(podRef.getPodId());
+        protected Config brokerConfig(PodRef podRef) throws ForeseeableProblem {
+            ForeseeableProblem problem = getConfigsException.apply(podRef.getPodId());
             if (problem != null) {
                 throw problem;
             } else return new Config(emptyList());
@@ -756,8 +756,8 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected void dynamicUpdateBrokerConfig(PodRef podRef, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff) throws ForceableProblem {
-            ForceableProblem problem = alterConfigsException.apply(podRef.getPodId());
+        protected void dynamicUpdateBrokerConfig(PodRef podRef, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff) throws ForeseeableProblem {
+            ForeseeableProblem problem = alterConfigsException.apply(podRef.getPodId());
             if (problem != null) {
                 throw problem;
             }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When the kafka roller skips a pod rolling in one cycle and retries again, such as if the pod is the controller, it rolls it as the last pod. Yet, it spits out this message which can be confusing for the user since it gets roller successfully after other pods are rolled.
```
Could not roll pod {my-cluster-kafka-1} due to io.strimzi.operator.cluster.operator.resource.KafkaRoller$ForceableProblem: Pod my-cluster-kafka-1 is currently the controller and there are other pods still to roll, retrying after at least 250ms
```

This PR changes those logs to debug message which says "Skipped rolling pod" instead. 



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards