### PR TITLE
Improve the Kafka Connect Build with some Java 17 features

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -10,6 +10,9 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 
+/**
+ * Utility methods for Kafka Connect Build
+ */
 public class KafkaConnectBuildUtils {
     /**
      * Checks if Pod already completed

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -128,11 +128,11 @@ public class ConnectBuildOperator {
             LOGGER.debugCr(reconciliation, "Build configuration did not change. Nothing new to build. Container image {} will be used.", currentImage);
             return Future.succeededFuture(new BuildInfo(currentImage, newBuildRevision));
         } else if (pfa.supportsS2I()) {
-            // Revisions differ and we have S2I support => we are on OpenShift and should do a build
+            // Revisions differ, and we have S2I support => we are on OpenShift and should do a build
             return openShiftBuild(reconciliation, namespace, connectBuild, forceRebuild, dockerfile, newBuildRevision)
                     .compose(image -> Future.succeededFuture(new BuildInfo(image, newBuildRevision)));
         } else {
-            // Revisions differ and no S2I support => we are on Kubernetes and should do a build
+            // Revisions differ, and no S2I support => we are on Kubernetes and should do a build
             return kubernetesBuild(reconciliation, namespace, connectBuild, forceRebuild, dockerFileConfigMap, newBuildRevision)
                     .compose(image -> Future.succeededFuture(new BuildInfo(image, newBuildRevision)));
         }
@@ -162,7 +162,7 @@ public class ConnectBuildOperator {
                         if (newBuildRevision.equals(existingBuildRevision)
                                 && !KafkaConnectBuildUtils.buildPodFailed(pod, KafkaConnectBuildUtils.getBuildContainerName(connectBuild.getCluster(), pfa.isOpenshift()))
                                 && !forceRebuild) {
-                            // Builder pod exists, is not failed, and is building the same Dockerfile and we are not
+                            // Builder pod exists, is not failed, and is building the same Dockerfile, and we are not
                             // asked to force re-build by the annotation => we re-use the existing build
                             LOGGER.infoCr(reconciliation, "Previous build exists with the same Dockerfile and will be reused.");
                             return Future.succeededFuture();
@@ -281,7 +281,7 @@ public class ConnectBuildOperator {
                         if (newBuildRevision.equals(existingBuildRevision)
                                 && !KafkaConnectBuildUtils.buildFailed(build)
                                 && !forceRebuild) {
-                            // Build exists, is not failed, and is building the same Dockerfile and we are not
+                            // Build exists, is not failed, and is building the same Dockerfile, and we are not
                             // asked to force re-build by the annotation => we re-use the existing build
                             LOGGER.infoCr(reconciliation, "Previous build exists with the same Dockerfile and will be reused.");
                             return Future.succeededFuture(build.getMetadata().getName());
@@ -345,7 +345,7 @@ public class ConnectBuildOperator {
                 .compose(ignore -> buildOperator.getAsync(namespace, buildName))
                 .compose(build -> {
                     if (KafkaConnectBuildUtils.buildSucceeded(build))   {
-                        // Build completed successfully. Lets extract the new image
+                        // Build completed successfully. Let's extract the new image
                         if (build.getStatus().getOutputDockerImageReference() != null
                                 && build.getStatus().getOutput() != null
                                 && build.getStatus().getOutput().getTo() != null
@@ -378,21 +378,5 @@ public class ConnectBuildOperator {
     /**
      * Utility class to return the information about the Kafka Connect Build.
      */
-    static class BuildInfo {
-        private final String image;
-        private final String buildRevision;
-
-        public BuildInfo(String image, String buildRevision) {
-            this.image = image;
-            this.buildRevision = buildRevision;
-        }
-
-        public String getImage() {
-            return image;
-        }
-
-        public String getBuildRevision() {
-            return buildRevision;
-        }
-    }
+    record BuildInfo(String image, String buildRevision) { }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -64,6 +64,8 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     protected final long connectBuildTimeoutMs;
 
     /**
+     * Constructor
+     *
      * @param vertx The Vertx instance
      * @param pfa Platform features availability properties
      * @param supplier Supplies the operators for different resources
@@ -75,13 +77,36 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         this(vertx, pfa, supplier, config, connect -> new KafkaConnectApiImpl(vertx));
     }
 
-    public KafkaConnectAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
+    /**
+     * Constructor which allows providing custom implementation of the Kafka Connect Client. This is used in tests.
+     *
+     * @param vertx                     The Vertx instance
+     * @param pfa                       Platform features availability properties
+     * @param supplier                  Supplies the operators for different resources
+     * @param config                    ClusterOperator configuration. Used to get the user-configured image pull policy
+     *                                  and the secrets.
+     * @param connectClientProvider     Provider of the Kafka Connect client
+     */
+    protected KafkaConnectAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
                                         ResourceOperatorSupplier supplier,
                                         ClusterOperatorConfig config,
                                         Function<Vertx, KafkaConnectApi> connectClientProvider) {
         this(vertx, pfa, supplier, config, connectClientProvider, KafkaConnectCluster.REST_API_PORT);
     }
-    public KafkaConnectAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
+
+    /**
+     * Constructor which allows providing custom implementation of the Kafka Connect Client and port on which the Kafka
+     * Connect REST API is listening. This is used in tests.
+     *
+     * @param vertx                     The Vertx instance
+     * @param pfa                       Platform features availability properties
+     * @param supplier                  Supplies the operators for different resources
+     * @param config                    ClusterOperator configuration. Used to get the user-configured image pull policy
+     *                                  and the secrets.
+     * @param connectClientProvider     Provider of the Kafka Connect client
+     * @param port                      Port of the Kafka Connect REST API
+     */
+    protected KafkaConnectAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
                                         ResourceOperatorSupplier supplier,
                                         ClusterOperatorConfig config,
                                         Function<Vertx, KafkaConnectApi> connectClientProvider, int port) {
@@ -125,8 +150,8 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> connectBuildOperator.reconcile(reconciliation, namespace, connect.getName(), build))
                 .compose(buildInfo -> {
                     if (buildInfo != null) {
-                        annotations.put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, buildInfo.getBuildRevision());
-                        image.set(buildInfo.getImage());
+                        annotations.put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, buildInfo.buildRevision());
+                        image.set(buildInfo.image());
                     }
                     return Future.succeededFuture();
                 })


### PR DESCRIPTION
### Type of change

- Task

### Description

As we now use Java 17, we can use some of the new features which it provides. This PR updates some of the classes used by Kafka Connect Build to use some of the new features such as records or _pattern matching_ when using `instanceof` operator. It also fixes some missing JavaDoc comments and some typo in comments as suggested by the IDE.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally