### PR TITLE
Move to Java 17 as a language level

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -4,9 +4,9 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'build_strimzi_java-11':
-          jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        'build_strimzi_java-17':
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/jobs/build/deploy_strimzi_java.yaml
+++ b/.azure/templates/jobs/build/deploy_strimzi_java.yaml
@@ -4,9 +4,9 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'deploy_strimzi_java-11':
-          jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        'deploy_strimzi_java-17':
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -4,9 +4,9 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'test_strimzi_java-11':
-          jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        'test_strimzi_java-17':
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 70

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -1,23 +1,23 @@
 # Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (currently, only 11 is used). Images are based on Java 11
+# We use openjdk-X, where X is Java version (currently, only 17 is used). Images are based on Java 17
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-11-openjdk-amd64'
+    default: '/usr/lib/jvm/java-17-openjdk-amd64'
   - name: JDK_VERSION
-    default: '11'
+    default: '17'
 steps:
   - bash: |
       sudo apt-get update
     displayName: 'Update package list'
   - bash: |
-      sudo apt-get install openjdk-11-jdk
-    displayName: 'Install openjdk11'
-    condition: eq(variables['JDK_VERSION'], '11')
+      sudo apt-get install openjdk-17-jdk
+    displayName: 'Install openjdk17'
+    condition: eq(variables['JDK_VERSION'], '17')
   - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]11"
-    displayName: 'Setup JAVA_VERSION=11'
-    condition: eq(variables['JDK_VERSION'], '11')
+      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
+      echo "##vso[task.setvariable variable=JAVA_VERSION]17"
+    displayName: 'Setup JAVA_VERSION=17'
+    condition: eq(variables['JDK_VERSION'], '17')
   - bash: |
       echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
       echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -20,8 +20,8 @@ jobs:
   strategy:
     matrix:
       ${{ parameters.name }}:
-        jdk_version: '11'
-        jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        jdk_version: '17'
+        jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
   # Base system
   pool:
     vmImage: 'Ubuntu-20.04'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,11 +43,12 @@ jobs:
           curl -L https://github.com/mikefarah/yq/releases/download/v4.2.1/yq_linux_amd64 > yq && chmod +x yq
           sudo cp -v yq /usr/bin/
 
-    # Setup OpenJDK 11
-    - name: Setup java
-      uses: joschi/setup-jdk@v2
+    # Setup OpenJDK 17
+    - uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
 
     # Setup Maven cache
     - name: Cache local Maven repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Support for automatically restarting failed Connect or Mirror Maker 2 connectors
 * Redesign of Strimzi User Operator to improve its scalability
-* Use Java 17 as the runtime for all containers
+* Use Java 17 as the runtime for all containers and language level for most modules
 * Upgrade Vert.x to 4.3.5
 
 ### Changes, deprecations and removals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Support for automatically restarting failed Connect or Mirror Maker 2 connectors
 * Redesign of Strimzi User Operator to improve its scalability
-* Use Java 17 as the runtime for all containers and language level for most modules
+* Use Java 17 as the runtime for all containers and language level for all modules except `api`, `crd-generator`, `crd-annotations`, and `test`
 * Upgrade Vert.x to 4.3.5
 
 ### Changes, deprecations and removals

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,6 +16,14 @@
         </license>
     </licenses>
 
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -69,7 +69,7 @@ public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
         if (addresses == null || addresses.isEmpty()) {
             bootstrapServers = null;
         } else {
-            bootstrapServers = addresses.stream().map(a -> a.getHost() + ":" + a.getPort()).distinct().collect(Collectors.joining(","));
+            bootstrapServers = addresses.stream().map(a -> a.getHost() + ":" + a.getPort()).distinct().sorted().collect(Collectors.joining(","));
         }
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaMirrorMakerTest.java
@@ -9,6 +9,7 @@ package io.strimzi.api.kafka.model;
  *
  * 1. we get a correct tree of POJOs when reading a JSON/YAML `KafkaMirrorMaker` resource.
  */
+@SuppressWarnings("deprecation")
 public class KafkaMirrorMakerTest extends AbstractCrdTest<KafkaMirrorMaker> {
 
     public KafkaMirrorMakerTest() {

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
@@ -78,7 +78,7 @@ public class OpenSslCertManagerIT {
         X509Certificate x509Certificate1 = loadCertificate(cert);
         assertTrue(selfVerifies(x509Certificate1),
                 "Unexpected self-verification");
-        assertEquals(x509Certificate1.getSubjectDN(), x509Certificate1.getIssuerDN(), "Unexpected self-signedness");
+        assertEquals(x509Certificate1.getSubjectX500Principal(), x509Certificate1.getIssuerX500Principal(), "Unexpected self-signedness");
         assertSubject(sbj, x509Certificate1);
         X509Certificate x509Certificate = x509Certificate1;
         assertEquals(0, x509Certificate.getBasicConstraints(),
@@ -112,7 +112,7 @@ public class OpenSslCertManagerIT {
         X509Certificate x509Certificate = loadCertificate(cert);
         assertTrue(selfVerifies(x509Certificate),
                 "Unexpected self-verification");
-        assertEquals(x509Certificate.getSubjectDN(), x509Certificate.getIssuerDN(), "Expected self-signed certificate");
+        assertEquals(x509Certificate.getSubjectX500Principal(), x509Certificate.getIssuerX500Principal(), "Expected self-signed certificate");
         assertSubject(sbj, x509Certificate);
         assertEquals(0, x509Certificate.getBasicConstraints(),
                 "Expected a certificate with CA:" + true + ", but basic constraints = " + x509Certificate.getBasicConstraints());
@@ -140,7 +140,7 @@ public class OpenSslCertManagerIT {
     private void assertCaCertificate(X509Certificate x509Certificate, boolean expectCa) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
         assertEquals(expectCa, selfVerifies(x509Certificate),
                 "Unexpected self-verification");
-        assertEquals(expectCa, x509Certificate.getIssuerDN().equals(x509Certificate.getSubjectDN()),
+        assertEquals(expectCa, x509Certificate.getIssuerX500Principal().equals(x509Certificate.getSubjectX500Principal()),
                 "Unexpected self-signedness");
         assertEquals(expectCa, x509Certificate.getBasicConstraints() >= 0,
                 "Expected a certificate with CA:" + expectCa + ", but basic constraints = " + x509Certificate.getBasicConstraints());
@@ -158,8 +158,8 @@ public class OpenSslCertManagerIT {
     }
 
     private void assertSubject(Subject sbj, X509Certificate x509Certificate) throws CertificateParsingException {
-        Principal p = x509Certificate.getSubjectDN();
-        assertThat(String.format("CN=%s, O=%s", sbj.commonName(), sbj.organizationName()), is(p.getName()));
+        Principal p = x509Certificate.getSubjectX500Principal();
+        assertThat(String.format("CN=%s,O=%s", sbj.commonName(), sbj.organizationName()), is(p.getName()));
 
         assertSubjectAlternativeNames(sbj, x509Certificate);
     }
@@ -176,8 +176,8 @@ public class OpenSslCertManagerIT {
     }
 
     private void assertIssuer(Subject sbj, X509Certificate x509Certificate) {
-        Principal p = x509Certificate.getIssuerDN();
-        assertThat(String.format("CN=%s, O=%s", sbj.commonName(), sbj.organizationName()), is(p.getName()));
+        Principal p = x509Certificate.getIssuerX500Principal();
+        assertThat(String.format("CN=%s,O=%s", sbj.commonName(), sbj.organizationName()), is(p.getName()));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class OpenSslCertManagerIT {
         X509Certificate rootX509 = loadCertificate(rootCert);
         assertTrue(selfVerifies(rootX509),
                 "Unexpected self-verification");
-        assertTrue(rootX509.getIssuerDN().equals(rootX509.getSubjectDN()),
+        assertTrue(rootX509.getIssuerX500Principal().equals(rootX509.getSubjectX500Principal()),
                 "Unexpected self-signed cert");
         assertSubject(rootSubject, rootX509);
         assertEquals(rootPathLen, rootX509.getBasicConstraints(),
@@ -213,7 +213,7 @@ public class OpenSslCertManagerIT {
         ssl.generateIntermediateCaCert(rootKey, rootCert, intermediateSubject, intermediateKey, intermediateCert, notBefore, notAfter, intermediatePathLen);
 
         X509Certificate intermediateX509 = loadCertificate(intermediateCert);
-        assertTrue(intermediateX509.getIssuerDN().equals(rootX509.getSubjectDN()),
+        assertTrue(intermediateX509.getIssuerX500Principal().equals(rootX509.getSubjectX500Principal()),
                 "Unexpected intermediate's issued to be root");
         assertSubject(intermediateSubject, intermediateX509);
         assertEquals(intermediatePathLen, intermediateX509.getBasicConstraints(),
@@ -332,9 +332,9 @@ public class OpenSslCertManagerIT {
 
         c.verify(ca.getPublicKey());
 
-        Principal p = c.getSubjectDN();
+        Principal p = c.getSubjectX500Principal();
 
-        assertThat(String.format("CN=%s, O=%s", sbj.commonName(), sbj.organizationName()), is(p.getName()));
+        assertThat(String.format("CN=%s,O=%s", sbj.commonName(), sbj.organizationName()), is(p.getName()));
 
         if (sbj != null && sbj.subjectAltNames() != null && sbj.subjectAltNames().size() > 0) {
             final Collection<List<?>> snas = c.getSubjectAlternativeNames();
@@ -383,7 +383,7 @@ public class OpenSslCertManagerIT {
         X509Certificate x509Certificate1 = loadCertificate(originalCert);
         assertTrue(selfVerifies(x509Certificate1),
                 "Unexpected self-verification");
-        assertTrue(x509Certificate1.getIssuerDN().equals(x509Certificate1.getSubjectDN()),
+        assertTrue(x509Certificate1.getIssuerX500Principal().equals(x509Certificate1.getSubjectX500Principal()),
                 "Unexpected self-signedness");
         // subject verification if provided
         if (caSubject != null) {

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -16,6 +16,11 @@
         </license>
     </licenses>
 
+    <properties>
+        <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -108,10 +113,6 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>certificate-manager</artifactId>
         </dependency>
@@ -165,11 +166,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <!-- This should be removed once https://github.com/strimzi/strimzi-kafka-operator/issues/7702 is fixed -->
         <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
     </properties>
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -294,14 +294,13 @@ public class KafkaReconcilerStatusTest {
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
             assertThat(status.getListeners().get(0).getType(), is("external"));
-            assertThat(status.getListeners().get(0).getBootstrapServers(), is("5.124.16.8:31234,55.36.78.115:31234,50.35.18.119:31234"));
+            assertThat(status.getListeners().get(0).getBootstrapServers(), is("5.124.16.8:31234,50.35.18.119:31234,55.36.78.115:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(3));
-            assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("5.124.16.8"));
-            assertThat(status.getListeners().get(0).getAddresses().get(1).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(1).getHost(), is("55.36.78.115"));
-            assertThat(status.getListeners().get(0).getAddresses().get(2).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(2).getHost(), is("50.35.18.119"));
+
+            // Assert the listener addresses independently on their order
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "5.124.16.8".equals(a.getHost())), is(true));
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "55.36.78.115".equals(a.getHost())), is(true));
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "50.35.18.119".equals(a.getHost())), is(true));
 
             async.flag();
         }));
@@ -400,14 +399,13 @@ public class KafkaReconcilerStatusTest {
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
             assertThat(status.getListeners().get(0).getType(), is("external"));
-            assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-address-0:31234,5.124.16.8:31234,my-address-1:31234"));
+            assertThat(status.getListeners().get(0).getBootstrapServers(), is("5.124.16.8:31234,my-address-0:31234,my-address-1:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(3));
-            assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-address-0"));
-            assertThat(status.getListeners().get(0).getAddresses().get(1).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(1).getHost(), is("5.124.16.8"));
-            assertThat(status.getListeners().get(0).getAddresses().get(2).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(2).getHost(), is("my-address-1"));
+
+            // Assert the listener addresses independently on their order
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "my-address-0".equals(a.getHost())), is(true));
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "my-address-1".equals(a.getHost())), is(true));
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "5.124.16.8".equals(a.getHost())), is(true));
 
             async.flag();
         }));
@@ -498,12 +496,11 @@ public class KafkaReconcilerStatusTest {
             assertThat(status.getListeners().get(0).getType(), is("external"));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("node-0.my-kube:31234,node-1.my-kube:31234,node-3.my-kube:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(3));
-            assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("node-0.my-kube"));
-            assertThat(status.getListeners().get(0).getAddresses().get(1).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(1).getHost(), is("node-1.my-kube"));
-            assertThat(status.getListeners().get(0).getAddresses().get(2).getPort(), is(31234));
-            assertThat(status.getListeners().get(0).getAddresses().get(2).getHost(), is("node-3.my-kube"));
+
+            // Assert the listener addresses independently on their order
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "node-0.my-kube".equals(a.getHost())), is(true));
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "node-1.my-kube".equals(a.getHost())), is(true));
+            assertThat(status.getListeners().get(0).getAddresses().stream().anyMatch(a -> a.getPort() == 31234 && "node-3.my-kube".equals(a.getHost())), is(true));
 
             async.flag();
         }));

--- a/crd-annotations/pom.xml
+++ b/crd-annotations/pom.xml
@@ -11,6 +11,11 @@
 
     <artifactId>crd-annotations</artifactId>
 
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -17,6 +17,11 @@
     </license>
   </licenses>
 
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.strimzi</groupId>

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -66,17 +66,17 @@ run `brew install bash` to install a compatible version of `bash`. If you wish t
 updated bash run `sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'` and `chsh -s /usr/local/bin/bash`
 
 The `mvn` tool might install the latest version of OpenJDK during the brew install. For builds on macOS to succeed,
-OpenJDK version 11 needs to be installed. This can be done by running `brew install openjdk@11`. For maven to read the
+OpenJDK version 17 needs to be installed. This can be done by running `brew install openjdk@17`. For maven to read the
 new Java version, you will need to edit the `~/.mavenrc` file and paste the following
-line `export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-11.jdk/Contents/Home`.
+line `export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home`.
 
 You may come across an issue of linking from the above step. To solve this run this command: 
-`sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk`.
+`sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk`.
 If this throws an error that it cannot find the file or directory, navigate into `/Library/Java/` (or however deep you
-can) and create a new folder named `JavaVirtualMachines` followed by creating a file named `openjdk-11.jdk`. The folder
-structure after everything is said and done should look like `/Library/Java/JavaVirtualMachines/openjdk-11.jdk`. After
+can) and create a new folder named `JavaVirtualMachines` followed by creating a file named `openjdk-17.jdk`. The folder
+structure after everything is said and done should look like `/Library/Java/JavaVirtualMachines/openjdk-17.jdk`. After
 doing that run the command at the beginning again and this should link the file and allow you to use maven with OpenJDK
-version 11.
+version 17.
 
 When running the tests, you may encounter `OpenSSL` related errors for parts that you may not have even worked on, in 
 which case you need to make sure you are using `OpenSSL` and not LibreSSL which comes by default with macOS.
@@ -247,9 +247,9 @@ Commonly used Make targets:
 ### Java versions
 
 To use different Java version for the Maven build, you can specify the environment variable `JAVA_VERSION_BUILD` and set
-it to the desired Java version. For example, for building with Java 11 you can use `export JAVA_VERSION_BUILD=11`.
+it to the desired Java version. For example, for building with Java 17 you can use `export JAVA_VERSION_BUILD=17`.
 
-> *Note*: Strimzi currently developed and tested with Java 11.
+> *Note*: Strimzi currently developed and tested with Java 17.
 
 ### Building Docker images
 
@@ -282,8 +282,8 @@ When building the Docker images you can use an alternative JRE or use an alterna
 #### Alternative Docker image JRE
 
 The docker images can be built with an alternative Java version by setting the environment variable `JAVA_VERSION`. For
-example, to build docker images that have the Java 11 JRE installed use `JAVA_VERSION=11 make docker_build`. If not
-present, the container images will use Java **11** by default.
+example, to build docker images that have the Java 19 JRE installed use `JAVA_VERSION=19 make docker_build`. If not
+present, the container images will use Java **17** by default.
 
 #### Alternative `docker` command
 

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -16,6 +16,11 @@
         </license>
     </licenses>
 
+    <properties>
+        <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <!-- This should be removed once https://github.com/strimzi/strimzi-kafka-operator/issues/7704 is fixed -->
         <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
     </properties>
 

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -890,7 +890,7 @@ public abstract class Ca {
     public boolean certNeedsRenewal(X509Certificate cert)  {
         Instant notAfter = cert.getNotAfter().toInstant();
         Instant renewalPeriodBegin = notAfter.minus(renewalDays, ChronoUnit.DAYS);
-        LOGGER.traceCr(reconciliation, "Certificate {} expires on {} renewal period begins on {}", cert.getSubjectDN(), notAfter, renewalPeriodBegin);
+        LOGGER.traceCr(reconciliation, "Certificate {} expires on {} renewal period begins on {}", cert.getSubjectX500Principal(), notAfter, renewalPeriodBegin);
         return this.clock.instant().isAfter(renewalPeriodBegin);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -273,7 +273,7 @@ public class Util {
 
             int aliasIndex = 0;
             for (X509Certificate certificate : certificates) {
-                trustStore.setEntry(certificate.getSubjectDN().getName() + "-" + aliasIndex, new KeyStore.TrustedCertificateEntry(certificate), null);
+                trustStore.setEntry(certificate.getSubjectX500Principal().getName() + "-" + aliasIndex, new KeyStore.TrustedCertificateEntry(certificate), null);
                 aliasIndex++;
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,18 +71,21 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
+        <!-- Configures if we should fail on warnings when generating Javadocs -->
+        <javadoc.fail.on.warnings>true</javadoc.fail.on.warnings>
 
         <!-- Maven plugin versions -->
-        <maven.compiler.version>3.8.1</maven.compiler.version>
+        <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.surefire.version>3.0.0-M7</maven.surefire.version>
         <maven.failsafe.version>3.0.0-M7</maven.failsafe.version>
-        <maven.assembly.version>3.3.0</maven.assembly.version>
-        <maven.shade.version>3.1.0</maven.shade.version>
-        <maven.javadoc.version>3.1.0</maven.javadoc.version>
+        <maven.assembly.version>3.4.2</maven.assembly.version>
+        <maven.shade.version>3.4.1</maven.shade.version>
+        <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.source.version>3.0.1</maven.source.version>
-        <maven.dependency.version>3.1.1</maven.dependency.version>
+        <maven.dependency.version>3.3.0</maven.dependency.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
@@ -90,14 +93,14 @@
         <sonatype.nexus.staging.version>1.6.3</sonatype.nexus.staging.version>
         <maven.spotbugs.version>4.5.3.0</maven.spotbugs.version>
         <maven.jacoco.version>0.8.8</maven.jacoco.version>
-        <maven.exec.version>1.6.0</maven.exec.version>
+        <maven.exec.version>3.1.0</maven.exec.version>
         <maven.resources.version>3.1.0</maven.resources.version>
 
         <!-- Build tools -->
         <checkstyle.version>9.2.1</checkstyle.version>
         <spotbugs.version>4.7.2</spotbugs.version>
         <sundrio.version>0.91.1</sundrio.version>
-        <lombok.version>1.18.4</lombok.version>
+        <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
         <fabric8.kubernetes-client.version>6.2.0</fabric8.kubernetes-client.version>
@@ -866,16 +869,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven.dependency.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <!-- Override dep to support Java 11,
-                                 can remove this once maven.dependency.version >= 3.1.2
-                                 see https://issues.apache.org/jira/browse/MDEP-613 -->
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>1.11.1</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <execution>
                             <id>copy-dependencies</id>
@@ -1106,6 +1099,8 @@
                                 <ignoredUnusedDeclaredDependency>io.fabric8:openshift-client</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-clients</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-streams</ignoredUnusedDeclaredDependency>
+                                <!-- Used in Kafka Agent through reflection -->
+                                <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-server-common</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
@@ -1126,6 +1121,12 @@
                             <ignoredUsedUndeclaredDependencies>
                                 <ignoredUsedUndeclaredDependency>org.apache.kafka:kafka-raft:jar</ignoredUsedUndeclaredDependency>
                             </ignoredUsedUndeclaredDependencies>
+                            <ignoredNonTestScopedDependencies>
+                                <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
+                                <ignoredNonTestScopedDependency>org.apache.zookeeper:zookeeper-jute</ignoredNonTestScopedDependency>
+                                <ignoredNonTestScopedDependency>io.fabric8:kubernetes-model-coordination</ignoredNonTestScopedDependency>
+                                <ignoredNonTestScopedDependency>io.fabric8:kubernetes-model-common</ignoredNonTestScopedDependency>
+                            </ignoredNonTestScopedDependencies>
                         </configuration>
                     </execution>
                 </executions>
@@ -1157,7 +1158,7 @@
                             <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
                             <show>public</show>
                             <failOnError>true</failOnError>
-                            <failOnWarnings>true</failOnWarnings>
+                            <failOnWarnings>${javadoc.fail.on.warnings}</failOnWarnings>
                         </configuration>
                     </execution>
                 </executions>
@@ -1269,30 +1270,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <id>java-version</id>
-            <activation>
-                <property>
-                    <name>env.JAVA_VERSION_BUILD</name>
-                </property>
-            </activation>
-            <properties>
-                <maven.compiler.source>${env.JAVA_VERSION_BUILD}</maven.compiler.source>
-                <maven.compiler.target>${env.JAVA_VERSION_BUILD}</maven.compiler.target>
-            </properties>
-        </profile>
-        <profile>
-            <id>jdk-11-config</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-                <maven.compiler.source>11</maven.compiler.source>
-                <maven.compiler.target>11</maven.compiler.target>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.valid4j</groupId>
             <artifactId>json-path-matchers</artifactId>
-            <scope>compile</scope>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-storageclass</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -88,6 +89,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-model</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -97,6 +99,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -193,11 +196,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>kafka-oauth-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
@@ -230,6 +228,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-coordination</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -78,6 +78,8 @@ public class SystemTestCertAndKeyBuilder {
         this.keyPair = keyPair;
         this.caCert = caCert;
         if (caCert != null) {
+            // getSubjectDN is deprecated, but BouncyCastle does not seem to work well with getSubjectX500Principal which replaces it
+            // The fix for this issue is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/7698
             this.issuer = new X500Name(caCert.getCertificate().getSubjectDN().getName());
         }
         this.extensions = new ArrayList<>(extensions);

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,6 +11,11 @@
 
     <artifactId>test</artifactId>
 
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -17,6 +17,11 @@
         </license>
     </licenses>
 
+    <properties>
+        <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -111,6 +116,7 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-common</artifactId>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
+        <!-- This should be removed once https://github.com/strimzi/strimzi-kafka-operator/issues/7703 is fixed -->
         <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
     </properties>
 


### PR DESCRIPTION
### Type of change

- Task

### Description

The PR #7624 moved Strimzi operators to Java 17 as the runtime. This PR moves the Strimzi Operators to Java 17 as a language level as well.

The exception to this are the following modules - `api`, `test`, `crd-generator` and `crd-annotations` which stay on the Java 11 language level. The reason for that is that the `api` module is a published artifact which we expect users to use and we want it to be still usable in Java 11. The other 3 modules are dependnecies of the `api` module so they need to stay on Java 11 as well.

Java 17 also does a much more strict validation of the JavaDocs. When configured to raise warnings as errors, it requires Javadocs for all public classes, methods or fields. The PR #7664 already fixed Javadocs for most modules. But there are still hundreds of errors in the `api`, `operator-common`, `cluster-operator` and `topic-operator` modules.  This PR for the time being disables the raising of warnings as errors for the time being. We should try to fix the Javadocs for `operator-common`, `cluster-operator` and `topic-operator` in the future. But I would suggest to keep this disabled for `api` permanently. The `api` classes are mostly getters and setters without any real functionality. Documenting all of them will not add much value but will be a lot of effort. In addition, the missing comments are also on the generated classes where we cannot add the comments easily but we want to have them in the Javadocs as well.

This PR also updates the Azure pipelines to use Java 17 and updates various Maven plugins to make them compatible with Java 17.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md