### PR TITLE
Print configuration at the User Operator startup

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -69,8 +69,11 @@ public class Main {
         String dnsCacheTtl = System.getenv("STRIMZI_DNS_CACHE_TTL") == null ? "30" : System.getenv("STRIMZI_DNS_CACHE_TTL");
         Security.setProperty("networkaddress.cache.ttl", dnsCacheTtl);
 
-        // Create UserOperatorConfig, KubernetesClient, AdminClient and KafkaUserOperator classes
+        // Create and log UserOperatorConfig
         UserOperatorConfig config = UserOperatorConfig.fromMap(System.getenv());
+        LOGGER.info("Cluster Operator configuration is {}", config);
+
+        // Create KubernetesClient, AdminClient and KafkaUserOperator classes
         KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-user-operator", Main.class.getPackage().getImplementationVersion()).build();
         Admin adminClient = createAdminClient(config, client, new DefaultAdminClientProvider());
         AtomicInteger kafkaUserOperatorExecutorThreadCounter = new AtomicInteger(0);

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -529,29 +529,29 @@ public class UserOperatorConfig {
     public String toString() {
         return "ClusterOperatorConfig(" +
                 "namespace=" + namespace +
-                ",reconciliationIntervalMs=" + reconciliationIntervalMs +
-                ",kafkaBootstrapServers=" + kafkaBootstrapServers +
-                ",labels=" + labels +
-                ",caName=" + caCertSecretName +
-                ",clusterCaCertSecretName=" + clusterCaCertSecretName +
-                ",euoKeySecretName=" + euoKeySecretName +
-                ",caNamespace=" + caNamespace +
-                ",secretPrefix=" + secretPrefix +
-                ",aclsAdminApiSupported=" + aclsAdminApiSupported +
-                ",kraftEnabled=" + kraftEnabled +
-                ",clientsCaValidityDays=" + clientsCaValidityDays +
-                ",clientsCaRenewalDays=" + clientsCaRenewalDays +
-                ",scramPasswordLength=" + scramPasswordLength +
-                ",maintenanceWindows=" + maintenanceWindows +
-                ",kafkaAdminClientConfiguration=" + kafkaAdminClientConfiguration +
-                ",operationTimeoutMs=" + operationTimeoutMs +
-                ",workQueueSize=" + workQueueSize +
-                ",controllerThreadPoolSize=" + controllerThreadPoolSize +
-                ",cacheRefresh=" + cacheRefresh +
-                ",batchQueueSize=" + batchQueueSize +
-                ",batchMaxBlockSize=" + batchMaxBlockSize +
-                ",batchMaxBlockTime=" + batchMaxBlockTime +
-                ",userOperationsThreadPoolSize=" + userOperationsThreadPoolSize +
+                ", reconciliationIntervalMs=" + reconciliationIntervalMs +
+                ", kafkaBootstrapServers=" + kafkaBootstrapServers +
+                ", labels=" + labels +
+                ", caName=" + caCertSecretName +
+                ", clusterCaCertSecretName=" + clusterCaCertSecretName +
+                ", euoKeySecretName=" + euoKeySecretName +
+                ", caNamespace=" + caNamespace +
+                ", secretPrefix=" + secretPrefix +
+                ", aclsAdminApiSupported=" + aclsAdminApiSupported +
+                ", kraftEnabled=" + kraftEnabled +
+                ", clientsCaValidityDays=" + clientsCaValidityDays +
+                ", clientsCaRenewalDays=" + clientsCaRenewalDays +
+                ", scramPasswordLength=" + scramPasswordLength +
+                ", maintenanceWindows=" + maintenanceWindows +
+                ", kafkaAdminClientConfiguration=" + kafkaAdminClientConfiguration +
+                ", operationTimeoutMs=" + operationTimeoutMs +
+                ", workQueueSize=" + workQueueSize +
+                ", controllerThreadPoolSize=" + controllerThreadPoolSize +
+                ", cacheRefresh=" + cacheRefresh +
+                ", batchQueueSize=" + batchQueueSize +
+                ", batchMaxBlockSize=" + batchMaxBlockSize +
+                ", batchMaxBlockTime=" + batchMaxBlockTime +
+                ", userOperationsThreadPoolSize=" + userOperationsThreadPoolSize +
                 ")";
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Unlike the Cluster Operator, the User Operator does not currently prints its configuration at startup. Knowing the configuration from the log is useful when trying to resolve issues. This PR adds a new log message with the configuration similar to what we have in the Cluster Operator. It also adds some spacing to the `toString` method of the config class to have a better readability of the configuration.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally