### PR TITLE
Feature/support load balancer class attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.33.0
 
+* Support loadBalancerClass attribute in service with type loadBalancer
 * Support for automatically restarting failed Connect or Mirror Maker 2 connectors
 * Redesign of Strimzi User Operator to improve its scalability
 * Use Java 17 as the runtime for all containers and language level for all modules except `api`, `crd-generator`, `crd-annotations`, and `test`

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -43,7 +43,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     private static final long serialVersionUID = 1L;
 
     private CertAndKeySecretSource brokerCertChainAndKey;
-    private String ingressClass;
+    private String controllerClass;
     private NodeAddressType preferredNodePortAddressType;
     private ExternalTrafficPolicy externalTrafficPolicy;
     private List<String> loadBalancerSourceRanges;
@@ -70,17 +70,19 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
         this.brokerCertChainAndKey = brokerCertChainAndKey;
     }
 
-    @Description("Configures the `Ingress` class that defines which `Ingress` controller will be used. " +
-            "This field can be used only with `ingress` type listener. " +
-            "If not specified, the default Ingress controller will be used.")
+    @Description("Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. " +
+            "This field can only be used with `ingress` and `loadbalancer` type listeners. " +
+            "If not specified, the default controller is used. " +
+            "For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. " +
+            "For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("class")
-    public String getIngressClass() {
-        return ingressClass;
+    public String getControllerClass() {
+        return controllerClass;
     }
 
-    public void setIngressClass(String ingressClass) {
-        this.ingressClass = ingressClass;
+    public void setControllerClass(String controllerClass) {
+        this.controllerClass = controllerClass;
     }
 
     @Description("Defines which address type should be used as the node address. " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -736,6 +736,11 @@ public class KafkaCluster extends AbstractModel {
                         && !finalizers.isEmpty()) {
                     service.getMetadata().setFinalizers(finalizers);
                 }
+
+                String loadBalancerClass = ListenersUtils.controllerClass(listener);
+                if (loadBalancerClass != null) {
+                    service.getSpec().setLoadBalancerClass(loadBalancerClass);
+                }
             }
 
             if (KafkaListenerType.LOADBALANCER == listener.getType() || KafkaListenerType.NODEPORT == listener.getType()) {
@@ -805,6 +810,11 @@ public class KafkaCluster extends AbstractModel {
                         && !finalizers.isEmpty()) {
                     service.getMetadata().setFinalizers(finalizers);
                 }
+
+                String loadBalancerClass = ListenersUtils.controllerClass(listener);
+                if (loadBalancerClass != null) {
+                    service.getSpec().setLoadBalancerClass(loadBalancerClass);
+                }
             }
 
             if (KafkaListenerType.LOADBALANCER == listener.getType() || KafkaListenerType.NODEPORT == listener.getType()) {
@@ -822,7 +832,7 @@ public class KafkaCluster extends AbstractModel {
         return services;
     }
 
-        /**
+    /**
      * Generates a list of bootstrap route which can be used to bootstrap clients outside of OpenShift.
      *
      * @return The list of generated Routes
@@ -927,7 +937,7 @@ public class KafkaCluster extends AbstractModel {
             String serviceName = ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener);
 
             String host = ListenersUtils.bootstrapHost(listener);
-            String ingressClass = ListenersUtils.ingressClass(listener);
+            String ingressClass = ListenersUtils.controllerClass(listener);
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()
                     .withPath("/")
@@ -988,7 +998,7 @@ public class KafkaCluster extends AbstractModel {
             String serviceName = ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener);
 
             String host = ListenersUtils.bootstrapHost(listener);
-            String ingressClass = ListenersUtils.ingressClass(listener);
+            String ingressClass = ListenersUtils.controllerClass(listener);
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
                     .withPath("/")
@@ -1043,7 +1053,7 @@ public class KafkaCluster extends AbstractModel {
         for (GenericKafkaListener listener : ingressListeners)   {
             String ingressName = ListenersUtils.backwardsCompatibleBrokerServiceName(cluster, pod, listener);
             String host = ListenersUtils.brokerHost(listener, pod);
-            String ingressClass = ListenersUtils.ingressClass(listener);
+            String ingressClass = ListenersUtils.controllerClass(listener);
 
             HTTPIngressPath path = new HTTPIngressPathBuilder()
                     .withPath("/")
@@ -1103,7 +1113,7 @@ public class KafkaCluster extends AbstractModel {
         for (GenericKafkaListener listener : ingressListeners)   {
             String ingressName = ListenersUtils.backwardsCompatibleBrokerServiceName(cluster, pod, listener);
             String host = ListenersUtils.brokerHost(listener, pod);
-            String ingressClass = ListenersUtils.ingressClass(listener);
+            String ingressClass = ListenersUtils.controllerClass(listener);
 
             io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
                     .withPath("/")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -662,14 +662,14 @@ public class ListenersUtils {
     }
 
     /**
-     * Finds ingress class
+     * Finds controller class which mean ingress class or loadbalancer class
      *
-     * @param listener  Listener for which the ingress class should be found
-     * @return          Ingress class or null if not specified
+     * @param listener  Listener for which the controller class should be found
+     * @return          Controller class or null if not specified
      */
-    public static String ingressClass(GenericKafkaListener listener)    {
+    public static String controllerClass(GenericKafkaListener listener)    {
         if (listener.getConfiguration() != null) {
-            return listener.getConfiguration().getIngressClass();
+            return listener.getConfiguration().getControllerClass();
         } else {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -76,7 +76,7 @@ public class ListenersValidator {
                 validateServiceDnsDomain(errors, listener);
                 validateIpFamilyPolicy(errors, listener);
                 validateIpFamilies(errors, listener);
-                validateIngressClass(errors, listener);
+                validateControllerClass(errors, listener);
                 validateExternalTrafficPolicy(errors, listener);
                 validateLoadBalancerSourceRanges(errors, listener);
                 validateFinalizers(errors, listener);
@@ -240,15 +240,15 @@ public class ListenersValidator {
     }
 
     /**
-     * Validates that ingressClass is used only with Ingress type listener
+     * Validates that controllerClass is used only with Ingress or LoadBalancer type listener
      *
      * @param errors    List where any found errors will be added
      * @param listener  Listener which needs to be validated
      */
-    private static void validateIngressClass(Set<String> errors, GenericKafkaListener listener) {
-        if (!KafkaListenerType.INGRESS.equals(listener.getType())
-                && listener.getConfiguration().getIngressClass() != null)    {
-            errors.add("listener " + listener.getName() + " cannot configure ingressClass because it is not Ingress based listener");
+    private static void validateControllerClass(Set<String> errors, GenericKafkaListener listener) {
+        if (!(KafkaListenerType.INGRESS.equals(listener.getType()) || KafkaListenerType.LOADBALANCER.equals(listener.getType()))
+                && listener.getConfiguration().getControllerClass() != null)    {
+            errors.add("listener " + listener.getName() + " cannot configure class because it is not an Ingress or LoadBalancer based listener");
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -1367,7 +1367,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withType(KafkaListenerType.INGRESS)
                 .withTls(true)
                 .withNewConfiguration()
-                    .withIngressClass("nginx-ingress")
+                    .withControllerClass("nginx-ingress")
                     .withNewBootstrap()
                         .withHost("bootstrap.mytld.com")
                     .endBootstrap()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -251,7 +251,7 @@ public class ListenersUtilsTest {
             .withType(KafkaListenerType.INGRESS)
             .withTls(true)
             .withNewConfiguration()
-                .withIngressClass("my-ingress")
+                .withControllerClass("my-ingress")
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-ing-1", "my-ing-2"))
                     .withHost("my-ing-host")
@@ -677,15 +677,15 @@ public class ListenersUtilsTest {
 
     @ParallelTest
     public void testIngressClass() {
-        assertThat(ListenersUtils.ingressClass(newLoadBalancer), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(oldExternal), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(newIngress), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(newClusterIP), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(newIngress2), is("my-ingress"));
-        assertThat(ListenersUtils.ingressClass(oldPlain), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(newTls), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(newNodePort), is(nullValue()));
-        assertThat(ListenersUtils.ingressClass(newNodePort3), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(oldExternal), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newIngress), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newClusterIP), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newIngress2), is("my-ingress"));
+        assertThat(ListenersUtils.controllerClass(oldPlain), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newTls), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newNodePort), is(nullValue()));
+        assertThat(ListenersUtils.controllerClass(newNodePort3), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -214,7 +214,7 @@ public class ListenersValidatorTest {
                 .withPort(9092)
                 .withType(KafkaListenerType.INTERNAL)
                 .withNewConfiguration()
-                    .withIngressClass("my-ingress")
+                    .withControllerClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
@@ -256,7 +256,7 @@ public class ListenersValidatorTest {
         List<GenericKafkaListener> listeners = asList(listener1);
 
         List<String> expectedErrors = asList(
-                "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
+                "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
@@ -287,7 +287,7 @@ public class ListenersValidatorTest {
                 .withPort(9092)
                 .withType(KafkaListenerType.LOADBALANCER)
                 .withNewConfiguration()
-                    .withIngressClass("my-ingress")
+                    .withControllerClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
@@ -326,7 +326,6 @@ public class ListenersValidatorTest {
         List<GenericKafkaListener> listeners = asList(listener1);
 
         List<String> expectedErrors = asList(
-                "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
@@ -365,7 +364,7 @@ public class ListenersValidatorTest {
                 .withPort(9092)
                 .withType(KafkaListenerType.NODEPORT)
                 .withNewConfiguration()
-                    .withIngressClass("my-ingress")
+                    .withControllerClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
@@ -404,7 +403,7 @@ public class ListenersValidatorTest {
         List<GenericKafkaListener> listeners = asList(listener1);
 
         List<String> expectedErrors = asList(
-                "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
+                "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
@@ -447,7 +446,7 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.ROUTE)
                 .withTls(true)
                 .withNewConfiguration()
-                    .withIngressClass("my-ingress")
+                    .withControllerClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
@@ -489,7 +488,7 @@ public class ListenersValidatorTest {
         List<GenericKafkaListener> listeners = asList(listener1);
 
         List<String> expectedErrors = asList(
-                "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
+                "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
@@ -547,7 +546,7 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INGRESS)
                 .withTls(true)
                 .withNewConfiguration()
-                    .withIngressClass("my-ingress")
+                    .withControllerClass("my-ingress")
                     .withUseServiceDnsDomain(true)
                     .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
@@ -700,7 +699,7 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.CLUSTER_IP)
                 .withTls(true)
                 .withNewConfiguration()
-                .withIngressClass("my-ingress")
+                .withControllerClass("my-ingress")
                 .withUseServiceDnsDomain(true)
                 .withExternalTrafficPolicy(ExternalTrafficPolicy.LOCAL)
                 .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
@@ -747,7 +746,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
-                "listener " + name + " cannot configure ingressClass because it is not Ingress based listener",
+                "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
         );

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -342,7 +342,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string (one or more of [IPv6, IPv4]) array
 |createBootstrapService        1.2+<.<a|Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
 |boolean
-|class                         1.2+<.<a|Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used.
+|class                         1.2+<.<a|Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources.
 |string
 |finalizers                    1.2+<.<a|A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
 |string array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -364,7 +364,7 @@ spec:
                                 description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
                               class:
                                 type: string
-                                description: "Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used."
+                                description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                               finalizers:
                                 type: array
                                 items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -363,7 +363,7 @@ spec:
                               description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
                             class:
                               type: string
-                              description: "Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used."
+                              description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                             finalizers:
                               type: array
                               items:

--- a/tools/prerequisites-check.sh
+++ b/tools/prerequisites-check.sh
@@ -18,7 +18,7 @@ check_command_present "${DOCKER_CMD:-docker}"
 check_command_present shellcheck
 
 # After version 3.3.1, yq --version sends the string to STDERR instead of STDOUT
-YQ_VERSION="$(yq --version 2>&1 | ${SED} 's/^.* //g')"
+YQ_VERSION="$(yq --version 2>&1 | ${SED} -r 's/^.* v?//g')"
 
 IFS="." read -r -a YQ_ARRAY <<< "$YQ_VERSION"
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add support for service spec attribute loadBalancerClass documentation https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class, spec https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec

The purpose to support this attribute is to globally allow broker services to use a custom controller class. Theses controller class allow multiple loadbalancer ip provider to live together in same kubernetes cluster.
.i.e. metallb and openstack provider.
 
This change have been discussed on CNCF strimzi-dev slack https://cloud-native.slack.com/archives/C018247K8T0/p1670167684500789
This first version use opportunistically the existing `spec.listeners[*].configuration.class` crd's attribute of kind Kafka.
Now the `configuration.class` could be use for listener of type ingress and for listener of type loadbalancer.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass (unitary test ✅, integration ❌ they failed with openssl error i think is related to local problem on my own computer)
```
 java.lang.RuntimeException: openssl status code 1
        at io.strimzi.certs.OpenSslCertManager$OpensslArgs.exec(OpenSslCertManager.java:650)
        at io.strimzi.certs.OpenSslCertManager$OpensslArgs.exec(OpenSslCertManager.java:608)
        at io.strimzi.certs.OpenSslCertManager.generateCsr(OpenSslCertManager.java:435)
        at io.strimzi.operator.cluster.model.Ca.generateSignedCert(Ca.java:365)
        at io.strimzi.operator.cluster.model.Ca.maybeCopyOrGenerateCerts(Ca.java:503)
        at io.strimzi.operator.cluster.model.ClusterCa.generateBrokerCerts(ClusterCa.java:214)
        at io.strimzi.operator.cluster.model.KafkaCluster.generateCertificatesSecret(KafkaCluster.java:1271)
        at io.strimzi.operator.cluster.operator.assembly.KafkaReconciler.lambda$certificateSecret$48(KafkaReconciler.java:728)
        at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38)
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60)
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211)
        at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23)
        at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49)
        at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:833
```
- [x] Update documentation (not sure if enough, i update documentation with annotation `@Description`)
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] ~Reference relevant issue(s) and close them after merging~
- [x] Update CHANGELOG.md
- [ ] ~Supply screenshots for visual changes, such as Grafana dashboards~

Thanks for review 🙂 
