### PR TITLE
[systemtest] Add tests for Oauth password grants

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -66,6 +66,11 @@ public class OauthAbstractST extends AbstractST {
     protected static final String OAUTH_KAFKA_CLIENT_SECRET = "kafka-client-secret";
     protected static final String OAUTH_KEY = "clientSecret";
 
+    protected static final String OAUTH_BRIDGE_CLIENT_ID = "kafka-bridge";
+    protected static final String OAUTH_CONNECT_CLIENT_ID = "kafka-connect";
+    protected static final String OAUTH_MM_CLIENT_ID = "kafka-mirror-maker";
+    protected static final String OAUTH_MM2_CLIENT_ID = "kafka-mirror-maker-2";
+
     // broker oauth configuration
     protected static final Integer CONNECT_TIMEOUT_S = 100;
     protected static final Integer READ_TIMEOUT_S = 100;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsIsolatedST.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
@@ -42,14 +43,25 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.time.Duration;
 
+import static io.strimzi.systemtest.Constants.BRIDGE;
+import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
 import static io.strimzi.systemtest.Constants.HTTP_BRIDGE_DEFAULT_PORT;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
+import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
+import static io.strimzi.systemtest.Constants.OAUTH;
+import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
-public class OauthPasswordGrantsST extends OauthAbstractST {
+@Tag(OAUTH)
+@Tag(REGRESSION)
+@IsolatedSuite
+public class OauthPasswordGrantsIsolatedST extends OauthAbstractST {
     protected static final Logger LOGGER = LogManager.getLogger(OauthAuthorizationIsolatedST.class);
     private final String oauthClusterName = "oauth-pass-grants-cluster-name";
     private static final String TEST_REALM = "internal";
@@ -58,6 +70,7 @@ public class OauthPasswordGrantsST extends OauthAbstractST {
     private static final String ALICE_PASSWORD_KEY = "password";
 
     @ParallelTest
+    @Tag(MIRROR_MAKER)
     void testPasswordGrantsKafkaMirrorMaker(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
@@ -194,6 +207,7 @@ public class OauthPasswordGrantsST extends OauthAbstractST {
     }
 
     @ParallelTest
+    @Tag(MIRROR_MAKER2)
     void testPasswordGrantsKafkaMirrorMaker2(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
@@ -339,6 +353,8 @@ public class OauthPasswordGrantsST extends OauthAbstractST {
     }
 
     @ParallelTest
+    @Tag(CONNECT)
+    @Tag(CONNECT_COMPONENTS)
     void testPasswordGrantsKafkaConnect(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
@@ -414,6 +430,7 @@ public class OauthPasswordGrantsST extends OauthAbstractST {
     }
 
     @ParallelTest
+    @Tag(BRIDGE)
     void testPasswordGrantsKafkaBridge(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsST.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.security.oauth;
+
+import io.strimzi.api.kafka.model.KafkaBridgeResources;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpecBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaOauthClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaOauthClientsBuilder;
+import io.strimzi.systemtest.templates.crd.KafkaBridgeTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaMirrorMaker2Templates;
+import io.strimzi.systemtest.templates.crd.KafkaMirrorMakerTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
+import io.strimzi.systemtest.utils.specific.KeycloakUtils;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.WaitException;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.time.Duration;
+
+import static io.strimzi.systemtest.Constants.HTTP_BRIDGE_DEFAULT_PORT;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
+public class OauthPasswordGrantsST extends OauthAbstractST {
+    protected static final Logger LOGGER = LogManager.getLogger(OauthAuthorizationIsolatedST.class);
+    private final String oauthClusterName = "oauth-pass-grants-cluster-name";
+    private static final String TEST_REALM = "internal";
+    private static final String ALICE_SECRET = "alice-secret";
+    private static final String ALICE_USERNAME = "alice";
+    private static final String ALICE_PASSWORD_KEY = "password";
+
+    @ParallelTest
+    void testPasswordGrantsKafkaMirrorMaker(ExtensionContext extensionContext) {
+        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
+        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
+        resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        String targetKafkaCluster = clusterName + "-target";
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(targetKafkaCluster, 1, 1)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                            .withPort(9092)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(false)
+                            .withNewKafkaListenerAuthenticationOAuth()
+                                .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                                .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                                .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                                .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                                .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                            .endKafkaListenerAuthenticationOAuth()
+                            .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        resourceManager.createResource(extensionContext, KafkaMirrorMakerTemplates.kafkaMirrorMaker(oauthClusterName, oauthClusterName, targetKafkaCluster,
+                ClientUtils.generateRandomConsumerGroup(), 1, false)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editSpec()
+                .withNewConsumer()
+                    .withBootstrapServers(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                    .withGroupId(ClientUtils.generateRandomConsumerGroup())
+                    .addToConfig(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                    .withNewKafkaClientAuthenticationOAuth()
+                        .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                        .withClientId("kafka-mirror-maker")
+                        .withUsername(ALICE_USERNAME)
+                        .withNewPasswordSecret()
+                            .withSecretName(ALICE_SECRET)
+                            .withPassword(ALICE_PASSWORD_KEY)
+                        .endPasswordSecret()
+                        .withNewClientSecret()
+                            .withSecretName(MIRROR_MAKER_OAUTH_SECRET)
+                            .withKey(OAUTH_KEY)
+                        .endClientSecret()
+                        .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
+                        .withReadTimeoutSeconds(READ_TIMEOUT_S)
+                    .endKafkaClientAuthenticationOAuth()
+                    .withTls(null)
+                .endConsumer()
+                .withNewProducer()
+                    .withBootstrapServers(KafkaResources.plainBootstrapAddress(targetKafkaCluster))
+                    .withNewKafkaClientAuthenticationOAuth()
+                        .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                        .withClientId("kafka-mirror-maker")
+                        .withUsername(ALICE_USERNAME)
+                        .withNewPasswordSecret()
+                            .withSecretName(ALICE_SECRET)
+                            .withPassword(ALICE_PASSWORD_KEY)
+                        .endPasswordSecret()
+                        .withNewClientSecret()
+                            .withSecretName(MIRROR_MAKER_OAUTH_SECRET)
+                            .withKey(OAUTH_KEY)
+                        .endClientSecret()
+                        .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
+                        .withReadTimeoutSeconds(READ_TIMEOUT_S)
+                    .endKafkaClientAuthenticationOAuth()
+                    .addToConfig(ProducerConfig.ACKS_CONFIG, "all")
+                    .withTls(null)
+                .endProducer()
+            .endSpec()
+            .build());
+
+        final String kafkaMirrorMakerPodName = kubeClient().listPods(clusterOperator.getDeploymentNamespace(), oauthClusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND).get(0).getMetadata().getName();
+        final String kafkaMirrorMakerLogs = KubeClusterResource.cmdKubeClient(clusterOperator.getDeploymentNamespace()).execInCurrentNamespace(Level.DEBUG, "logs", kafkaMirrorMakerPodName).out();
+        verifyOauthConfiguration(kafkaMirrorMakerLogs);
+
+        TestUtils.waitFor("Waiting for Mirror Maker will copy messages from " + oauthClusterName + " to " + targetKafkaCluster,
+            Constants.GLOBAL_CLIENTS_POLL, Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
+            () -> {
+                LOGGER.info("Deleting the Job");
+                JobUtils.deleteJobWithWait(clusterOperator.getDeploymentNamespace(), OAUTH_CONSUMER_NAME);
+
+                LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", targetKafkaCluster);
+                KafkaOauthClients kafkaOauthClientJob = new KafkaOauthClientsBuilder()
+                    .withNamespaceName(clusterOperator.getDeploymentNamespace())
+                    .withProducerName(consumerName)
+                    .withConsumerName(OAUTH_CONSUMER_NAME)
+                    .withBootstrapAddress(KafkaResources.plainBootstrapAddress(targetKafkaCluster))
+                    .withTopicName(topicName)
+                    .withMessageCount(MESSAGE_COUNT)
+                    .withOauthClientId(OAUTH_CLIENT_NAME)
+                    .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+                    .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .build();
+
+                resourceManager.createResource(extensionContext, kafkaOauthClientJob.consumerStrimziOauthPlain());
+
+                try {
+                    ClientUtils.waitForClientSuccess(OAUTH_CONSUMER_NAME, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+                    return  true;
+                } catch (WaitException e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            });
+    }
+
+    @ParallelTest
+    void testPasswordGrantsKafkaMirrorMaker2(ExtensionContext extensionContext) {
+        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
+        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
+        resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        String kafkaSourceClusterName = oauthClusterName;
+        String kafkaTargetClusterName = clusterName + "-target";
+        // mirror maker 2 adding prefix to mirrored topic for in this case mirrotopic will be : my-cluster.my-topic
+        String kafkaTargetClusterTopicName = kafkaSourceClusterName + "." + topicName;
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(kafkaTargetClusterName, 1, 1)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                            .withPort(9092)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(false)
+                            .withNewKafkaListenerAuthenticationOAuth()
+                                .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                                .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                                .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                                .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                                .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                            .endKafkaListenerAuthenticationOAuth()
+                            .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        // Deploy Mirror Maker 2.0 with oauth
+        KafkaMirrorMaker2ClusterSpec sourceClusterWithOauth = new KafkaMirrorMaker2ClusterSpecBuilder()
+            .withAlias(kafkaSourceClusterName)
+            .withConfig(connectorConfig)
+            .withBootstrapServers(KafkaResources.plainBootstrapAddress(kafkaSourceClusterName))
+            .withNewKafkaClientAuthenticationOAuth()
+                .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                .withClientId("kafka-mirror-maker-2")
+                .withUsername(ALICE_USERNAME)
+                .withNewPasswordSecret()
+                    .withSecretName(ALICE_SECRET)
+                    .withPassword(ALICE_PASSWORD_KEY)
+                .endPasswordSecret()
+                .withNewClientSecret()
+                    .withSecretName(MIRROR_MAKER_2_OAUTH_SECRET)
+                    .withKey(OAUTH_KEY)
+                .endClientSecret()
+                .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
+                .withReadTimeoutSeconds(READ_TIMEOUT_S)
+            .endKafkaClientAuthenticationOAuth()
+            .build();
+
+        KafkaMirrorMaker2ClusterSpec targetClusterWithOauth = new KafkaMirrorMaker2ClusterSpecBuilder()
+            .withAlias(kafkaTargetClusterName)
+            .withConfig(connectorConfig)
+            .withBootstrapServers(KafkaResources.plainBootstrapAddress(kafkaTargetClusterName))
+            .withNewKafkaClientAuthenticationOAuth()
+                .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                .withClientId("kafka-mirror-maker-2")
+                .withUsername(ALICE_USERNAME)
+                .withNewPasswordSecret()
+                    .withSecretName(ALICE_SECRET)
+                    .withPassword(ALICE_PASSWORD_KEY)
+                .endPasswordSecret()
+                .withNewClientSecret()
+                    .withSecretName(MIRROR_MAKER_2_OAUTH_SECRET)
+                    .withKey(OAUTH_KEY)
+                .endClientSecret()
+                .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
+                .withReadTimeoutSeconds(READ_TIMEOUT_S)
+            .endKafkaClientAuthenticationOAuth()
+            .build();
+
+        resourceManager.createResource(extensionContext, KafkaMirrorMaker2Templates.kafkaMirrorMaker2(oauthClusterName, kafkaTargetClusterName, kafkaSourceClusterName, 1, false)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editSpec()
+                .withClusters(sourceClusterWithOauth, targetClusterWithOauth)
+                .editFirstMirror()
+                    .withSourceCluster(kafkaSourceClusterName)
+                .endMirror()
+            .endSpec()
+            .build());
+
+        final String kafkaMirrorMaker2PodName = kubeClient().listPods(clusterOperator.getDeploymentNamespace(), oauthClusterName, Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).get(0).getMetadata().getName();
+        final String kafkaMirrorMaker2Logs = KubeClusterResource.cmdKubeClient(clusterOperator.getDeploymentNamespace()).execInCurrentNamespace(Level.DEBUG, "logs", kafkaMirrorMaker2PodName).out();
+        verifyOauthConfiguration(kafkaMirrorMaker2Logs);
+
+        TestUtils.waitFor("Waiting for Mirror Maker 2 will copy messages from " + kafkaSourceClusterName + " to " + kafkaTargetClusterName,
+            Duration.ofSeconds(30).toMillis(), Constants.TIMEOUT_FOR_MIRROR_MAKER_COPY_MESSAGES_BETWEEN_BROKERS,
+            () -> {
+                LOGGER.info("Deleting the Job {}", consumerName);
+                JobUtils.deleteJobWithWait(clusterOperator.getDeploymentNamespace(), consumerName);
+
+                LOGGER.info("Creating new client with new consumer-group and also to point on {} cluster", kafkaTargetClusterName);
+
+                KafkaOauthClients kafkaOauthClientJob = new KafkaOauthClientsBuilder()
+                    .withNamespaceName(clusterOperator.getDeploymentNamespace())
+                    .withProducerName(producerName)
+                    .withConsumerName(consumerName)
+                    .withBootstrapAddress(KafkaResources.plainBootstrapAddress(kafkaTargetClusterName))
+                    .withTopicName(kafkaTargetClusterTopicName)
+                    .withMessageCount(MESSAGE_COUNT)
+                    .withOauthClientId(OAUTH_CLIENT_NAME)
+                    .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+                    .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .build();
+
+                resourceManager.createResource(extensionContext, kafkaOauthClientJob.consumerStrimziOauthPlain());
+
+                try {
+                    ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+                    return  true;
+                } catch (WaitException e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            });
+    }
+
+    @ParallelTest
+    void testPasswordGrantsKafkaConnect(ExtensionContext extensionContext) {
+        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
+        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
+        resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        KafkaConnect connect = KafkaConnectTemplates.kafkaConnectWithFilePlugin(clusterName, clusterOperator.getDeploymentNamespace(), oauthClusterName, 1)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editOrNewSpec()
+                .withBootstrapServers(KafkaResources.plainBootstrapAddress(oauthClusterName))
+                .withConfig(connectorConfig)
+                .addToConfig("key.converter.schemas.enable", false)
+                .addToConfig("value.converter.schemas.enable", false)
+                .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
+                .withNewKafkaClientAuthenticationOAuth()
+                    .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .withClientId("kafka-connect")
+                    .withUsername(ALICE_USERNAME)
+                    .withNewPasswordSecret()
+                        .withSecretName(ALICE_SECRET)
+                        .withPassword(ALICE_PASSWORD_KEY)
+                    .endPasswordSecret()
+                    .withNewClientSecret()
+                        .withSecretName(CONNECT_OAUTH_SECRET)
+                        .withKey(OAUTH_KEY)
+                    .endClientSecret()
+                    .withConnectTimeoutSeconds(CONNECT_TIMEOUT_S)
+                    .withReadTimeoutSeconds(READ_TIMEOUT_S)
+                .endKafkaClientAuthenticationOAuth()
+                .withNewInlineLogging()
+                    // needed for a verification of oauth configuration
+                    .addToLoggers("connect.root.logger.level", "DEBUG")
+                .endInlineLogging()
+            .endSpec()
+            .build();
+        // This is required to be able to remove the TLS setting, the builder cannot remove it
+        connect.getSpec().setTls(null);
+
+        resourceManager.createResource(extensionContext, connect);
+
+        final String kafkaConnectPodName = kubeClient().listPods(clusterOperator.getDeploymentNamespace(), clusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(clusterOperator.getDeploymentNamespace(), kafkaConnectPodName);
+
+        KafkaConnectorUtils.createFileSinkConnector(clusterOperator.getDeploymentNamespace(), kafkaConnectPodName, topicName, Constants.DEFAULT_SINK_FILE_PATH, "http://localhost:8083");
+
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(clusterOperator.getDeploymentNamespace(), kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
+
+        final String kafkaConnectLogs = KubeClusterResource.cmdKubeClient(clusterOperator.getDeploymentNamespace()).execInCurrentNamespace(Level.DEBUG, "logs", kafkaConnectPodName).out();
+        verifyOauthConfiguration(kafkaConnectLogs);
+    }
+
+    @ParallelTest
+    void testPasswordGrantsKafkaBridge(ExtensionContext extensionContext) {
+        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
+        String producerName = OAUTH_PRODUCER_NAME + "-" + clusterName;
+        String consumerName = OAUTH_CONSUMER_NAME + "-" + clusterName;
+        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+
+        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
+
+        KafkaOauthClients oauthExampleClients = new KafkaOauthClientsBuilder()
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(oauthClusterName))
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withOauthClientId(OAUTH_CLIENT_NAME)
+            .withOauthClientSecret(OAUTH_CLIENT_SECRET)
+            .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            .build();
+
+        resourceManager.createResource(extensionContext, oauthExampleClients.producerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, oauthExampleClients.consumerStrimziOauthPlain());
+        ClientUtils.waitForClientSuccess(consumerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+
+        resourceManager.createResource(extensionContext, KafkaBridgeTemplates.kafkaBridge(oauthClusterName, KafkaResources.plainBootstrapAddress(oauthClusterName), 1)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editSpec()
+                .withNewKafkaClientAuthenticationOAuth()
+                    .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                    .withClientId("kafka-bridge")
+                    .withUsername(ALICE_USERNAME)
+                    .withNewPasswordSecret()
+                        .withSecretName(ALICE_SECRET)
+                        .withPassword(ALICE_PASSWORD_KEY)
+                    .endPasswordSecret()
+                    .withNewClientSecret()
+                        .withSecretName(BRIDGE_OAUTH_SECRET)
+                        .withKey(OAUTH_KEY)
+                    .endClientSecret()
+                .endKafkaClientAuthenticationOAuth()
+            .endSpec()
+            .build());
+
+        producerName = "bridge-producer-" + clusterName;
+
+        BridgeClients kafkaBridgeClientJob = new BridgeClientsBuilder()
+            .withProducerName(producerName)
+            .withBootstrapAddress(KafkaBridgeResources.serviceName(oauthClusterName))
+            .withTopicName(topicName)
+            .withMessageCount(MESSAGE_COUNT)
+            .withPort(HTTP_BRIDGE_DEFAULT_PORT)
+            .withDelayMs(1000)
+            .withPollInterval(1000)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .build();
+
+        resourceManager.createResource(extensionContext, kafkaBridgeClientJob.producerStrimziBridge());
+        ClientUtils.waitForClientSuccess(producerName, clusterOperator.getDeploymentNamespace(), MESSAGE_COUNT);
+    }
+
+    @BeforeAll
+    void setUp(ExtensionContext extensionContext)  {
+        super.setupCoAndKeycloak(extensionContext, clusterOperator.getDeploymentNamespace());
+
+        keycloakInstance.setRealm(TEST_REALM, false);
+
+        LOGGER.info("Keycloak settings {}", keycloakInstance.toString());
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(oauthClusterName, 3)
+            .editMetadata()
+                .withNamespace(clusterOperator.getDeploymentNamespace())
+            .endMetadata()
+            .editSpec()
+                .editKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                        .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                        .withPort(9092)
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withTls(false)
+                        .withNewKafkaListenerAuthenticationOAuth()
+                            .withValidIssuerUri(keycloakInstance.getValidIssuerUri())
+                            .withJwksExpirySeconds(keycloakInstance.getJwksExpireSeconds())
+                            .withJwksRefreshSeconds(keycloakInstance.getJwksRefreshSeconds())
+                            .withJwksEndpointUri(keycloakInstance.getJwksEndpointUri())
+                            .withUserNameClaim(keycloakInstance.getUserNameClaim())
+                            .withEnablePlain(true)
+                            .withTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+                            .withGroupsClaim(GROUPS_CLAIM)
+                            .withGroupsClaimDelimiter(GROUPS_CLAIM_DELIMITER)
+                        .endKafkaListenerAuthenticationOAuth()
+                        .build())
+                .endKafka()
+            .endSpec()
+            .build());
+
+        SecretUtils.createSecret(clusterOperator.getDeploymentNamespace(), ALICE_SECRET, ALICE_PASSWORD_KEY, "alice-password");
+    }
+
+    @AfterAll
+    void tearDown(ExtensionContext extensionContext) throws Exception {
+        // delete keycloak before namespace
+        KeycloakUtils.deleteKeycloak(clusterOperator.getDeploymentNamespace(), clusterOperator.getDeploymentNamespace());
+        // delete namespace etc.
+        super.afterAllMayOverride(extensionContext);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New tests

### Description

This PR adds tests for all components and new feature, Oauth password grants, which was added as part of #7169 .
These tests are more or less copied from `OauthPlainST` - we can have it there, but I decided to create new class for these tests to keep the code clear.

Password grants using deprecated "username and password" mechanism, I picked up our `alice` user from our `internal` Keycloak realm.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
