### PR TITLE
docs(bridge): Updates the procedure to expose the Kafka Bridge service

### DIFF
--- a/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
+++ b/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
@@ -21,7 +21,7 @@ kubectl get pods -o name
 pod/kafka-consumer
 # ...
 pod/my-bridge-bridge-7cbd55496b-nclrt
-pod/my-cluster-operator-<version>-5886bccd9c-4nsxc
+pod/strimzi-cluster-operator-<version>-5886bccd9c-4nsxc
 ----
 
 . Connect to the Kafka Bridge pod on port `8080`:

--- a/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
+++ b/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// assembly-kafka-bridge-quickstart.adoc
+// assembly-deploy-kafka-bridge.adoc
 
 [id='proc-exposing-kafka-bridge-service-local-machine-{context}']
 = Exposing the Kafka Bridge service to your local machine
@@ -20,15 +20,15 @@ kubectl get pods -o name
 
 pod/kafka-consumer
 # ...
-pod/quickstart-bridge-589d78784d-9jcnr
-pod/strimzi-cluster-operator-76bcf9bc76-8dnfm
+pod/my-bridge-bridge-7cbd55496b-nclrt
+pod/my-cluster-operator-<version>-5886bccd9c-4nsxc
 ----
 
 . Connect to the Kafka Bridge pod on port `8080`:
 +
 [source,shell,subs=attributes+]
 ----
-kubectl port-forward pod/quickstart-bridge-589d78784d-9jcnr 8080:8080 &
+kubectl port-forward pod/my-bridge-bridge-7cbd55496b-nclrt 8080:8080 &
 ----
 +
 NOTE: If port 8080 on your local machine is already in use, use an alternative HTTP port, such as `8008`.

--- a/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
+++ b/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
@@ -21,7 +21,6 @@ kubectl get pods -o name
 pod/kafka-consumer
 # ...
 pod/my-bridge-bridge-7cbd55496b-nclrt
-pod/strimzi-cluster-operator-<version>-5886bccd9c-4nsxc
 ----
 
 . Connect to the Kafka Bridge pod on port `8080`:


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates [Exposing the Kafka Bridge service to your local machine](https://strimzi.io/docs/operators/in-development/deploying.html#proc-exposing-kafka-bridge-service-local-machine-str) in the _) Deploying guide.
Change to pod names 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

