### PR TITLE
Add proper startup and shutdown to the Kafka Admin API operators

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -92,8 +92,9 @@ public class Main {
         // Create the health check and metrics server
         HealthCheckAndMetricsServer healthCheckAndMetricsServer = new HealthCheckAndMetricsServer(controller, metricsProvider);
 
-        // Start health check server and the controller
+        // Start health check server, KafkaUser operator and the controller
         healthCheckAndMetricsServer.start();
+        kafkaUserOperator.start();
         controller.start();
 
         // Register shutdown hooks
@@ -101,6 +102,9 @@ public class Main {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             LOGGER.info("Requesting controller to stop");
             controller.stop();
+
+            LOGGER.info("Requesting KafkaUser operator to stop");
+            kafkaUserOperator.stop();
 
             LOGGER.info("Requesting controller to stop");
             healthCheckAndMetricsServer.stop();

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
@@ -33,6 +33,16 @@ public interface AdminApiOperator<T, S extends Collection<String>> {
     CompletionStage<S> getAllUsers();
 
     /**
+     * Starts the API Operator - this is used for example to start the Cache and BatchReconcilers
+     */
+    void start();
+
+    /**
+     * Stops the Admin API Operator - this is used for example to stop the Cache and BatchReconcilers
+     */
+    void stop();
+
+    /**
      * Class used to pass the reconciliation results
      *
      * @param <T>   Request type (type of the desired resource)

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledScramCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledScramCredentialsOperator.java
@@ -35,4 +35,14 @@ public class DisabledScramCredentialsOperator implements AdminApiOperator<String
     public CompletionStage<List<String>> getAllUsers() {
         return CompletableFuture.failedFuture(new UnsupportedOperationException("DisabledScramCredentialsOperator cannot be used to get list of all users"));
     }
+
+    @Override
+    public void start() {
+        // Nothing to do
+    }
+
+    @Override
+    public void stop() {
+        // Nothing to do
+    }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledSimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/DisabledSimpleAclOperator.java
@@ -36,4 +36,14 @@ public class DisabledSimpleAclOperator implements AdminApiOperator<Set<SimpleAcl
     public CompletionStage<Set<String>> getAllUsers() {
         return CompletableFuture.failedFuture(new UnsupportedOperationException("DisabledSimpleAclOperator cannot be used to get list of all users"));
     }
+
+    @Override
+    public void start() {
+        // Nothing to do
+    }
+
+    @Override
+    public void stop() {
+        // Nothing to do
+    }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/QuotasOperator.java
@@ -46,10 +46,6 @@ public class QuotasOperator implements AdminApiOperator<KafkaUserQuotas, Set<Str
 
         // Create micro-batching reconcilers for managing the quotas
         this.patchReconciler = new QuotasBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
-
-        // Start the cache and reconcilers
-        this.cache.start();
-        this.patchReconciler.start();
     }
 
     /**
@@ -88,6 +84,29 @@ public class QuotasOperator implements AdminApiOperator<KafkaUserQuotas, Set<Str
                         }
                     }
                 });
+    }
+
+    /**
+     * Starts the Cache and the patch reconciler
+     */
+    @Override
+    public void start() {
+        cache.start();
+        patchReconciler.start();
+    }
+
+    /**
+     * Stops the Cache and the patch reconciler
+     */
+    @Override
+    public void stop() {
+        cache.stop();
+
+        try {
+            patchReconciler.stop();
+        } catch (InterruptedException e) {
+            LOGGER.warnOp("Interrupted while stopping Quotas PatchReconciler");
+        }
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramCredentialsOperator.java
@@ -52,10 +52,6 @@ public class ScramCredentialsOperator implements AdminApiOperator<String, List<S
 
         // Create micro-batching reconciler for updating the SCRAM-SHA credentials
         this.patchReconciler = new ScramShaCredentialsBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
-
-        // Start the cache and reconcilers
-        this.cache.start();
-        this.patchReconciler.start();
     }
 
     /**
@@ -122,6 +118,30 @@ public class ScramCredentialsOperator implements AdminApiOperator<String, List<S
                     }
                 }
             });
+        }
+    }
+
+
+    /**
+     * Starts the Cache and the patch reconciler
+     */
+    @Override
+    public void start() {
+        cache.start();
+        patchReconciler.start();
+    }
+
+    /**
+     * Stops the Cache and the patch reconciler
+     */
+    @Override
+    public void stop() {
+        cache.stop();
+
+        try {
+            patchReconciler.stop();
+        } catch (InterruptedException e) {
+            LOGGER.warnOp("Interrupted while stopping ScramShaCredentials PatchReconciler");
         }
     }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/SimpleAclOperator.java
@@ -53,11 +53,6 @@ public class SimpleAclOperator implements AdminApiOperator<Set<SimpleAclRule>, S
         // Create micro-batching reconcilers for managing the ACLs
         this.addReconciler = new AddAclsBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
         this.deleteReconciler = new DeleteAclsBatchReconciler(adminClient, config.getBatchQueueSize(), config.getBatchMaxBlockSize(), config.getBatchMaxBlockTime());
-
-        // Start the cache and reconcilers
-        this.cache.start();
-        this.addReconciler.start();
-        this.deleteReconciler.start();
     }
 
     /**
@@ -91,6 +86,37 @@ public class SimpleAclOperator implements AdminApiOperator<Set<SimpleAclRule>, S
                         }
                     }
                 });
+    }
+
+
+    /**
+     * Starts the Cache and the patch reconciler
+     */
+    @Override
+    public void start() {
+        cache.start();
+        addReconciler.start();
+        deleteReconciler.start();
+    }
+
+    /**
+     * Stops the Cache and the patch reconciler
+     */
+    @Override
+    public void stop() {
+        cache.stop();
+
+        try {
+            addReconciler.stop();
+        } catch (InterruptedException e) {
+            LOGGER.warnOp("Interrupted while stopping ACL AddReconciler");
+        }
+
+        try {
+            deleteReconciler.stop();
+        } catch (InterruptedException e) {
+            LOGGER.warnOp("Interrupted while stopping ACL DeleteReconciler");
+        }
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Kafka Admin API operators (part of User Operator) use the Cache and BatchReconciler instances to improve their performance. But currently, they do not have proper management of the lifecycles. They are simply started from the constructor and never stopped. While that works in general, it is not perfect.

This PR improves it by adding proper `start()` and `stop()` methods to them which allow them to be started and stopped. They are called through the `KafkaUserOperator` class which uses them. The `start()` method is called at startup of the operator and the `stop()` method is called from the shutdown hook.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally