### PR TITLE
Add support for Batch reconciliation in the Kubernetes resource operators

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -477,6 +477,8 @@ public class KafkaAssemblyOperatorTest {
 
         Map<String, Service> expectedServicesMap = createdServices.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockServiceOps.batchReconcile(any(), eq(kafkaNamespace), any(), any())).thenCallRealMethod();
         when(mockServiceOps.get(eq(kafkaNamespace), anyString())).thenAnswer(i -> Future.succeededFuture(expectedServicesMap.get(i.<String>getArgument(1))));
         when(mockServiceOps.getAsync(eq(kafkaNamespace), anyString())).thenAnswer(i -> {
             Service svc = expectedServicesMap.get(i.<String>getArgument(1));
@@ -492,6 +494,9 @@ public class KafkaAssemblyOperatorTest {
         when(mockServiceOps.listAsync(eq(kafkaNamespace), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Ingress mocks
+
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockIngressOps.batchReconcile(any(), eq(kafkaNamespace), any(), any())).thenCallRealMethod();
         when(mockIngressOps.listAsync(eq(kafkaNamespace), any(Labels.class))).thenReturn(
                 Future.succeededFuture(emptyList())
         );
@@ -505,6 +510,8 @@ public class KafkaAssemblyOperatorTest {
 
             Map<String, Route> expectedRoutesMap = expectedRoutes.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
+            // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+            when(mockRouteOps.batchReconcile(any(), eq(kafkaNamespace), any(), any())).thenCallRealMethod();
             when(mockRouteOps.get(eq(kafkaNamespace), anyString())).thenAnswer(i -> Future.succeededFuture(expectedRoutesMap.get(i.<String>getArgument(1))));
             when(mockRouteOps.getAsync(eq(kafkaNamespace), anyString())).thenAnswer(i -> {
                 Route rt = expectedRoutesMap.get(i.<String>getArgument(1));
@@ -1025,6 +1032,8 @@ public class KafkaAssemblyOperatorTest {
 
         Map<String, Service> expectedServicesMap = expectedServices.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockServiceOps.batchReconcile(any(), eq(clusterNamespace), any(), any())).thenCallRealMethod();
         when(mockServiceOps.endpointReadiness(any(), eq(clusterNamespace), any(), anyLong(), anyLong())).thenReturn(
                 Future.succeededFuture()
         );
@@ -1049,6 +1058,9 @@ public class KafkaAssemblyOperatorTest {
         );
 
         // Ingress mocks
+
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockIngressOps.batchReconcile(any(), eq(clusterNamespace), any(), any())).thenCallRealMethod();
         when(mockIngressOps.listAsync(eq(clusterNamespace), any(Labels.class))).thenReturn(
                 Future.succeededFuture(emptyList())
         );
@@ -1062,6 +1074,8 @@ public class KafkaAssemblyOperatorTest {
 
             Map<String, Route> expectedRoutesMap = expectedRoutes.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
+            // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+            when(mockRouteOps.batchReconcile(any(), eq(clusterNamespace), any(), any())).thenCallRealMethod();
             when(mockRouteOps.get(eq(clusterNamespace), anyString())).thenAnswer(i -> Future.succeededFuture(expectedRoutesMap.get(i.<String>getArgument(1))));
             when(mockRouteOps.getAsync(eq(clusterNamespace), anyString())).thenAnswer(i -> {
                 Route rt = expectedRoutesMap.get(i.<String>getArgument(1));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerClusterIPTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerClusterIPTest.java
@@ -336,6 +336,9 @@ public class KafkaListenerReconcilerClusterIPTest {
         // Mock the ServiceOperator for the kafka services.
         ServiceOperator mockServiceOperator = supplier.serviceOperations;
 
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockServiceOperator.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
+
         // Mock getting of services and their readiness
         when(mockServiceOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-external-bootstrap"))).thenReturn(Future.succeededFuture(mockServiceBootstrap));
         when(mockServiceOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-0"))).thenReturn(Future.succeededFuture(mockServiceBroker0));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerSkipBootstrapLoadBalancerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerSkipBootstrapLoadBalancerTest.java
@@ -284,6 +284,9 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
         // Mock the ServiceOperator for the kafka services.
         ServiceOperator mockServiceOperator = supplier.serviceOperations;
 
+        // Delegate the batchReconcile call to the real method which calls the other mocked methods. This allows us to better test the exact behavior.
+        when(mockServiceOperator.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
+
         // Mock getting of services and their readiness
         when(mockServiceOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-external-bootstrap"))).thenReturn(Future.succeededFuture(mockServiceBootstrap));
         when(mockServiceOperator.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME + "-kafka-0"))).thenReturn(Future.succeededFuture(mockServiceBroker0));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -44,6 +44,7 @@ import java.util.function.BiPredicate;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -67,11 +68,11 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
     }
 
     @Override
-    protected StatefulSet resource() {
+    protected StatefulSet resource(String name) {
         return new StatefulSetBuilder()
                 .withNewMetadata()
                     .withNamespace(AbstractResourceOperatorTest.NAMESPACE)
-                    .withName(AbstractResourceOperatorTest.RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(3)
@@ -85,8 +86,8 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
     }
 
     @Override
-    protected StatefulSet modifiedResource() {
-        return new StatefulSetBuilder(resource())
+    protected StatefulSet modifiedResource(String name) {
+        return new StatefulSetBuilder(resource(name))
                 .editSpec()
                     .withReplicas(5)
                     .withNewTemplate()
@@ -396,5 +397,11 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
                 assertThat(e.getMessage(), is("Something failed"));
                 async.flag();
             })));
+    }
+
+    @Override
+    @Test
+    public void testBatchReconciliation(VertxTestContext context) {
+        assumeTrue(false, "StatefulSetOperator reconciliation uses custom code. This test should be skipped.");
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
@@ -43,11 +43,11 @@ public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenSh
     }
 
     @Override
-    protected BuildConfig resource() {
+    protected BuildConfig resource(String name) {
         return new BuildConfigBuilder()
             .withNewMetadata()
                 .withNamespace(NAMESPACE)
-                .withName(RESOURCE_NAME)
+                .withName(name)
             .endMetadata()
             .withNewSpec()
                 .withTriggers(new BuildTriggerPolicy())
@@ -55,8 +55,8 @@ public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenSh
     }
 
     @Override
-    protected BuildConfig modifiedResource() {
-        return new BuildConfigBuilder(resource())
+    protected BuildConfig modifiedResource(String name) {
+        return new BuildConfigBuilder(resource(name))
                 .editSpec()
                     .withServiceAccount("service-account")
                 .endSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildOperatorTest.java
@@ -37,10 +37,10 @@ public class BuildOperatorTest extends AbstractResourceOperatorTest<OpenShiftCli
     }
 
     @Override
-    protected Build resource() {
+    protected Build resource(String name) {
         return new BuildBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                 .endMetadata()
                 .withNewSpec()
@@ -64,8 +64,8 @@ public class BuildOperatorTest extends AbstractResourceOperatorTest<OpenShiftCli
     }
 
     @Override
-    protected Build modifiedResource() {
-        return new BuildBuilder(resource())
+    protected Build modifiedResource(String name) {
+        return new BuildBuilder(resource(name))
                 .editSpec()
                     .editSource()
                         .withDockerfile("FROM centos:8\nUSER 1001")

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
@@ -38,10 +38,10 @@ public class ConfigMapOperatorTest extends AbstractResourceOperatorTest<Kubernet
     }
 
     @Override
-    protected ConfigMap resource() {
+    protected ConfigMap resource(String name) {
         return new ConfigMapBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -50,8 +50,8 @@ public class ConfigMapOperatorTest extends AbstractResourceOperatorTest<Kubernet
     }
 
     @Override
-    protected ConfigMap modifiedResource() {
-        return new ConfigMapBuilder(resource())
+    protected ConfigMap modifiedResource(String name) {
+        return new ConfigMapBuilder(resource(name))
                 .withData(singletonMap("FOO", "BAR2"))
                 .build();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperatorTest.java
@@ -29,11 +29,11 @@ public class DeploymentConfigOperatorTest extends ScalableResourceOperatorTest<O
     }
 
     @Override
-    protected DeploymentConfig resource() {
+    protected DeploymentConfig resource(String name) {
         return new DeploymentConfigBuilder()
             .withNewMetadata()
                 .withNamespace(NAMESPACE)
-                .withName(RESOURCE_NAME)
+                .withName(name)
             .endMetadata()
             .withNewSpec()
                 .withNewTemplate()
@@ -45,8 +45,8 @@ public class DeploymentConfigOperatorTest extends ScalableResourceOperatorTest<O
     }
 
     @Override
-    protected DeploymentConfig modifiedResource() {
-        return new DeploymentConfigBuilder(resource())
+    protected DeploymentConfig modifiedResource(String name) {
+        return new DeploymentConfigBuilder(resource(name))
                 .editSpec()
                     .editTemplate()
                         .editSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/DeploymentOperatorTest.java
@@ -31,11 +31,11 @@ public class DeploymentOperatorTest extends
     }
 
     @Override
-    protected Deployment resource() {
+    protected Deployment resource(String name) {
         return new DeploymentBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .addToAnnotations(Annotations.ANNO_DEP_KUBE_IO_REVISION, "test")
                 .endMetadata()
                 .withNewSpec()
@@ -47,8 +47,8 @@ public class DeploymentOperatorTest extends
     }
 
     @Override
-    protected Deployment modifiedResource() {
-        return new DeploymentBuilder(resource())
+    protected Deployment modifiedResource(String name) {
+        return new DeploymentBuilder(resource(name))
                 .editSpec()
                     .editStrategy()
                         .withType("Recreate")

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/EndpointOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/EndpointOperatorTest.java
@@ -27,21 +27,21 @@ public class EndpointOperatorTest extends AbstractReadyResourceOperatorTest<Kube
     }
 
     @Override
-    protected Endpoints resource() {
+    protected Endpoints resource(String name) {
         return new EndpointsBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .build();
     }
 
     @Override
-    protected Endpoints modifiedResource() {
+    protected Endpoints modifiedResource(String name) {
         return new EndpointsBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .addToLabels("foo", "bar")
                 .endMetadata()
                 .build();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ImageStreamOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ImageStreamOperatorTest.java
@@ -27,21 +27,21 @@ public class ImageStreamOperatorTest extends AbstractResourceOperatorTest<OpenSh
     }
 
     @Override
-    protected ImageStream resource() {
+    protected ImageStream resource(String name) {
         return new ImageStreamBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .build();
     }
 
     @Override
-    protected ImageStream modifiedResource() {
+    protected ImageStream modifiedResource(String name) {
         return new ImageStreamBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .addToLabels("foo", "bar")
                 .endMetadata()
                 .build();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
@@ -34,10 +34,10 @@ public class IngressOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     }
 
     @Override
-    protected Ingress resource() {
+    protected Ingress resource(String name) {
         return new IngressBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -45,10 +45,10 @@ public class IngressOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     }
 
     @Override
-    protected Ingress modifiedResource() {
+    protected Ingress modifiedResource(String name) {
         return new IngressBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo2", "bar2"))
                 .endMetadata()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -42,11 +42,11 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
     }
 
     @Override
-    protected Kafka resource() {
+    protected Kafka resource(String name) {
         return new KafkaBuilder()
                 .withApiVersion(Kafka.RESOURCE_GROUP + "/" + Kafka.V1BETA1)
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                 .endMetadata()
                 .withNewSpec()
@@ -74,8 +74,8 @@ public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<Kubernete
     }
 
     @Override
-    protected Kafka modifiedResource() {
-        return new KafkaBuilder(resource())
+    protected Kafka modifiedResource(String name) {
+        return new KafkaBuilder(resource(name))
                 .editOrNewSpec()
                     .withNewEntityOperator()
                         .withNewTopicOperator()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -45,10 +45,10 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
     }
 
     @Override
-    protected PodDisruptionBudget resource() {
+    protected PodDisruptionBudget resource(String name) {
         return new PodDisruptionBudgetBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -59,8 +59,8 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
     }
 
     @Override
-    protected PodDisruptionBudget modifiedResource() {
-        return new PodDisruptionBudgetBuilder(resource())
+    protected PodDisruptionBudget modifiedResource(String name) {
+        return new PodDisruptionBudgetBuilder(resource(name))
                 .editSpec()
                     .withNewMaxUnavailable(2)
                 .endSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetV1Beta1OperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetV1Beta1OperatorTest.java
@@ -45,10 +45,10 @@ public class PodDisruptionBudgetV1Beta1OperatorTest extends AbstractResourceOper
     }
 
     @Override
-    protected PodDisruptionBudget resource() {
+    protected PodDisruptionBudget resource(String name) {
         return new PodDisruptionBudgetBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -59,8 +59,8 @@ public class PodDisruptionBudgetV1Beta1OperatorTest extends AbstractResourceOper
     }
 
     @Override
-    protected PodDisruptionBudget modifiedResource() {
-        return new PodDisruptionBudgetBuilder(resource())
+    protected PodDisruptionBudget modifiedResource(String name) {
+        return new PodDisruptionBudgetBuilder(resource(name))
                 .editSpec()
                     .withNewMaxUnavailable(2)
                 .endSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodOperatorTest.java
@@ -28,11 +28,11 @@ public class PodOperatorTest extends
     }
 
     @Override
-    protected Pod resource() {
+    protected Pod resource(String name) {
         return new PodBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .withNewSpec()
                     .withHostname("foo")
@@ -41,8 +41,8 @@ public class PodOperatorTest extends
     }
 
     @Override
-    protected Pod modifiedResource() {
-        return new PodBuilder(resource())
+    protected Pod modifiedResource(String name) {
+        return new PodBuilder(resource(name))
                 .editSpec()
                     .withHostname("bar")
                 .endSpec()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
@@ -35,21 +35,21 @@ public class PvcOperatorTest extends AbstractResourceOperatorTest<KubernetesClie
     }
 
     @Override
-    protected PersistentVolumeClaim resource() {
+    protected PersistentVolumeClaim resource(String name) {
         return new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .build();
     }
 
     @Override
-    protected PersistentVolumeClaim modifiedResource() {
+    protected PersistentVolumeClaim modifiedResource(String name) {
         return new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .addToLabels("foo", "bar")
                 .endMetadata()
                 .build();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorTest.java
@@ -36,7 +36,7 @@ public class RoleBindingOperatorTest extends AbstractResourceOperatorTest<Kubern
     }
 
     @Override
-    protected RoleBinding resource() {
+    protected RoleBinding resource(String name) {
         Subject ks = new SubjectBuilder()
                 .withKind("ServiceAccount")
                 .withName("some-service-account")
@@ -51,7 +51,7 @@ public class RoleBindingOperatorTest extends AbstractResourceOperatorTest<Kubern
 
         return new RoleBindingBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -61,14 +61,14 @@ public class RoleBindingOperatorTest extends AbstractResourceOperatorTest<Kubern
     }
 
     @Override
-    protected RoleBinding modifiedResource() {
+    protected RoleBinding modifiedResource(String name) {
         RoleRef roleRef = new RoleRefBuilder()
                 .withName("some-other-role")
                 .withApiGroup("rbac.authorization.k8s.io")
                 .withKind("ClusterRole")
                 .build();
 
-        return new RoleBindingBuilder(resource())
+        return new RoleBindingBuilder(resource(name))
                 .withRoleRef(roleRef)
                 .build();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorTest.java
@@ -36,7 +36,7 @@ public class RoleOperatorTest extends AbstractResourceOperatorTest<
     }
 
     @Override
-    protected Role resource() {
+    protected Role resource(String name) {
         PolicyRule rule = new PolicyRuleBuilder()
                 .withApiGroups("somegroup")
                 .addToVerbs("someverb")
@@ -44,7 +44,7 @@ public class RoleOperatorTest extends AbstractResourceOperatorTest<
 
         return new RoleBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -53,13 +53,13 @@ public class RoleOperatorTest extends AbstractResourceOperatorTest<
     }
 
     @Override
-    protected Role modifiedResource() {
+    protected Role modifiedResource(String name) {
         PolicyRule rule = new PolicyRuleBuilder()
                 .withApiGroups("somegroup2")
                 .addToVerbs("someverb2")
                 .build();
 
-        return new RoleBuilder(resource())
+        return new RoleBuilder(resource(name))
                 .withRules(rule)
                 .build();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
@@ -26,21 +26,21 @@ public class RouteOperatorTest extends AbstractResourceOperatorTest<OpenShiftCli
     }
 
     @Override
-    protected Route resource() {
+    protected Route resource(String name) {
         return new RouteBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .build();
     }
 
     @Override
-    protected Route modifiedResource() {
+    protected Route modifiedResource(String name) {
         return new RouteBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .addToLabels("foo", "bar")
                 .endMetadata()
                 .build();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/SecretOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/SecretOperatorTest.java
@@ -29,10 +29,10 @@ public class SecretOperatorTest extends AbstractResourceOperatorTest<KubernetesC
     }
 
     @Override
-    protected Secret resource() {
+    protected Secret resource(String name) {
         return new SecretBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -41,8 +41,8 @@ public class SecretOperatorTest extends AbstractResourceOperatorTest<KubernetesC
     }
 
     @Override
-    protected Secret modifiedResource() {
-        return new SecretBuilder(resource())
+    protected Secret modifiedResource(String name) {
+        return new SecretBuilder(resource(name))
                 .withData(singletonMap("FOO2", "BAR2"))
                 .build();
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -53,10 +53,10 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
     }
 
     @Override
-    protected ServiceAccount resource() {
+    protected ServiceAccount resource(String name) {
         return new ServiceAccountBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo", "bar"))
                 .endMetadata()
@@ -64,10 +64,10 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
     }
 
     @Override
-    protected ServiceAccount modifiedResource() {
+    protected ServiceAccount modifiedResource(String name) {
         return new ServiceAccountBuilder()
                 .withNewMetadata()
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                     .withNamespace(NAMESPACE)
                     .withLabels(singletonMap("foo2", "bar2"))
                 .endMetadata()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -38,11 +38,11 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     }
 
     @Override
-    protected Service resource() {
+    protected Service resource(String name) {
         return new ServiceBuilder()
                 .withNewMetadata()
                     .withNamespace(NAMESPACE)
-                    .withName(RESOURCE_NAME)
+                    .withName(name)
                 .endMetadata()
                 .withNewSpec()
                     .withType("LoadBalancer")
@@ -51,8 +51,8 @@ public class ServiceOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     }
 
     @Override
-    protected Service modifiedResource() {
-        return new ServiceBuilder(resource())
+    protected Service modifiedResource(String name) {
+        return new ServiceBuilder(resource(name))
                 .editSpec()
                     .withType("NodePort")
                 .endSpec()


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In some situations, we need to reconcile a _list_ of Kubernetes resources based on some selector. We want to:
* Create or patch the desired resources
* Delete the resources matching the selector but not desired anymore

We use this logic in several places for example when managing services, routes or ingresses. Moving the logic to the resource operators simplifies the code and makes it easier to use in the future.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally