### PR TITLE
Move from OkHttp client to JDK HTTP client (for use with Fabric8 Kubernetes client)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube2/MockKube2.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube2/MockKube2.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube2.controllers.AbstractMockController;
@@ -185,7 +186,7 @@ public class MockKube2 {
          * @return  MockKube builder instance
          */
         public MockKube2Builder withKafkaUserCrd()  {
-            mock.registerCrd("kafka.strimzi.io/v1beta2", "KafkaUser", KafkaRebalance.class, TestUtils.CRD_KAFKA_USER);
+            mock.registerCrd("kafka.strimzi.io/v1beta2", "KafkaUser", KafkaUser.class, TestUtils.CRD_KAFKA_USER);
             return this;
         }
 

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>openshift-client-api</artifactId>
         </dependency>
         <dependency>

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -196,7 +196,8 @@ public class PlatformFeaturesAvailabilityTest {
     }
 
     KubernetesClient buildKubernetesClient(String masterUrl)    {
-        return new KubernetesClientBuilder().withConfig(new ConfigBuilder().withMasterUrl(masterUrl).build()).build();
+        // We have to disable HTTP2 => the mock webserver used here does not support HTTP2 without TLS
+        return new KubernetesClientBuilder().withConfig(new ConfigBuilder().withMasterUrl(masterUrl).withHttp2Disable().build()).build();
     }
 
     void startMockApi(Vertx vertx, String version, List<APIGroup> apis) throws InterruptedException, ExecutionException {

--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,9 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.2.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.2.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.2.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.3.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.3.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.3.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.13.4</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.13.4.1</fasterxml.jackson-databind.version>
@@ -273,6 +273,17 @@
                 <artifactId>kubernetes-client</artifactId>
                 <version>${fabric8.kubernetes-client.version}</version>
                 <scope>runtime</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-httpclient-jdk</artifactId>
+                <version>${fabric8.kubernetes-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>
@@ -1096,6 +1107,7 @@
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:openshift-client</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-clients</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-streams</ignoredUnusedDeclaredDependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -215,8 +215,7 @@ public class KubeClusterResource {
                     .forEach(namespaceName -> {
                         LOGGER.debug("Deleting Namespace: {}", namespaceName);
                         kubeClient().deleteNamespace(namespaceName);
-                        client.getClient().namespaces().withName(namespaceName).waitUntilCondition(
-                            namespace -> client.getClient().namespaces().withName(namespaceName).get() == null, 4, TimeUnit.MINUTES);
+                        client.getClient().namespaces().withName(namespaceName).waitUntilCondition(namespace -> namespace == null, 4, TimeUnit.MINUTES);
                     }));
 
         MAP_WITH_SUITE_NAMESPACES.clear();

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserControllerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserControllerTest.java
@@ -275,7 +275,8 @@ public class UserControllerTest {
                     10_000,
                     () -> {
                         KafkaUser u = Crds.kafkaUserOperation(client).inNamespace(NAMESPACE).withName(NAME).get();
-                        return u.getStatus() != null
+                        return u != null
+                                && u.getStatus() != null
                                 && u.getStatus().getConditions() != null
                                 && u.getStatus().getConditions().stream().filter(c -> "NotReady".equals(c.getType())).findFirst().orElse(null) != null;
                     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Today, with Fabric8 Kubernetes client, we use the OkHttp 3 client for HTTP communication. This PR tries to move from the OkHttp client to the JDK HTTP client. This might have some advantages - for example getting rid of the CVEs in OkHttp 3.

This PR is only a draft at this point to be able to run the tests with the JDK HTTP client more easily.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

