### PR TITLE
[systemtest] Fix CruiseControlApiST - testKafkaRebalanceAutoApprovalMechanism

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -201,7 +201,7 @@ public class CruiseControlApiST extends AbstractST {
             .endMetadata()
             .build());
 
-        KafkaRebalanceUtils.doRebalancingProcess(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND,
+        KafkaRebalanceUtils.doRebalancingProcessWithAutoApproval(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND,
             testStorage.getNamespaceName(), testStorage.getClusterName()), testStorage.getNamespaceName(), testStorage.getClusterName());
     }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

In our `doRebalancingProcess` we are going through all the stages of the rebalance, which is good for manual approvals.
But with auto-approval mechanism, there can be a lot of race conditions, so there can be situations, where we are waiting for state to appear in `KafkaRebalance` CR, but the KR CR is in next state - so after the time runs out, the exception is thrown, even though the KR is in `Ready` state.

This PR should fix this behavior.

### Checklist

- [ ] Make sure all tests pass

