### PR TITLE
Allow ClusterIP listeners to configure host

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -187,7 +187,7 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that useServiceDnsDomain is used only with internal type listener
+     * Validates that useServiceDnsDomain is used only with internal or cluster-ip type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
@@ -307,15 +307,15 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that bootstrap.host is used only with Route or Ingress type listener
+     * Validates that bootstrap.host is used only with ClusterIP, Ingress or Route type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
      */
     private static void validateBootstrapHost(Set<String> errors, GenericKafkaListener listener) {
-        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()))
+        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()) && !KafkaListenerType.CLUSTER_IP.equals(listener.getType()))
                 && listener.getConfiguration().getBootstrap().getHost() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure bootstrap.host because it is not Route ot Ingress based listener");
+            errors.add("listener " + listener.getName() + " cannot configure bootstrap.host because it is not ClusterIP, Ingress or Route based listener");
         }
     }
 
@@ -347,8 +347,8 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that bootstrap.annotations and bootstrap.labels are used only with LoadBalancer, NodePort, Route, or
-     * Ingress type listener
+     * Validates that bootstrap.annotations and bootstrap.labels are used only with LoadBalancer, NodePort, Route,
+     * Ingress, or ClusterIP type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
@@ -372,16 +372,16 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that brokers[].host is used only with Route or Ingress type listener
+     * Validates that brokers[].host is used only with ClusterIP, Ingress or Route type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
      * @param broker    Broker configuration which needs to be validated
      */
     private static void validateBrokerHost(Set<String> errors, GenericKafkaListener listener, GenericKafkaListenerConfigurationBroker broker) {
-        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()))
+        if ((!KafkaListenerType.ROUTE.equals(listener.getType()) && !KafkaListenerType.INGRESS.equals(listener.getType()) && !KafkaListenerType.CLUSTER_IP.equals(listener.getType()))
                 && broker.getHost() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure brokers[].host because it is not Route ot Ingress based listener");
+            errors.add("listener " + listener.getName() + " cannot configure brokers[].host because it is not ClusterIP, Ingress or Route based listener");
         }
     }
 
@@ -415,8 +415,8 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that brokers[].annotations and brokers[].labels are used only with LoadBalancer, NodePort, Route or
-     * Ingress type listener
+     * Validates that brokers[].annotations and brokers[].labels are used only with LoadBalancer, NodePort, Route,
+     * Ingress, or ClusterIP type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -261,12 +261,12 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.host because it is not ClusterIP, Ingress or Route based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
                 "listener " + name + " cannot configure bootstrap.labels because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not ClusterIP, Ingress or Route based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
@@ -329,8 +329,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener"
+                "listener " + name + " cannot configure bootstrap.host because it is not ClusterIP, Ingress or Route based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not ClusterIP, Ingress or Route based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -408,9 +408,9 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
+                "listener " + name + " cannot configure bootstrap.host because it is not ClusterIP, Ingress or Route based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not ClusterIP, Ingress or Route based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener"
         );
 
@@ -748,8 +748,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
-                "listener " + name + " cannot configure bootstrap.host because it is not Route ot Ingress based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route ot Ingress based listener"
+                "listener " + name + " cannot configure bootstrap.host because it is not ClusterIP, Ingress or Route based listener",
+                "listener " + name + " cannot configure brokers[].host because it is not ClusterIP, Ingress or Route based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), containsInAnyOrder(expectedErrors.toArray()));


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

With the merge of #7365, one can manually expose Kafka in one's preferred way.

When manually configuring ingress TCP configurations, e.g., with Traefik's IngressRouteTCP CRD, one will get confronted with a `No subject alternative DNS name matching` error message.

To fix this, one would have to be able to configure the bootstrap's and brokers' host names, yet this currently is only possible for `Ingress` or `Route` listeners.

(I've also fixed a typo in the error message changing `ot` to `or.`)

### Checklist

- [X] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [X] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

