### PR TITLE
Update SnakeYAML to 1.33

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
@@ -348,12 +348,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
+        <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once jackson-dataformat-yaml uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
+            <version>1.33</version>
         </dependency>
         <!-- EnvVar Configuration Provider for Apache Kafka -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -384,12 +384,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
+        <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once jackson-dataformat-yaml uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
+            <version>1.33</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -32,12 +32,12 @@
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
         </dependency>
-        <!-- This is used to override CVE-2022-25857 => should be removed once swagger uses it out of the box -->
+        <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once swagger uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
+            <version>1.33</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,9 @@
         <fasterxml.jackson-databind.version>2.13.4.1</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.13.4</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.13.4</fasterxml.jackson-annotations.version>
-        <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
+        <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once jackson-dataformat-yaml uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
-        <snakeyaml.version>1.32</snakeyaml.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
         <vertx.version>4.3.5</vertx.version>
         <vertx-junit5.version>4.3.5</vertx-junit5.version>
         <kafka.version>3.3.1</kafka.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates SnakeYAML to 1.33 to address the dependabot reports.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally