### PR TITLE
Use special disabled operators when some functionality is disabled

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -22,6 +22,8 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.user.operator.DisabledScramCredentialsOperator;
+import io.strimzi.operator.user.operator.DisabledSimpleAclOperator;
 import io.strimzi.operator.user.operator.KafkaUserOperator;
 import io.strimzi.operator.user.operator.QuotasOperator;
 import io.strimzi.operator.user.operator.ScramCredentialsOperator;
@@ -72,9 +74,9 @@ public class Main {
                 config,
                 client,
                 new OpenSslCertManager(),
-                new ScramCredentialsOperator(adminClient, config),
+                config.isKraftEnabled() ? new DisabledScramCredentialsOperator() : new ScramCredentialsOperator(adminClient, config),
                 new QuotasOperator(adminClient, config),
-                new SimpleAclOperator(adminClient, config)
+                config.isAclsAdminApiSupported() ? new SimpleAclOperator(adminClient, config) : new DisabledSimpleAclOperator()
         );
 
         MetricsProvider metricsProvider = createMetricsProvider();

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
@@ -12,32 +12,25 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Abstract operator using the Kafka Admin API
+ * Interface for operators using the Kafka Admin API
  */
-public abstract class AbstractAdminApiOperator<T, S extends Collection<String>> {
-    /**
-     * Constructor
-     */
-    public AbstractAdminApiOperator()  {
-        // Nothing to do
-    }
-
+public interface AdminApiOperator<T, S extends Collection<String>> {
     /**
      * Reconcile using Kafka Admin API
      *
      * @param reconciliation The reconciliation
-     * @param username  User name of the reconciled user. When using TLS client auth, the username should be already in the Kafka format, e.g. CN=my-user
+     * @param username  Username of the reconciled user. When using TLS client auth, the username should be already in the Kafka format, e.g. CN=my-user
      * @param desired   The desired object
      * @return the Future with reconcile result
      */
-    public abstract CompletionStage<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String username, T desired);
+    CompletionStage<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String username, T desired);
 
     /**
      * Returns set with all usernames which have some value set right now
      *
      * @return The set with all usernames which have some value set right now
      */
-    public abstract CompletionStage<S> getAllUsers();
+    CompletionStage<S> getAllUsers();
 
     /**
      * Class used to pass the reconciliation results
@@ -45,7 +38,7 @@ public abstract class AbstractAdminApiOperator<T, S extends Collection<String>> 
      * @param <T>   Request type (type of the desired resource)
      * @param <R>   Response type (type of the repsonse)
      */
-    public static class ReconcileRequest<T, R>    {
+    class ReconcileRequest<T, R>    {
         /**
          * Reconciliation marker
          */

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledScramCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledScramCredentialsOperator.java
@@ -8,6 +8,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -27,11 +28,11 @@ public class DisabledScramCredentialsOperator implements AdminApiOperator<String
 
     @Override
     public CompletionStage<ReconcileResult<String>> reconcile(Reconciliation reconciliation, String username, String desired) {
-        throw new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to reconcile users");
+        return CompletableFuture.failedFuture(new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to reconcile users"));
     }
 
     @Override
     public CompletionStage<List<String>> getAllUsers() {
-        throw new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to get list of all users");
+        return CompletableFuture.failedFuture(new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to get list of all users"));
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledScramCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledScramCredentialsOperator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.operator;
+
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * DisabledScramCredentialsOperator is used when the use of SCRAM-SHA users is not allowed. It does not provide any
+ * functionality and throws UnsupportedOperationException exception when used. The logic in KafkaUserOperator class
+ * should make sure it is never called, but having this special implementation makes sure we do not need to keep around
+ * the proper ScramCredentialsOperator with its cache and batch reconciler etc. And in case it is somewhere called by
+ * mistake, the unsupported exceptions make it easier to detect it.
+ */
+public class DisabledScramCredentialsOperator implements AdminApiOperator<String, List<String>> {
+    /**
+     * Constructor
+     */
+    public DisabledScramCredentialsOperator() {
+        // Nothing to do here => the DisabledScramCredentialsOperator just throws unsupported exceptions
+    }
+
+    @Override
+    public CompletionStage<ReconcileResult<String>> reconcile(Reconciliation reconciliation, String username, String desired) {
+        throw new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to reconcile users");
+    }
+
+    @Override
+    public CompletionStage<List<String>> getAllUsers() {
+        throw new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to get list of all users");
+    }
+}

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledSimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledSimpleAclOperator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.user.operator;
+
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.user.model.acl.SimpleAclRule;
+
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * DisabledSimpleAclOperator is used when the management of ACL rules is not allowed. It does not provide any
+ * functionality and throws UnsupportedOperationException exception when used. The logic in KafkaUserOperator class
+ * should make sure it is never called, but having this special implementation makes sure we do not need to keep around
+ * the proper SimpleAclOperator with its cache and batch reconciler etc. And in case it is somewhere called by mistake,
+ * the unsupported exceptions make it easier to detect it.
+ */
+public class DisabledSimpleAclOperator implements AdminApiOperator<Set<SimpleAclRule>, Set<String>> {
+    /**
+     * Constructor
+     */
+    public DisabledSimpleAclOperator() {
+        // Nothing to do here => the DisabledSimpleAclOperator just throws unsupported exceptions
+    }
+
+    @Override
+    public CompletionStage<ReconcileResult<Set<SimpleAclRule>>> reconcile(Reconciliation reconciliation, String username, Set<SimpleAclRule> desired) {
+        throw new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to reconcile users");
+    }
+
+    @Override
+    public CompletionStage<Set<String>> getAllUsers() {
+        throw new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to get list of all users");
+    }
+}

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledSimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledSimpleAclOperator.java
@@ -9,6 +9,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.user.model.acl.SimpleAclRule;
 
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -28,11 +29,11 @@ public class DisabledSimpleAclOperator implements AdminApiOperator<Set<SimpleAcl
 
     @Override
     public CompletionStage<ReconcileResult<Set<SimpleAclRule>>> reconcile(Reconciliation reconciliation, String username, Set<SimpleAclRule> desired) {
-        throw new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to reconcile users");
+        return CompletableFuture.failedFuture(new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to reconcile users"));
     }
 
     @Override
     public CompletionStage<Set<String>> getAllUsers() {
-        throw new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to get list of all users");
+        return CompletableFuture.failedFuture(new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to get list of all users"));
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -44,9 +44,9 @@ public class KafkaUserOperator {
 
     private final CertManager certManager;
     private final KubernetesClient client;
-    private final SimpleAclOperator aclOperations;
-    private final ScramCredentialsOperator scramCredentialsOperator;
-    private final QuotasOperator quotasOperator;
+    private final AdminApiOperator<Set<SimpleAclRule>, Set<String>> aclOperations;
+    private final AdminApiOperator<String, List<String>> scramCredentialsOperator;
+    private final AdminApiOperator<KafkaUserQuotas, Set<String>> quotasOperator;
     private final UserOperatorConfig config;
     private final PasswordGenerator passwordGenerator;
     private final LabelSelector selector;
@@ -65,9 +65,9 @@ public class KafkaUserOperator {
             UserOperatorConfig config,
             KubernetesClient client,
             CertManager certManager,
-            ScramCredentialsOperator scramCredentialsOperator,
-            QuotasOperator quotasOperator,
-            SimpleAclOperator aclOperations
+            AdminApiOperator<String, List<String>> scramCredentialsOperator,
+            AdminApiOperator<KafkaUserQuotas, Set<String>> quotasOperator,
+            AdminApiOperator<Set<SimpleAclRule>, Set<String>> aclOperations
     ) {
         this.certManager = certManager;
         this.client = client;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletionStage;
 /**
  * KafkaUserQuotasOperator is responsible for managing quotas in Apache Kafka
  */
-public class QuotasOperator extends AbstractAdminApiOperator<KafkaUserQuotas, Set<String>> {
+public class QuotasOperator implements AdminApiOperator<KafkaUserQuotas, Set<String>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(QuotasOperator.class.getName());
 
     private final QuotasBatchReconciler patchReconciler;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramCredentialsOperator.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletionStage;
 /**
  * ScramCredentialsOperator is responsible for managing the SCRAM-SHA credentials in Apache Kafka.
  */
-public class ScramCredentialsOperator extends AbstractAdminApiOperator<String, List<String>> {
+public class ScramCredentialsOperator implements AdminApiOperator<String, List<String>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ScramCredentialsOperator.class.getName());
     private final static int ITERATIONS = 4096;
     private final static ScramMechanism SCRAM_MECHANISM = ScramMechanism.SCRAM_SHA_512;
@@ -53,11 +53,9 @@ public class ScramCredentialsOperator extends AbstractAdminApiOperator<String, L
         // Create micro-batching reconciler for updating the SCRAM-SHA credentials
         this.patchReconciler = new ScramShaCredentialsBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
 
-        if (!config.isKraftEnabled()) {
-            // Start the cache and reconcilers => we start them only outside of KRaft where SCRAM-SHA is not supported
-            this.cache.start();
-            this.patchReconciler.start();
-        }
+        // Start the cache and reconcilers
+        this.cache.start();
+        this.patchReconciler.start();
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletionStage;
 /**
  * SimpleAclOperator is responsible for managing the authorization rules in Apache Kafka.
  */
-public class SimpleAclOperator extends AbstractAdminApiOperator<Set<SimpleAclRule>, Set<String>> {
+public class SimpleAclOperator implements AdminApiOperator<Set<SimpleAclRule>, Set<String>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(SimpleAclOperator.class.getName());
     private static final List<String> IGNORED_USERS = Arrays.asList("*", "ANONYMOUS");
 
@@ -54,12 +54,10 @@ public class SimpleAclOperator extends AbstractAdminApiOperator<Set<SimpleAclRul
         this.addReconciler = new AddAclsBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
         this.deleteReconciler = new DeleteAclsBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
 
-        if (config.isAclsAdminApiSupported()) {
-            // Start the cache and reconcilers => We start them only if ACLs Admin APIs are enabled
-            this.cache.start();
-            this.addReconciler.start();
-            this.deleteReconciler.start();
-        }
+        // Start the cache and reconcilers
+        this.cache.start();
+        this.addReconciler.start();
+        this.deleteReconciler.start();
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/AddAclsBatchReconciler.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/AddAclsBatchReconciler.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateAclsResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Micro-batching reconciler for creating new ACL rules using the Kafka Admin API.
  */
-public class AddAclsBatchReconciler extends AbstractBatchReconciler<AbstractAdminApiOperator.ReconcileRequest<Collection<AclBinding>, ReconcileResult<Collection<AclBinding>>>> {
+public class AddAclsBatchReconciler extends AbstractBatchReconciler<AdminApiOperator.ReconcileRequest<Collection<AclBinding>, ReconcileResult<Collection<AclBinding>>>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AddAclsBatchReconciler.class);
 
     private final Admin adminClient;
@@ -45,7 +45,7 @@ public class AddAclsBatchReconciler extends AbstractBatchReconciler<AbstractAdmi
      * @param items Batch of requests which should be executed
      */
     @Override
-    protected void reconcile(Collection<AbstractAdminApiOperator.ReconcileRequest<Collection<AclBinding>, ReconcileResult<Collection<AclBinding>>>> items) {
+    protected void reconcile(Collection<AdminApiOperator.ReconcileRequest<Collection<AclBinding>, ReconcileResult<Collection<AclBinding>>>> items) {
         List<AclBinding> aclBindings = new ArrayList<>();
         items.forEach(req -> aclBindings.addAll(req.desired));
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/DeleteAclsBatchReconciler.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/DeleteAclsBatchReconciler.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteAclsResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Micro-batching reconciler for deleting ACL rules using the Kafka Admin API.
  */
-public class DeleteAclsBatchReconciler extends AbstractBatchReconciler<AbstractAdminApiOperator.ReconcileRequest<Collection<AclBindingFilter>, ReconcileResult<Collection<AclBindingFilter>>>> {
+public class DeleteAclsBatchReconciler extends AbstractBatchReconciler<AdminApiOperator.ReconcileRequest<Collection<AclBindingFilter>, ReconcileResult<Collection<AclBindingFilter>>>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(DeleteAclsBatchReconciler.class);
 
     private final Admin adminClient;
@@ -45,7 +45,7 @@ public class DeleteAclsBatchReconciler extends AbstractBatchReconciler<AbstractA
      * @param items Batch of requests which should be executed
      */
     @Override
-    protected void reconcile(Collection<AbstractAdminApiOperator.ReconcileRequest<Collection<AclBindingFilter>, ReconcileResult<Collection<AclBindingFilter>>>> items) {
+    protected void reconcile(Collection<AdminApiOperator.ReconcileRequest<Collection<AclBindingFilter>, ReconcileResult<Collection<AclBindingFilter>>>> items) {
         List<AclBindingFilter> aclFilters = new ArrayList<>();
         items.forEach(req -> aclFilters.addAll(req.desired));
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/QuotasBatchReconciler.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/QuotasBatchReconciler.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterClientQuotasResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -21,7 +21,7 @@ import java.util.Map;
 /**
  * Micro-batching reconciler for patching Kafka quotas using the Kafka Admin API.
  */
-public class QuotasBatchReconciler extends AbstractBatchReconciler<AbstractAdminApiOperator.ReconcileRequest<ClientQuotaAlteration, ReconcileResult<ClientQuotaAlteration>>> {
+public class QuotasBatchReconciler extends AbstractBatchReconciler<AdminApiOperator.ReconcileRequest<ClientQuotaAlteration, ReconcileResult<ClientQuotaAlteration>>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(QuotasBatchReconciler.class);
 
     private final Admin adminClient;
@@ -45,7 +45,7 @@ public class QuotasBatchReconciler extends AbstractBatchReconciler<AbstractAdmin
      * @param items Batch of requests which should be executed
      */
     @Override
-    protected void reconcile(Collection<AbstractAdminApiOperator.ReconcileRequest<ClientQuotaAlteration, ReconcileResult<ClientQuotaAlteration>>> items) {
+    protected void reconcile(Collection<AdminApiOperator.ReconcileRequest<ClientQuotaAlteration, ReconcileResult<ClientQuotaAlteration>>> items) {
         List<ClientQuotaAlteration> quotas = new ArrayList<>();
         items.forEach(req -> quotas.add(req.desired));
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/ScramShaCredentialsBatchReconciler.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/ScramShaCredentialsBatchReconciler.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterUserScramCredentialsResult;
 import org.apache.kafka.clients.admin.UserScramCredentialAlteration;
@@ -22,7 +22,7 @@ import java.util.Map;
 /**
  * Micro-batching reconciler for patching SCRAM-SHA credentials using the Kafka Admin API.
  */
-public class ScramShaCredentialsBatchReconciler extends AbstractBatchReconciler<AbstractAdminApiOperator.ReconcileRequest<UserScramCredentialAlteration, ReconcileResult<UserScramCredentialAlteration>>> {
+public class ScramShaCredentialsBatchReconciler extends AbstractBatchReconciler<AdminApiOperator.ReconcileRequest<UserScramCredentialAlteration, ReconcileResult<UserScramCredentialAlteration>>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ScramShaCredentialsBatchReconciler.class);
 
     private final Admin adminClient;
@@ -46,7 +46,7 @@ public class ScramShaCredentialsBatchReconciler extends AbstractBatchReconciler<
      * @param items Batch of requests which should be executed
      */
     @Override
-    protected void reconcile(Collection<AbstractAdminApiOperator.ReconcileRequest<UserScramCredentialAlteration, ReconcileResult<UserScramCredentialAlteration>>> items) {
+    protected void reconcile(Collection<AdminApiOperator.ReconcileRequest<UserScramCredentialAlteration, ReconcileResult<UserScramCredentialAlteration>>> items) {
         List<UserScramCredentialAlteration> alterations = new ArrayList<>();
         items.forEach(req -> alterations.add(req.desired));
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/AdminApiOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/AdminApiOperatorIT.java
@@ -30,8 +30,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 @Timeout(10)
-public abstract class AbstractAdminApiOperatorIT<T, S extends Collection<String>> {
-    protected static final Logger LOGGER = LogManager.getLogger(AbstractAdminApiOperatorIT.class);
+public abstract class AdminApiOperatorIT<T, S extends Collection<String>> {
+    protected static final Logger LOGGER = LogManager.getLogger(AdminApiOperatorIT.class);
 
     public static final String SCRAM_USERNAME = "my-user";
     public static final String TLS_USERNAME = "CN=my-user";
@@ -63,7 +63,7 @@ public abstract class AbstractAdminApiOperatorIT<T, S extends Collection<String>
         kafkaContainer.stop();
     }
 
-    abstract AbstractAdminApiOperator<T, S> operator();
+    abstract AdminApiOperator<T, S> operator();
     abstract T getOriginal();
     abstract T getModified();
     abstract T get(String username);
@@ -112,7 +112,7 @@ public abstract class AbstractAdminApiOperatorIT<T, S extends Collection<String>
      * @param username   Username
      */
     public void testCreateModifyDelete(String username) throws ExecutionException, InterruptedException {
-        AbstractAdminApiOperator<T, S> op = operator();
+        AdminApiOperator<T, S> op = operator();
 
         T newResource = getOriginal();
         T modResource = getModified();

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorIT.java
@@ -19,9 +19,9 @@ import java.util.concurrent.ExecutionException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class QuotasOperatorIT extends AbstractAdminApiOperatorIT<KafkaUserQuotas, Set<String>> {
+public class QuotasOperatorIT extends AdminApiOperatorIT<KafkaUserQuotas, Set<String>> {
     @Override
-    AbstractAdminApiOperator<KafkaUserQuotas, Set<String>> operator() {
+    AdminApiOperator<KafkaUserQuotas, Set<String>> operator() {
         return new QuotasOperator(adminClient, ResourceUtils.createUserOperatorConfig());
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialsOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialsOperatorIT.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-public class ScramCredentialsOperatorIT extends AbstractAdminApiOperatorIT<String, List<String>> {
+public class ScramCredentialsOperatorIT extends AdminApiOperatorIT<String, List<String>> {
     protected boolean createPatches = true;
 
     @Override
-    AbstractAdminApiOperator<String, List<String>> operator() {
+    AdminApiOperator<String, List<String>> operator() {
         return new ScramCredentialsOperator(adminClient, ResourceUtils.createUserOperatorConfig());
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -26,9 +26,9 @@ import java.util.concurrent.ExecutionException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-public class SimpleAclOperatorIT extends AbstractAdminApiOperatorIT<Set<SimpleAclRule>, Set<String>> {
+public class SimpleAclOperatorIT extends AdminApiOperatorIT<Set<SimpleAclRule>, Set<String>> {
     @Override
-    AbstractAdminApiOperator<Set<SimpleAclRule>, Set<String>> operator() {
+    AdminApiOperator<Set<SimpleAclRule>, Set<String>> operator() {
         return new SimpleAclOperator(adminClient, ResourceUtils.createUserOperatorConfig());
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/AddAclsBatchReconcilerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/AddAclsBatchReconcilerTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateAclsResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -87,13 +87,13 @@ public class AddAclsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
 
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
 
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUser3Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user3", List.of(MY_USER_3_READ), myUser3Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user3", List.of(MY_USER_3_READ), myUser3Future));
 
             // Wait for completion
             ReconcileResult<Collection<AclBinding>> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);
@@ -149,10 +149,10 @@ public class AddAclsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
 
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
 
             // Wait for completion
             ExecutionException myUserException = assertThrows(ExecutionException.class, () -> myUserFuture.get(1_000, TimeUnit.MILLISECONDS));
@@ -200,10 +200,10 @@ public class AddAclsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
 
             CompletableFuture<ReconcileResult<Collection<AclBinding>>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
 
             // Wait for completion
             ReconcileResult<Collection<AclBinding>> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/DeleteAclsBatchReconcilerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/DeleteAclsBatchReconcilerTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteAclsResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -87,13 +87,13 @@ public class DeleteAclsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
 
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
 
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUser3Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user3", List.of(MY_USER_3_READ), myUser3Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user3", List.of(MY_USER_3_READ), myUser3Future));
 
             // Wait for completion
             ReconcileResult<Collection<AclBindingFilter>> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);
@@ -143,10 +143,10 @@ public class DeleteAclsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
 
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
 
             // Wait for completion
             ExecutionException myUserException = assertThrows(ExecutionException.class, () -> myUserFuture.get(1_000, TimeUnit.MILLISECONDS));
@@ -194,10 +194,10 @@ public class DeleteAclsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", List.of(MY_USER_READ, MY_USER_WRITE), myUserFuture));
 
             CompletableFuture<ReconcileResult<Collection<AclBindingFilter>>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", List.of(MY_USER_2_READ, MY_USER_2_WRITE), myUser2Future));
 
             // Wait for completion
             ReconcileResult<Collection<AclBindingFilter>> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/QuotasBatchReconcilerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/QuotasBatchReconcilerTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterClientQuotasResult;
 import org.apache.kafka.common.KafkaFuture;
@@ -72,10 +72,10 @@ public class QuotasBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<ClientQuotaAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_ALTERATION, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_ALTERATION, myUserFuture));
 
             CompletableFuture<ReconcileResult<ClientQuotaAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2_ALTERATION, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2_ALTERATION, myUser2Future));
 
             // Wait for completion
             ReconcileResult<ClientQuotaAlteration> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);
@@ -123,10 +123,10 @@ public class QuotasBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<ClientQuotaAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_ALTERATION, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_ALTERATION, myUserFuture));
 
             CompletableFuture<ReconcileResult<ClientQuotaAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2_ALTERATION, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2_ALTERATION, myUser2Future));
 
             // Wait for completion
             ExecutionException myUserException = assertThrows(ExecutionException.class, () -> myUserFuture.get(1_000, TimeUnit.MILLISECONDS));
@@ -171,10 +171,10 @@ public class QuotasBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<ClientQuotaAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_ALTERATION, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_ALTERATION, myUserFuture));
 
             CompletableFuture<ReconcileResult<ClientQuotaAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2_ALTERATION, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2_ALTERATION, myUser2Future));
 
             // Wait for completion
             ReconcileResult<ClientQuotaAlteration> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/ScramShaCredentialsBatchReconcilerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/batching/ScramShaCredentialsBatchReconcilerTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.user.operator.batching;
 
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
-import io.strimzi.operator.user.operator.AbstractAdminApiOperator;
+import io.strimzi.operator.user.operator.AdminApiOperator;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterUserScramCredentialsResult;
 import org.apache.kafka.clients.admin.ScramCredentialInfo;
@@ -66,10 +66,10 @@ public class ScramShaCredentialsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
 
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
 
             // Wait for completion
             ReconcileResult<UserScramCredentialAlteration> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);
@@ -117,10 +117,10 @@ public class ScramShaCredentialsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
 
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
 
             // Wait for completion
             ExecutionException myUserException = assertThrows(ExecutionException.class, () -> myUserFuture.get(1_000, TimeUnit.MILLISECONDS));
@@ -165,10 +165,10 @@ public class ScramShaCredentialsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
 
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
 
             // Wait for completion
             ReconcileResult<UserScramCredentialAlteration> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);
@@ -216,10 +216,10 @@ public class ScramShaCredentialsBatchReconcilerTest {
         try {
             // Enqueue reconciliations
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUserFuture = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user", MY_USER_1, myUserFuture));
 
             CompletableFuture<ReconcileResult<UserScramCredentialAlteration>> myUser2Future = new CompletableFuture<>();
-            reconciler.enqueue(new AbstractAdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
+            reconciler.enqueue(new AdminApiOperator.ReconcileRequest<>(Reconciliation.DUMMY_RECONCILIATION, "my-user2", MY_USER_2, myUser2Future));
 
             // Wait for completion
             ReconcileResult<UserScramCredentialAlteration> myUserResult = myUserFuture.get(1_000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Today - in the User Operator - it is possible that some features are disabled. This includes:
* ACL management is disabled when authorization is disabled in the KAfka cluster or when _incompatible_ authorizer is used which does not support the Kafka Admin APi for managing ACLs
* SCRAM-SHA credentials management is disabled in KRaft mode which currently doesn't support SCRAM-SHA authentication

Right now, when these features are disabled, it is handled in the following way:
* The `KafkaUser` custom resources are validated to not use the disabled features and are rejected rigth away if they do
* All calls to the disabled operations are only conditional and are not executed when the feature is disabled. This is needed because for example even if KafkaUser does not specify any ACL rules, we normally check that the user doesn't have any ACL rules set.

Despite this, we create the `ScramCredentialsOperator` and `SimpleAclOperator` as we do when the feature is enabled. They create the Cache and the Batch reconciler, but do not starts them. So they are nto running, but they exist and use some memory.

This PR creates new `DisabledSimpleAclOperator` and `DisabledScramCredentialsOperator` classes. These classes do not have any logic and when any of the methods in them is called they throw `UnsupportedOperationException` error. When the SCRAM-SHA or ACLs are not supported, these classes are created instead of the `ScramCredentialsOperator` and `SimpleAclOperator` classes to be more efficient. But it should also help to detect any bugs in the handling of the disabled features because if they are somewhere called by mistake, the exceptions will be visible in the logs.

Other alternative I considered  wasto have these _dummy_ classes always return succeeded futures without doing anything. This might have helped us to eliminate the conditional logic when the operators should or should not be called (see for example [here](https://github.com/strimzi/strimzi-kafka-operator/blob/0c1f7ef79aed58d257421dd430598b16c75acff8/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java#L197-L199)). But it would make it harder to see if they are somewhere called by mistake. So at the end, I decided to implement the solution where they throw the exceptions.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally