### PR TITLE
Add ability to create REST API users for Cruise Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Kafka Exporter support for `Recreate` deployment strategy
 * `ImageStream` validation for Kafka Connect builds on OpenShift
-* Add read-only REST API user for Cruise Control
+* Add ability to create REST API users for Cruise Control
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Kafka Exporter support for `Recreate` deployment strategy
 * `ImageStream` validation for Kafka Connect builds on OpenShift
+* Add read-only REST API user for Cruise Control
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.strimzi.api.annotations.DeprecatedProperty;
+import io.strimzi.api.kafka.model.balancing.ApiUser;
 import io.strimzi.api.kafka.model.balancing.BrokerCapacity;
 import io.strimzi.api.kafka.model.template.CruiseControlTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -16,6 +17,7 @@ import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 
@@ -28,7 +30,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "image", "tlsSidecar", "resources", "livenessProbe", "readinessProbe", "jvmOptions", "logging", "template",
-    "brokerCapacity", "config", "metricsConfig"})
+    "brokerCapacity", "apiUsers", "config", "metricsConfig"})
 @EqualsAndHashCode
 public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
@@ -49,6 +51,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropert
     private Logging logging;
     private CruiseControlTemplate template;
     private BrokerCapacity brokerCapacity;
+    private List<ApiUser> apiUsers;
     private Map<String, Object> config = new HashMap<>(0);
     private MetricsConfig metricsConfig;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
@@ -83,6 +86,16 @@ public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropert
 
     public void setBrokerCapacity(BrokerCapacity brokerCapacity) {
         this.brokerCapacity = brokerCapacity;
+    }
+
+    @Description("List of Cruise Control REST API users")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public List<ApiUser> getApiUsers() {
+        return apiUsers;
+    }
+
+    public void setApiUsers(List<ApiUser> apiUsers) {
+        this.apiUsers = apiUsers;
     }
 
     @Description("The Cruise Control configuration. For a full list of configuration options refer to" +

--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/ApiUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/ApiUser.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.balancing;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.Constants;
+import io.strimzi.api.kafka.model.Password;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the Cruise Control API user settings.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"name", "password", "role"})
+@EqualsAndHashCode
+public class ApiUser implements UnknownPropertyPreserving, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+    private Password password;
+    private String role;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Cruise Control REST API user")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Specify the password for the user   Cruise Control REST API user.")
+    public Password getPassword() {
+        return password;
+    }
+
+    public void setPassword(Password password) {
+        this.password = password;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Cruise Control REST API user role." +
+            "Valid API user roles are VIEWER, USER, and ADMIN" +
+            "For more information on valid API user roles see https://github.com/linkedin/cruise-control/wiki/Security#authorization")
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -81,14 +81,15 @@ public class CruiseControl extends AbstractModel {
      */
     public static final String API_ADMIN_NAME = "admin";
     private static final String API_ADMIN_ROLE = "ADMIN";
-    protected static final String API_USER_NAME = "user";
+    protected static final String API_HEALTHCHECK_NAME = "healthcheck";
+    private static final String API_HEALTHCHECK_ROLE = "USER";
+    public static final String API_USER_NAME = "user";
     private static final String API_USER_ROLE = "USER";
-
-    /**
-     * Key for the admin user password
-     */
+    public static final String API_USER_PASSWORD = "user";
     public static final String API_ADMIN_PASSWORD_KEY = APPLICATION_NAME + ".apiAdminPassword";
+    private static final String API_HEALTHCHECK_PASSWORD_KEY = APPLICATION_NAME + ".apiHealthcheckPassword";
     private static final String API_USER_PASSWORD_KEY = APPLICATION_NAME + ".apiUserPassword";
+
     private static final String API_AUTH_FILE_KEY = APPLICATION_NAME + ".apiAuthFile";
     protected static final String API_HEALTHCHECK_PATH = "/kafkacruisecontrol/state";
 
@@ -140,7 +141,7 @@ public class CruiseControl extends AbstractModel {
 
     protected static final String ENV_VAR_API_SSL_ENABLED = "STRIMZI_CC_API_SSL_ENABLED";
     protected static final String ENV_VAR_API_AUTH_ENABLED = "STRIMZI_CC_API_AUTH_ENABLED";
-    protected static final String ENV_VAR_API_USER = "API_USER";
+    protected static final String ENV_VAR_API_HEALTHCHECK = "API_HEALTHCHECK";
     protected static final String ENV_VAR_API_PORT = "API_PORT";
     protected static final String ENV_VAR_API_HEALTHCHECK_PATH = "API_HEALTHCHECK_PATH";
 
@@ -430,7 +431,7 @@ public class CruiseControl extends AbstractModel {
 
         varList.add(buildEnvVar(ENV_VAR_API_SSL_ENABLED,  String.valueOf(this.sslEnabled)));
         varList.add(buildEnvVar(ENV_VAR_API_AUTH_ENABLED,  String.valueOf(this.authEnabled)));
-        varList.add(buildEnvVar(ENV_VAR_API_USER,  API_USER_NAME));
+        varList.add(buildEnvVar(ENV_VAR_API_HEALTHCHECK, API_HEALTHCHECK_NAME));
         varList.add(buildEnvVar(ENV_VAR_API_PORT,  String.valueOf(REST_API_PORT)));
         varList.add(buildEnvVar(ENV_VAR_API_HEALTHCHECK_PATH, API_HEALTHCHECK_PATH));
 
@@ -486,7 +487,7 @@ public class CruiseControl extends AbstractModel {
     public static Map<String, String> generateCruiseControlApiCredentials() {
         PasswordGenerator passwordGenerator = new PasswordGenerator(16);
         String apiAdminPassword = passwordGenerator.generate();
-        String apiUserPassword = passwordGenerator.generate();
+        String apiHealthcheckPassword = passwordGenerator.generate();
 
         /*
          * Create Cruise Control API auth credentials file following Jetty's
@@ -494,11 +495,14 @@ public class CruiseControl extends AbstractModel {
          */
         String authCredentialsFile =
                 API_ADMIN_NAME + ": " + apiAdminPassword + "," + API_ADMIN_ROLE + "\n" +
-                API_USER_NAME + ": " + apiUserPassword + "," + API_USER_ROLE + "\n";
+                API_HEALTHCHECK_NAME + ": " + apiHealthcheckPassword + "," + API_HEALTHCHECK_ROLE + "\n" +
+                API_USER_NAME + ": " + API_USER_PASSWORD + "," + API_USER_ROLE + "\n";
 
         Map<String, String> data = new HashMap<>(3);
         data.put(API_ADMIN_PASSWORD_KEY, Util.encodeToBase64(apiAdminPassword));
-        data.put(API_USER_PASSWORD_KEY, Util.encodeToBase64(apiUserPassword));
+        data.put(API_HEALTHCHECK_PASSWORD_KEY, Util.encodeToBase64(apiHealthcheckPassword));
+        data.put(API_USER_PASSWORD_KEY, Util.encodeToBase64(API_USER_PASSWORD));
+
         data.put(API_AUTH_FILE_KEY, Util.encodeToBase64(authCredentialsFile));
 
         return data;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/ApiRole.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/ApiRole.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+public enum ApiRole {
+    VIEWER,
+    USER,
+    ADMIN,
+    NONE;
+
+    public static ApiRole forValue(String value) {
+        switch (value) {
+            case "VIEWER":
+                return ApiRole.VIEWER;
+            case "USER":
+                return ApiRole.USER;
+            case "ADMIN":
+                return ApiRole.ADMIN;
+            default:
+                return ApiRole.NONE;
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/ApiUser.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/ApiUser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+public class ApiUser {
+    private String name;
+    private String password;
+    private ApiRole role;
+
+    public ApiUser(String name, String password, ApiRole role) {
+        this.name = name;
+        this.password = password;
+        this.role = role;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setUser(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public ApiRole getRole() {
+        return role;
+    }
+
+    public void setRole(ApiRole role) {
+        this.role = role;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -81,7 +81,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         }
     }
 
-    private static HTTPHeader generateAuthHttpHeader(String user, String password) {
+    public static HTTPHeader generateAuthHttpHeader(String user, String password) {
         String headerName = "Authorization";
         String headerValue = "Basic " + Util.encodeToBase64(String.join(":", user, password));
 
@@ -460,5 +460,9 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         } else {
             result.fail(t);
         }
+    }
+
+    public void setAuthHttpHeader(HTTPHeader authHttpHeader) {
+        this.authHttpHeader = authHttpHeader;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -76,7 +76,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import static io.strimzi.operator.cluster.model.CruiseControl.API_HEALTHCHECK_PATH;
-import static io.strimzi.operator.cluster.model.CruiseControl.API_USER_NAME;
+import static io.strimzi.operator.cluster.model.CruiseControl.API_HEALTHCHECK_NAME;
 import static io.strimzi.operator.cluster.model.CruiseControl.ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION;
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.ANOMALY_DETECTION_CONFIG_KEY;
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY;
@@ -185,7 +185,7 @@ public class CruiseControlTest {
         expected.add(new EnvVarBuilder().withName(ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION).withValue(cc.capacity.toString()).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_SSL_ENABLED).withValue(Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_AUTH_ENABLED).withValue(Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED)).build());
-        expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_USER).withValue(API_USER_NAME).build());
+        expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_HEALTHCHECK).withValue(API_HEALTHCHECK_NAME).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_PORT).withValue(Integer.toString(CruiseControl.REST_API_PORT)).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_HEALTHCHECK_PATH).withValue(API_HEALTHCHECK_PATH).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_KAFKA_HEAP_OPTS).withValue("-Xms" + AbstractModel.DEFAULT_JVM_XMS).build());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
+import io.strimzi.operator.cluster.model.CruiseControl;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -63,7 +64,7 @@ public class CruiseControlClientTest {
     public void testGetCCState(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         MockCruiseControl.setupCCStateResponse(ccServer);
 
-        CruiseControlApi client = cruiseControlClientProvider(vertx);
+        CruiseControlApiImpl client = (CruiseControlApiImpl) cruiseControlClientProvider(vertx);
 
         Checkpoint checkpoint = context.checkpoint();
         client.getCruiseControlState(HOST, PORT, false)
@@ -72,6 +73,14 @@ public class CruiseControlClientTest {
                         hasEntry("state", "NO_TASK_IN_PROGRESS"));
                 checkpoint.flag();
             })));
+
+        client.setAuthHttpHeader(CruiseControlApiImpl.generateAuthHttpHeader(CruiseControl.API_USER_NAME, CruiseControl.API_USER_NAME));
+        client.getCruiseControlState(HOST, PORT, false)
+                .onComplete(context.succeeding(result -> context.verify(() -> {
+                    assertThat(result.getJson().getJsonObject("ExecutorState"),
+                            hasEntry("state", "NO_TASK_IN_PROGRESS"));
+                    checkpoint.flag();
+                })));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
-import io.strimzi.operator.cluster.model.CruiseControl;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -74,7 +73,7 @@ public class CruiseControlClientTest {
                 checkpoint.flag();
             })));
 
-        client.setAuthHttpHeader(CruiseControlApiImpl.generateAuthHttpHeader(CruiseControl.API_USER_NAME, CruiseControl.API_USER_NAME));
+        client.setAuthHttpHeader(CruiseControlApiImpl.generateAuthHttpHeader("test", "test"));
         client.getCruiseControlState(HOST, PORT, false)
                 .onComplete(context.succeeding(result -> context.verify(() -> {
                     assertThat(result.getJson().getJsonObject("ExecutorState"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -79,7 +79,8 @@ public class MockCruiseControl {
     public static final Secret CC_API_SECRET = ModelUtils.createSecret(CruiseControlResources.apiSecretName(CLUSTER), NAMESPACE, Labels.EMPTY, null,
             CruiseControl.generateCruiseControlApiCredentials(), Collections.emptyMap(), Collections.emptyMap());
 
-    private static final Header AUTH_HEADER = convertToHeader(CruiseControlApiImpl.getAuthHttpHeader(true, CC_API_SECRET));
+    private static final Header ADMIN_AUTH_HEADER = convertToHeader(CruiseControlApiImpl.getAuthHttpHeader(true, CC_API_SECRET));
+    private static final Header USER_AUTH_HEADER = convertToHeader(CruiseControlApiImpl.generateAuthHttpHeader(CruiseControl.API_USER_NAME, CruiseControl.API_USER_PASSWORD));
 
     /**
      * Sets up and returns the Cruise Control MockSever.
@@ -151,7 +152,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withPath(CruiseControlEndpoints.STATE.path)
                                 .withHeaders(header(CruiseControlApi.CC_REST_API_USER_ID_HEADER, STATE_PROPOSAL_NOT_READY),
-                                        AUTH_HEADER)
+                                        ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -170,7 +171,22 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "false"))
                                 .withPath(CruiseControlEndpoints.STATE.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
+                                .withSecure(true))
+                .respond(
+                        response()
+                                .withBody(json)
+                                .withHeaders(header("User-Task-ID", "cruise-control-state"))
+                                .withDelay(TimeUnit.SECONDS, RESPONSE_DELAY_SEC));
+
+        ccServer
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "false"))
+                                .withPath(CruiseControlEndpoints.STATE.path)
+                                .withHeader(USER_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -188,7 +204,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true"))
                                 .withPath(CruiseControlEndpoints.STATE.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -217,7 +233,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withQueryStringParameter(buildBrokerIdParameter(endpoint))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -244,7 +260,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withQueryStringParameter(buildBrokerIdParameter(endpoint))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true)
                 )
                 .respond(
@@ -278,7 +294,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withQueryStringParameter(buildBrokerIdParameter(endpoint))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.exactly(pendingCalls))
                 .respond(
@@ -300,7 +316,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "false"))
                                 .withQueryStringParameter(buildBrokerIdParameter(endpoint))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.unlimited())
                 .respond(
@@ -321,7 +337,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true"))
                                 .withQueryStringParameter(buildBrokerIdParameter(endpoint))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -349,7 +365,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.GOALS.key, ".+"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.SKIP_HARD_GOAL_CHECK.key, "false"))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -372,7 +388,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.GOALS.key, ".+"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.SKIP_HARD_GOAL_CHECK.key, "true"))
                                 .withPath(endpoint.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -408,7 +424,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_RESPONSE_UTID))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.exactly(activeCalls))
                 .respond(
@@ -426,7 +442,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_RESPONSE_UTID))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.exactly(inExecutionCalls))
                 .respond(
@@ -444,7 +460,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_RESPONSE_UTID))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.unlimited())
                 .respond(
@@ -468,7 +484,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(
                                         Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.exactly(activeCalls))
                 .respond(
@@ -486,7 +502,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(
                                         Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.exactly(inExecutionCalls))
                 .respond(
@@ -504,7 +520,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(
                                         Parameter.param(CruiseControlParameters.USER_TASK_IDS.key, REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true),
                         Times.unlimited())
                 .respond(
@@ -529,7 +545,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.key, "true"))
                                 .withPath(CruiseControlEndpoints.USER_TASKS.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()
@@ -552,7 +568,7 @@ public class MockCruiseControl {
                                 .withMethod("POST")
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true|false"))
                                 .withPath(CruiseControlEndpoints.STOP.path)
-                                .withHeader(AUTH_HEADER)
+                                .withHeader(ADMIN_AUTH_HEADER)
                                 .withSecure(true))
                 .respond(
                         response()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -76,11 +76,10 @@ public class MockCruiseControl {
             .endMetadata()
             .addToData("cruise-control.crt", MockCertManager.clusterCaCert())
             .build();
-    public static final Secret CC_API_SECRET = ModelUtils.createSecret(CruiseControlResources.apiSecretName(CLUSTER), NAMESPACE, Labels.EMPTY, null,
-            CruiseControl.generateCruiseControlApiCredentials(), Collections.emptyMap(), Collections.emptyMap());
+    public static final Secret CC_API_SECRET = ModelUtils.createSecret(CruiseControlResources.apiSecretName(CLUSTER), NAMESPACE, Labels.EMPTY, null, CruiseControl.generateCruiseControlApiCredentials(Collections.emptyList(), Collections.emptyList()), Collections.emptyMap(), Collections.emptyMap());
 
     private static final Header ADMIN_AUTH_HEADER = convertToHeader(CruiseControlApiImpl.getAuthHttpHeader(true, CC_API_SECRET));
-    private static final Header USER_AUTH_HEADER = convertToHeader(CruiseControlApiImpl.generateAuthHttpHeader(CruiseControl.API_USER_NAME, CruiseControl.API_USER_PASSWORD));
+    private static final Header USER_AUTH_HEADER = convertToHeader(CruiseControlApiImpl.generateAuthHttpHeader("test", "test"));
 
     /**
      * Sets up and returns the Cruise Control MockSever.

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_healthcheck.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_healthcheck.sh
@@ -11,7 +11,7 @@ else
 fi
 
 if [ "$STRIMZI_CC_API_AUTH_ENABLED" = true ] ; then
-  ARGS+=(--user "${API_USER}:$(cat /opt/cruise-control/api-auth-config/cruise-control.apiUserPassword)")
+  ARGS+=(--user "${API_HEALTHCHECK}:$(cat /opt/cruise-control/api-auth-config/cruise-control.apiHealthcheckPassword)")
 fi
 
 curl "${ARGS[@]}" "${SCHEME}://localhost:${API_PORT}${API_HEALTHCHECK_PATH}"

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -103,6 +103,10 @@ spec:
 The Cruise Control REST API is secured with HTTP Basic authentication and SSL to protect the cluster against potentially destructive Cruise Control operations, such as decommissioning Kafka brokers.
 We recommend that Cruise Control in Strimzi is **only used with these settings enabled**.
 
+Strimzi only provides read-only access to the REST API through a public API user.
+
+The username for this public API user is `user` and the password is `user`.
+
 However, it is possible to disable these settings by specifying the following Cruise Control configuration:
 
 * To disable the built-in HTTP Basic authentication, set `webserver.security.enable` to `false`.

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -103,10 +103,6 @@ spec:
 The Cruise Control REST API is secured with HTTP Basic authentication and SSL to protect the cluster against potentially destructive Cruise Control operations, such as decommissioning Kafka brokers.
 We recommend that Cruise Control in Strimzi is **only used with these settings enabled**.
 
-Strimzi only provides read-only access to the REST API through a public API user.
-
-The username for this public API user is `user` and the password is `user`.
-
 However, it is possible to disable these settings by specifying the following Cruise Control configuration:
 
 * To disable the built-in HTTP Basic authentication, set `webserver.security.enable` to `false`.
@@ -128,6 +124,34 @@ spec:
 # ...
 ----
 
+You can create
+
+.Cruise Control configuration to add REST API users
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  # ...
+  cruiseControl:
+    apiUsers:
+      - name: strimzi
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: my-secret (1)
+              key: my-password (2)
+        role: USER (3)
+
+# ...
+----
+1. The name of the secret containing the predefined password.
+2. The key for the password stored inside the secret.
+3. Valid API roles are VIEWER, USER, and ADMIN".
+
+For more information on valid API user roles see https://github.com/linkedin/cruise-control/wiki/Security#authorization
 
 [id='property-cruise-control-broker-capacity-{context}']
 === brokerCapacity

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1344,6 +1344,8 @@ include::../api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc[leveloffset=+1
 |xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`]
 |brokerCapacity  1.2+<.<a|The Cruise Control `brokerCapacity` configuration.
 |xref:type-BrokerCapacity-{context}[`BrokerCapacity`]
+|apiUsers        1.2+<.<a|List of Cruise Control REST API users.
+|xref:type-ApiUser-{context}[`ApiUser`] array
 |config          1.2+<.<a|The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, capacity.config.file, self.healing., ssl., kafka.broker.failure.detection.enable, topic.config.provider.class (with the exception of: ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled, webserver.http.cors.origin, webserver.http.cors.exposeheaders, webserver.security.enable, webserver.ssl.enable).
 |map
 |metricsConfig   1.2+<.<a|Metrics configuration. The type depends on the value of the `metricsConfig.type` property within the given object, which must be one of [jmxPrometheusExporter].
@@ -1415,6 +1417,51 @@ Used in: xref:type-BrokerCapacity-{context}[`BrokerCapacity`]
 |string
 |outboundNetwork  1.2+<.<a|Broker capacity for outbound network throughput in bytes per second. Use an integer value with standard Kubernetes byte units (K, M, G) or their bibyte (power of two) equivalents (Ki, Mi, Gi) per second. For example, 10000KiB/s.
 |string
+|====
+
+[id='type-ApiUser-{context}']
+### `ApiUser` schema reference
+
+Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
+
+
+[options="header"]
+|====
+|Property         |Description
+|name      1.2+<.<a|Cruise Control REST API user.
+|string
+|password  1.2+<.<a|Specify the password for the user   Cruise Control REST API user.
+|xref:type-Password-{context}[`Password`]
+|role      1.2+<.<a|Cruise Control REST API user role.Valid API user roles are VIEWER, USER, and ADMINFor more information on valid API user roles see https://github.com/linkedin/cruise-control/wiki/Security#authorization.
+|string
+|====
+
+[id='type-Password-{context}']
+### `Password` schema reference
+
+Used in: xref:type-ApiUser-{context}[`ApiUser`], xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`]
+
+
+[options="header"]
+|====
+|Property          |Description
+|valueFrom  1.2+<.<a|Secret from which the password should be read.
+|xref:type-PasswordSource-{context}[`PasswordSource`]
+|====
+
+[id='type-PasswordSource-{context}']
+### `PasswordSource` schema reference
+
+Used in: xref:type-Password-{context}[`Password`]
+
+
+[options="header"]
+|====
+|Property             |Description
+|secretKeyRef  1.2+<.<a|Selects a key of a Secret in the resource's namespace. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
+
+
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[SecretKeySelector]
 |====
 
 [id='type-JmxTransSpec-{context}']
@@ -2425,34 +2472,6 @@ It must have the value `scram-sha-512` for the type `KafkaUserScramSha512ClientA
 |xref:type-Password-{context}[`Password`]
 |type      1.2+<.<a|Must be `scram-sha-512`.
 |string
-|====
-
-[id='type-Password-{context}']
-### `Password` schema reference
-
-Used in: xref:type-KafkaUserScramSha512ClientAuthentication-{context}[`KafkaUserScramSha512ClientAuthentication`]
-
-
-[options="header"]
-|====
-|Property          |Description
-|valueFrom  1.2+<.<a|Secret from which the password should be read.
-|xref:type-PasswordSource-{context}[`PasswordSource`]
-|====
-
-[id='type-PasswordSource-{context}']
-### `PasswordSource` schema reference
-
-Used in: xref:type-Password-{context}[`Password`]
-
-
-[options="header"]
-|====
-|Property             |Description
-|secretKeyRef  1.2+<.<a|Selects a key of a Secret in the resource's namespace. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[external documentation for core/v1 secretkeyselector].
-
-
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[SecretKeySelector]
 |====
 
 [id='type-KafkaUserAuthorizationSimple-{context}']


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR gives ability  to create REST API users for  the Cruise Control REST API. 
This allows developers and third-party applications to define roles and permissions to access to the Cruise Control REST API without having to disable HTTP basic authentication. 

The rough plan is to add an `apiUsers` section to the `cruiseControl.spec` where an API users can be defined by name and predefined Cruise Control role [1]. As of right now, the schema will look something like this:
```
spec:
  cruiseControl:
    apiUsers:
      - name: user
        password:
          valueFrom:
            secretKeyRef:
              name: my-secret (1)
              key: my-password (2)
        role: USER (3)
     ...
```
(1) The name of the secret containing the predefined password.
(2) The key for the password stored inside the secret.
(3) By default Cruise Control defines three roles: VIEWER, USER and ADMIN.

    VIEWER role: has access to the most lightweight kafka_cluster_state, user_tasks and review_board endpoints.
    USER role: has access to all the GET endpoints except bootstrap and train.
    ADMIN role: has access to all endpoints.

 https://github.com/linkedin/cruise-control/wiki/Security#authorization

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

