### PR TITLE
Update Config Providers to 1.1.0

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.3/pom.xml
@@ -21,8 +21,8 @@
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.2.x/pom.xml
@@ -21,8 +21,8 @@
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -21,8 +21,8 @@
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
@@ -340,6 +340,20 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-kubernetes-config-provider</artifactId>
             <version>${kafka-kubernetes-config-provider.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kubernetes Config Provider and Env Var Config Provider to their new release 1.1.0 which brings Java 17 support and dependency updates.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally