### PR TITLE
add log for troubleshooting when init admin client error

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -179,6 +179,7 @@ public class KafkaRoller {
             try {
                 this.allClient = adminClient(IntStream.range(0, podList.size()).boxed().collect(Collectors.toList()), false);
             } catch (ForceableProblem | FatalProblem e) {
+                LOGGER.warnCr(reconciliation, "Failed to create adminClient.", e);
                 return false;
             }
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When initAdminClient got error, we'll force restarting pods. But we didn't log any exception while the error happened, which will be difficult to identify the reason why we didn't successfully create admin client. Log it in this PR when exception thrown.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

