### PR TITLE
[systemtest] LogCollector - fix exception when SPS CRD is not applied

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -281,7 +281,10 @@ public class LogCollector {
         if (!Environment.isStrimziPodSetEnabled()) {
             resources.add(Constants.STATEFUL_SET);
         } else {
-            resources.add(StrimziPodSet.RESOURCE_KIND);
+            // check if StrimziPodSets CRD is applied, if so, collect the yamls
+            if (kubeClient.getCustomResourceDefinition(StrimziPodSet.CRD_NAME) != null) {
+                resources.add(StrimziPodSet.RESOURCE_KIND);
+            }
         }
 
         resources.forEach(resource -> collectResource(resource, namespace));


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

There can be situations, when the test fails during preparation steps, just before the `StrimziPodSet` CRD is not applied. When we are collecting logs then, exception about not existing SPS resource is thrown.
This PR fixes this issue.

### Checklist

- [x] Make sure all tests pass
