### PR TITLE
Fix validation of the `useServiceDnsDomain` for `cluster-ip` type listeners

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -148,7 +148,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
             "If set to `true`, the generated addresses will contain the service DNS domain suffix " +
             "(by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). " +
             "Defaults to `false`." +
-            "This field can be used only with `internal` type listener.")
+            "This field can be used only with `internal` and `cluster-ip type listeners.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getUseServiceDnsDomain() {
         return useServiceDnsDomain;

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -148,7 +148,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
             "If set to `true`, the generated addresses will contain the service DNS domain suffix " +
             "(by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). " +
             "Defaults to `false`." +
-            "This field can be used only with `internal` and `cluster-ip type listeners.")
+            "This field can be used only with `internal` and `cluster-ip` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getUseServiceDnsDomain() {
         return useServiceDnsDomain;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -193,9 +193,9 @@ public class ListenersValidator {
      * @param listener  Listener which needs to be validated
      */
     private static void validateServiceDnsDomain(Set<String> errors, GenericKafkaListener listener) {
-        if (KafkaListenerType.INTERNAL != listener.getType()
+        if (!(KafkaListenerType.INTERNAL.equals(listener.getType()) || KafkaListenerType.CLUSTER_IP.equals(listener.getType()))
                 && listener.getConfiguration().getUseServiceDnsDomain() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure useServiceDnsDomain because it is not internal listener");
+            errors.add("listener " + listener.getName() + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener");
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -327,7 +327,7 @@ public class ListenersValidatorTest {
 
         List<String> expectedErrors = asList(
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
-                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
+                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
                 "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener"
@@ -405,7 +405,7 @@ public class ListenersValidatorTest {
 
         List<String> expectedErrors = asList(
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
-                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
+                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
@@ -490,7 +490,7 @@ public class ListenersValidatorTest {
 
         List<String> expectedErrors = asList(
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
-                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
+                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
@@ -586,7 +586,7 @@ public class ListenersValidatorTest {
         List<GenericKafkaListener> listeners = asList(listener1);
 
         List<String> expectedErrors = asList(
-                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
+                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
@@ -739,7 +739,6 @@ public class ListenersValidatorTest {
         List<GenericKafkaListener> listeners = asList(listener1);
 
         List<String> expectedErrors = asList(
-                "listener " + name + " cannot configure useServiceDnsDomain because it is not internal listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -112,7 +112,7 @@ listeners:
 [id='property-listener-config-dns-{context}']
 === `useServiceDnsDomain`
 
-The `useServiceDnsDomain` property is only used with `internal` listeners.
+The `useServiceDnsDomain` property is only used with `internal` and `cluster-ip` listeners.
 It defines whether the fully-qualified DNS names that include the cluster service suffix (usually `.cluster.local`) are used.
 With `useServiceDnsDomain` set as `false`, the advertised addresses are generated without the service suffix; for example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc`.
 With `useServiceDnsDomain` set as `true`, the advertised addresses are generated with the service suffix; for example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc.cluster.local`.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -360,7 +360,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 
 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
 |string (one of [ExternalDNS, ExternalIP, Hostname, InternalIP, InternalDNS])
-|useServiceDnsDomain           1.2+<.<a|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip type listeners.
+|useServiceDnsDomain           1.2+<.<a|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -360,7 +360,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 
 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
 |string (one of [ExternalDNS, ExternalIP, Hostname, InternalIP, InternalDNS])
-|useServiceDnsDomain           1.2+<.<a|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener.
+|useServiceDnsDomain           1.2+<.<a|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip type listeners.
 |boolean
 |====
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -396,7 +396,7 @@ spec:
                                   This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
-                                description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip type listeners."
+                                description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -396,7 +396,7 @@ spec:
                                   This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                               useServiceDnsDomain:
                                 type: boolean
-                                description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener."
+                                description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip type listeners."
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -395,7 +395,7 @@ spec:
                                 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
-                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener."
+                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip type listeners."
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -395,7 +395,7 @@ spec:
                                 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
-                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip type listeners."
+                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like the `useServiceDnsDomain` for `cluster-ip` type listeners is already supported in the code. But it does not pass the validation. The PR fixes the validation as well as the related descriptions and docs.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally