### PR TITLE
Use more Java 17 features in assembly operators and other minor fixes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -526,13 +526,5 @@ public class CaReconciler {
     /**
      * Helper class to pass both Cluster and Clients CA as a result of the reconciliation
      */
-    protected static class CaReconciliationResult {
-        protected final ClusterCa clusterCa;
-        protected final ClientsCa clientsCa;
-
-        protected CaReconciliationResult(ClusterCa clusterCa, ClientsCa clientsCa) {
-            this.clusterCa = clusterCa;
-            this.clientsCa = clientsCa;
-        }
-    }
+    protected record CaReconciliationResult(ClusterCa clusterCa, ClientsCa clientsCa) { }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -358,8 +358,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return caReconciler()
                     .reconcile(clock)
                     .compose(cas -> {
-                        this.clusterCa = cas.clusterCa;
-                        this.clientsCa = cas.clientsCa;
+                        this.clusterCa = cas.clusterCa();
+                        this.clientsCa = cas.clientsCa();
                         return Future.succeededFuture(this);
                     });
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -42,17 +42,12 @@ import io.vertx.core.json.JsonObject;
 
 import static java.util.Arrays.asList;
 
-@SuppressWarnings({"deprecation"})
 class KafkaConnectApiImpl implements KafkaConnectApi {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaConnectApiImpl.class);
-    public static final TypeReference<Map<String, Object>> TREE_TYPE = new TypeReference<Map<String, Object>>() {
-    };
-    public static final TypeReference<Map<String, String>> MAP_OF_STRINGS = new TypeReference<Map<String, String>>() {
-    };
-    public static final TypeReference<Map<String, Map<String, String>>> MAP_OF_MAP_OF_STRINGS = new TypeReference<Map<String, Map<String, String>>>() {
-    };
-    public static final TypeReference<Map<String, Map<String, List<String>>>> MAP_OF_MAP_OF_LIST_OF_STRING = new TypeReference<Map<String, Map<String, List<String>>>>() {
-    };
+    public static final TypeReference<Map<String, Object>> TREE_TYPE = new TypeReference<>() { };
+    public static final TypeReference<Map<String, String>> MAP_OF_STRINGS = new TypeReference<>() { };
+    public static final TypeReference<Map<String, Map<String, String>>> MAP_OF_MAP_OF_STRINGS = new TypeReference<>() { };
+    public static final TypeReference<Map<String, Map<String, List<String>>>> MAP_OF_MAP_OF_LIST_OF_STRING = new TypeReference<>() { };
     private final ObjectMapper mapper = new ObjectMapper();
     private final Vertx vertx;
 
@@ -82,6 +77,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                             if (response.result().statusCode() == 200 || response.result().statusCode() == 201) {
                                 response.result().bodyHandler(buffer -> {
                                     try {
+                                        @SuppressWarnings({ "rawtypes" })
                                         Map t = mapper.readValue(buffer.getBytes(), Map.class);
                                         LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}: {}", response.result().statusCode(), path, t);
                                         result.complete(t);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -329,8 +329,7 @@ public class KafkaListenersReconciler {
             String bootstrapAddress = getInternalServiceHostname(reconciliation.namespace(), ListenersUtils.backwardsCompatibleBootstrapServiceName(reconciliation.name(), listener), useServiceDnsDomain);
 
             if (listener.isTls()) {
-                ModelUtils.generateAllServiceDnsNames(reconciliation.namespace(), ListenersUtils.backwardsCompatibleBootstrapServiceName(reconciliation.name(), listener))
-                                .forEach(dnsName -> result.bootstrapDnsNames.add(dnsName));
+                result.bootstrapDnsNames.addAll(ModelUtils.generateAllServiceDnsNames(reconciliation.namespace(), ListenersUtils.backwardsCompatibleBootstrapServiceName(reconciliation.name(), listener)));
             }
 
             ListenerStatus ls = new ListenerStatusBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -5,6 +5,8 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
@@ -329,6 +331,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                     .compose(i -> {
                         boolean failedConnector = mirrorMaker2Status.getConnectors().stream()
                                 .anyMatch(connector -> {
+                                    @SuppressWarnings({ "rawtypes" })
                                     Object state = ((Map) connector.getOrDefault("connector", emptyMap())).get("state");
                                     return "FAILED".equalsIgnoreCase(state.toString());
                                 });
@@ -529,6 +532,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * The comparison is done by using only one property - 'name'
      */
     static class ConnectorsComparatorByName implements Comparator<Map<String, Object>>, Serializable {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         @Override
@@ -548,6 +552,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * @return true if the provided resource instance has the strimzio.io/restart-connector annotation; false otherwise
      */
     @Override
+    @SuppressWarnings({ "rawtypes" })
     protected boolean hasRestartAnnotation(CustomResource resource, String connectorName) {
         String restartAnnotationConnectorName = Annotations.stringAnnotation(resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR, null);
         return connectorName.equals(restartAnnotationConnectorName);
@@ -560,6 +565,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * @param connectorName connectorName name of the MM2 connector to check
      * @return the ID of the task to be restarted if the provided KafkaConnector resource instance has the strimzio.io/restart-connector-task annotation or -1 otherwise.
      */
+    @SuppressWarnings({ "rawtypes" })
     protected int getRestartTaskAnnotationTaskID(CustomResource resource, String connectorName) {
         int taskID = -1;
         String connectorTask = Annotations.stringAnnotation(resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK, "").trim();
@@ -575,6 +581,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * the restart action specified by user has been completed.
      */
     @Override
+    @SuppressWarnings({ "rawtypes" })
     protected Future<Void> removeRestartAnnotation(Reconciliation reconciliation, CustomResource resource) {
         return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR);
     }
@@ -585,6 +592,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * the restart action specified by user has been completed.
      */
     @Override
+    @SuppressWarnings({ "rawtypes" })
     protected Future<Void> removeRestartTaskAnnotation(Reconciliation reconciliation, CustomResource resource) {
         return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -103,7 +104,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> Util.metricsAndLogging(reconciliation, configMapOperations, namespace, mirror.getLogging(), mirror.getMetricsConfigInCm()))
                 .compose(metricsAndLoggingCm -> {
                     ConfigMap logAndMetricsConfigMap = mirror.generateMetricsAndLogConfigMap(metricsAndLoggingCm);
-                    annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(mirror.ANCILLARY_CM_KEY_LOG_CONFIG));
+                    annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG));
                     return configMapOperations.reconcile(reconciliation, namespace, mirror.getAncillaryConfigMapName(), logAndMetricsConfigMap);
                 })
                 .compose(i -> pfa.hasPodDisruptionBudgetV1() ? podDisruptionBudgetOperator.reconcile(reconciliation, namespace, mirror.getName(), mirror.generatePodDisruptionBudget()) : Future.succeededFuture())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -261,7 +261,7 @@ public class KafkaRebalanceAssemblyOperator
                     .filter(condition -> condition.getType() != null)
                     .filter(condition -> Arrays.stream(KafkaRebalanceState.values())
                             .anyMatch(stateValue -> stateValue.toString().equals(condition.getType())))
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (statusConditions.size() == 1) {
                 return statusConditions.get(0);
@@ -1337,10 +1337,12 @@ public class KafkaRebalanceAssemblyOperator
 
     /**
      * Return warning condition if the rebalance annotation wrong corresponding to the state
-
-     * @param state Contains the KafkaRebalanceState for which we are checking the valid annotation
-     * @param rebalanceAnnotation Contains the rebalance annotation
-     * @return the value for the strimzio.io/rebalance annotation on the provided KafkaRebalance resource instance
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param conditions            Set of conditions
+     * @param state                 Contains the KafkaRebalanceState for which we are checking the valid annotation
+     * @param rebalanceAnnotation   Contains the rebalance annotation
+     * @param kafkaRebalance        Kafka Rebalance resource
      */
 
     private void validateAnnotation(Reconciliation reconciliation, Set<Condition> conditions, KafkaRebalanceState state, KafkaRebalanceAnnotation rebalanceAnnotation, KafkaRebalance kafkaRebalance) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -641,7 +641,7 @@ public class KafkaReconciler {
                     // Delete all existing ConfigMaps which are not desired and are not the shared config map
                     List<String> desiredNames = new ArrayList<>(desiredConfigMaps.size() + 1);
                     desiredNames.add(kafka.getAncillaryConfigMapName()); // We do not want to delete the shared ConfigMap, so we add it here
-                    desiredNames.addAll(desiredConfigMaps.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toList()));
+                    desiredNames.addAll(desiredConfigMaps.stream().map(cm -> cm.getMetadata().getName()).toList());
 
                     for (ConfigMap cm : existingConfigMaps) {
                         // We delete the cms not on the desired names list
@@ -950,9 +950,8 @@ public class KafkaReconciler {
         //   * JBOD storage is actually used as storage
         //   * and StatefulSets are used
         // StrimziPodSets do not need special rolling update, they can add / remove volumes during regular rolling updates
-        if (storage instanceof JbodStorage
+        if (storage instanceof JbodStorage jbodStorage
                 && !featureGates.useStrimziPodSetsEnabled()) {
-            JbodStorage jbodStorage = (JbodStorage) storage;
             return kafkaRollToAddOrRemoveVolumesInStatefulSet(jbodStorage);
         } else {
             return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -146,9 +146,7 @@ public class ReconcilerUtils {
             return restartReasons;
         }
 
-        if (ctrlResource instanceof StatefulSet) {
-            StatefulSet sts = (StatefulSet) ctrlResource;
-
+        if (ctrlResource instanceof StatefulSet sts) {
             if (!isStatefulSetGenerationUpToDate(reconciliation, sts, pod)) {
                 restartReasons.add(RestartReason.POD_HAS_OLD_GENERATION);
             }
@@ -156,9 +154,7 @@ public class ReconcilerUtils {
             if (!isCustomCertUpToDate(reconciliation, sts, pod)) {
                 restartReasons.add(RestartReason.CUSTOM_LISTENER_CA_CERT_CHANGE);
             }
-        } else if (ctrlResource instanceof StrimziPodSet) {
-            StrimziPodSet podSet = (StrimziPodSet) ctrlResource;
-
+        } else if (ctrlResource instanceof StrimziPodSet podSet) {
             if (PodRevision.hasChanged(pod, podSet)) {
                 restartReasons.add(RestartReason.POD_HAS_OLD_REVISION);
             }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR continues with some more minor improvements to our code. It uses some more of the new Java 17 features, suppresses some warnings and does some other minor improvements. It focuses on the assembly operator classes and the related util classes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally