### PR TITLE
Fix remaining Javadocs issues in the `cluster-operator` module

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -16,12 +16,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
-        <!-- This should be removed once https://github.com/strimzi/strimzi-kafka-operator/issues/7702 is fixed -->
-        <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.strimzi</groupId>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -596,6 +596,9 @@ public class ClusterOperatorConfig {
         return networkPolicyGeneration;
     }
 
+    /**
+     * @return  Supported Kafka versions and informations about them
+     */
     public KafkaVersion.Lookup versions() {
         return versions;
     }
@@ -635,6 +638,9 @@ public class ClusterOperatorConfig {
         return customResourceSelector;
     }
 
+    /**
+     * @return  Feature gates configuration
+     */
     public FeatureGates featureGates()  {
         return featureGates;
     }
@@ -667,7 +673,9 @@ public class ClusterOperatorConfig {
         return podSetControllerWorkQueueSize;
     }
 
-
+    /**
+     * @return  The name of this operator
+     */
     public String getOperatorName() {
         return operatorName;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/KafkaUpgradeException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/KafkaUpgradeException.java
@@ -11,11 +11,11 @@ import io.strimzi.operator.cluster.model.InvalidResourceException;
  * one Kafka version to another.
  */
 public class KafkaUpgradeException extends InvalidResourceException {
-
-    public KafkaUpgradeException() {
-        super();
-    }
-
+    /**
+     * Constructor
+     *
+     * @param s     Error message
+     */
     public KafkaUpgradeException(String s) {
         super(s);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -69,6 +69,11 @@ public class Main {
         }
     }
 
+    /**
+     * The main method used to run the Cluster Operator
+     *
+     * @param args  The command line arguments
+     */
     public static void main(String[] args) {
         final String strimziVersion = Main.class.getPackage().getImplementationVersion();
         LOGGER.info("ClusterOperator {} is starting", strimziVersion);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerConfig.java
@@ -13,12 +13,34 @@ import java.util.Map;
  * Configuration class for the Leader Election Manager
  */
 public class LeaderElectionManagerConfig {
-    // Environment variables
+    /**
+     * Name of the Kubernetes Lease resource
+     */
     public final static String ENV_VAR_LEADER_ELECTION_LEASE_NAME = "STRIMZI_LEADER_ELECTION_LEASE_NAME";
+
+    /**
+     * Namespace of the Kubernetes Lease resource
+     */
     public final static String ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE = "STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE";
+
+    /**
+     * Identity of this operator for claiming the leadership
+     */
     public final static String ENV_VAR_LEADER_ELECTION_IDENTITY = "STRIMZI_LEADER_ELECTION_IDENTITY";
+
+    /**
+     * Duration of the leadership
+     */
     public final static String ENV_VAR_LEADER_ELECTION_LEASE_DURATION_MS = "STRIMZI_LEADER_ELECTION_LEASE_DURATION_MS";
+
+    /**
+     * Hw often should the leadership be renewed
+     */
     public final static String ENV_VAR_LEADER_ELECTION_RENEW_DEADLINE_MS = "STRIMZI_LEADER_ELECTION_RENEW_DEADLINE_MS";
+
+    /**
+     * Retry period for accessing the Lease resource
+     */
     public final static String ENV_VAR_LEADER_ELECTION_RETRY_PERIOD_MS = "STRIMZI_LEADER_ELECTION_RETRY_PERIOD_MS";
 
     // Default values
@@ -52,6 +74,13 @@ public class LeaderElectionManagerConfig {
         this.retryPeriod = retryPeriod;
     }
 
+    /**
+     * Creates the LeaderElectionManager configuration from Map with environment variables
+     *
+     * @param map   Map with environment variables
+     *
+     * @return  Instance of LeaderElectionManagerConfig
+     */
     public static LeaderElectionManagerConfig fromMap(Map<String, String> map) {
         String leaseName = map.get(ENV_VAR_LEADER_ELECTION_LEASE_NAME);
         String namespace = map.get(ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -161,6 +161,7 @@ public abstract class AbstractConfiguration {
      * Returns a value for a specific config option or a default value
      *
      * @param configOption  Config option which should be looked-up
+     * @param defaultValue  Default value
      *
      * @return  The configured value for this option or the default value if given option is not configured
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -1619,6 +1619,9 @@ public abstract class AbstractModel {
         }
     }
 
+    /**
+     * @return  The key under which tge logging configuration is stored in the Logging Config Map
+     */
     public String getAncillaryConfigMapKeyLogConfig() {
         return ANCILLARY_CM_KEY_LOG_CONFIG;
     }
@@ -1754,7 +1757,10 @@ public abstract class AbstractModel {
         return warningConditions;
     }
 
-    public DeploymentStrategy getDeploymentStrategy() {
+    /**
+     * @return  The deployment strategy which should be used in deployments
+     */
+    protected DeploymentStrategy getDeploymentStrategy() {
         if (templateDeploymentStrategy == io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE) {
             return new DeploymentStrategyBuilder()
                     .withType("RollingUpdate")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -67,18 +67,26 @@ import static io.strimzi.operator.cluster.model.VolumeUtils.createConfigMapVolum
 import static io.strimzi.operator.cluster.model.VolumeUtils.createSecretVolume;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createVolumeMount;
 
+/**
+ * Cruise Control model
+ */
 public class CruiseControl extends AbstractModel {
     protected static final String APPLICATION_NAME = "cruise-control";
-
-    public static final String CRUISE_CONTROL_METRIC_REPORTER = "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter";
-
+    protected static final String CRUISE_CONTROL_METRIC_REPORTER = "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter";
     protected static final String CRUISE_CONTROL_CONTAINER_NAME = "cruise-control";
 
     // Fields used for Cruise Control API authentication
+    /**
+     * Name of the admin user
+     */
     public static final String API_ADMIN_NAME = "admin";
     private static final String API_ADMIN_ROLE = "ADMIN";
     protected static final String API_USER_NAME = "user";
     private static final String API_USER_ROLE = "USER";
+
+    /**
+     * Key for the admin user password
+     */
     public static final String API_ADMIN_PASSWORD_KEY = APPLICATION_NAME + ".apiAdminPassword";
     private static final String API_USER_PASSWORD_KEY = APPLICATION_NAME + ".apiUserPassword";
     private static final String API_AUTH_FILE_KEY = APPLICATION_NAME + ".apiAuthFile";
@@ -95,17 +103,17 @@ public class CruiseControl extends AbstractModel {
 
     protected static final String API_AUTH_CREDENTIALS_FILE = API_AUTH_CONFIG_VOLUME_MOUNT + API_AUTH_FILE_KEY;
 
-    public static final String ENV_VAR_CRUISE_CONTROL_METRICS_ENABLED = "CRUISE_CONTROL_METRICS_ENABLED";
+    protected static final String ENV_VAR_CRUISE_CONTROL_METRICS_ENABLED = "CRUISE_CONTROL_METRICS_ENABLED";
 
     // Configuration defaults
     protected static final int DEFAULT_REPLICAS = 1;
-    public static final boolean DEFAULT_CRUISE_CONTROL_METRICS_ENABLED = false;
+    protected static final boolean DEFAULT_CRUISE_CONTROL_METRICS_ENABLED = false;
 
     // Default probe settings (liveness and readiness) for health checks
     protected static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     protected static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
 
-    public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
+    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT)
             .build();
@@ -113,11 +121,15 @@ public class CruiseControl extends AbstractModel {
     private String minInsyncReplicas = "1";
     private boolean sslEnabled;
     private boolean authEnabled;
-    public Capacity capacity;
+    protected Capacity capacity;
 
-    public static final String REST_API_PORT_NAME = "rest-api";
+    /**
+     * Port of the Cruise Control REST API
+     */
     public static final int REST_API_PORT = 9090;
-    public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
+    /* test */ static final String REST_API_PORT_NAME = "rest-api";
+
+    /* test */ static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
 
     // Cruise Control configuration keys (EnvVariables)
     protected static final String ENV_VAR_CRUISE_CONTROL_CONFIGURATION = "CRUISE_CONTROL_CONFIGURATION";
@@ -263,7 +275,7 @@ public class CruiseControl extends AbstractModel {
         }
     }
 
-    public void updateConfiguration(CruiseControlSpec spec) {
+    private void updateConfiguration(CruiseControlSpec spec) {
         CruiseControlConfiguration userConfiguration = new CruiseControlConfiguration(reconciliation, spec.getConfig().entrySet());
         for (Map.Entry<String, String> defaultEntry : CruiseControlConfiguration.getCruiseControlDefaultPropertiesMap().entrySet()) {
             if (userConfiguration.getConfigOption(defaultEntry.getKey()) == null) {
@@ -313,6 +325,9 @@ public class CruiseControl extends AbstractModel {
         }
     }
 
+    /**
+     * @return  Generates a Kuberneets Service for Cruise Control
+     */
     public Service generateService() {
         return createService("ClusterIP", List.of(createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP")), templateServiceAnnotations);
     }
@@ -345,6 +360,15 @@ public class CruiseControl extends AbstractModel {
                 createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath));
     }
 
+    /**
+     * Generates Kubernetes Deployment for Cruise Cotnrol
+     *
+     * @param isOpenShift       Flag indicating if we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  Image pull secrets
+     *
+     * @return  Cruise Control Kubernetes Deployment
+     */
     public Deployment generateDeployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
                 .withType("RollingUpdate")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -44,7 +44,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             CruiseControlGoals.PREFERRED_LEADER_ELECTION_GOAL.toString()
     );
 
-    public static final String CRUISE_CONTROL_GOALS = String.join(",", CRUISE_CONTROL_GOALS_LIST);
+    protected static final String CRUISE_CONTROL_GOALS = String.join(",", CRUISE_CONTROL_GOALS_LIST);
 
     /**
      * A list of case insensitive goals that Cruise Control will use as hard goals that must all be met for an optimization
@@ -59,7 +59,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             CruiseControlGoals.CPU_CAPACITY_GOAL.toString()
     );
 
-    public static final String CRUISE_CONTROL_HARD_GOALS = String.join(",", CRUISE_CONTROL_HARD_GOALS_LIST);
+    private static final String CRUISE_CONTROL_HARD_GOALS = String.join(",", CRUISE_CONTROL_HARD_GOALS_LIST);
 
     protected static final List<String> CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST = List.of(
             CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
@@ -68,7 +68,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             CruiseControlGoals.DISK_CAPACITY_GOAL.toString()
     );
 
-    public static final String CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS =
+    protected static final String CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS =
             String.join(",", CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST);
 
     /*
@@ -107,7 +107,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
         super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
-    public static Map<String, String> getCruiseControlDefaultPropertiesMap() {
+    protected static Map<String, String> getCruiseControlDefaultPropertiesMap() {
         return CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
     }
 
@@ -116,10 +116,16 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
         return Boolean.parseBoolean(s);
     }
 
+    /**
+     * @return  True if API authentication is enabled. False otherwise.
+     */
     public boolean isApiAuthEnabled() {
         return isEnabledInConfiguration(CruiseControlConfigurationParameters.WEBSERVER_SECURITY_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED));
     }
 
+    /**
+     * @return  True if TLS is enabled. False otherwise.
+     */
     public boolean isApiSslEnabled() {
         return isEnabledInConfiguration(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED));
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -56,17 +56,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Kafka Bridge model class
+ */
 public class KafkaBridgeCluster extends AbstractModel {
-    public static final String APPLICATION_NAME = "kafka-bridge";
-
-
-    // Port configuration
+    /**
+     * HTTP port configuration
+     */
     public static final int DEFAULT_REST_API_PORT = 8080;
-    protected static final String REST_API_PORT_NAME = "rest-api";
 
+    /* test */ static final String APPLICATION_NAME = "kafka-bridge";
+    protected static final String REST_API_PORT_NAME = "rest-api";
     protected static final String TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/strimzi/bridge-certs/";
     protected static final String PASSWORD_VOLUME_MOUNT = "/opt/strimzi/bridge-password/";
-
     protected static final String ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY = "INIT_FOLDER";
 
     // Configuration defaults
@@ -75,7 +77,7 @@ public class KafkaBridgeCluster extends AbstractModel {
     protected static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     protected static final boolean DEFAULT_KAFKA_BRIDGE_METRICS_ENABLED = false;
 
-    public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
+    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT)
             .withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).build();
 
@@ -165,6 +167,15 @@ public class KafkaBridgeCluster extends AbstractModel {
         this.logAndMetricsConfigMountPath = "/opt/strimzi/custom-config/";
     }
 
+    /**
+     * Create the KafkaBridge model instance from the KafkaBridge custom resource
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param kafkaBridge       KafkaBridge custom resource
+     * @param versions          List of supported Kafka versions
+     *
+     * @return  KafkaBridgeCluster instance
+     */
     @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static KafkaBridgeCluster fromCrd(Reconciliation reconciliation, KafkaBridge kafkaBridge, KafkaVersion.Lookup versions) {
 
@@ -226,7 +237,6 @@ public class KafkaBridgeCluster extends AbstractModel {
         return kafkaBridgeCluster;
     }
 
-
     private static void fromCrdTemplate(final KafkaBridgeCluster kafkaBridgeCluster, final KafkaBridgeSpec spec) {
         KafkaBridgeTemplate template = spec.getTemplate();
 
@@ -263,7 +273,9 @@ public class KafkaBridgeCluster extends AbstractModel {
         ModelUtils.parsePodDisruptionBudgetTemplate(kafkaBridgeCluster, template.getPodDisruptionBudget());
     }
 
-
+    /**
+     * @return  Generates and returns the Kubernetes service for the Kafka Bridge
+     */
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(3);
 
@@ -339,6 +351,16 @@ public class KafkaBridgeCluster extends AbstractModel {
         return volumeMountList;
     }
 
+    /**
+     * Generates the Bridge Kubernetes Deployment
+     *
+     * @param annotations       Map with annotations
+     * @param isOpenShift       Flag indicating if we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy configuration
+     * @param imagePullSecrets  List of image pull secrets
+     *
+     * @return  Generated Kubernetes Deployment resource
+     */
     public Deployment generateDeployment(Map<String, String> annotations, boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         return createDeployment(
                 getDeploymentStrategy(),
@@ -530,10 +552,12 @@ public class KafkaBridgeCluster extends AbstractModel {
         this.bootstrapServers = bootstrapServers;
     }
 
+    /**
+     * @return  The HTTP configuration of the Bridge
+     */
     public KafkaBridgeHttpConfig getHttp() {
         return this.http;
     }
-
 
     /**
      * Returns a combined affinity: Adding the affinity needed for the "kafka-rack" to the {@link #getUserAffinity()}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -29,10 +29,24 @@ import static java.util.Collections.emptyList;
  * Class for handling Kafka configuration passed by the user
  */
 public class KafkaConfiguration extends AbstractConfiguration {
-
+    /**
+     * Configuration key of the inter-broker protocol version option
+     */
     public static final String INTERBROKER_PROTOCOL_VERSION = "inter.broker.protocol.version";
+
+    /**
+     * Configuration key of the message format version option
+     */
     public static final String LOG_MESSAGE_FORMAT_VERSION = "log.message.format.version";
+
+    /**
+     * Configuration key of the default replication factor option
+     */
     public static final String DEFAULT_REPLICATION_FACTOR = "default.replication.factor";
+
+    /**
+     * Configuration key of the min-insync replicas version option
+     */
     public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
 
     private static final List<String> FORBIDDEN_PREFIXES;
@@ -208,6 +222,9 @@ public class KafkaConfiguration extends AbstractConfiguration {
         return result;
     }
 
+    /**
+     * @return  True if the configuration is empty. False otherwise.
+     */
     public boolean isEmpty() {
         return this.asOrderedProperties().asMap().size() == 0;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -73,33 +73,35 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Base64;
 
-
+/**
+ * Kafka Connect model class
+ */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaConnectCluster extends AbstractModel {
-    protected static final String APPLICATION_NAME = "kafka-connect";
-
-    // Port configuration
+    /**
+     * Port of the Kafka Connect REST API
+     */
     public static final int REST_API_PORT = 8083;
-    protected static final String REST_API_PORT_NAME = "rest-api";
 
+    protected static final String APPLICATION_NAME = "kafka-connect";
+    protected static final String REST_API_PORT_NAME = "rest-api";
     protected static final String TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/connect-certs/";
     protected static final String PASSWORD_VOLUME_MOUNT = "/opt/kafka/connect-password/";
     protected static final String EXTERNAL_CONFIGURATION_VOLUME_MOUNT_BASE_PATH = "/opt/kafka/external-configuration/";
     protected static final String EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX = "ext-conf-";
 
     // Configuration defaults
-    protected static final int DEFAULT_REPLICAS = 3;
-    static final int DEFAULT_HEALTHCHECK_DELAY = 60;
-    static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
-    public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withInitialDelaySeconds(DEFAULT_HEALTHCHECK_TIMEOUT)
+    /* test */ static final int DEFAULT_REPLICAS = 3;
+    /* test */ static final int DEFAULT_HEALTHCHECK_DELAY = 60;
+    /* test */ static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
+    private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withInitialDelaySeconds(DEFAULT_HEALTHCHECK_TIMEOUT)
             .withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).build();
-    protected static final boolean DEFAULT_KAFKA_CONNECT_METRICS_ENABLED = false;
+    private static final boolean DEFAULT_KAFKA_CONNECT_METRICS_ENABLED = false;
 
     private static final String NAME_SUFFIX = "-" + APPLICATION_NAME;
-    protected static final String KAFKA_CONNECT_JMX_SECRET_SUFFIX = NAME_SUFFIX + "-jmx";
-    protected static final String SECRET_JMX_USERNAME_KEY = "jmx-username";
-    protected static final String SECRET_JMX_PASSWORD_KEY = "jmx-password";
-
+    private static final String KAFKA_CONNECT_JMX_SECRET_SUFFIX = NAME_SUFFIX + "-jmx";
+    private static final String SECRET_JMX_USERNAME_KEY = "jmx-username";
+    private static final String SECRET_JMX_PASSWORD_KEY = "jmx-password";
 
     // Kafka Connect configuration keys (EnvVariables)
     protected static final String ENV_VAR_PREFIX = "KAFKA_CONNECT_";
@@ -186,6 +188,15 @@ public class KafkaConnectCluster extends AbstractModel {
         this.logAndMetricsConfigMountPath = "/opt/kafka/custom-config/";
     }
 
+    /**
+     * Creates the Kafka Connect model instance from the Kafka Connect CRD
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param kafkaConnect      Kafka connect custom resource
+     * @param versions          Supported Kafka versions
+     *
+     * @return  Instance of the Kafka Connect model class
+     */
     public static KafkaConnectCluster fromCrd(Reconciliation reconciliation, KafkaConnect kafkaConnect, KafkaVersion.Lookup versions) {
         KafkaConnectCluster cluster = fromSpec(reconciliation, kafkaConnect.getSpec(), versions,
                 new KafkaConnectCluster(reconciliation, kafkaConnect));
@@ -199,6 +210,13 @@ public class KafkaConnectCluster extends AbstractModel {
      * Abstracts the calling of setters on a (subclass of) KafkaConnectCluster
      * from the instantiation of the (subclass of) KafkaConnectCluster,
      * thus permitting reuse of the setter-calling code for subclasses.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param spec              Spec section of the Kafka Connect resource
+     * @param versions          Supported Kafka versions
+     * @param kafkaConnect      Kafka Connect resource
+     *
+     * @param <C>   Type of the Kafka Connect cluster
      */
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "deprecation"})
     protected static <C extends KafkaConnectCluster> C fromSpec(Reconciliation reconciliation,
@@ -323,6 +341,9 @@ public class KafkaConnectCluster extends AbstractModel {
         return kafkaConnect;
     }
 
+    /**
+     * @return  Generates the Kafka Connect service
+     */
     public Service generateService() {
         List<ServicePort> ports = new ArrayList<>(1);
         ports.add(createServicePort(REST_API_PORT_NAME, REST_API_PORT, REST_API_PORT, "TCP"));
@@ -463,6 +484,16 @@ public class KafkaConnectCluster extends AbstractModel {
         return builder.build();
     }
 
+    /**
+     * Generates the Kafka Connect deployment
+     *
+     * @param annotations       Map with annotations
+     * @param isOpenShift       Flag indicating if we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  List of image pull Secrets
+     *
+     * @return  Generated deployment
+     */
     public Deployment generateDeployment(Map<String, String> annotations, boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         return createDeployment(
                 getDeploymentStrategy(),
@@ -700,6 +731,9 @@ public class KafkaConnectCluster extends AbstractModel {
         return KafkaConnectResources.serviceAccountName(cluster);
     }
 
+    /**
+     * @return  Name of the ClusterRoleBinding for the Connect init container
+     */
     public String getInitContainerClusterRoleBindingName() {
         return KafkaConnectResources.initContainerClusterRoleBindingName(cluster, namespace);
     }
@@ -720,11 +754,14 @@ public class KafkaConnectCluster extends AbstractModel {
         isJmxEnabled = jmxEnabled;
     }
 
+    /**
+     * @return  True if the JMX authentication is enabled. False otherwise.
+     */
     public boolean isJmxAuthenticated() {
         return isJmxAuthenticated;
     }
 
-    public void setJmxAuthenticated(boolean jmxAuthenticated) {
+    protected void setJmxAuthenticated(boolean jmxAuthenticated) {
         isJmxAuthenticated = jmxAuthenticated;
     }
 
@@ -751,8 +788,6 @@ public class KafkaConnectCluster extends AbstractModel {
 
         return createJmxSecret(KafkaConnectCluster.jmxSecretName(cluster), data);
     }
-
-
 
     /**
      * Generates the NetworkPolicies relevant for Kafka Connect nodes

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java
@@ -48,12 +48,11 @@ public class KafkaConnectDockerfile {
     private static final String DEFAULT_MAVEN_IMAGE = "quay.io/strimzi/maven-builder:latest";
     private final String mavenBuilder;
 
-    public static Cmd run(String cmd, String... args) {
+    private static Cmd run(String cmd, String... args) {
         return new Cmd(new StringBuilder(), cmd, args);
     }
 
-    public static class Cmd {
-
+    private static class Cmd {
         private final StringBuilder stringBuilder;
         boolean doneFirst = false;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -35,6 +35,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Kafka Exporter model
+ */
 public class KafkaExporter extends AbstractModel {
     protected static final String APPLICATION_NAME = "kafka-exporter";
 
@@ -48,7 +51,7 @@ public class KafkaExporter extends AbstractModel {
     /*test*/ static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     /*test*/ static final int DEFAULT_HEALTHCHECK_TIMEOUT = 15;
     /*test*/ static final int DEFAULT_HEALTHCHECK_PERIOD = 30;
-    public static final Probe READINESS_PROBE_OPTIONS = new ProbeBuilder().withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT).withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).withPeriodSeconds(DEFAULT_HEALTHCHECK_PERIOD).build();
+    private static final Probe READINESS_PROBE_OPTIONS = new ProbeBuilder().withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT).withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY).withPeriodSeconds(DEFAULT_HEALTHCHECK_PERIOD).build();
 
     protected static final String ENV_VAR_KAFKA_EXPORTER_LOGGING = "KAFKA_EXPORTER_LOGGING";
     protected static final String ENV_VAR_KAFKA_EXPORTER_KAFKA_VERSION = "KAFKA_EXPORTER_KAFKA_VERSION";
@@ -179,6 +182,15 @@ public class KafkaExporter extends AbstractModel {
         return portList;
     }
 
+    /**
+     * Generates Kafka Exporter Deployment
+     *
+     * @param isOpenShift       Flag indicating whether we are on OpenShift or not
+     * @param imagePullPolicy   Image pull policy
+     * @param imagePullSecrets  List of Image Pull Secrets
+     *
+     * @return  Generated deployment
+     */
     public Deployment generateDeployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         return createDeployment(
                 getDeploymentStrategy(),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaListenerCustomAuthConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaListenerCustomAuthConfiguration.java
@@ -15,13 +15,17 @@ import java.util.Map;
  * Class for handling Kafka listener configuration passed by the user
  */
 public class KafkaListenerCustomAuthConfiguration extends AbstractConfiguration {
-
     private static final List<String> FORBIDDEN_PREFIXES;
-
     static {
         FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaListenerAuthenticationCustom.FORBIDDEN_PREFIXES);
     }
 
+    /**
+     * Constructor
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param jsonOptions       Configuration options
+     */
     public KafkaListenerCustomAuthConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
         super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -35,6 +35,9 @@ import java.util.function.Supplier;
 
 import static io.strimzi.operator.cluster.ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE;
 
+/**
+ * Kafka Mirror Maker 2 model
+ */
 public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     protected static final String APPLICATION_NAME = "kafka-mirror-maker-2";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -73,8 +73,11 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         }
     }
 
+    /**
+     * Lookup class for looking-up Kafka versions and the container images belonging to them
+     */
     public static class Lookup {
-        public static final String KAFKA_VERSIONS_RESOURCE = "kafka-versions.yaml";
+        private static final String KAFKA_VERSIONS_RESOURCE = "kafka-versions.yaml";
         private final Map<String, KafkaVersion> map;
         private final KafkaVersion defaultVersion;
         private final Map<String, String> kafkaImages;
@@ -82,6 +85,14 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         private final Map<String, String> kafkaMirrorMakerImages;
         private final Map<String, String> kafkaMirrorMaker2Images;
 
+        /**
+         * Constructor
+         *
+         * @param kafkaImages               Map with container images for various Kafka versions to be used for Kafka brokers and ZooKeeper
+         * @param kafkaConnectImages        Map with container images for various Kafka versions to be used for Kafka Connect
+         * @param kafkaMirrorMakerImages    Map with container images for various Kafka versions to be used for Kafka Mirror Maker
+         * @param kafkaMirrorMaker2Images   Map with container images for various Kafka versions to be used for Kafka Mirror Maker 2
+         */
         public Lookup(Map<String, String> kafkaImages,
                       Map<String, String> kafkaConnectImages,
                       Map<String, String> kafkaMirrorMakerImages,
@@ -109,6 +120,9 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             this.kafkaMirrorMaker2Images = kafkaMirrorMaker2Images;
         }
 
+        /**
+         * @return  The default Kafka version
+         */
         public KafkaVersion defaultVersion() {
             return defaultVersion;
         }
@@ -170,10 +184,20 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             return result;
         }
 
+        /**
+         * @return  Set of supported Kafka versions
+         */
         public Set<String> supportedVersions() {
             return map.keySet().stream().filter(version -> map.get(version).isSupported).collect(Collectors.toCollection(TreeSet::new));
         }
 
+        /**
+         * Finds Kafka versions which support some feature
+         *
+         * @param feature   Feature which we want to be supported
+         *
+         * @return  Set of Kafka versions which support a particular feature
+         */
         public Set<String> supportedVersionsForFeature(String feature) {
             return map.entrySet().stream()
                     .filter(version -> version.getValue().isSupported)
@@ -369,11 +393,11 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      * Thrown to indicate that given Kafka version is not valid or not supported.
      */
     public static class UnsupportedKafkaVersionException extends InvalidResourceException {
-
-        public UnsupportedKafkaVersionException() {
-            super();
-        }
-
+        /**
+         * Constructor
+         *
+         * @param s     The error message
+         */
         public UnsupportedKafkaVersionException(String s) {
             super(s);
         }
@@ -387,6 +411,17 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
     private final boolean isSupported;
     private final String unsupportedFeatures;
 
+    /**
+     * Class describing a Kafka version. This is used to deserialize the YAML file with the Kafka versions
+     *
+     * @param version               Kafka version
+     * @param protocolVersion       Inter-broker protocol version
+     * @param messageVersion        Log message format version
+     * @param zookeeperVersion      ZooKeeper version
+     * @param isDefault             Flag indicating if this Kafka version is default
+     * @param isSupported           Flag indicating if this Kafka version is supported by this operator version
+     * @param unsupportedFeatures   Unsupported features
+     */
     @JsonCreator
     public KafkaVersion(@JsonProperty("version") String version,
                         @JsonProperty("protocol") String protocolVersion,
@@ -418,30 +453,51 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
                 '}';
     }
 
+    /**
+     * @return  Kafka version
+     */
     public String version() {
         return version;
     }
 
+    /**
+     * @return  Inter-broker protocol version
+     */
     public String protocolVersion() {
         return protocolVersion;
     }
 
+    /**
+     * @return  Log message format version
+     */
     public String messageVersion() {
         return messageVersion;
     }
 
+    /**
+     * @return  ZooKeeper version
+     */
     public String zookeeperVersion() {
         return zookeeperVersion;
     }
 
+    /**
+     * @return  True if this Kafka version is the default. False otherwise.
+     */
     public boolean isDefault() {
         return isDefault;
     }
 
+    /**
+     * @return  True if this Kafka version is supported. False otherwise.
+     */
     public boolean isSupported() {
         return isSupported;
     }
 
+    /**
+     * @return  Unsupported Kafka versions
+     */
     public String unsupportedFeatures() {
         return unsupportedFeatures;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersionChange.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersionChange.java
@@ -14,6 +14,14 @@ public class KafkaVersionChange {
     private final String interBrokerProtocolVersion;
     private final int compare;
 
+    /**
+     * Constructor
+     *
+     * @param from                          Current Kafka version
+     * @param to                            Desired Kafka version
+     * @param interBrokerProtocolVersion    Inter-broker protocol version
+     * @param logMessageFormatVersion       Log-message format version
+     */
     public KafkaVersionChange(KafkaVersion from, KafkaVersion to, String interBrokerProtocolVersion, String logMessageFormatVersion) {
         this.from = from;
         this.to = to;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -29,8 +29,8 @@ import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithOAu
 public class ListenersValidator {
     protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ListenersValidator.class.getName());
     private final static Pattern LISTENER_NAME_PATTERN = Pattern.compile(GenericKafkaListener.LISTENER_NAME_REGEX);
-    public final static List<Integer> FORBIDDEN_PORTS = List.of(9404, 9999);
-    public final static int LOWEST_ALLOWED_PORT_NUMBER = 9092;
+    private final static List<Integer> FORBIDDEN_PORTS = List.of(9404, 9999);
+    private final static int LOWEST_ALLOWED_PORT_NUMBER = 9092;
 
     /**
      * Validated the listener configuration. If the configuration is not valid, InvalidResourceException will be thrown.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -63,7 +63,7 @@ public class ModelUtils {
     private ModelUtils() {}
 
     protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ModelUtils.class.getName());
-    public static final String TLS_SIDECAR_LOG_LEVEL = "TLS_SIDECAR_LOG_LEVEL";
+    protected static final String TLS_SIDECAR_LOG_LEVEL = "TLS_SIDECAR_LOG_LEVEL";
 
     /**
      * @param certificateAuthority The CA configuration.
@@ -110,6 +110,22 @@ public class ModelUtils {
                         tlsSidecar.getLogLevel() : TlsSidecarLogLevel.NOTICE).toValue());
     }
 
+    /**
+     * Builds a certificate secret for the different Strimzi components (TO, UO, KE, ...)
+     *
+     * @param reconciliation                        Reconciliation marker
+     * @param clusterCa                             The Cluster CA
+     * @param secret                                Kubernetes Secret
+     * @param namespace                             Namespace
+     * @param secretName                            Name of the Kubernetes secret
+     * @param commonName                            Common Name of the certificate
+     * @param keyCertName                           Key under which the certificate will be stored in the new Secret
+     * @param labels                                Labels
+     * @param ownerReference                        Owner reference
+     * @param isMaintenanceTimeWindowsSatisfied     Flag whether we are inside a maintenance window or not
+     *
+     * @return  Newly built Secret
+     */
     public static Secret buildSecret(Reconciliation reconciliation, ClusterCa clusterCa, Secret secret, String namespace, String secretName,
                                      String commonName, String keyCertName, Labels labels, OwnerReference ownerReference, boolean isMaintenanceTimeWindowsSatisfied) {
         Map<String, String> data = new HashMap<>(4);
@@ -174,6 +190,19 @@ public class ModelUtils {
                 Collections.singletonMap(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())), emptyMap());
     }
 
+    /**
+     * Creates Secret
+     *
+     * @param name                  Name of the Secret
+     * @param namespace             Namespace of the Secret
+     * @param labels                Labels
+     * @param ownerReference        Owner reference
+     * @param data                  Data which should be stored in the Secret
+     * @param customAnnotations     Custom annotations
+     * @param customLabels          Custom Labels
+     *
+     * @return  Created Kubernetes Secret
+     */
     public static Secret createSecret(String name, String namespace, Labels labels, OwnerReference ownerReference,
                                       Map<String, String> data, Map<String, String> customAnnotations, Map<String, String> customLabels) {
         if (ownerReference == null) {
@@ -309,6 +338,13 @@ public class ModelUtils {
         }
     }
 
+    /**
+     * Decodes Storage configuration from JSON into Java object
+     *
+     * @param json  Storage configuration in the JSON format
+     *
+     * @return  Storage configuration
+     */
     public static Storage decodeStorageFromJson(String json) {
         try {
             return new ObjectMapper().readValue(json, Storage.class);
@@ -317,6 +353,13 @@ public class ModelUtils {
         }
     }
 
+    /**
+     * Encodes storage configuration from Java object to JSON
+     *
+     * @param storage   Storage configuration
+     *
+     * @return  JSON String with the configuration
+     */
     public static String encodeStorageToJson(Storage storage) {
         try {
             return new ObjectMapper().writeValueAsString(storage);
@@ -371,6 +414,16 @@ public class ModelUtils {
         return false;
     }
 
+    /**
+     * Checks for the list passed to this method if it is null or not. And either returns the same list, or empty list
+     * if it is null.
+     *
+     * @param list  List which should be checked for null
+     *
+     * @param <T>   Type of the obejcts in the list
+     *
+     * @return  The original list of empty list if it as null.
+     */
     public static <T> List<T> asListOrEmptyList(List<T> list) {
         return Optional.ofNullable(list)
                 .orElse(Collections.emptyList());
@@ -581,6 +634,7 @@ public class ModelUtils {
     }
 
     /**
+     * Adds user-configured affinity to the AffinityBuilder
      *
      * @param builder the builder which is used to populate the node affinity
      * @param userAffinity the userAffinity which is defined by the user

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NoImageException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NoImageException.java
@@ -8,6 +8,11 @@ package io.strimzi.operator.cluster.model;
  * Thrown to indicate that an image could not be found for a given Kafka version or custom resource.
  */
 public class NoImageException extends Exception {
+    /**
+     * Constructor
+     *
+     * @param message   Error message
+     */
     public NoImageException(String message) {
         super(message);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeGenerator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ProbeGenerator.java
@@ -11,6 +11,9 @@ import io.strimzi.api.kafka.model.TlsSidecar;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Utility for generating healthcheck probes
+ */
 public class ProbeGenerator {
 
     private ProbeGenerator() { }
@@ -40,32 +43,49 @@ public class ProbeGenerator {
         return pb;
     }
 
+    /**
+     * Creates HTTP based probe
+     *
+     * @param probeConfig   Probe configuration
+     * @param path          Path which should be checked
+     * @param port          Port which should be used
+     *
+     * @return  Kubernetes Probe
+     */
     public static io.fabric8.kubernetes.api.model.Probe httpProbe(Probe probeConfig, String path, String port) {
         if (path == null || path.isEmpty() || port == null || port.isEmpty()) {
             throw new IllegalArgumentException();
         }
-        io.fabric8.kubernetes.api.model.Probe probe = defaultBuilder(probeConfig)
+
+        return defaultBuilder(probeConfig)
                 .withNewHttpGet()
                     .withPath(path)
                     .withNewPort(port)
                 .endHttpGet()
                 .build();
-        return probe;
     }
 
+    /**
+     * Creates Exec based probe
+     *
+     * @param probeConfig   Probe configuration
+     * @param command       Command which should be executed
+     *
+     * @return  Kubernetes Probe
+     */
     public static io.fabric8.kubernetes.api.model.Probe execProbe(Probe probeConfig, List<String> command) {
         if (command == null || command.isEmpty()) {
             throw new IllegalArgumentException();
         }
-        io.fabric8.kubernetes.api.model.Probe probe = defaultBuilder(probeConfig)
+
+        return defaultBuilder(probeConfig)
                 .withNewExec()
                     .withCommand(command)
                 .endExec()
                 .build();
-        return probe;
     }
 
-    public static final io.strimzi.api.kafka.model.Probe DEFAULT_TLS_SIDECAR_PROBE = new io.strimzi.api.kafka.model.ProbeBuilder()
+    private static final io.strimzi.api.kafka.model.Probe DEFAULT_TLS_SIDECAR_PROBE = new io.strimzi.api.kafka.model.ProbeBuilder()
             .withInitialDelaySeconds(TlsSidecar.DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(TlsSidecar.DEFAULT_HEALTHCHECK_TIMEOUT)
             .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
@@ -13,21 +13,84 @@ import java.util.regex.Pattern;
  * Defines all the (existing) reasons a Kafka broker pod may need to be restarted
  */
 public enum RestartReason {
+    /**
+     * CA has old generation
+     */
     CA_CERT_HAS_OLD_GENERATION("CA cert has old generation"),
+
+    /**
+     * CA certificate has been removed
+     */
     CA_CERT_REMOVED("CA certificate removed"),
+
+    /**
+     * CA has been renewed
+     */
     CA_CERT_RENEWED("CA certificate renewed"),
+
+    /**
+     * Clients CA provate key was replaced
+     */
     CLIENT_CA_CERT_KEY_REPLACED("Trust new clients CA certificate signed by new key"),
+
+    /**
+     * Cluster CA private key was replaced
+     */
     CLUSTER_CA_CERT_KEY_REPLACED("Trust new cluster CA certificate signed by new key"),
+
+    /**
+     * Configuration change
+     */
     CONFIG_CHANGE_REQUIRES_RESTART("Pod needs to be restarted, because reconfiguration cannot be done dynamically"),
+
+    /**
+     * Custom listener certificate changed
+     */
     CUSTOM_LISTENER_CA_CERT_CHANGE("Custom certificate one or more listeners changed"),
+
+    /**
+     * File system resize is needed
+     */
     FILE_SYSTEM_RESIZE_NEEDED("File system needs to be resized"),
+
+    /**
+     * JBOD volumes configuration changed
+     */
     JBOD_VOLUMES_CHANGED("JBOD volumes were added or removed"),
+
+    /**
+     * Mnaual rolling update was requested
+     */
     MANUAL_ROLLING_UPDATE("Pod was manually annotated to be rolled"),
+
+    /**
+     * Force restart is needed due to an error
+     */
     POD_FORCE_RESTART_ON_ERROR("Pod needs to be forcibly restarted due to an error"),
+
+    /**
+     * Pod has an old genenration
+     */
     POD_HAS_OLD_GENERATION("Pod has old generation"),
+
+    /**
+     * Pod has an old revision
+     */
     POD_HAS_OLD_REVISION("Pod has old revision"),
+
+    /**
+     * Pod is stuck
+     */
     POD_STUCK("Pod needs to be restarted, because it seems to be stuck and restart might help"),
+
+    /**
+     * Pod is unresponsive
+     */
     POD_UNRESPONSIVE("Pod needs to be restarted, because it does not seem to responding to connection attempts"),
+
+    /**
+     * Kafka TLS certificates changed
+     */
     KAFKA_CERTIFICATES_CHANGED("Kafka broker TLS certificates updated");
 
     //Used in logging and Kubernetes event notes
@@ -36,15 +99,25 @@ public enum RestartReason {
     // Matches first character or characters following an underscore
     private static final Pattern PASCAL_CASE_HELPER = Pattern.compile("^.|_.");
 
+    /**
+     * Constructor
+     *
+     * @param defaultNote   The default note
+     */
     RestartReason(String defaultNote) {
         this.defaultNote = defaultNote;
     }
 
+    /**
+     * @return  The default note
+     */
     public String getDefaultNote() {
         return defaultNote;
     }
 
-    // Go loves PascalCase so Kubernetes does too
+    /**
+     * @return  The pascal-cased variant of the reason (this is used by Kubernetes and Golang)
+     */
     public String pascalCased() {
         Matcher matcher = PASCAL_CASE_HELPER.matcher(this.name().toLowerCase(Locale.ROOT));
         return matcher.replaceAll(result -> result.group().replace("_", "").toUpperCase(Locale.ROOT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReasons.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReasons.java
@@ -17,14 +17,22 @@ import java.util.stream.Stream;
  * Collects reasons to restart a pod, along with additional logging messages for each kind of restart.
  */
 public class RestartReasons implements Iterable<RestartReason> {
-
     private final EnumMap<RestartReason, Set<String>> reasons = new EnumMap<>(RestartReason.class);
 
-
+    /**
+     * @return  Empty restart reasons instance
+     */
     public static RestartReasons empty() {
         return new RestartReasons();
     }
 
+    /**
+     * Restart reasons instance with the provider restart reason
+     *
+     * @param reason    Restart reason
+     *
+     * @return  New RestartReasons instance with given restart reason
+     */
     public static RestartReasons of(RestartReason reason) {
         return new RestartReasons().add(reason);
     }
@@ -54,14 +62,27 @@ public class RestartReasons implements Iterable<RestartReason> {
         return add(reason, null);
     }
 
+    /**
+     * @return  Set with all restart reasons
+     */
     public Set<RestartReason> getReasons() {
         return reasons.keySet();
     }
 
+    /**
+     * @return  True if component should be restarts (there are some restart reasons). False otherwise.
+     */
     public boolean shouldRestart() {
         return !reasons.isEmpty();
     }
 
+    /**
+     * Checks if given restart reason is among the restart reasons
+     *
+     * @param reason    Restart reason which should be checked if it is present
+     *
+     * @return  True if the reason is present in this instance. False otherwise.
+     */
     public boolean contains(RestartReason reason) {
         return reasons.containsKey(reason);
     }
@@ -71,6 +92,13 @@ public class RestartReasons implements Iterable<RestartReason> {
         return reasons.keySet().iterator();
     }
 
+    /**
+     * Gets note for given restart reason
+     *
+     * @param reason    Restart reason for which we want to get the note
+     *
+     * @return  The note for given reason. Null if the reason is not present in this instance.
+     */
     public String getNoteFor(RestartReason reason) {
         if (!reasons.containsKey(reason)) {
             return null;
@@ -84,7 +112,11 @@ public class RestartReasons implements Iterable<RestartReason> {
         }
     }
 
-    // For logging, generally
+    /**
+     * Used mainly for logging
+     *
+     * @return  Gets a list with all reason notes
+     */
     public List<String> getAllReasonNotes() {
         return reasons.entrySet().stream().flatMap(entry -> {
             Set<String> explicitNotes = entry.getValue();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/UnsupportedVersionException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/UnsupportedVersionException.java
@@ -8,6 +8,11 @@ package io.strimzi.operator.cluster.model;
  * Thrown to indicate that given Kafka version is not supported.
  */
 public class UnsupportedVersionException extends Exception {
+    /**
+     * Constructor
+     *
+     * @param message   Error message
+     */
     public UnsupportedVersionException(String message) {
         super(message);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZooKeeperSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZooKeeperSpecChecker.java
@@ -28,6 +28,11 @@ public class ZooKeeperSpecChecker {
         this.zk = zk;
     }
 
+    /**
+     * Runs the spec checker
+     *
+     * @return  List of warning conditions
+     */
     public List<Condition> run() {
         List<Condition> warnings = new ArrayList<>();
         checkZooKeeperStorage(warnings);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransOutputWriter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransOutputWriter.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model.components;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
@@ -18,59 +19,115 @@ import java.util.List;
  * flushDelayInSeconds: how often to push the data in seconds
  */
 public class JmxTransOutputWriter implements Serializable {
+    @Serial
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Class for formatting the data output
+     */
     @JsonProperty("@class")
     private String atClass;
 
+    /**
+     * Host where the data should be sent / written to
+     */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private String host;
 
+    /**
+     * Port where the data should be sent / written to
+     */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private int port;
 
+    /**
+     * How often will the data be flushed
+     */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private int flushDelayInSeconds;
 
+    /**
+     * List with type names
+     */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private List<String> typeNames;
 
+    /**
+     * @return  The class for formatting the data output
+     */
     public String getAtClass() {
         return atClass;
     }
 
+    /**
+     * Sets the class for formatting the data output
+     *
+     * @param atClass   Output class
+     */
     public void setAtClass(String atClass) {
         this.atClass = atClass;
     }
 
+    /**
+     * @return  The host where the data should be sent / written to
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Sets the host where the date should be sent / written to
+     *
+     * @param host  Hostname
+     */
     public void setHost(String host) {
         this.host = host;
     }
 
+    /**
+     * @return  The port where the data should be sent / written to
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets the port where the date should be sent / written to
+     *
+     * @param port  Port number
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * @return  How often will the data be flushed
+     */
     public int getFlushDelayInSeconds() {
         return flushDelayInSeconds;
     }
 
+    /**
+     * Sets the flush delay
+     *
+     * @param flushDelayInSeconds   Flush delay in seconds
+     */
     public void setFlushDelayInSeconds(int flushDelayInSeconds) {
         this.flushDelayInSeconds = flushDelayInSeconds;
     }
 
+    /**
+     * @return  List with type names
+     */
     public List<String> getTypeNames() {
         return typeNames;
     }
 
+    /**
+     * Sets the type names
+     *
+     * @param typeNames     List with type names
+     */
     public void setTypeNames(List<String> typeNames) {
         this.typeNames = typeNames;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransQueries.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransQueries.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model.components;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
@@ -14,34 +15,68 @@ import java.util.List;
  * outputDefinitionTemplates: Which hosts and how to output to the hosts
  */
 public class JmxTransQueries implements Serializable {
+    @Serial
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Kafka MBean object whch should be queried
+     */
     private String obj;
 
+    /**
+     * MBean attributes which should be queried
+     */
     private List<String> attr;
 
+    /**
+     * Output writer
+     */
     private List<JmxTransOutputWriter> outputWriters;
 
+    /**
+     * @return  The Kafka MBean which will be queried
+     */
     public String getObj() {
         return obj;
     }
 
+    /**
+     * Sets the Kafka MBean which will be queried
+     *
+     * @param obj   Name of the Kafka MBean to query
+     */
     public void setObj(String obj) {
         this.obj = obj;
     }
 
+    /**
+     * @return  Attributes from the MBean which should be queried
+     */
     public List<String> getAttr() {
         return attr;
     }
 
+    /**
+     * Sets the MBean attributes which should be queried
+     *
+     * @param attr  List of attributes
+     */
     public void setAttr(List<String> attr) {
         this.attr = attr;
     }
 
+    /**
+     * @return  List of output writers
+     */
     public List<JmxTransOutputWriter> getOutputWriters() {
         return outputWriters;
     }
 
+    /**
+     * Sets the output writers
+     *
+     * @param outputDefinitionTemplates     List with output writers
+     */
     public void setOutputWriters(List<JmxTransOutputWriter> outputDefinitionTemplates) {
         this.outputWriters = outputDefinitionTemplates;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransServer.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransServer.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model.components;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
@@ -17,57 +18,113 @@ import java.util.List;
  * queries: what queries are passed in
  */
 public class JmxTransServer implements Serializable {
+    @Serial
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Server host
+     */
     private String host;
 
+    /**
+     * Server port
+     */
     private int port;
 
+    /**
+     * List of JMXTrans queries
+     */
     @JsonProperty("queries")
     private List<JmxTransQueries> queriesTemplate;
 
+    /**
+     * Server username
+     */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private String username;
 
+    /**
+     * Server password
+     */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public String password;
+    private String password;
 
+    /**
+     * @return  Server host
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Sets the host field
+     *
+     * @param host  Server host
+     */
     public void setHost(String host) {
         this.host = host;
     }
 
+    /**
+     * @return  Server port
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets the port field
+     *
+     * @param port  Server port
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * @return  List of JMXTrans queries
+     */
     public List<JmxTransQueries> getQueries() {
         return queriesTemplate;
     }
 
+    /**
+     * Sets the list of JMXTrans queries
+     *
+     * @param queriesTemplate   List with queries
+     */
     public void setQueries(List<JmxTransQueries> queriesTemplate) {
         this.queriesTemplate = queriesTemplate;
     }
 
+    /**
+     * @return  Server username
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * Sets the server username
+     *
+     * @param username  Server username
+     */
     public void setUsername(String username) {
         this.username = username;
     }
 
+    /**
+     * @return  Server password
+     */
     public String getPassword() {
         return password;
     }
 
+    /**
+     * Sets the server password
+     *
+     * @param password  Server password
+     */
     public void setPassword(String password) {
         this.password = password;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransServers.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/components/JmxTransServers.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model.components;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
@@ -12,13 +13,26 @@ import java.util.List;
  * Servers: A list of servers and what they will query and output
  */
 public class JmxTransServers implements Serializable {
+    @Serial
     private static final long serialVersionUID = 1L;
+
+    /**
+     * List of JMX Trans servers
+     */
     private List<JmxTransServer> servers;
 
+    /**
+     * @return  List of JMXTrans servers
+     */
     public List<JmxTransServer> getServers() {
         return servers;
     }
 
+    /**
+     * Sets the JMXTrans servers
+     *
+     * @param servers   List ofJMX Trans servers
+     */
     public void setServers(List<JmxTransServer> servers) {
         this.servers = servers;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CpuCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CpuCapacity.java
@@ -7,23 +7,32 @@ package io.strimzi.operator.cluster.model.cruisecontrol;
 import io.strimzi.operator.cluster.operator.resource.Quantities;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * Cruise Control CPU Capacity class
+ */
 public class CpuCapacity {
     private static final String CORES_KEY = "num.cores";
 
-    private String cores;
+    private final String cores;
 
+    /**
+     * Constructor
+     *
+     * @param cores     CPU cores configuration
+     */
     public CpuCapacity(String cores) {
         this.cores = milliCpuToCpu(Quantities.parseCpuAsMilliCpus(cores));
     }
 
-    public static String milliCpuToCpu(int milliCPU) {
+    protected static String milliCpuToCpu(int milliCPU) {
         return String.valueOf(milliCPU / 1000.0);
     }
 
-    public JsonObject getJson() {
+    protected JsonObject getJson() {
         return new JsonObject().put(CORES_KEY, this.cores);
     }
 
+    @Override
     public String toString() {
         return this.getJson().toString();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/DiskCapacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/DiskCapacity.java
@@ -9,10 +9,16 @@ import io.vertx.core.json.JsonObject;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Cruise Control disk capactiy
+ */
 public class DiskCapacity {
     private static final String SINGLE_DISK = "";
     private Map<String, String> map;
 
+    /**
+     * Constructor
+     */
     public DiskCapacity() {
         map = new HashMap<>(1);
     }
@@ -22,18 +28,18 @@ public class DiskCapacity {
         map.put(SINGLE_DISK, size);
     }
 
-    public static DiskCapacity of(String size) {
+    protected static DiskCapacity of(String size) {
         return new DiskCapacity(size);
     }
 
-    public void add(String path, String size) {
+    protected void add(String path, String size) {
         if (path == null || SINGLE_DISK.equals(path)) {
             throw new IllegalArgumentException("The disk path cannot be null or empty");
         }
         map.put(path, size);
     }
 
-    public Object getJson() {
+    protected Object getJson() {
         if (map.size() == 1 && map.containsKey(SINGLE_DISK)) {
             return map.get(SINGLE_DISK);
         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -42,6 +42,17 @@ public interface KafkaConnectApi {
      */
     Future<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, String host, int port, String connectorName);
 
+    /**
+     * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.
+     *
+     * @param reconciliation    The reconciliation
+     * @param backOff           The backoff parameters
+     * @param host              The host to make the request to.
+     * @param port              The port to make the request to.
+     * @param connectorName     The name of the connector to get the config of.
+     *
+     * @return A Future which completes with the result of the request. If the request was successful, this returns the connector's config.
+     */
     Future<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -860,17 +860,39 @@ public class KafkaListenersReconciler {
      *   - Custom listener certificates
      */
     public static class ReconciliationResult {
-        // List of ListenerStatus objects for the Kafka custom resource status
+        /**
+         * List of ListenerStatus objects for the Kafka custom resource status
+         */
         public final List<ListenerStatus> listenerStatuses = new ArrayList<>();
 
-        // Information collected about listeners
+        /**
+         * Bootstrap DNS names
+         */
         public final Set<String> bootstrapDnsNames = new HashSet<>();
+
+        /**
+         * Broker DNS names
+         */
         public final Map<Integer, Set<String>> brokerDnsNames = new HashMap<>();
+
+        /**
+         * Advertised hostnames
+         */
         public final Map<Integer, Map<String, String>> advertisedHostnames = new HashMap<>();
+
+        /**
+         * Advertised ports
+         */
         public final Map<Integer, Map<String, String>> advertisedPorts = new HashMap<>();
+
+        /**
+         * Bootstrap node ports
+         */
         public final Map<String, Integer> bootstrapNodePorts = new HashMap<>();
 
-        // Custom Listener certificates hash stubs to be used for rolling updates when the certificate changes
+        /**
+         * Custom Listener certificates hash stubs to be used for rolling updates when the certificate changes
+         */
         public final Map<String, String> customListenerCertificateThumbprints = new HashMap<>();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -88,10 +88,10 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     private final DeploymentOperator deploymentOperations;
     private final KafkaVersion.Lookup versions;
 
-    public static final String MIRRORMAKER2_CONNECTOR_PACKAGE = "org.apache.kafka.connect.mirror";
-    public static final String MIRRORMAKER2_SOURCE_CONNECTOR_SUFFIX = ".MirrorSourceConnector";
-    public static final String MIRRORMAKER2_CHECKPOINT_CONNECTOR_SUFFIX = ".MirrorCheckpointConnector";
-    public static final String MIRRORMAKER2_HEARTBEAT_CONNECTOR_SUFFIX = ".MirrorHeartbeatConnector";
+    private static final String MIRRORMAKER2_CONNECTOR_PACKAGE = "org.apache.kafka.connect.mirror";
+    private static final String MIRRORMAKER2_SOURCE_CONNECTOR_SUFFIX = ".MirrorSourceConnector";
+    private static final String MIRRORMAKER2_CHECKPOINT_CONNECTOR_SUFFIX = ".MirrorCheckpointConnector";
+    private static final String MIRRORMAKER2_HEARTBEAT_CONNECTOR_SUFFIX = ".MirrorHeartbeatConnector";
     private static final Map<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> MIRRORMAKER2_CONNECTORS = new HashMap<>(3);
 
     static {
@@ -100,8 +100,8 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         MIRRORMAKER2_CONNECTORS.put(MIRRORMAKER2_HEARTBEAT_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getHeartbeatConnector);
     }
 
-    public static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
-    public static final String SOURCE_CLUSTER_PREFIX = "source.cluster.";
+    private static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
+    private static final String SOURCE_CLUSTER_PREFIX = "source.cluster.";
 
     private static final String STORE_LOCATION_ROOT = "/tmp/kafka/clusters/";
     private static final String TRUSTSTORE_SUFFIX = ".truststore.p12";
@@ -110,10 +110,12 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     private static final String CONNECTORS_CONFIG_FILE = "/tmp/strimzi-mirrormaker2-connector.properties";
 
     /**
-     * @param vertx The Vertx instance
-     * @param pfa Platform features availability properties
-     * @param supplier Supplies the operators for different resources
-     * @param config ClusterOperator configuration. Used to get the user-configured image pull policy and the secrets.
+     * Constructor
+     *
+     * @param vertx     The Vertx instance
+     * @param pfa       Platform features availability properties
+     * @param supplier  Supplies the operators for different resources
+     * @param config    ClusterOperator configuration. Used to get the user-configured image pull policy and the secrets.
      */
     public KafkaMirrorMaker2AssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
                                         ResourceOperatorSupplier supplier,
@@ -121,7 +123,16 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         this(vertx, pfa, supplier, config, connect -> new KafkaConnectApiImpl(vertx));
     }
 
-    public KafkaMirrorMaker2AssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
+    /**
+     * Constructor used for tests
+     *
+     * @param vertx                     The Vertx instance
+     * @param pfa                       Platform features availability properties
+     * @param supplier                  Supplies the operators for different resources
+     * @param config                    ClusterOperator configuration. Used to get the user-configured image pull policy and the secrets.
+     * @param connectClientProvider     Connect REST APi client provider
+     */
+    protected KafkaMirrorMaker2AssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa,
                                         ResourceOperatorSupplier supplier,
                                         ClusterOperatorConfig config,
                                         Function<Vertx, KafkaConnectApi> connectClientProvider) {
@@ -238,7 +249,6 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         }
         return authHash.future();
     }
-
 
     /**
      * Reconcile all the MirrorMaker 2.0 connectors selected by the given MirrorMaker 2.0 instance.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -66,6 +66,16 @@ public class ReconcilerUtils {
         );
     }
 
+    /**
+     * Waits for Pod readiness
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param podOperator           Pod operator
+     * @param operationTimeoutMs    Operations timeout in milliseconds
+     * @param podNames              List with the pod names which should be ready
+     *
+     * @return  Future which completes when all pods are ready or fails when they are not ready in time
+     */
     public static Future<Void> podsReady(Reconciliation reconciliation, PodOperator podOperator, long operationTimeoutMs, List<String> podNames) {
         @SuppressWarnings({ "rawtypes" }) // Has to use Raw type because of the CompositeFuture
         List<Future> podFutures = new ArrayList<>(podNames.size());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -65,7 +65,16 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
             + "|zookeeper\\.clientCnxnSocket"
             + "|broker\\.rack)$");
 
-    public KafkaBrokerConfigurationDiff(Reconciliation reconciliation, Config brokerConfigs, String desired, KafkaVersion kafkaVersion, int brokerId) {
+    /**
+     * Constructor
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param brokerConfigs     Broker configuration from Kafka Admin API
+     * @param desired           Desired configuration
+     * @param kafkaVersion      Kafka version
+     * @param brokerId          Broker ID
+     */
+    protected KafkaBrokerConfigurationDiff(Reconciliation reconciliation, Config brokerConfigs, String desired, KafkaVersion kafkaVersion, int brokerId) {
         this.reconciliation = reconciliation;
         this.configModel = KafkaConfiguration.readConfigModel(kafkaVersion);
         this.diff = diff(brokerId, desired, brokerConfigs, configModel);
@@ -78,7 +87,10 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
         });
     }
 
-    public boolean canBeUpdatedDynamically() {
+    /**
+     * @return  Returns true if the configuration can be updated dynamically
+     */
+    protected boolean canBeUpdatedDynamically() {
         boolean result = true;
         for (AlterConfigOp entry : diff) {
             if (isEntryReadOnly(entry.configEntry())) {
@@ -102,14 +114,14 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
      * Returns configuration difference
      * @return Collection of AlterConfigOp containing difference between current and desired configuration
      */
-    public Collection<AlterConfigOp> getConfigDiff() {
+    protected Collection<AlterConfigOp> getConfigDiff() {
         return diff;
     }
 
     /**
      * @return The number of broker configs which are different.
      */
-    public int getDiffSize() {
+    protected int getDiffSize() {
         return diff.size();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -22,13 +22,24 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Diffs Kafka broker logging configuration
+ */
 public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaBrokerLoggingConfigurationDiff.class);
     private final Collection<AlterConfigOp> diff;
     private final Reconciliation reconciliation;
 
-    public KafkaBrokerLoggingConfigurationDiff(Reconciliation reconciliation, Config brokerConfigs, String desired, int brokerId) {
+    /**
+     * Constructor
+     *
+     * @param reconciliation    Reconciliatin marker
+     * @param brokerConfigs     Current broker configuration from Kafka Admin API
+     * @param desired           Desired logging configuration
+     * @param brokerId          Broker ID
+     */
+    protected KafkaBrokerLoggingConfigurationDiff(Reconciliation reconciliation, Config brokerConfigs, String desired, int brokerId) {
         this.reconciliation = reconciliation;
         this.diff = diff(brokerId, desired, brokerConfigs);
     }
@@ -37,14 +48,14 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
      * Returns logging difference
      * @return Collection of AlterConfigOp containing difference between current and desired logging configuration
      */
-    public Collection<AlterConfigOp> getLoggingDiff() {
+    protected Collection<AlterConfigOp> getLoggingDiff() {
         return diff;
     }
 
     /**
      * @return The number of broker configs which are different.
      */
-    public int getDiffSize() {
+    protected int getDiffSize() {
         return diff.size();
     }
 
@@ -97,6 +108,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
 
         return updatedCE;
     }
+
     protected Map<String, String> readLog4jConfig(String config) {
         Map<String, String> parsed = new LinkedHashMap<>();
         Map<String, String> env = new HashMap<>();
@@ -185,7 +197,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
      * where key is the category name, and the value is whatever comes to the right of '=' sign in log4j.properties,
      * which is either a logging level, or a logging level followed by a comma, and followed by the appender name.
      */
-    static class LoggingLevelResolver {
+    private static class LoggingLevelResolver {
 
         private final Map<String, String> config;
         private final Reconciliation reconciliation;
@@ -247,7 +259,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
         }
     }
 
-    enum LoggingLevel {
+    private enum LoggingLevel {
         OFF,
         FATAL,
         ERROR,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -129,6 +129,25 @@ public class KafkaRoller {
     private final boolean allowReconfiguration;
     private Admin allClient;
 
+    /**
+     * Constructor
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param vertx                 Vert.x instance
+     * @param podOperations         Pod operator for managing pods
+     * @param pollingIntervalMs     Polling interval in milliseconds
+     * @param operationTimeoutMs    Operation timeout in milliseconds
+     * @param backOffSupplier       Backoff supplier
+     * @param podList               List of Kafka pods
+     * @param clusterCaCertSecret   Secret with the Cluster CA public key
+     * @param coKeySecret           Secret with the Cluster CA private key
+     * @param adminClientProvider   Kafka Admin client provider
+     * @param kafkaConfigProvider   Kafka configuration provider
+     * @param kafkaLogging          Kafka logging configuration
+     * @param kafkaVersion          Kafka version
+     * @param allowReconfiguration  Flag indicting whether reconfiguration is allowed or not
+     * @param eventsPublisher       Kubernetes Events publisher for publishing events about pod restarts
+     */
     public KafkaRoller(Reconciliation reconciliation, Vertx vertx, PodOperator podOperations,
                        long pollingIntervalMs, long operationTimeoutMs, Supplier<BackOff> backOffSupplier, List<String> podList,
                        Secret clusterCaCertSecret, Secret coKeySecret,
@@ -824,7 +843,7 @@ public class KafkaRoller {
             });
     }
 
-    public static class PodRef {
+    protected static class PodRef {
 
         private final String podName;
         private final int podId;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -47,6 +47,11 @@ public class KafkaSpecChecker {
         }
     }
 
+    /**
+     * Runs the SpecChecker and returns a list of warning conditions
+     *
+     * @return  List with warning conditions
+     */
     public List<Condition> run() {
         List<Condition> warnings = new ArrayList<>();
         checkKafkaLogMessageFormatVersion(warnings);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/PodRevision.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/PodRevision.java
@@ -20,6 +20,9 @@ import io.strimzi.operator.common.model.Labels;
  * a bit simple.
  */
 public class PodRevision {
+    /**
+     * Annotation for tracking pod revisions
+     */
     public static final String STRIMZI_REVISION_ANNOTATION = Labels.STRIMZI_DOMAIN + "revision";
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(PodRevision.class.getName());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/Quantities.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.operator.cluster.operator.resource;
 
+/**
+ * Utility class for working with Quantities (memory, CPU, ...)
+ */
 public class Quantities {
     private Quantities() {
 
@@ -88,14 +91,13 @@ public class Quantities {
         return factor;
     }
 
-    public static String formatMemory(long bytes) {
+    protected static String formatMemory(long bytes) {
         return Long.toString(bytes);
     }
 
-    public static String normalizeMemory(String memory) {
+    /* test */ static String normalizeMemory(String memory) {
         return formatMemory(parseMemory(memory));
     }
-
 
     /**
      * Parse a K8S-style representation of a quantity of cpu, such as {@code 1000m},
@@ -116,7 +118,7 @@ public class Quantities {
         }
     }
 
-    public static String formatMilliCpu(int milliCpu) {
+    /* test */ static String formatMilliCpu(int milliCpu) {
         if (milliCpu % 1000 == 0) {
             return Long.toString(milliCpu / 1000L);
         } else {
@@ -124,7 +126,7 @@ public class Quantities {
         }
     }
 
-    public static String normalizeCpu(String milliCpu) {
+    /* test */ static String normalizeCpu(String milliCpu) {
         return formatMilliCpu(parseCpuAsMilliCpus(milliCpu));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -49,43 +49,187 @@ import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.vertx.core.Vertx;
 
+/**
+ * Class holding the various resource operator and providers of various clients
+ */
 // Deprecation is suppressed because of KafkaMirrorMaker
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "deprecation"})
 public class ResourceOperatorSupplier {
+    /**
+     * Secret operator
+     */
     public final SecretOperator secretOperations;
+
+    /**
+     * Service operator
+     */
     public final ServiceOperator serviceOperations;
+
+    /**
+     * Route operator
+     */
     public final RouteOperator routeOperations;
+
+    /**
+     * StatefulSet operator
+     */
     public final StatefulSetOperator stsOperations;
+
+    /**
+     * Config Map operator
+     */
     public final ConfigMapOperator configMapOperations;
+
+    /**
+     * PVC operator
+     */
     public final PvcOperator pvcOperations;
+
+    /**
+     * Deployment operator
+     */
     public final DeploymentOperator deploymentOperations;
+
+    /**
+     * Service Account operator
+     */
     public final ServiceAccountOperator serviceAccountOperations;
+
+    /**
+     * Role Binding operator
+     */
     public final RoleBindingOperator roleBindingOperations;
+
+    /**
+     * Role operator
+     */
     public final RoleOperator roleOperations;
+
+    /**
+     * Cluster Role Binding operator
+     */
     public final ClusterRoleBindingOperator clusterRoleBindingOperator;
+
+    /**
+     * Kafka CR operator
+     */
     public final CrdOperator<KubernetesClient, Kafka, KafkaList> kafkaOperator;
+
+    /**
+     * KafkaConnect CR operator
+     */
     public final CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> connectOperator;
+
+    /**
+     * KafkaMirrorMaker CR operator
+     */
     public final CrdOperator<KubernetesClient, KafkaMirrorMaker, KafkaMirrorMakerList> mirrorMakerOperator;
+
+    /**
+     * KafkaBridge CR operator
+     */
     public final CrdOperator<KubernetesClient, KafkaBridge, KafkaBridgeList> kafkaBridgeOperator;
+
+    /**
+     * KafkaConnector CR operator
+     */
     public final CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> kafkaConnectorOperator;
+
+    /**
+     * KafkaMirrorMaker2 CR operator
+     */
     public final CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> mirrorMaker2Operator;
+
+    /**
+     * KafkaRebalance CR operator
+     */
     public final CrdOperator<KubernetesClient, KafkaRebalance, KafkaRebalanceList> kafkaRebalanceOperator;
+
+    /**
+     * Strimzi Pod Set operator
+     */
     public final StrimziPodSetOperator strimziPodSetOperator;
+
+    /**
+     * Network Policy operator
+     */
     public final NetworkPolicyOperator networkPolicyOperator;
+
+    /**
+     * PDB operator
+     */
     public final PodDisruptionBudgetOperator podDisruptionBudgetOperator;
+
+    /**
+     * PDB v1beta1 operator
+     */
     public final PodDisruptionBudgetV1Beta1Operator podDisruptionBudgetV1Beta1Operator;
+
+    /**
+     * Pod operator
+     */
     public final PodOperator podOperations;
+
+    /**
+     * Ingress operator
+     */
     public final IngressOperator ingressOperations;
+
+    /**
+     * Build Config operator
+     */
     public final BuildConfigOperator buildConfigOperations;
+
+    /**
+     * Build operator
+     */
     public final BuildOperator buildOperations;
+
+    /**
+     * Storage Class operator
+     */
     public final StorageClassOperator storageClassOperations;
+
+    /**
+     * Node operator
+     */
     public final NodeOperator nodeOperator;
+
+    /**
+     * ZooKeeper Scaler provider
+     */
     public final ZookeeperScalerProvider zkScalerProvider;
+
+    /**
+     * Metrics provider
+     */
     public final MetricsProvider metricsProvider;
+
+    /**
+     * Kafka Admin API client provider
+     */
     public final AdminClientProvider adminClientProvider;
+
+    /**
+     * ZooKeeper Leader finder
+     */
     public final ZookeeperLeaderFinder zookeeperLeaderFinder;
+
+    /**
+     * Restart Events publisher
+     */
     public final KubernetesRestartEventPublisher restartEventsPublisher;
 
+    /**
+     * Constructor
+     *
+     * @param vertx                 Vert.x instance
+     * @param client                Kubernetes Client
+     * @param metricsProvider       Metrics provider
+     * @param pfa                   Platform Availability Features
+     * @param operationTimeoutMs    Operation timeout in milliseconds
+     * @param operatorName          Name of this operator instance
+     */
     public ResourceOperatorSupplier(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, long operationTimeoutMs, String operatorName) {
         this(vertx,
                 client,
@@ -101,7 +245,18 @@ public class ResourceOperatorSupplier {
         );
     }
 
-    // Exposed for testing
+    /**
+     * Constructor used for tests
+     *
+     * @param vertx                 Vert.x instance
+     * @param client                Kubernetes Client
+     * @param zlf                   ZooKeeper Leader Finder
+     * @param adminClientProvider   Kafka Admin client provider
+     * @param zkScalerProvider      ZooKeeper Scaler provider
+     * @param metricsProvider       Metrics provider
+     * @param pfa                   Platform Availability Features
+     * @param operationTimeoutMs    Operation timeout in milliseconds
+     */
     public ResourceOperatorSupplier(Vertx vertx,
                                     KubernetesClient client,
                                     ZookeeperLeaderFinder zlf,
@@ -122,8 +277,7 @@ public class ResourceOperatorSupplier {
         );
     }
 
-    //Exposed for testing
-    public ResourceOperatorSupplier(Vertx vertx,
+    private ResourceOperatorSupplier(Vertx vertx,
                                     KubernetesClient client,
                                     ZookeeperLeaderFinder zlf,
                                     AdminClientProvider adminClientProvider,
@@ -167,6 +321,43 @@ public class ResourceOperatorSupplier {
                 restartEventPublisher);
     }
 
+    /**
+     * Constructor
+     *
+     * @param serviceOperations                     Service operator
+     * @param routeOperations                       Route operator
+     * @param stsOperations                         StatefulSet operator
+     * @param configMapOperations                   ConfigMap operator
+     * @param secretOperations                      Secret operator
+     * @param pvcOperations                         PVC operator
+     * @param deploymentOperations                  Deployment operator
+     * @param serviceAccountOperations              Service Account operator
+     * @param roleBindingOperations                 Role Binding operator
+     * @param roleOperations                        Role operator
+     * @param clusterRoleBindingOperator            Cluster Role Binding operator
+     * @param networkPolicyOperator                 Network Policy operator
+     * @param podDisruptionBudgetOperator           Pod Disruption Budget operator
+     * @param podDisruptionBudgetV1Beta1Operator    Pod Disruption Budget v1beta1 operator
+     * @param podOperations                         Pod operator
+     * @param ingressOperations                     Ingress operator
+     * @param buildConfigOperations                 Build Config operator
+     * @param buildOperations                       Build operator
+     * @param kafkaOperator                         Kafka CR operator
+     * @param connectOperator                       KafkaConnect CR operator
+     * @param mirrorMakerOperator                   KafkaMirrorMaker CR operator
+     * @param kafkaBridgeOperator                   KafkaBridge operator
+     * @param kafkaConnectorOperator                KafkaConnector operator
+     * @param mirrorMaker2Operator                  KafkaMirrorMaker2 operator
+     * @param kafkaRebalanceOperator                KafkaRebalance operator
+     * @param strimziPodSetOperator                 StrimziPodSet operator
+     * @param storageClassOperator                  StorageClass operator
+     * @param nodeOperator                          Node operator
+     * @param zkScalerProvider                      ZooKeeper Scaler provider
+     * @param metricsProvider                       Metrics provider
+     * @param adminClientProvider                   Kafka Admin client provider
+     * @param zookeeperLeaderFinder                 ZooKeeper Leader Finder
+     * @param restartEventsPublisher                Kubernetes Events publisher
+     */
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
                                     RouteOperator routeOperations,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetDiff.java
@@ -17,6 +17,9 @@ import io.strimzi.operator.common.operator.resource.AbstractJsonDiff;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Class for diffing StatefulSets
+ */
 public class StatefulSetDiff extends AbstractJsonDiff {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StatefulSetDiff.class.getName());
 
@@ -70,6 +73,13 @@ public class StatefulSetDiff extends AbstractJsonDiff {
     private final boolean changesLabels;
     private final boolean changesSpecReplicas;
 
+    /**
+     * Constructor
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param current           Current StatefulSet
+     * @param desired           Desired StatefulSet
+     */
     public StatefulSetDiff(Reconciliation reconciliation, StatefulSet current, StatefulSet desired) {
         JsonNode source = PATCH_MAPPER.valueToTree(current);
         JsonNode target = PATCH_MAPPER.valueToTree(desired);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -104,6 +104,14 @@ public class StatefulSetOperator extends AbstractScalableResourceOperator<Kubern
         return !diff.isEmpty() && needsRollingUpdate(reconciliation, diff);
     }
 
+    /**
+     * Checks if rolling update is needed or not
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param diff              StatefulSet diff
+     *
+     * @return  True if restart is needed. False otherwise.
+     */
     public static boolean needsRollingUpdate(Reconciliation reconciliation, StatefulSetDiff diff) {
         if (diff.changesLabels()) {
             LOGGER.debugCr(reconciliation, "Changed labels => needs rolling update");

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -33,6 +33,13 @@ public class ZooKeeperRoller {
     private final ZookeeperLeaderFinder leaderFinder;
     private final long operationTimeoutMs;
 
+    /**
+     * Constructor
+     *
+     * @param podOperator           Pod operator
+     * @param leaderFinder          ZooKeeper Leader Finder
+     * @param operationTimeoutMs    Operation timeout in milliseconds
+     */
     public ZooKeeperRoller(PodOperator podOperator, ZookeeperLeaderFinder leaderFinder, long operationTimeoutMs) {
         this.podOperator = podOperator;
         this.leaderFinder = leaderFinder;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -42,11 +42,20 @@ public class ZookeeperLeaderFinder {
 
     private static final Pattern LEADER_MODE_PATTERN = Pattern.compile("^Mode: leader$", Pattern.MULTILINE);
 
+    /**
+     * Unknown leader marker
+     */
     public static final String UNKNOWN_LEADER = "-1";
 
     private final Vertx vertx;
     private final Supplier<BackOff> backOffSupplier;
 
+    /**
+     * Constructor
+     *
+     * @param vertx             Vert.x instance
+     * @param backOffSupplier   Backoff supplier
+     */
     public ZookeeperLeaderFinder(Vertx vertx, Supplier<BackOff> backOffSupplier) {
         this.vertx = vertx;
         this.backOffSupplier = backOffSupplier;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalingException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScalingException.java
@@ -8,15 +8,12 @@ package io.strimzi.operator.cluster.operator.resource;
  * Thrown for exceptional circumstances when scaling Zookeeper clusters up or down fails.
  */
 public class ZookeeperScalingException extends RuntimeException {
-    public ZookeeperScalingException() {
-        super();
-    }
-    public ZookeeperScalingException(String s) {
-        super(s);
-    }
-    public ZookeeperScalingException(Throwable cause) {
-        super(cause);
-    }
+    /**
+     * Constructor
+     *
+     * @param message   Error message
+     * @param cause     Exception which caused this error
+     */
     public ZookeeperScalingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
@@ -10,9 +10,19 @@ import io.vertx.core.Future;
  * Cruise Control REST API interface definition
  */
 public interface CruiseControlApi {
-
+    /**
+     * Error key
+     */
     String CC_REST_API_ERROR_KEY = "errorMessage";
+
+    /**
+     * Progress key
+     */
     String CC_REST_API_PROGRESS_KEY = "progress";
+
+    /**
+     * User ID header key
+     */
     String CC_REST_API_USER_ID_HEADER = "User-Task-ID";
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -26,9 +26,15 @@ import java.net.NoRouteToHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * Implementation of the Cruise Control API client
+ */
 public class CruiseControlApiImpl implements CruiseControlApi {
+    /**
+     * Default timeout for the HTTP client (-1 means use the clients default)
+     */
+    public static final int HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS = -1;
     private static final boolean HTTP_CLIENT_ACTIVITY_LOGGING = false;
-    public static final int HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS = -1; // use default internal HTTP client timeout
     private static final String STATUS_KEY = "Status";
 
     private final Vertx vertx;
@@ -37,6 +43,16 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     private HTTPHeader authHttpHeader;
     private PemTrustOptions pto;
 
+    /**
+     * Constructor
+     *
+     * @param vertx             Vert.x instance
+     * @param idleTimeout       Idle timeout
+     * @param ccSecret          Cruise Control Secret
+     * @param ccApiSecret       Cruise Control API Secret
+     * @param apiAuthEnabled    Flag indicating if authentication is enabled
+     * @param apiSslEnabled     Flag indicating if TLS is enabled
+     */
     public CruiseControlApiImpl(Vertx vertx, int idleTimeout, Secret ccSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
         this.vertx = vertx;
         this.idleTimeout = idleTimeout;
@@ -50,7 +66,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         return getCruiseControlState(host, port, verbose, null);
     }
 
-    public HttpClientOptions getHttpClientOptions() {
+    private HttpClientOptions getHttpClientOptions() {
         if (apiSslEnabled) {
             return new HttpClientOptions()
                 .setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING)
@@ -72,7 +88,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         return new HTTPHeader(headerName, headerValue);
     }
 
-    public static HTTPHeader getAuthHttpHeader(boolean apiAuthEnabled, Secret apiSecret) {
+    protected static HTTPHeader getAuthHttpHeader(boolean apiAuthEnabled, Secret apiSecret) {
         if (apiAuthEnabled) {
             String password = new String(Util.decodeFromSecret(apiSecret, CruiseControl.API_ADMIN_PASSWORD_KEY), StandardCharsets.US_ASCII);
             HTTPHeader header = generateAuthHttpHeader(CruiseControl.API_ADMIN_NAME, password);
@@ -83,7 +99,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     }
 
     @SuppressWarnings("deprecation")
-    public Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose, String userTaskId) {
+    private Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose, String userTaskId) {
 
         String path = new PathBuilder(CruiseControlEndpoints.STATE)
                 .withParameter(CruiseControlParameters.JSON, "true")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceResponse.java
@@ -6,11 +6,19 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import io.vertx.core.json.JsonObject;
 
+/**
+ * Response to rebalance request
+ */
 public class CruiseControlRebalanceResponse extends CruiseControlResponse {
-
     private boolean isNotEnoughDataForProposal;
     private boolean isProposalStillCalculating;
 
+    /**
+     * Cosntructor
+     *
+     * @param userTaskId    User task ID
+     * @param json          JSON data
+     */
     CruiseControlRebalanceResponse(String userTaskId, JsonObject json) {
         super(userTaskId, json);
         // There is sufficient data for proposal unless response from Cruise Control says otherwise
@@ -21,19 +29,25 @@ public class CruiseControlRebalanceResponse extends CruiseControlResponse {
         this.isProposalStillCalculating = false;
     }
 
+    /**
+     * @return  True if there is not enough data to generate a proposal. False otherwise.
+     */
     public boolean isNotEnoughDataForProposal() {
         return this.isNotEnoughDataForProposal;
     }
 
-    public void setNotEnoughDataForProposal(boolean notEnoughDataForProposal) {
+    protected void setNotEnoughDataForProposal(boolean notEnoughDataForProposal) {
         this.isNotEnoughDataForProposal = notEnoughDataForProposal;
     }
 
+    /**
+     * @return  True if the proposal is still being calculated. False otherwise.
+     */
     public boolean isProposalStillCalculating() {
         return isProposalStillCalculating;
     }
 
-    public void setProposalStillCalculating(boolean proposalStillCalculating) {
+    protected void setProposalStillCalculating(boolean proposalStillCalculating) {
         this.isProposalStillCalculating = proposalStillCalculating;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlResponse.java
@@ -6,31 +6,40 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import io.vertx.core.json.JsonObject;
 
+/**
+ * Cruise Control response
+ */
 public class CruiseControlResponse {
-
     private String userTaskId;
     private JsonObject json;
 
+    /**
+     * Constructor
+     *
+     * @param userTaskId    User task ID
+     * @param json          JSON data
+     */
     CruiseControlResponse(String userTaskId, JsonObject json) {
         this.userTaskId = userTaskId;
         this.json = json;
     }
 
+    /**
+     * @return  User task ID
+     */
     public String getUserTaskId() {
         return userTaskId;
     }
 
+    /**
+     * @return  The JSON data of the response
+     */
     public JsonObject getJson() {
         return json;
     }
 
-    public String prettyPrint() {
-        return "User Task ID: " + userTaskId + "\nJSON:\n " + json.encodePrettily();
-    }
-
+    @Override
     public String toString() {
         return "User Task ID: " + userTaskId + " JSON: " + json.toString();
     }
-
-
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRestException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRestException.java
@@ -8,7 +8,11 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
  * Represents an exception related to Cruise Control REST API interaction
  */
 public class CruiseControlRestException extends RuntimeException {
-
+    /**
+     * Constructor
+     *
+     * @param message   Error message
+     */
     public CruiseControlRestException(String message) {
         super(message);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectionException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRetriableConnectionException.java
@@ -4,8 +4,15 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
+/**
+ * Retryable Cruise Control connection exception
+ */
 public class CruiseControlRetriableConnectionException extends RuntimeException {
-
+    /**
+     * Constructor
+     *
+     * @param cause     Cause of this error
+     */
     public CruiseControlRetriableConnectionException(Throwable cause) {
         super(cause);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
@@ -10,16 +10,31 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Builds the path to the Cruise Control APi
+ */
 public class PathBuilder {
 
     String constructedPath;
     boolean firstParam;
 
+    /**
+     * Constructor
+     *
+     * @param endpoint  Cruise COntrol endpoint
+     */
     public PathBuilder(CruiseControlEndpoints endpoint) {
         constructedPath = endpoint.path + "?";
         firstParam = true;
     }
 
+    /**
+     * Adds parameter to the path
+     *
+     * @param parameter     Parameter
+     *
+     * @return  Instance of this builder
+     */
     public PathBuilder withParameter(String parameter) {
         if (!firstParam) {
             constructedPath += "&";
@@ -34,6 +49,14 @@ public class PathBuilder {
         return this;
     }
 
+    /**
+     * Adds parameter with value to the path
+     *
+     * @param param     Cruise Control parameter
+     * @param value     Parameter value
+     *
+     * @return  Instance of this builder
+     */
     public PathBuilder withParameter(CruiseControlParameters param, String value) {
         if (!firstParam) {
             constructedPath += "&";
@@ -48,6 +71,14 @@ public class PathBuilder {
         return this;
     }
 
+    /**
+     * Adds parameter with multiple values to the path
+     *
+     * @param param     Cruise Control parameter
+     * @param values    List of parameter value
+     *
+     * @return  Instance of this builder
+     */
     public PathBuilder withParameter(CruiseControlParameters param, List<String> values) {
         if (!firstParam) {
             constructedPath += "&";
@@ -68,6 +99,13 @@ public class PathBuilder {
         }
     }
 
+    /**
+     * Adds Rebalance parameters to the path
+     *
+     * @param options   Rebalance options
+     *
+     * @return  Instance of this builder
+     */
     public PathBuilder withRebalanceParameters(RebalanceOptions options) {
         if (options != null) {
             PathBuilder builder = withAbstractRebalanceParameters(options)
@@ -105,6 +143,13 @@ public class PathBuilder {
         }
     }
 
+    /**
+     * Adds add-broker options to the path
+     *
+     * @param options   Add broker options
+     *
+     * @return  Instance of this builder
+     */
     public PathBuilder withAddBrokerParameters(AddBrokerOptions options) {
         if (options != null) {
             PathBuilder builder = withAbstractRebalanceParameters(options)
@@ -115,6 +160,13 @@ public class PathBuilder {
         }
     }
 
+    /**
+     * Adds remove broker options to the path
+     *
+     * @param options   Remove-broker options
+     *
+     * @return  Instance of this builder
+     */
     public PathBuilder withRemoveBrokerParameters(RemoveBrokerOptions options) {
         if (options != null) {
             PathBuilder builder = withAbstractRebalanceParameters(options)
@@ -125,6 +177,9 @@ public class PathBuilder {
         }
     }
 
+    /**
+     * @return  Builds and returns the path
+     */
     public String build() {
         return constructedPath;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisher.java
@@ -50,12 +50,18 @@ public class KubernetesRestartEventPublisher {
         this(client, operatorName, Clock.systemDefaultZone());
     }
 
-    public KubernetesRestartEventPublisher(KubernetesClient client, String operatorName, Clock clock) {
+    protected KubernetesRestartEventPublisher(KubernetesClient client, String operatorName, Clock clock) {
         this.clock = clock;
         this.operatorName = operatorName;
         this.client = client;
     }
 
+    /**
+     * Publishes an Kubernetes Event about Pod restart
+     *
+     * @param pod       Pod which is restarted
+     * @param reasons   Reasons for the restart
+     */
     public void publishRestartEvents(Pod pod, RestartReasons reasons) {
         MicroTime k8sEventTime = new MicroTime(K8S_MICROTIME.format(ZonedDateTime.now(clock)));
         ObjectReference podReference = createPodReference(pod);


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR fixes the remaining Javadocs issues in the `cluster-operator` module by either adding the Javadoc (or their missing parts) or making the methods / fields not public where they don't need to be public.

This should close #7702 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging