### PR TITLE
Add missing Javadoc comments in cluster-operator module - part I

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -67,6 +67,20 @@ public class ClusterOperator extends AbstractVerticle {
     @SuppressWarnings("unused")
     private WorkerExecutor sharedWorkerExecutor;
 
+    /**
+     * Constructor
+     *
+     * @param namespace                             Namespace which this operator instance manages
+     * @param config                                Cluster Operator configuration
+     * @param client                                Kubernetes client
+     * @param kafkaAssemblyOperator                 Kafka operator
+     * @param kafkaConnectAssemblyOperator          KafkaConnect operator
+     * @param kafkaMirrorMakerAssemblyOperator      KafkaMirrorMaker operator
+     * @param kafkaMirrorMaker2AssemblyOperator     KafkaMirrorMaker2 operator
+     * @param kafkaBridgeAssemblyOperator           KafkaBridge operator
+     * @param kafkaRebalanceAssemblyOperator        KafkaRebalance operator
+     * @param resourceOperatorSupplier              Resource operator supplier
+     */
     public ClusterOperator(String namespace,
                            ClusterOperatorConfig config,
                            KubernetesClient client,
@@ -132,7 +146,7 @@ public class ClusterOperator extends AbstractVerticle {
                 .onComplete(start);
     }
 
-    public Future<Void> maybeStartStrimziPodSetController() {
+    private Future<Void> maybeStartStrimziPodSetController() {
         Promise<Void> handler = Promise.promise();
         vertx.executeBlocking(future -> {
             try {
@@ -184,6 +198,13 @@ public class ClusterOperator extends AbstractVerticle {
         }
     }
 
+    /**
+     * Name of the secret with the Cluster Operator certificates for connecting to the cluster
+     *
+     * @param cluster   Name of the Kafka cluster
+     *
+     * @return  Name of the Cluster Operator certificate secret
+     */
     public static String secretName(String cluster) {
         return cluster + CERTS_SUFFIX;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -35,74 +35,157 @@ import static java.util.Arrays.asList;
 public class ClusterOperatorConfig {
     private static final Logger LOGGER = LogManager.getLogger(ClusterOperatorConfig.class.getName());
 
-    public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
+    /* test */ static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
+
+    /**
+     * Configures how often should the periodical reconciliation be triggered
+     */
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
-    public static final String STRIMZI_OPERATION_TIMEOUT_MS = "STRIMZI_OPERATION_TIMEOUT_MS";
-    public static final String STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS";
-    public static final String STRIMZI_CONNECT_BUILD_TIMEOUT_MS = "STRIMZI_CONNECT_BUILD_TIMEOUT_MS";
-    public static final String STRIMZI_IMAGE_PULL_POLICY = "STRIMZI_IMAGE_PULL_POLICY";
-    public static final String STRIMZI_IMAGE_PULL_SECRETS = "STRIMZI_IMAGE_PULL_SECRETS";
-    public static final String STRIMZI_OPERATOR_NAMESPACE = "STRIMZI_OPERATOR_NAMESPACE";
-    public static final String STRIMZI_OPERATOR_NAMESPACE_LABELS = "STRIMZI_OPERATOR_NAMESPACE_LABELS";
-    public static final String STRIMZI_CUSTOM_RESOURCE_SELECTOR = "STRIMZI_CUSTOM_RESOURCE_SELECTOR";
-    public static final String STRIMZI_FEATURE_GATES = "STRIMZI_FEATURE_GATES";
-    public static final String STRIMZI_OPERATIONS_THREAD_POOL_SIZE = "STRIMZI_OPERATIONS_THREAD_POOL_SIZE";
-    public static final String STRIMZI_DNS_CACHE_TTL = "STRIMZI_DNS_CACHE_TTL";
-    public static final String STRIMZI_POD_SET_RECONCILIATION_ONLY = "STRIMZI_POD_SET_RECONCILIATION_ONLY";
-    public static final String STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = "STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE";
-    public static final String STRIMZI_POD_SECURITY_PROVIDER_CLASS = "STRIMZI_POD_SECURITY_PROVIDER_CLASS";
-    public static final String STRIMZI_LEADER_ELECTION_ENABLED = "STRIMZI_LEADER_ELECTION_ENABLED";
+
+    /* test */ static final String STRIMZI_OPERATION_TIMEOUT_MS = "STRIMZI_OPERATION_TIMEOUT_MS";
+    private static final String STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS";
+    /* test */ static final String STRIMZI_CONNECT_BUILD_TIMEOUT_MS = "STRIMZI_CONNECT_BUILD_TIMEOUT_MS";
+    /* test */ static final String STRIMZI_IMAGE_PULL_POLICY = "STRIMZI_IMAGE_PULL_POLICY";
+    /* test */ static final String STRIMZI_IMAGE_PULL_SECRETS = "STRIMZI_IMAGE_PULL_SECRETS";
+    /* test */ static final String STRIMZI_OPERATOR_NAMESPACE = "STRIMZI_OPERATOR_NAMESPACE";
+    /* test */ static final String STRIMZI_OPERATOR_NAMESPACE_LABELS = "STRIMZI_OPERATOR_NAMESPACE_LABELS";
+    /* test */ static final String STRIMZI_CUSTOM_RESOURCE_SELECTOR = "STRIMZI_CUSTOM_RESOURCE_SELECTOR";
+    /* test */ static final String STRIMZI_FEATURE_GATES = "STRIMZI_FEATURE_GATES";
+    private static final String STRIMZI_OPERATIONS_THREAD_POOL_SIZE = "STRIMZI_OPERATIONS_THREAD_POOL_SIZE";
+    /* test */ static final String STRIMZI_DNS_CACHE_TTL = "STRIMZI_DNS_CACHE_TTL";
+    /* test */ static final String STRIMZI_POD_SET_RECONCILIATION_ONLY = "STRIMZI_POD_SET_RECONCILIATION_ONLY";
+    private static final String STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = "STRIMZI_POD_SET_CONTROLLER_WORK_QUEUE_SIZE";
+    /* test */ static final String STRIMZI_POD_SECURITY_PROVIDER_CLASS = "STRIMZI_POD_SECURITY_PROVIDER_CLASS";
+    /* test */ static final String STRIMZI_LEADER_ELECTION_ENABLED = "STRIMZI_LEADER_ELECTION_ENABLED";
 
     //Used to identify which cluster operator created a Kubernetes event
-    public static final String STRIMZI_OPERATOR_NAME = "STRIMZI_OPERATOR_NAME";
+    private static final String STRIMZI_OPERATOR_NAME = "STRIMZI_OPERATOR_NAME";
 
     // Feature Flags
-    public static final String STRIMZI_CREATE_CLUSTER_ROLES = "STRIMZI_CREATE_CLUSTER_ROLES";
-    public static final String STRIMZI_NETWORK_POLICY_GENERATION = "STRIMZI_NETWORK_POLICY_GENERATION";
+    /* test */ static final String STRIMZI_CREATE_CLUSTER_ROLES = "STRIMZI_CREATE_CLUSTER_ROLES";
+    private static final String STRIMZI_NETWORK_POLICY_GENERATION = "STRIMZI_NETWORK_POLICY_GENERATION";
 
     // Env vars for configuring images
+    /**
+     * Configures the Kafka container images
+     */
     public static final String STRIMZI_KAFKA_IMAGES = "STRIMZI_KAFKA_IMAGES";
+
+    /**
+     * Configures the Kafka Connect container images
+     */
     public static final String STRIMZI_KAFKA_CONNECT_IMAGES = "STRIMZI_KAFKA_CONNECT_IMAGES";
+
+    /**
+     * Configures the Kafka Mirror Maker container images
+     */
     public static final String STRIMZI_KAFKA_MIRROR_MAKER_IMAGES = "STRIMZI_KAFKA_MIRROR_MAKER_IMAGES";
+
+    /**
+     * Configures the Kafka Mirror Maker 2 container images
+     */
     public static final String STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES = "STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES";
+
+    /**
+     * Configures the Entity Operator TLS sidecar container images
+     */
     public static final String STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE";
-    public static final String STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE"; // Used only to produce warning if defined at startup
-    public static final String STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE"; // Used only to produce warning if defined at startup
+    private static final String STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE"; // Used only to produce warning if defined at startup
+    private static final String STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE = "STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE"; // Used only to produce warning if defined at startup
+
+    /**
+     * Configures the Kafka Exporter container image
+     */
     public static final String STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE = "STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE";
+
+    /**
+     * Configures the Topic Operator container image
+     */
     public static final String STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE = "STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE";
+
+    /**
+     * Configures the User Operator container image
+     */
     public static final String STRIMZI_DEFAULT_USER_OPERATOR_IMAGE = "STRIMZI_DEFAULT_USER_OPERATOR_IMAGE";
+
+    /**
+     * Configures the Kafka init container image
+     */
     public static final String STRIMZI_DEFAULT_KAFKA_INIT_IMAGE = "STRIMZI_DEFAULT_KAFKA_INIT_IMAGE";
+
+    /**
+     * Configures the HTTP Bridge container image
+     */
     public static final String STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE = "STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE";
+
+    /**
+     * Configures the Cruise Control container image
+     */
     public static final String STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE = "STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE";
+
+    /**
+     * Configures the Kaniko container image
+     */
     public static final String STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE = "STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE";
+
+    /**
+     * Configures the Maven container image
+     */
     public static final String STRIMZI_DEFAULT_MAVEN_BUILDER = "STRIMZI_DEFAULT_MAVEN_BUILDER";
 
     // Env vars configured in the Cluster operator deployment but passed to all operands
+    /**
+     * HTTP Proxy
+     */
     public static final String HTTP_PROXY = "HTTP_PROXY";
+
+    /**
+     * HTTPS Proxy
+     */
     public static final String HTTPS_PROXY = "HTTPS_PROXY";
+
+    /**
+     * Server which should not use proxy to connect to
+     */
     public static final String NO_PROXY = "NO_PROXY";
+
+    /**
+     * Enabled or disables the FIPS mode
+     */
     public static final String FIPS_MODE = "FIPS_MODE";
 
     // Default values
-    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
+    /* test */ static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
+
+    /**
+     * Default work queue size for the Pod Set controller
+     */
     public static final int DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE = 1024;
+
+    /**
+     * Default operations timeout
+     */
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
-    public static final String DEFAULT_OPERATOR_NAME = "cluster-operator-name-unset";
-    public static final int DEFAULT_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS = 10_000;
-    public static final long DEFAULT_CONNECT_BUILD_TIMEOUT_MS = 300_000;
-    public static final int DEFAULT_OPERATIONS_THREAD_POOL_SIZE = 10;
-    public static final int DEFAULT_DNS_CACHE_TTL = 30;
-    public static final boolean DEFAULT_NETWORK_POLICY_GENERATION = true;
-    public static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
-    public static final boolean DEFAULT_POD_SET_RECONCILIATION_ONLY = false;
+    private static final String DEFAULT_OPERATOR_NAME = "cluster-operator-name-unset";
+    private static final int DEFAULT_ZOOKEEPER_ADMIN_SESSION_TIMEOUT_MS = 10_000;
+    /* test */ static final long DEFAULT_CONNECT_BUILD_TIMEOUT_MS = 300_000;
+    private static final int DEFAULT_OPERATIONS_THREAD_POOL_SIZE = 10;
+    /* test */ static final int DEFAULT_DNS_CACHE_TTL = 30;
+    private static final boolean DEFAULT_NETWORK_POLICY_GENERATION = true;
+    private static final boolean DEFAULT_CREATE_CLUSTER_ROLES = false;
+    private static final boolean DEFAULT_POD_SET_RECONCILIATION_ONLY = false;
+
+    /**
+     * Default Pod Security Provider class
+     */
     public static final String DEFAULT_POD_SECURITY_PROVIDER_CLASS = "io.strimzi.plugin.security.profiles.impl.BaselinePodSecurityProvider";
-    public static final boolean DEFAULT_LEADER_ELECTION_ENABLED = false;
+    private static final boolean DEFAULT_LEADER_ELECTION_ENABLED = false;
 
     // PodSecurityPolicy shortcut keywords and the corresponding class names
-    public static final String POD_SECURITY_PROVIDER_BASELINE_SHORTCUT = "baseline";
-    public static final String POD_SECURITY_PROVIDER_BASELINE_CLASS = "io.strimzi.plugin.security.profiles.impl.BaselinePodSecurityProvider";
-    public static final String POD_SECURITY_PROVIDER_RESTRICTED_SHORTCUT = "restricted";
-    public static final String POD_SECURITY_PROVIDER_RESTRICTED_CLASS = "io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider";
+    private static final String POD_SECURITY_PROVIDER_BASELINE_SHORTCUT = "baseline";
+    /* test */ static final String POD_SECURITY_PROVIDER_BASELINE_CLASS = "io.strimzi.plugin.security.profiles.impl.BaselinePodSecurityProvider";
+    private static final String POD_SECURITY_PROVIDER_RESTRICTED_SHORTCUT = "restricted";
+    /* test */ static final String POD_SECURITY_PROVIDER_RESTRICTED_CLASS = "io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider";
 
     private final Set<String> namespaces;
     private final long reconciliationIntervalMs;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -14,7 +14,7 @@ import static java.util.Arrays.asList;
  * Class for handling the configuration of feature gates
  */
 public class FeatureGates {
-    public static final FeatureGates NONE = new FeatureGates("");
+    /* test */ static final FeatureGates NONE = new FeatureGates("");
 
     private static final String USE_STRIMZI_POD_SETS = "UseStrimziPodSets";
     private static final String USE_KRAFT = "UseKRaft";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -146,18 +146,43 @@ public abstract class AbstractConfiguration {
         this.filterForbidden(reconciliation, forbiddenPrefixes, Collections.emptyList());
     }
 
+    /**
+     * Returns a value for a specific config option
+     *
+     * @param configOption  Config option which should be looked-up
+     *
+     * @return  The configured value for this option
+     */
     public String getConfigOption(String configOption) {
         return options.asMap().get(configOption);
     }
 
+    /**
+     * Returns a value for a specific config option or a default value
+     *
+     * @param configOption  Config option which should be looked-up
+     *
+     * @return  The configured value for this option or the default value if given option is not configured
+     */
     public String getConfigOption(String configOption, String defaultValue) {
         return options.asMap().getOrDefault(configOption, defaultValue);
     }
 
+    /**
+     * Sets config option
+     *
+     * @param configOption  Configuration option which should be set
+     * @param value         The value to which it should be set
+     */
     public void setConfigOption(String configOption, String value) {
         options.asMap().put(configOption, value);
     }
 
+    /**
+     * Removes a configuration option from the configuration
+     *
+     * @param configOption  Configuration option which should be removed
+     */
     public void removeConfigOption(String configOption) {
         options.asMap().remove(configOption);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -114,7 +114,9 @@ import static java.util.Collections.emptyMap;
  */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public abstract class AbstractModel {
-
+    /**
+     * Name of the Strimzi Cluster operator a used in various labels
+     */
     public static final String STRIMZI_CLUSTER_OPERATOR_NAME = "strimzi-cluster-operator";
 
     protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractModel.class.getName());
@@ -132,17 +134,23 @@ public abstract class AbstractModel {
     protected static final String ENV_VAR_KAFKA_INIT_RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
     protected static final String ENV_VAR_KAFKA_INIT_NODE_NAME = "NODE_NAME";
 
+    /**
+     * Key under which the metrics configuration is stored in the ConfigMap
+     */
     public static final String ANCILLARY_CM_KEY_METRICS = "metrics-config.json";
+    /**
+     * Key under which the Log4j properties are stored in the ConfigMap
+     */
     public static final String ANCILLARY_CM_KEY_LOG_CONFIG = "log4j.properties";
 
-    public static final String ENV_VAR_DYNAMIC_HEAP_PERCENTAGE = "STRIMZI_DYNAMIC_HEAP_PERCENTAGE";
-    public static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
-    public static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
-    public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "STRIMZI_DYNAMIC_HEAP_MAX";
-    public static final String ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED = "STRIMZI_KAFKA_GC_LOG_ENABLED";
-    public static final String ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES = "STRIMZI_JAVA_SYSTEM_PROPERTIES";
-    public static final String ENV_VAR_STRIMZI_JAVA_OPTS = "STRIMZI_JAVA_OPTS";
-    public static final String ENV_VAR_STRIMZI_GC_LOG_ENABLED = "STRIMZI_GC_LOG_ENABLED";
+    protected static final String ENV_VAR_DYNAMIC_HEAP_PERCENTAGE = "STRIMZI_DYNAMIC_HEAP_PERCENTAGE";
+    protected static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
+    protected static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
+    protected static final String ENV_VAR_DYNAMIC_HEAP_MAX = "STRIMZI_DYNAMIC_HEAP_MAX";
+    protected static final String ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED = "STRIMZI_KAFKA_GC_LOG_ENABLED";
+    protected static final String ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES = "STRIMZI_JAVA_SYSTEM_PROPERTIES";
+    protected static final String ENV_VAR_STRIMZI_JAVA_OPTS = "STRIMZI_JAVA_OPTS";
+    protected static final String ENV_VAR_STRIMZI_GC_LOG_ENABLED = "STRIMZI_GC_LOG_ENABLED";
 
     /*
      * Default values for the Strimzi temporary directory
@@ -152,10 +160,13 @@ public abstract class AbstractModel {
     /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE = "5Mi";
 
     /**
-     * Annotation on PVCs storing the original configuration
-     * Used to revert changes
+     * Annotation on PVCs storing the original configuration. It is used to revert any illegal changes.
      */
     public static final String ANNO_STRIMZI_IO_STORAGE = Annotations.STRIMZI_DOMAIN + "storage";
+
+    /**
+     * Annotation for storing the information whether the PVC should be deleted when the node is scaled down or when the cluster is deleted.
+     */
     public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = Annotations.STRIMZI_DOMAIN + "delete-claim";
 
     /**
@@ -221,9 +232,11 @@ public abstract class AbstractModel {
      * Volume and Storage configuration
      */
     protected Storage storage;
+
+    /**
+     * Base name used to name data volumes
+     */
     public static final String VOLUME_NAME = "data";
-    public static final String KAFKA_MOUNT_PATH = "/var/lib/kafka";
-    public static final String KAFKA_LOG_DIR = "kafka-log";
     protected String mountPath;
 
     /**
@@ -319,11 +332,14 @@ public abstract class AbstractModel {
         this.labels = Labels.generateDefaultLabels(resource, applicationName, STRIMZI_CLUSTER_OPERATOR_NAME);
     }
 
+    /**
+     * @return The number of replicas
+     */
     public int getReplicas() {
         return replicas;
     }
 
-    public void setReplicas(int replicas) {
+    protected void setReplicas(int replicas) {
         this.replicas = replicas;
     }
 
@@ -652,6 +668,9 @@ public abstract class AbstractModel {
         this.metricsConfigInCm = metricsConfigInCm;
     }
 
+    /**
+     * @return  Returns the ConfigMap with metrics configuration
+     */
     public MetricsConfig getMetricsConfigInCm() {
         return metricsConfigInCm;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -28,14 +28,24 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
+/**
+ * Utils for working with different authentication types
+ */
 public class AuthenticationUtils {
-
-    public static final String TLS_AUTH_CERT = "TLS_AUTH_CERT";
-    public static final String TLS_AUTH_KEY = "TLS_AUTH_KEY";
+    /**
+     * Key for a SASL username
+     */
     public static final String SASL_USERNAME = "SASL_USERNAME";
-    public static final String SASL_PASSWORD_FILE = "SASL_PASSWORD_FILE";
+
+    /**
+     * Key for a SASL mechanism
+     */
     public static final String SASL_MECHANISM = "SASL_MECHANISM";
-    public static final String OAUTH_CONFIG = "OAUTH_CONFIG";
+
+    private static final String TLS_AUTH_CERT = "TLS_AUTH_CERT";
+    private static final String TLS_AUTH_KEY = "TLS_AUTH_KEY";
+    private static final String SASL_PASSWORD_FILE = "SASL_PASSWORD_FILE";
+    private static final String OAUTH_CONFIG = "OAUTH_CONFIG";
 
     /**
      * Validates Kafka client authentication for all components based on Apache Kafka clients.
@@ -75,7 +85,6 @@ public class AuthenticationUtils {
     }
 
     private static void validateClientAuthenticationOAuth(KafkaClientAuthenticationOAuth auth) {
-
         boolean accessTokenCase = auth.getAccessToken() != null;
         boolean refreshTokenCase = auth.getTokenEndpointUri() != null && auth.getClientId() != null && auth.getRefreshToken() != null;
         boolean clientSecretCase = auth.getTokenEndpointUri() != null && auth.getClientId() != null && auth.getClientSecret() != null;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/DnsNameGenerator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/DnsNameGenerator.java
@@ -16,7 +16,7 @@ public class DnsNameGenerator {
 
     // cluster.local is the default DNS domain for Kubernetes, if modified a user must provide the custom domain
     // via the KUBERNETES_SERVICE_DNS_DOMAIN environment variable
-    public static final String KUBERNETES_SERVICE_DNS_DOMAIN =
+    private static final String KUBERNETES_SERVICE_DNS_DOMAIN =
             System.getenv().getOrDefault("KUBERNETES_SERVICE_DNS_DOMAIN", "cluster.local");
 
     private DnsNameGenerator(String namespace, String serviceName) {
@@ -24,6 +24,14 @@ public class DnsNameGenerator {
         this.serviceName = serviceName;
     }
 
+    /**
+     * Creates the DnsNameGenerator instance from namespace and service name
+     *
+     * @param namespace     Namespace of the service
+     * @param serviceName   Name of the service
+     *
+     * @return  DnsNameGenerator instance
+     */
     public static DnsNameGenerator of(String namespace, String serviceName) {
         if (namespace == null || namespace.isEmpty() || serviceName == null || serviceName.isEmpty()) {
             throw new IllegalArgumentException();
@@ -48,6 +56,15 @@ public class DnsNameGenerator {
                 serviceDnsName());
     }
 
+    /**
+     * Generates a DNS name of a Pod
+     *
+     * @param namespace     Namespace of the Pod
+     * @param serviceName   Name of the headless service
+     * @param podName       Name of the Pod
+     *
+     * @return  Pod DNS name
+     */
     public static String podDnsName(String namespace, String serviceName, String podName) {
         return DnsNameGenerator.of(namespace, serviceName)
                 .podDnsName(podName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -68,10 +68,10 @@ public class EntityOperator extends AbstractModel {
 
     // Volume name of the temporary volume used by the TLS sidecar container
     // Because the container shares the pod with other containers, it needs to have unique name
-    /*test*/ static final String TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME = "strimzi-tls-sidecar-tmp";
+    /* test */ static final String TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME = "strimzi-tls-sidecar-tmp";
 
     // Entity Operator configuration keys
-    public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
+    /* test */ static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
 
     protected static final String CO_ENV_VAR_CUSTOM_ENTITY_OPERATOR_POD_LABELS = "STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS";
 
@@ -186,10 +186,16 @@ public class EntityOperator extends AbstractModel {
         }
     }
 
+    /**
+     * @return  The Topic Operator model
+     */
     public EntityTopicOperator topicOperator() {
         return topicOperator;
     }
 
+    /**
+     * @return  The User Operator model
+     */
     public EntityUserOperator userOperator() {
         return userOperator;
     }
@@ -199,6 +205,15 @@ public class EntityOperator extends AbstractModel {
         return null;
     }
 
+    /**
+     * Generates the Entity Operator deployment
+     *
+     * @param isOpenShift       Flag which identifies if we are running on OpenShift
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  Image pull secrets
+     *
+     * @return  Kubernetes Deployment with the Entity Operator
+     */
     public Deployment generateDeployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
                 .withType("Recreate")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -47,24 +47,24 @@ public class EntityTopicOperator extends AbstractModel {
     protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
 
     // Topic Operator configuration keys
-    public static final String ENV_VAR_RESOURCE_LABELS = "STRIMZI_RESOURCE_LABELS";
-    public static final String ENV_VAR_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
-    public static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
-    public static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
-    public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
-    public static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
-    public static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
-    public static final String ENV_VAR_SECURITY_PROTOCOL = "STRIMZI_SECURITY_PROTOCOL";
+    /* test */ static final String ENV_VAR_RESOURCE_LABELS = "STRIMZI_RESOURCE_LABELS";
+    /* test */ static final String ENV_VAR_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
+    /* test */ static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
+    /* test */ static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
+    /* test */ static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
+    /* test */ static final String ENV_VAR_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
+    /* test */ static final String ENV_VAR_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
+    /* test */ static final String ENV_VAR_SECURITY_PROTOCOL = "STRIMZI_SECURITY_PROTOCOL";
 
-    public static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
+    /* test */ static final String ENV_VAR_TLS_ENABLED = "STRIMZI_TLS_ENABLED";
 
-    public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
+    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT).build();
 
     // Volume name of the temporary volume used by the TO container
     // Because the container shares the pod with other containers, it needs to have unique name
-    /*test*/ static final String TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME = "strimzi-to-tmp";
+    /* test */ static final String TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME = "strimzi-to-tmp";
 
     // Kafka bootstrap servers and Zookeeper nodes can't be specified in the JSON
     /* test */ String kafkaBootstrapServers;
@@ -195,7 +195,7 @@ public class EntityTopicOperator extends AbstractModel {
         return varList;
     }
 
-    public List<Volume> getVolumes() {
+    protected List<Volume> getVolumes() {
         return List.of(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigMapName));
     }
 
@@ -211,6 +211,14 @@ public class EntityTopicOperator extends AbstractModel {
         return KafkaResources.entityOperatorDeploymentName(cluster);
     }
 
+    /**
+     * Generates the Topic Operator Role Binding
+     *
+     * @param namespace         Namespace where the Topic Operator is deployed
+     * @param watchedNamespace  Namespace which the Topic Operator is watching
+     *
+     * @return  Role Binding for the Topic Operator
+     */
     public RoleBinding generateRoleBindingForRole(String namespace, String watchedNamespace) {
         Subject ks = new SubjectBuilder()
                 .withKind("ServiceAccount")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -48,22 +48,23 @@ public class EntityUserOperator extends AbstractModel {
     protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
 
     // User Operator configuration keys
-    public static final String ENV_VAR_RESOURCE_LABELS = "STRIMZI_LABELS";
-    public static final String ENV_VAR_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
-    public static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
-    public static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
-    public static final String ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
-    public static final String ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
-    public static final String ENV_VAR_CLIENTS_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
-    public static final String ENV_VAR_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
-    public static final String ENV_VAR_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
-    public static final String ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
-    public static final String ENV_VAR_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
-    public static final String ENV_VAR_SECRET_PREFIX = "STRIMZI_SECRET_PREFIX";
-    public static final String ENV_VAR_ACLS_ADMIN_API_SUPPORTED = "STRIMZI_ACLS_ADMIN_API_SUPPORTED";
-    public static final String ENV_VAR_KRAFT_ENABLED = "STRIMZI_KRAFT_ENABLED";
-    public static final String ENV_VAR_MAINTENANCE_TIME_WINDOWS = "STRIMZI_MAINTENANCE_TIME_WINDOWS";
-    public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT)
+    /* test */ static final String ENV_VAR_RESOURCE_LABELS = "STRIMZI_LABELS";
+    /* test */ static final String ENV_VAR_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
+    /* test */ static final String ENV_VAR_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
+    /* test */ static final String ENV_VAR_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
+    /* test */ static final String ENV_VAR_CLIENTS_CA_CERT_SECRET_NAME = "STRIMZI_CA_CERT_NAME";
+    /* test */ static final String ENV_VAR_CLIENTS_CA_KEY_SECRET_NAME = "STRIMZI_CA_KEY_NAME";
+    /* test */ static final String ENV_VAR_CLIENTS_CA_NAMESPACE = "STRIMZI_CA_NAMESPACE";
+    /* test */ static final String ENV_VAR_CLIENTS_CA_VALIDITY = "STRIMZI_CA_VALIDITY";
+    /* test */ static final String ENV_VAR_CLIENTS_CA_RENEWAL = "STRIMZI_CA_RENEWAL";
+    /* test */ static final String ENV_VAR_CLUSTER_CA_CERT_SECRET_NAME = "STRIMZI_CLUSTER_CA_CERT_SECRET_NAME";
+    /* test */ static final String ENV_VAR_EO_KEY_SECRET_NAME = "STRIMZI_EO_KEY_SECRET_NAME";
+    /* test */ static final String ENV_VAR_SECRET_PREFIX = "STRIMZI_SECRET_PREFIX";
+    /* test */ static final String ENV_VAR_ACLS_ADMIN_API_SUPPORTED = "STRIMZI_ACLS_ADMIN_API_SUPPORTED";
+    /* test */ static final String ENV_VAR_KRAFT_ENABLED = "STRIMZI_KRAFT_ENABLED";
+    /* test */ static final String ENV_VAR_MAINTENANCE_TIME_WINDOWS = "STRIMZI_MAINTENANCE_TIME_WINDOWS";
+
+    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withTimeoutSeconds(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT)
             .withInitialDelaySeconds(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY).build();
 
     // Volume name of the temporary volume used by the UO container
@@ -225,7 +226,7 @@ public class EntityUserOperator extends AbstractModel {
         return varList;
     }
 
-    public List<Volume> getVolumes() {
+    protected List<Volume> getVolumes() {
         return List.of(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, ancillaryConfigMapName));
     }
 
@@ -241,6 +242,14 @@ public class EntityUserOperator extends AbstractModel {
         return KafkaResources.entityOperatorDeploymentName(cluster);
     }
 
+    /**
+     * Generates the User Operator Role Binding
+     *
+     * @param namespace         Namespace where the User Operator is deployed
+     * @param watchedNamespace  Namespace which the User Operator is watching
+     *
+     * @return  Role Binding for the User Operator
+     */
     public RoleBinding generateRoleBindingForRole(String namespace, String watchedNamespace) {
         Subject ks = new SubjectBuilder()
                 .withKind("ServiceAccount")
@@ -269,11 +278,11 @@ public class EntityUserOperator extends AbstractModel {
         return rb;
     }
 
-    public void setContainerEnvVars(List<ContainerEnvVar> envVars) {
+    protected void setContainerEnvVars(List<ContainerEnvVar> envVars) {
         templateContainerEnvVars = envVars;
     }
 
-    public void setContainerSecurityContext(SecurityContext securityContext) {
+    protected void setContainerSecurityContext(SecurityContext securityContext) {
         templateContainerSecurityContext = securityContext;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ImagePullPolicy.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ImagePullPolicy.java
@@ -11,8 +11,19 @@ package io.strimzi.operator.cluster.model;
  * - IfNotPresent
  */
 public enum ImagePullPolicy {
+    /**
+     * Always pull the container image
+     */
     ALWAYS("Always"),
+
+    /**
+     * Pull the container image when it is not present
+     */
     IFNOTPRESENT("IfNotPresent"),
+
+    /**
+     * Never pull the container image
+     */
     NEVER("Never");
 
     private final String imagePullPolicy;
@@ -21,6 +32,7 @@ public enum ImagePullPolicy {
         this.imagePullPolicy = imagePullPolicy;
     }
 
+    @Override
     public String toString()    {
         return imagePullPolicy;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/*
+/**
  * Class for handling JmxTrans configuration passed by the user. Used to get the resources needed to create the
  * JmxTrans deployment including: config map, deployment, and service accounts.
  */
@@ -58,17 +58,24 @@ public class JmxTrans extends AbstractModel {
 
     // Configuration defaults
     private static final String STRIMZI_DEFAULT_JMXTRANS_IMAGE = "STRIMZI_DEFAULT_JMXTRANS_IMAGE";
-    public static final Probe READINESS_PROBE_OPTIONS = new ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(15).build();
+    private static final Probe READINESS_PROBE_OPTIONS = new ProbeBuilder().withTimeoutSeconds(5).withInitialDelaySeconds(15).build();
     private static final io.strimzi.api.kafka.model.Probe DEFAULT_JMX_TRANS_PROBE = new io.strimzi.api.kafka.model.ProbeBuilder()
             .withInitialDelaySeconds(JmxTransSpec.DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(JmxTransSpec.DEFAULT_HEALTHCHECK_TIMEOUT)
             .build();
 
     // Configuration for mounting `config.json` to be used as Config during run time of the JmxTrans
+    /**
+     * Key under which the JMX Trans configuration is stored in the Config Map
+     */
     public static final String JMXTRANS_CONFIGMAP_KEY = "config.json";
-    public static final String JMXTRANS_VOLUME_NAME = "jmx-config";
+    /* test */ static final String JMXTRANS_VOLUME_NAME = "jmx-config";
+
+    /**
+     * JMX Trans Config Map revision used to trigger rolling update of JMX Trans when the configuration changes
+     */
     public static final String ANNO_JMXTRANS_CONFIG_MAP_HASH = Annotations.STRIMZI_DOMAIN + "config-map-revision";
-    public static final String JMX_FILE_PATH = "/var/lib/jmxtrans";
+    /* test */ static final String JMX_FILE_PATH = "/var/lib/jmxtrans";
 
     protected static final String ENV_VAR_JMXTRANS_LOGGING_LEVEL = "JMXTRANS_LOGGING_LEVEL";
 
@@ -174,6 +181,14 @@ public class JmxTrans extends AbstractModel {
         }
     }
 
+    /**
+     * Generates the JMX Trans deployment
+     *
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  Image pull secrets
+     *
+     * @return  Kubernetes Deployment with the JMX Trans
+     */
     public Deployment generateDeployment(ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
                 .withType("RollingUpdate")
@@ -302,7 +317,7 @@ public class JmxTrans extends AbstractModel {
         return createConfigMap(JmxTransResources.configMapName(cluster), data);
     }
 
-    public List<Volume> getVolumes() {
+    private List<Volume> getVolumes() {
         List<Volume> volumes = new ArrayList<>(2);
 
         volumes.add(createTempDirVolume());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/BrokerCapacity.java
@@ -4,15 +4,26 @@
  */
 package io.strimzi.operator.cluster.model.cruisecontrol;
 
+/**
+ * Configures the Kafka broker capacity
+ */
 public class BrokerCapacity {
     // CC allows specifying a generic "default" broker entry in the capacity configuration to apply to all brokers without a specific broker entry.
     // CC designates the id of this default broker entry as "-1".
+    /**
+     * Default broker ID
+     */
     public static final int DEFAULT_BROKER_ID = -1;
-    public static final String DEFAULT_BROKER_DOC = "This is the default capacity. Capacity unit used for disk is in MiB, cpu is in number of cores, network throughput is in KiB.";
-    public static final String DEFAULT_CPU_CORE_CAPACITY = "1";
-    public static final String DEFAULT_DISK_CAPACITY_IN_MIB = "100000";
-    public static final String DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";
+
+    /**
+     * Default outbound network capacity
+     */
     public static final String DEFAULT_OUTBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";
+
+    private static final String DEFAULT_BROKER_DOC = "This is the default capacity. Capacity unit used for disk is in MiB, cpu is in number of cores, network throughput is in KiB.";
+    protected static final String DEFAULT_CPU_CORE_CAPACITY = "1";
+    protected static final String DEFAULT_DISK_CAPACITY_IN_MIB = "100000";
+    protected static final String DEFAULT_INBOUND_NETWORK_CAPACITY_IN_KIB_PER_SECOND = "10000";
 
     private int id;
     private CpuCapacity cpu;
@@ -21,6 +32,15 @@ public class BrokerCapacity {
     private String outboundNetwork;
     private final String doc;
 
+    /**
+     * Constructor
+     *
+     * @param brokerId          ID of the broker
+     * @param cpu               CPU capacity
+     * @param disk              Disk capacity
+     * @param inboundNetwork    Inbound network capacity
+     * @param outboundNetwork   Outbound network capacity
+     */
     public BrokerCapacity(int brokerId, CpuCapacity cpu, DiskCapacity disk, String inboundNetwork, String outboundNetwork) {
         this.id = brokerId;
         this.cpu = cpu;
@@ -30,47 +50,54 @@ public class BrokerCapacity {
         this.doc = brokerId == -1 ? DEFAULT_BROKER_DOC : "Capacity for Broker " + brokerId;
     }
 
-    public Integer getId() {
+    /**
+     * @return  Broker ID
+     */
+    protected Integer getId() {
         return id;
     }
 
+    /**
+     * @return  CPU capacity
+     */
     public CpuCapacity getCpu() {
         return cpu;
     }
 
-    public DiskCapacity getDisk() {
+    /**
+     * @return  Disk capacity
+     */
+    protected DiskCapacity getDisk() {
         return disk;
     }
 
+    /**
+     * @return  Inbound network capacity
+     */
     public String getInboundNetwork() {
         return inboundNetwork;
     }
 
+    /**
+     * @return  Outbound network capacity
+     */
     public String getOutboundNetwork() {
         return outboundNetwork;
     }
 
-    public String getDoc() {
+    protected String getDoc() {
         return doc;
     }
 
-    public void setId(Integer id) {
-        this.id = id;
-    }
-
-    public void setCpu(CpuCapacity cpu) {
+    protected void setCpu(CpuCapacity cpu) {
         this.cpu = cpu;
     }
 
-    public void setDisk(DiskCapacity disk) {
-        this.disk = disk;
-    }
-
-    public void setInboundNetwork(String inboundNetwork) {
+    protected void setInboundNetwork(String inboundNetwork) {
         this.inboundNetwork = inboundNetwork;
     }
 
-    public void setOutboundNetwork(String outboundNetwork) {
+    protected void setOutboundNetwork(String outboundNetwork) {
         this.outboundNetwork = outboundNetwork;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -526,11 +526,11 @@ public class CaReconciler {
     /**
      * Helper class to pass both Cluster and Clients CA as a result of the reconciliation
      */
-    public static class CaReconciliationResult {
-        public final ClusterCa clusterCa;
-        public final ClientsCa clientsCa;
+    protected static class CaReconciliationResult {
+        protected final ClusterCa clusterCa;
+        protected final ClientsCa clientsCa;
 
-        public CaReconciliationResult(ClusterCa clusterCa, ClientsCa clientsCa) {
+        protected CaReconciliationResult(ClusterCa clusterCa, ClientsCa clientsCa) {
             this.clusterCa = clusterCa;
             this.clientsCa = clientsCa;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -33,8 +33,10 @@ import io.vertx.core.Future;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * Manages the Kafka Connect Build
+ */
 public class ConnectBuildOperator {
-
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ConnectBuildOperator.class.getName());
 
     private final DeploymentOperator deploymentOperations;
@@ -49,6 +51,13 @@ public class ConnectBuildOperator {
     private final long connectBuildTimeoutMs;
     private final PlatformFeaturesAvailability pfa;
 
+    /**
+     * Constructor
+     *
+     * @param pfa       Describes the features available in the Kubernetes cluster
+     * @param supplier  Resource operator supplier
+     * @param config    Cluster OPerator configuration
+     */
     public ConnectBuildOperator(PlatformFeaturesAvailability pfa, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
         this.deploymentOperations = supplier.deploymentOperations;
         this.podOperator = supplier.podOperations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ConcurrentDeletionException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ConcurrentDeletionException.java
@@ -8,16 +8,12 @@ package io.strimzi.operator.cluster.operator.resource;
  * Thrown for exceptional circumstances when deleting already deleted (at that time) resource.
  */
 public class ConcurrentDeletionException extends RuntimeException {
-    public ConcurrentDeletionException() {
-        super();
-    }
+    /**
+     * Constructor
+     *
+     * @param s     Error message
+     */
     public ConcurrentDeletionException(String s) {
         super(s);
-    }
-    public ConcurrentDeletionException(Throwable cause) {
-        super(cause);
-    }
-    public ConcurrentDeletionException(String message, Throwable cause) {
-        super(message, cause);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/HttpClientUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/HttpClientUtils.java
@@ -12,8 +12,10 @@ import io.vertx.core.http.HttpClientOptions;
 
 import java.util.function.BiConsumer;
 
+/**
+ * Utils for creating Http client and working with them
+ */
 public class HttpClientUtils {
-
     /**
      * Perform the given operation, which completes the promise, using an HTTP client instance,
      * after which the client is closed and the future for the promise returned.
@@ -37,5 +39,4 @@ public class HttpClientUtils {
                 return Future.failedFuture(error);
             });
     }
-
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/AbstractRebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/AbstractRebalanceOptions.java
@@ -6,9 +6,11 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import java.util.List;
 
+/**
+ * Abstract class for different sets of rebalance options - e.g. regular rebalance, add-brokers rebalance, remove-brokers rebalance.
+ */
 @SuppressWarnings("unchecked")
 public abstract class AbstractRebalanceOptions {
-
     /** Sets whether this rebalance only provides an optimisation proposal (true) or starts a rebalance (false) */
     private boolean isDryRun;
     /** List of optimisation goal class names, must be a sub-set of the configured main goals and include all hard.goals unless skipHardGoals=true */
@@ -30,42 +32,72 @@ public abstract class AbstractRebalanceOptions {
     /** A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. */
     private List<String> replicaMovementStrategies;
 
+    /**
+     * @return  True if this is dry-run only. False otherwise.
+     */
     public boolean isDryRun() {
         return isDryRun;
     }
 
+    /**
+     * @return  True if the rebalance should use verbose response. False otherwise.
+     */
     public boolean isVerbose() {
         return verbose;
     }
 
+    /**
+     * @return  True if hard-goals check should be skipped. False otherwise.
+     */
     public boolean isSkipHardGoalCheck() {
         return skipHardGoalCheck;
     }
 
+    /**
+     * @return  List of goals
+     */
     public List<String> getGoals() {
         return goals;
     }
 
+    /**
+     * @return  True if response should be in the JSON format. False otherwise.
+     */
     public boolean isJson() {
         return json;
     }
 
+    /**
+     * @return  Excludes topics
+     */
     public String getExcludedTopics() {
         return excludedTopics;
     }
 
+    /**
+     * @return  Number of concurrent partition movements per broker
+     */
     public int getConcurrentPartitionMovementsPerBroker() {
         return concurrentPartitionMovementsPerBroker;
     }
 
+    /**
+     * @return  Number of concurrent movements
+     */
     public int getConcurrentLeaderMovements() {
         return concurrentLeaderMovements;
     }
 
+    /**
+     * @return  Replication throttle
+     */
     public long getReplicationThrottle() {
         return replicationThrottle;
     }
 
+    /**
+     * @return  List of configured replica movement strategies
+     */
     public List<String> getReplicaMovementStrategies() {
         return replicaMovementStrategies;
     }
@@ -83,8 +115,13 @@ public abstract class AbstractRebalanceOptions {
         this.replicaMovementStrategies = builder.replicaMovementStrategies;
     }
 
+    /**
+     * Abstract class for rebalance options builder
+     *
+     * @param <B>   Rebalance Options Builder type
+     * @param <T>   Rebalance Options type
+     */
     public abstract static class AbstractRebalanceOptionsBuilder<B extends AbstractRebalanceOptionsBuilder<B, T>, T extends AbstractRebalanceOptions> {
-
         private boolean isDryRun;
         private List<String> goals;
         private boolean verbose;
@@ -111,33 +148,72 @@ public abstract class AbstractRebalanceOptions {
 
         protected abstract B self();
 
+        /**
+         * @return  Builds the rebalance options and returns them
+         */
         public abstract T build();
 
+        /**
+         * Enable full run
+         *
+         * @return  Instance of this builder
+         */
         public B withFullRun() {
             this.isDryRun = false;
             return self();
         }
 
+        /**
+         * Enable verbose response
+         *
+         * @return  Instance of this builder
+         */
         public B withVerboseResponse() {
             this.verbose = true;
             return self();
         }
 
+        /**
+         * Skip hard goals check
+         *
+         * @return  Instance of this builder
+         */
         public B withSkipHardGoalCheck() {
             this.skipHardGoalCheck = true;
             return self();
         }
 
+        /**
+         * Set rebalance goals
+         *
+         * @param goals     List of rebalance goals
+         *
+         * @return  Instance of this builder
+         */
         public B withGoals(List<String> goals) {
             this.goals = goals;
             return self();
         }
 
+        /**
+         * Set excluded topics
+         *
+         * @param excludedTopics    Excluded topics
+         *
+         * @return  Instance of this builder
+         */
         public B withExcludedTopics(String excludedTopics) {
             this.excludedTopics = excludedTopics;
             return self();
         }
 
+        /**
+         * Sets number of concurrent partition movements per-broker
+         *
+         * @param movements Number of movements
+         *
+         * @return  Instance of this builder
+         */
         public B withConcurrentPartitionMovementsPerBroker(int movements) {
             if (movements < 0) {
                 throw new IllegalArgumentException("The max number of concurrent movements between brokers should be greater than zero");
@@ -146,6 +222,13 @@ public abstract class AbstractRebalanceOptions {
             return self();
         }
 
+        /**
+         * Sets number of concurrent leader movements
+         *
+         * @param movements     Number of leader movements
+         *
+         * @return  Instance of this builder
+         */
         public B withConcurrentLeaderMovements(int movements) {
             if (movements < 0) {
                 throw new IllegalArgumentException("The max number of concurrent partition leadership movements should be greater than zero");
@@ -154,6 +237,13 @@ public abstract class AbstractRebalanceOptions {
             return self();
         }
 
+        /**
+         * Sets replication throttle
+         *
+         * @param bandwidth     The throttle bandwidth
+         *
+         * @return  Instance of this builder
+         */
         public B withReplicationThrottle(long bandwidth) {
             if (bandwidth < 0) {
                 throw new IllegalArgumentException("The max replication bandwidth should be greater than zero");
@@ -162,6 +252,13 @@ public abstract class AbstractRebalanceOptions {
             return self();
         }
 
+        /**
+         * Sets replica movement strategies
+         *
+         * @param replicaMovementStrategies     List of replica movement strategies
+         *
+         * @return  Instance of this builder
+         */
         public B withReplicaMovementStrategies(List<String> replicaMovementStrategies) {
             this.replicaMovementStrategies = replicaMovementStrategies;
             return self();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/AddBrokerOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/AddBrokerOptions.java
@@ -6,11 +6,16 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import java.util.List;
 
+/**
+ * Rebalance options for adding a new broker(s) to the cluster
+ */
 public class AddBrokerOptions extends AbstractRebalanceOptions {
-
     /** list with the ids of the new brokers added to the cluster */
     private List<Integer> brokers;
 
+    /**
+     * @return  List of broker IDs which should be added
+     */
     public List<Integer> getBrokers() {
         return brokers;
     }
@@ -20,10 +25,15 @@ public class AddBrokerOptions extends AbstractRebalanceOptions {
         this.brokers = builder.brokers;
     }
 
+    /**
+     * The builder class for building AddBrokerOptions
+     */
     public static class AddBrokerOptionsBuilder extends AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<AddBrokerOptionsBuilder, AddBrokerOptions> {
-
         private List<Integer> brokers;
 
+        /**
+         * Constructs the builder
+         */
         public AddBrokerOptionsBuilder() {
             this.brokers = null;
         }
@@ -33,6 +43,13 @@ public class AddBrokerOptions extends AbstractRebalanceOptions {
             return this;
         }
 
+        /**
+         * Add list of brokers which should be added
+         *
+         * @param brokers   List of broker IDs
+         *
+         * @return  Instance of this builder
+         */
         public AddBrokerOptionsBuilder withBrokers(List<Integer> brokers) {
             this.brokers = brokers;
             return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RebalanceOptions.java
@@ -4,17 +4,25 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
+/**
+ * Rebalance options for full Kafka cluster rebalance
+ */
 public class RebalanceOptions extends AbstractRebalanceOptions {
-
     /** Whether to balance load between disks within brokers (requires JBOD Kafka deployment) */
     private boolean rebalanceDisk;
     /** The upper bound of ongoing replica movements between disks within each broker */
     private int concurrentIntraBrokerPartitionMovements;
 
+    /**
+     * @return  True if intra-broker relbalance is enabled. False otherwise.
+     */
     public boolean isRebalanceDisk() {
         return rebalanceDisk;
     }
 
+    /**
+     * @return  Number of concurrent intra-broker partition movements
+     */
     public int getConcurrentIntraBrokerPartitionMovements() {
         return concurrentIntraBrokerPartitionMovements;
     }
@@ -25,11 +33,16 @@ public class RebalanceOptions extends AbstractRebalanceOptions {
         this.concurrentIntraBrokerPartitionMovements = builder.concurrentIntraPartitionMovements;
     }
 
+    /**
+     * Builder for the full rebalance options
+     */
     public static class RebalanceOptionsBuilder extends AbstractRebalanceOptionsBuilder<RebalanceOptionsBuilder, RebalanceOptions> {
-
         private boolean rebalanceDisk;
         private int concurrentIntraPartitionMovements;
 
+        /**
+         * Constructor
+         */
         public RebalanceOptionsBuilder() {
             rebalanceDisk = false;
             concurrentIntraPartitionMovements = 0;
@@ -40,11 +53,23 @@ public class RebalanceOptions extends AbstractRebalanceOptions {
             return this;
         }
 
+        /**
+         * Enabled intra-broker rebalancing
+         *
+         * @return  Instance of this builder
+         */
         public RebalanceOptionsBuilder withRebalanceDisk() {
             this.rebalanceDisk = true;
             return self();
         }
 
+        /**
+         * Number of concurrent intra-broker partition movements
+         *
+         * @param movements Number of intra-broker partition movements
+         *
+         * @return  Instance of this builder
+         */
         public RebalanceOptionsBuilder withConcurrentIntraPartitionMovements(int movements) {
             if (movements < 0) {
                 throw new IllegalArgumentException("The max number of concurrent intra partition movements should be greater than zero");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RemoveBrokerOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/RemoveBrokerOptions.java
@@ -6,11 +6,16 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import java.util.List;
 
+/**
+ * Rebalance options for removing brokers from the Kafka cluster
+ */
 public class RemoveBrokerOptions extends AbstractRebalanceOptions {
-
     /** list with the ids of the brokers removed from the cluster */
     private List<Integer> brokers;
 
+    /**
+     * @return  List of brokers which will be removed
+     */
     public List<Integer> getBrokers() {
         return brokers;
     }
@@ -20,10 +25,15 @@ public class RemoveBrokerOptions extends AbstractRebalanceOptions {
         this.brokers = builder.brokers;
     }
 
+    /**
+     * Builder class for RemoveBrokerOptions
+     */
     public static class RemoveBrokerOptionsBuilder extends AbstractRebalanceOptionsBuilder<RemoveBrokerOptionsBuilder, RemoveBrokerOptions> {
-
         private List<Integer> brokers;
 
+        /**
+         * Constructor
+         */
         public RemoveBrokerOptionsBuilder() {
             this.brokers = null;
         }
@@ -33,6 +43,13 @@ public class RemoveBrokerOptions extends AbstractRebalanceOptions {
             return this;
         }
 
+        /**
+         * List of brokers which should be removed
+         *
+         * @param brokers   List of broker IDs
+         *
+         * @return  Instance of this builder
+         */
         public RemoveBrokerOptionsBuilder withBrokers(List<Integer> brokers) {
             this.brokers = brokers;
             return this;


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds first batch of missing Javadoc comments in the `cluster-operator` module or where possible changes the fields / methods to not be public. As it is not yet complete for the complete module, it does not enable the strict Javadoc checking. But it can be done and merged over smaller parts to make it easier to tackle the large number of missing Javadocs with Java 17.

This contributes to #7702

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally