### PR TITLE
Add Log4j-jul to properly integrate OkHttp logging

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
+            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-server</artifactId>
         </dependency>

--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -27,6 +27,9 @@ else
     echo "Configuration file log4j2.properties not found. Using default static logging setting. Dynamic updates of logging configuration will not work."
 fi
 
+# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
+export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+
 # Used to identify cluster operator instance when publishing events
 if [[ -z "$STRIMZI_OPERATOR_NAME" ]]; then
   STRIMZI_OPERATOR_NAME="$(cat /proc/sys/kernel/hostname)"

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
+            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>

--- a/kafka-init/scripts/kafka_init_run.sh
+++ b/kafka-init/scripts/kafka_init_run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
+export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+
 export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.kafka.init.Main
 exec "${STRIMZI_HOME}/bin/launch_java.sh"

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,12 @@
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
+                <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jul</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
@@ -1104,6 +1110,7 @@
                                 <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-jul</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.sundr:builder-annotations</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.sundr:sundr-codegen</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.projectlombok:lombok</ignoredUnusedDeclaredDependency>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
+            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -10,6 +10,9 @@ then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/topic-operator/custom-config/log4j2.properties"
 fi
 
+# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
+export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
+            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -10,6 +10,9 @@ then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/user-operator/custom-config/log4j2.properties"
 fi
 
+# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
+export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, as part of Fabric8 Kubernetes client we use the OkHttp HTTP client for communication with the Kubernetes API server. OkHttp is using JUL (java.util.logging) for logging. But we currently don't have any integration between Log4j2 used by out operators and the JUL stack used by OkHttp. That makes it hard to control properly the log levels of OkHttp when needed.

This Pr ads dependency on `log4j-jul` module and configures the JUL Logging Manager at startup to properly integrate the OkHttp logging. This allows use to change log levels properly for OkHttp classes and for example get proper logs when OkHttp connections are not closed properly.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

