### PR TITLE
Add minor build process improvements

### DIFF
--- a/docker-images/kafka-based/find-classpath-collision.sh
+++ b/docker-images/kafka-based/find-classpath-collision.sh
@@ -4,15 +4,17 @@ image_jar_dir=$2 #/opt/kafka/libs
 whilelist_file=$3
 DOCKER_CMD=${DOCKER_CMD:-docker}
 
-jars_dir=`mktemp -d`
-trap "[ -e $jars_dir ] && rm -rf $jars_dir" EXIT
+jars_dir=$(mktemp -d)
+classes_root=$(mktemp -d)
+exit_handler() {
+  [ -e $jars_dir ] && rm -rf $jars_dir
+  [ -e $classes_root ] && rm -rf $classes_root
+}
+trap exit_handler EXIT
 
 ${DOCKER_CMD} run --name temp-container-name "$image" /bin/true || exit 2
 ${DOCKER_CMD} cp "temp-container-name:$image_jar_dir" "$jars_dir"
 ${DOCKER_CMD} rm temp-container-name > /dev/null
-
-classes_root=`mktemp -d`
-trap "[ -e $classes_root ] && rm -rf $classes_root" EXIT
 
 $(dirname $0)/../artifacts/extract-jars.sh "$jars_dir" "$classes_root"
 

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -8,7 +8,7 @@ ARG THIRD_PARTY_LIBS
 ARG strimzi_version
 ARG TARGETPLATFORM
 
-RUN microdnf install gettext nmap-ncat stunnel net-tools unzip hostname findutils tar \
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install gettext nmap-ncat stunnel net-tools unzip hostname findutils tar \
     && microdnf clean all
 
 # Add kafka user with UID 1001


### PR DESCRIPTION
- Add `install_weak_deps` and `nodoc` microdnf options to Kafka Dockerfile (3/4 MB lighter image)
- Fix `find-classpath-collision.sh` bug where a tmp folder was not cleaned
