### PR TITLE
Add missing labels to the Logging `ConfigMap` in Helm Chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -4,7 +4,11 @@ metadata:
   name: {{ .Values.logConfigMap }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: strimzi
+    app: {{ template "strimzi.name" . }}
+    chart: {{ template "strimzi.chart" . }}
+    component: logging-config-map
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   log4j2.properties: |
     {{- if .Values.logConfiguration }}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For some reason, the logging Config Map in the Helm Chart has completely diferrent labels than all other resources in the Helm Chart. This PR fixes that and adds the same lbels to the Config Map as well.