### PR TITLE
Use more of Java 17 in the User Operator

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -174,9 +174,7 @@ public class KafkaUserModel {
      * @param user  The KafkaUser which should be validated
      */
     private static void validateDesiredPassword(KafkaUser user)  {
-        if (user.getSpec().getAuthentication() instanceof KafkaUserScramSha512ClientAuthentication) {
-            KafkaUserScramSha512ClientAuthentication scramAuth = (KafkaUserScramSha512ClientAuthentication) user.getSpec().getAuthentication();
-
+        if (user.getSpec().getAuthentication() instanceof KafkaUserScramSha512ClientAuthentication scramAuth) {
             if (scramAuth.getPassword() != null)    {
                 if (scramAuth.getPassword().getValueFrom() == null
                         || scramAuth.getPassword().getValueFrom().getSecretKeyRef() == null
@@ -441,7 +439,7 @@ public class KafkaUserModel {
      * Decodes the name of the User secret based on the username
      *
      * @param username The username.
-     * @return The decoded user name.
+     * @return The decoded username.
      */
     public static String decodeUsername(String username) {
         if (username.contains("CN="))   {
@@ -461,7 +459,7 @@ public class KafkaUserModel {
      * Generates the name of the User secret based on the username
      *
      * @param username The username.
-     * @return The TLS user name.
+     * @return The TLS username.
      */
     public static String getTlsUserName(String username)    {
         return "CN=" + username;
@@ -471,7 +469,7 @@ public class KafkaUserModel {
      * Generates the name of the User secret based on the username
      *
      * @param username The username.
-     * @return The SCRAM user name.
+     * @return The SCRAM username.
      */
     public static String getScramUserName(String username)    {
         return username;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRuleResource.java
@@ -222,16 +222,13 @@ public class SimpleAclRuleResource {
      * @return The resource.
      */
     public static SimpleAclRuleResource fromCrd(AclRuleResource resource)   {
-        if (resource instanceof AclRuleTopicResource)   {
-            AclRuleTopicResource adapted = (AclRuleTopicResource) resource;
+        if (resource instanceof AclRuleTopicResource adapted)   {
             return new SimpleAclRuleResource(adapted.getName(), SimpleAclRuleResourceType.TOPIC, adapted.getPatternType());
-        } else if (resource instanceof AclRuleGroupResource)   {
-            AclRuleGroupResource adapted = (AclRuleGroupResource) resource;
+        } else if (resource instanceof AclRuleGroupResource adapted)   {
             return new SimpleAclRuleResource(adapted.getName(), SimpleAclRuleResourceType.GROUP, adapted.getPatternType());
         } else if (resource instanceof AclRuleClusterResource)   {
             return new SimpleAclRuleResource("kafka-cluster", SimpleAclRuleResourceType.CLUSTER, AclResourcePatternType.LITERAL);
-        } else if (resource instanceof AclRuleTransactionalIdResource)   {
-            AclRuleTransactionalIdResource adapted = (AclRuleTransactionalIdResource) resource;
+        } else if (resource instanceof AclRuleTransactionalIdResource adapted)   {
             return new SimpleAclRuleResource(adapted.getName(), SimpleAclRuleResourceType.TRANSACTIONAL_ID, adapted.getPatternType());
         } else  {
             throw new IllegalArgumentException("Invalid Acl resource class: " + resource.getClass());

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
@@ -45,43 +45,12 @@ public interface AdminApiOperator<T, S extends Collection<String>> {
     /**
      * Class used to pass the reconciliation results
      *
-     * @param <T>   Request type (type of the desired resource)
-     * @param <R>   Response type (type of the repsonse)
+     * @param <T>            Request type (type of the desired resource)
+     * @param <R>            Response type (type of the repsonse)
+     * @param reconciliation Reconciliation marker
+     * @param username       Name of the user
+     * @param desired        Desired resource
+     * @param result         Completable future for the reconciliation result
      */
-    class ReconcileRequest<T, R>    {
-        /**
-         * Reconciliation marker
-         */
-        public final Reconciliation reconciliation;
-
-        /**
-         * Name of the user
-         */
-        public final String username;
-
-        /**
-         * Desired resource
-         */
-        public final T desired;
-
-        /**
-         * Completable future for the reconciliation result
-         */
-        public final CompletableFuture<R> result;
-
-        /**
-         * Constructs the reconciliation result
-         *
-         * @param reconciliation    Reconciliation marker
-         * @param username          Name of the user
-         * @param desired           Desired resource
-         * @param result            Completable future for the reconciliation result
-         */
-        public ReconcileRequest(Reconciliation reconciliation, String username, T desired, CompletableFuture<R> result) {
-            this.reconciliation = reconciliation;
-            this.username = username;
-            this.desired = desired;
-            this.result = result;
-        }
-    }
+    record ReconcileRequest<T, R>(Reconciliation reconciliation, String username, T desired, CompletableFuture<R> result) { }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR uses some more of Java 17 features in the User Operator code (such as records or pattern matching). It also fixes some typos in the Javadocs.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally