### PR TITLE
Add ImageStream validation to Kafka Connect builds on OpenShift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Upgrade Vert.x to 4.3.5
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Kafka Exporter support for `Recreate` deployment strategy
+* `ImageStream` validation for Kafka Connect builds on OpenShift
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.NodeOperator;
@@ -71,8 +72,13 @@ public class ResourceOperatorSupplier {
     public final RouteOperator routeOperations;
 
     /**
-     * StatefulSet operator
+     * ImageStream operator
      */
+    public final ImageStreamOperator imageStreamOperations;
+
+    /**
+     * StatefulSet operator
+     */    
     public final StatefulSetOperator stsOperations;
 
     /**
@@ -288,6 +294,7 @@ public class ResourceOperatorSupplier {
                                     KubernetesRestartEventPublisher restartEventPublisher) {
         this(new ServiceOperator(vertx, client),
                 pfa.hasRoutes() ? new RouteOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
+                pfa.hasImages() ? new ImageStreamOperator(vertx, client.adapt(OpenShiftClient.class)) : null,
                 new StatefulSetOperator(vertx, client, operationTimeoutMs),
                 new ConfigMapOperator(vertx, client),
                 new SecretOperator(vertx, client),
@@ -361,6 +368,7 @@ public class ResourceOperatorSupplier {
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public ResourceOperatorSupplier(ServiceOperator serviceOperations,
                                     RouteOperator routeOperations,
+                                    ImageStreamOperator imageStreamOperations,
                                     StatefulSetOperator stsOperations,
                                     ConfigMapOperator configMapOperations,
                                     SecretOperator secretOperations,
@@ -394,6 +402,7 @@ public class ResourceOperatorSupplier {
                                     KubernetesRestartEventPublisher restartEventsPublisher) {
         this.serviceOperations = serviceOperations;
         this.routeOperations = routeOperations;
+        this.imageStreamOperations = imageStreamOperations;
         this.stsOperations = stsOperations;
         this.configMapOperations = configMapOperations;
         this.secretOperations = secretOperations;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ResourceOperatorSupplier.java
@@ -333,6 +333,7 @@ public class ResourceOperatorSupplier {
      *
      * @param serviceOperations                     Service operator
      * @param routeOperations                       Route operator
+     * @param imageStreamOperations                 ImageStream operator
      * @param stsOperations                         StatefulSet operator
      * @param configMapOperations                   ConfigMap operator
      * @param secretOperations                      Secret operator

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -131,6 +131,13 @@ rules:
       - patch
       - update
   - apiGroups:
+      - image.openshift.io
+    resources:
+      # The cluster operator needs to verify the image stream when used for Kafka Connect image build
+      - imagestreams
+    verbs:
+      - get
+  - apiGroups:
       - policy
     resources:
       # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -64,6 +64,7 @@ import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.IngressOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
 import io.strimzi.operator.common.operator.resource.NodeOperator;
@@ -540,10 +541,12 @@ public class ResourceUtils {
     @SuppressWarnings("unchecked")
     public static ResourceOperatorSupplier supplierWithMocks(boolean openShift) {
         RouteOperator routeOps = openShift ? mock(RouteOperator.class) : null;
+        ImageStreamOperator imageOps = openShift ? mock(ImageStreamOperator.class) : null;
 
         ResourceOperatorSupplier supplier = new ResourceOperatorSupplier(
                 mock(ServiceOperator.class),
                 routeOps,
+                imageOps,
                 mock(StatefulSetOperator.class),
                 mock(ConfigMapOperator.class),
                 mock(SecretOperator.class),

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -136,6 +136,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - image.openshift.io
+  resources:
+  # The cluster operator needs to verify the image stream when used for Kafka Connect image build
+  - imagestreams
+  verbs:
+  - get
+- apiGroups:
   - policy
   resources:
     # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions

--- a/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -131,6 +131,13 @@ rules:
       - patch
       - update
   - apiGroups:
+      - image.openshift.io
+    resources:
+      # The cluster operator needs to verify the image stream when used for Kafka Connect image build
+      - imagestreams
+    verbs:
+      - get
+  - apiGroups:
       - policy
     resources:
       # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions


### PR DESCRIPTION
This change closes #7052 by adding ImageStream validation logic.