### PR TITLE
Use shared executor for async operations using the KAfka Admin API and Kubernetes API

### DIFF
--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -70,25 +70,27 @@ spec:
               value: 10000
             - name: STRIMZI_CONTROLLER_THREAD_POOL_SIZE <8>
               value: 10
-            - name: STRIMZI_LOG_LEVEL <9>
+            - name: STRIMZI_USER_OPERATIONS_THREAD_POOL_SIZE <9>
+              value: 4
+            - name: STRIMZI_LOG_LEVEL <10>
               value: INFO
-            - name: STRIMZI_GC_LOG_ENABLED <10>
+            - name: STRIMZI_GC_LOG_ENABLED <11>
               value: "true"
-            - name: STRIMZI_CA_VALIDITY <11>
+            - name: STRIMZI_CA_VALIDITY <12>
               value: "365"
-            - name: STRIMZI_CA_RENEWAL <12>
+            - name: STRIMZI_CA_RENEWAL <13>
               value: "30"
-            - name: STRIMZI_JAVA_OPTS <13>
+            - name: STRIMZI_JAVA_OPTS <14>
               value: "-Xmx=512M -Xms=256M"
-            - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <14>
+            - name: STRIMZI_JAVA_SYSTEM_PROPERTIES <15>
               value: "-Djavax.net.debug=verbose -DpropertyName=value"
-            - name: STRIMZI_SECRET_PREFIX <15>
+            - name: STRIMZI_SECRET_PREFIX <16>
               value: "kafka-"
-            - name: STRIMZI_ACLS_ADMIN_API_SUPPORTED <16>
+            - name: STRIMZI_ACLS_ADMIN_API_SUPPORTED <17>
               value: "true"
-            - name: STRIMZI_MAINTENANCE_TIME_WINDOWS <17>
+            - name: STRIMZI_MAINTENANCE_TIME_WINDOWS <18>
               value: '* * 8-10 * * ?;* * 14-15 * * ?'
-            - name: STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION <18>
+            - name: STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION <19>
               value: |
                 default.api.timeout.ms=120000
                 request.timeout.ms=60000
@@ -111,23 +113,26 @@ The default is `1024`.
 <8> The size of the worker pool for reconciling the users.
 Bigger pool might require more resources, but it will also handle more `KafkaUser` resources
 The default is `50`.
-<9> The level for printing logging messages.
+<9> The size of the worker pool for Kafka Admin API and Kubernetes operations.
+Bigger pool might require more resources, but it will also handle more `KafkaUser` resources
+The default is `4`.
+<10> The level for printing logging messages.
 You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
-<10> Enables garbage collection (GC) logging.
+<11> Enables garbage collection (GC) logging.
 The default is `true`.
-<11> The validity period for the CA.
+<12> The validity period for the CA.
 The default is `365` days.
-<12> The renewal period for the CA. The renewal period is measured backwards from the expiry date of the current certificate.
+<13> The renewal period for the CA. The renewal period is measured backwards from the expiry date of the current certificate.
 The default is `30` days to initiate certificate renewal before the old certificates expire.
-<13> (Optional) The Java options used by the JVM running the User Operator
-<14> (Optional) The debugging (`-D`) options set for the User Operator
-<15> (Optional) Prefix for the names of Kubernetes secrets created by the User Operator.
-<16> (Optional) Indicates whether the Kafka cluster supports management of authorization ACL rules using the Kafka Admin API.
+<14> (Optional) The Java options used by the JVM running the User Operator
+<15> (Optional) The debugging (`-D`) options set for the User Operator
+<16> (Optional) Prefix for the names of Kubernetes secrets created by the User Operator.
+<17> (Optional) Indicates whether the Kafka cluster supports management of authorization ACL rules using the Kafka Admin API.
 When set to `false`, the User Operator will reject all resources with `simple` authorization ACL rules.
 This helps to avoid unnecessary exceptions in the Kafka cluster logs.
 The default is `true`.
-<17> (Optional) Semi-colon separated list of Cron Expressions defining the maintenance time windows during which the expiring user certificates will be renewed.
-<18> (Optional) Configuration options for configuring the Kafka Admin client used by the User Operator in the properties format.
+<18> (Optional) Semi-colon separated list of Cron Expressions defining the maintenance time windows during which the expiring user certificates will be renewed.
+<19> (Optional) Configuration options for configuring the Kafka Admin client used by the User Operator in the properties format.
 
 . If you are using mTLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.
 Otherwise, go to the next step.

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import java.security.Security;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The main class of the Strimzi User Operator
@@ -72,7 +73,8 @@ public class Main {
         UserOperatorConfig config = UserOperatorConfig.fromMap(System.getenv());
         KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-user-operator", Main.class.getPackage().getImplementationVersion()).build();
         Admin adminClient = createAdminClient(config, client, new DefaultAdminClientProvider());
-        ExecutorService kafkaUserOperatorExecutor = Executors.newFixedThreadPool(config.getUserOperationsThreadPoolSize(), r -> new Thread(r, "operator-thread-pool"));
+        AtomicInteger kafkaUserOperatorExecutorThreadCounter = new AtomicInteger(0);
+        ExecutorService kafkaUserOperatorExecutor = Executors.newFixedThreadPool(config.getUserOperationsThreadPoolSize(), r -> new Thread(r, "operator-thread-pool-" + kafkaUserOperatorExecutorThreadCounter.getAndIncrement()));
         KafkaUserOperator kafkaUserOperator = new KafkaUserOperator(
                 config,
                 client,

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -44,6 +44,7 @@ public class UserOperatorConfig {
     static final String STRIMZI_BATCH_QUEUE_SIZE = "STRIMZI_BATCH_QUEUE_SIZE";
     static final String STRIMZI_BATCH_MAXIMUM_BLOCK_SIZE = "STRIMZI_BATCH_MAXIMUM_BLOCK_SIZE";
     static final String STRIMZI_BATCH_MAXIMUM_BLOCK_TIME_MS = "STRIMZI_BATCH_MAXIMUM_BLOCK_TIME_MS";
+    static final String STRIMZI_USER_OPERATIONS_THREAD_POOL_SIZE = "STRIMZI_USER_OPERATIONS_THREAD_POOL_SIZE";
 
     // Default values
     static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
@@ -66,6 +67,7 @@ public class UserOperatorConfig {
     static final int DEFAULT_BATCH_QUEUE_SIZE = 1024;
     static final int DEFAULT_BATCH_MAXIMUM_BLOCK_SIZE = 100;
     static final int DEFAULT_BATCH_MAXIMUM_BLOCK_TIME_MS = 100;
+    static final int DEFAULT_USER_OPERATIONS_THREAD_POOL_SIZE = 4;
 
     private final String namespace;
     private final long reconciliationIntervalMs;
@@ -91,6 +93,7 @@ public class UserOperatorConfig {
     private final int batchQueueSize;
     private final int batchMaxBlockSize;
     private final int batchMaxBlockTime;
+    private final int userOperationsThreadPoolSize;
 
     /**
      * Constructor
@@ -119,6 +122,8 @@ public class UserOperatorConfig {
      * @param batchQueueSize Maximal queue for requests when micro-batching the Kafka Admin API requests
      * @param batchMaxBlockSize Maximal batch size for micro-batching the Kafka Admin API requests
      * @param batchMaxBlockTime Maximal batch time for micro-batching the Kafka Admin API requests
+     * @param userOperationsThreadPoolSize Size of the thread pool for user operations done by KafkaUserOperator and
+     *                                     the classes used by it
      */
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public UserOperatorConfig(String namespace,
@@ -144,8 +149,8 @@ public class UserOperatorConfig {
                               long cacheRefresh,
                               int batchQueueSize,
                               int batchMaxBlockSize,
-                              int batchMaxBlockTime
-
+                              int batchMaxBlockTime,
+                              int userOperationsThreadPoolSize
     ) {
         this.namespace = namespace;
         this.reconciliationIntervalMs = reconciliationIntervalMs;
@@ -171,6 +176,7 @@ public class UserOperatorConfig {
         this.batchQueueSize = batchQueueSize;
         this.batchMaxBlockSize = batchMaxBlockSize;
         this.batchMaxBlockTime = batchMaxBlockTime;
+        this.userOperationsThreadPoolSize = userOperationsThreadPoolSize;
     }
 
     /**
@@ -199,6 +205,7 @@ public class UserOperatorConfig {
         int batchQueueSize = getIntProperty(map, STRIMZI_BATCH_QUEUE_SIZE, DEFAULT_BATCH_QUEUE_SIZE);
         int batchMaxBlockSize = getIntProperty(map, STRIMZI_BATCH_MAXIMUM_BLOCK_SIZE, DEFAULT_BATCH_MAXIMUM_BLOCK_SIZE);
         int batchMaxBlockTime = getIntProperty(map, STRIMZI_BATCH_MAXIMUM_BLOCK_TIME_MS, DEFAULT_BATCH_MAXIMUM_BLOCK_TIME_MS);
+        int userOperationsThreadPoolSize = getIntProperty(map, STRIMZI_USER_OPERATIONS_THREAD_POOL_SIZE, DEFAULT_USER_OPERATIONS_THREAD_POOL_SIZE);
 
         String kafkaBootstrapServers = DEFAULT_KAFKA_BOOTSTRAP_SERVERS;
         String kafkaBootstrapServersEnvVar = map.get(UserOperatorConfig.STRIMZI_KAFKA_BOOTSTRAP_SERVERS);
@@ -245,7 +252,8 @@ public class UserOperatorConfig {
                 caCertSecretName, caKeySecretName, clusterCaCertSecretName, euoKeySecretName, caNamespace, secretPrefix,
                 aclsAdminApiSupported, kraftEnabled, clientsCaValidityDays, clientsCaRenewalDays,
                 scramPasswordLength, maintenanceWindows, kafkaAdminClientConfiguration, operationTimeout, workQueueSize,
-                controllerThreadPoolSize, cacheRefresh, batchQueueSize, batchMaxBlockSize, batchMaxBlockTime);
+                controllerThreadPoolSize, cacheRefresh, batchQueueSize, batchMaxBlockSize, batchMaxBlockTime,
+                userOperationsThreadPoolSize);
     }
 
     /**
@@ -510,6 +518,13 @@ public class UserOperatorConfig {
         return batchMaxBlockTime;
     }
 
+    /**
+     * @return Size of the thread pool for user operations done by KafkaUserOperator and the classes used by it
+     */
+    public int getUserOperationsThreadPoolSize() {
+        return userOperationsThreadPoolSize;
+    }
+
     @Override
     public String toString() {
         return "ClusterOperatorConfig(" +
@@ -536,6 +551,7 @@ public class UserOperatorConfig {
                 ",batchQueueSize=" + batchQueueSize +
                 ",batchMaxBlockSize=" + batchMaxBlockSize +
                 ",batchMaxBlockTime=" + batchMaxBlockTime +
+                ",userOperationsThreadPoolSize=" + userOperationsThreadPoolSize +
                 ")";
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramCredentialsOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/ScramCredentialsOperator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
 
 /**
  * ScramCredentialsOperator is responsible for managing the SCRAM-SHA credentials in Apache Kafka.
@@ -39,14 +40,18 @@ public class ScramCredentialsOperator implements AdminApiOperator<String, List<S
 
     private final ScramShaCredentialsBatchReconciler patchReconciler;
     private final ScramShaCredentialsCache cache;
+    private final ExecutorService executor;
 
     /**
      * Constructor
      *
      * @param adminClient   Kafka Admin client instance
      * @param config        User operator configuration
+     * @param executor      Shared executor for executing async operations
      */
-    public ScramCredentialsOperator(Admin adminClient, UserOperatorConfig config) {
+    public ScramCredentialsOperator(Admin adminClient, UserOperatorConfig config, ExecutorService executor) {
+        this.executor = executor;
+
         // Create cache for querying the SCRAM-SHA Credentials locally
         this.cache = new ScramShaCredentialsCache(adminClient, config.getCacheRefresh());
 
@@ -117,7 +122,7 @@ public class ScramCredentialsOperator implements AdminApiOperator<String, List<S
                         }
                     }
                 }
-            });
+            }, executor);
         }
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserOperatorConfigTest.java
@@ -66,6 +66,7 @@ public class UserOperatorConfigTest {
         assertThat(config.getBatchQueueSize(), is(1_024));
         assertThat(config.getBatchMaxBlockSize(), is(100));
         assertThat(config.getBatchMaxBlockTime(), is(100));
+        assertThat(config.getUserOperationsThreadPoolSize(), is(4));
     }
 
     @Test

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -53,6 +55,8 @@ import static org.mockito.Mockito.when;
 @EnableKubernetesMockClient(crud = true)
 public class KafkaUserOperatorMockTest {
     public static final String NAMESPACE = "namespace";
+
+    private final static ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
 
     private final CertManager mockCertManager = new MockCertManager();
 
@@ -142,7 +146,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testCreateTlsUser() throws ExecutionException, InterruptedException {
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -212,7 +216,7 @@ public class KafkaUserOperatorMockTest {
                     .endKafkaUserTlsExternalClientAuthentication()
                 .endSpec()
                 .build();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -278,7 +282,7 @@ public class KafkaUserOperatorMockTest {
                     .endQuotas()
                 .endSpec()
                 .build();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), false, false, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), false, false, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -338,7 +342,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testCreateTlsUserWithKRaft() throws ExecutionException, InterruptedException {
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, true, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, true, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -401,7 +405,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testCreateScramShaUser() throws ExecutionException, InterruptedException {
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -466,7 +470,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testCreateScramShaUserWithConfigurableLength() throws ExecutionException, InterruptedException {
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig("30"), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig("30"), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -552,7 +556,7 @@ public class KafkaUserOperatorMockTest {
                 .endKafkaUserScramSha512ClientAuthentication()
             .endSpec()
             .build();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -617,7 +621,7 @@ public class KafkaUserOperatorMockTest {
     public void testCreateTlsUserWithSecretPrefix() throws ExecutionException, InterruptedException {
         String secretPrefix = "my-test-";
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, false, "32", secretPrefix), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, false, "32", secretPrefix), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -690,7 +694,7 @@ public class KafkaUserOperatorMockTest {
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -762,7 +766,7 @@ public class KafkaUserOperatorMockTest {
         user.getSpec().setAuthorization(null);
         user.getSpec().setQuotas(null);
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -834,7 +838,7 @@ public class KafkaUserOperatorMockTest {
                 .endSpec()
                 .build();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -894,7 +898,7 @@ public class KafkaUserOperatorMockTest {
                 .build());
 
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -960,7 +964,7 @@ public class KafkaUserOperatorMockTest {
     public void testUpdateTlsUserWithoutSecret() throws ExecutionException, InterruptedException {
         Secret existingUserSecret = ResourceUtils.createUserSecretTls();
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1028,7 +1032,7 @@ public class KafkaUserOperatorMockTest {
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1094,7 +1098,7 @@ public class KafkaUserOperatorMockTest {
     public void testUpdateScramShaUserWithoutSecret() throws ExecutionException, InterruptedException {
         Secret existingUserSecret = ResourceUtils.createUserSecretScramSha();
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1161,7 +1165,7 @@ public class KafkaUserOperatorMockTest {
         Secret existingUserSecret = ResourceUtils.createUserSecretTls();
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1209,7 +1213,7 @@ public class KafkaUserOperatorMockTest {
         Secret existingUserSecret = ResourceUtils.createUserSecretTls();
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), false, false, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), false, false, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1253,7 +1257,7 @@ public class KafkaUserOperatorMockTest {
         Secret existingUserSecret = ResourceUtils.createUserSecretTls();
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, true, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, true, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1297,7 +1301,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testDeleteTlsUserWithoutSecret() throws ExecutionException, InterruptedException {
         Secret existingUserSecret = ResourceUtils.createUserSecretTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1350,7 +1354,7 @@ public class KafkaUserOperatorMockTest {
                 .build();
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, false, "32", secretPrefix), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, false, "32", secretPrefix), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1400,7 +1404,7 @@ public class KafkaUserOperatorMockTest {
 
     @Test
     public void testDeleteExternalTlsUser() throws ExecutionException, InterruptedException {
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, null);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1448,7 +1452,7 @@ public class KafkaUserOperatorMockTest {
         Secret existingUserSecret = ResourceUtils.createUserSecretScramSha();
         client.secrets().inNamespace(ResourceUtils.NAMESPACE).resource(existingUserSecret).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), null, existingUserSecret);
         KafkaUserStatus status = futureResult.toCompletableFuture().get();
 
@@ -1497,7 +1501,7 @@ public class KafkaUserOperatorMockTest {
         when(aclOps.reconcile(any(), aclNameCaptor.capture(), aclRulesCaptor.capture())).thenReturn(CompletableFuture.failedStage(new KafkaException("Something failed!")));
 
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
 
         ExecutionException e = assertThrows(ExecutionException.class, () -> futureResult.toCompletableFuture().get());
@@ -1520,7 +1524,7 @@ public class KafkaUserOperatorMockTest {
                 .build();
         Crds.kafkaUserOperation(client).inNamespace(ResourceUtils.NAMESPACE).resource(user2).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<Set<NamespaceAndName>> futureResult = op.getAllUsers(ResourceUtils.NAMESPACE);
         Set<NamespaceAndName> users = futureResult.toCompletableFuture().get();
 
@@ -1548,7 +1552,7 @@ public class KafkaUserOperatorMockTest {
                 .build();
         Crds.kafkaUserOperation(client).inNamespace(ResourceUtils.NAMESPACE).resource(user2).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), false, false, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), false, false, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<Set<NamespaceAndName>> futureResult = op.getAllUsers(ResourceUtils.NAMESPACE);
         Set<NamespaceAndName> users = futureResult.toCompletableFuture().get();
 
@@ -1576,7 +1580,7 @@ public class KafkaUserOperatorMockTest {
                 .build();
         Crds.kafkaUserOperation(client).inNamespace(ResourceUtils.NAMESPACE).resource(user2).create();
 
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, true, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(Map.of(), true, true, "32", null), client, mockCertManager, scramOps, quotasOps, aclOps, EXECUTOR);
         CompletionStage<Set<NamespaceAndName>> futureResult = op.getAllUsers(ResourceUtils.NAMESPACE);
         Set<NamespaceAndName> users = futureResult.toCompletableFuture().get();
 
@@ -1591,7 +1595,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testReconciliationFailsWithDisabledAclOperator() {
         KafkaUser user = ResourceUtils.createKafkaUserTls();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, new DisabledSimpleAclOperator());
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, scramOps, quotasOps, new DisabledSimpleAclOperator(), EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
 
         ExecutionException e = assertThrows(ExecutionException.class, () -> futureResult.toCompletableFuture().get());
@@ -1601,7 +1605,7 @@ public class KafkaUserOperatorMockTest {
     @Test
     public void testReconciliationFailsWithDisabledScramShaOperator() {
         KafkaUser user = ResourceUtils.createKafkaUserScramSha();
-        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, new DisabledScramCredentialsOperator(), quotasOps, aclOps);
+        KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), client, mockCertManager, new DisabledScramCredentialsOperator(), quotasOps, aclOps, EXECUTOR);
         CompletionStage<KafkaUserStatus> futureResult = op.reconcile(new Reconciliation("test-trigger", KafkaUser.RESOURCE_KIND, ResourceUtils.NAMESPACE, ResourceUtils.NAME), user, null);
 
         ExecutionException e = assertThrows(ExecutionException.class, () -> futureResult.toCompletableFuture().get());

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/QuotasOperatorIT.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -22,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 public class QuotasOperatorIT extends AdminApiOperatorIT<KafkaUserQuotas, Set<String>> {
     @Override
     AdminApiOperator<KafkaUserQuotas, Set<String>> operator() {
-        return new QuotasOperator(adminClient, ResourceUtils.createUserOperatorConfig());
+        return new QuotasOperator(adminClient, ResourceUtils.createUserOperatorConfig(), Executors.newSingleThreadExecutor());
     }
 
     @Override

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialsOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/ScramCredentialsOperatorIT.java
@@ -11,13 +11,14 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 public class ScramCredentialsOperatorIT extends AdminApiOperatorIT<String, List<String>> {
     protected boolean createPatches = true;
 
     @Override
     AdminApiOperator<String, List<String>> operator() {
-        return new ScramCredentialsOperator(adminClient, ResourceUtils.createUserOperatorConfig());
+        return new ScramCredentialsOperator(adminClient, ResourceUtils.createUserOperatorConfig(), Executors.newSingleThreadExecutor());
     }
 
     @Override

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorIT.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -29,7 +30,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 public class SimpleAclOperatorIT extends AdminApiOperatorIT<Set<SimpleAclRule>, Set<String>> {
     @Override
     AdminApiOperator<Set<SimpleAclRule>, Set<String>> operator() {
-        return new SimpleAclOperator(adminClient, ResourceUtils.createUserOperatorConfig());
+        return new SimpleAclOperator(adminClient, ResourceUtils.createUserOperatorConfig(), Executors.newSingleThreadExecutor());
     }
 
     @Override

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/SimpleAclOperatorTest.java
@@ -38,6 +38,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -56,6 +58,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SimpleAclOperatorTest {
+    private final static ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+
     @Test
     public void testGetAllUsers() throws ExecutionException, InterruptedException {
         Admin mockAdminClient = mock(AdminClient.class);
@@ -84,7 +88,7 @@ public class SimpleAclOperatorTest {
 
         assertDoesNotThrow(() -> mockDescribeAcls(mockAdminClient, AclBindingFilter.ANY, aclBindings));
 
-        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig());
+        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig(), EXECUTOR);
         aclOp.start();
 
         try {
@@ -122,7 +126,7 @@ public class SimpleAclOperatorTest {
             mockCreateAcls(mockAdminClient, aclBindingsCaptor);
         });
 
-        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig());
+        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig(), EXECUTOR);
         aclOp.start();
 
         try {
@@ -166,7 +170,7 @@ public class SimpleAclOperatorTest {
             mockDeleteAcls(mockAdminClient, Collections.singleton(readAclBinding), aclBindingFiltersCaptor);
         });
 
-        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig());
+        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig(), EXECUTOR);
         aclOp.start();
 
         try {
@@ -212,7 +216,7 @@ public class SimpleAclOperatorTest {
             mockDeleteAcls(mockAdminClient, Collections.singleton(readAclBinding), aclBindingFiltersCaptor);
         });
 
-        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig());
+        SimpleAclOperator aclOp = new SimpleAclOperator(mockAdminClient, ResourceUtils.createUserOperatorConfig(), EXECUTOR);
         aclOp.start();
 
         try {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, the User Operator makes different `handleAsync` calls when using the Kubernetes or Kafka Admin APIs during the user reconciliations. These are in the `KafkaUserOperator` class and in the Admin API Operators used by it. Right now, these calls are using the JVM's default thread pool.

This PR creates a new shared thread pool executor for these operations. By default, it uses 4 threads. If needed, the pool size is user configurable to tune it for the best performance.

This should close #7611 

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging