### PR TITLE
Refactor resource operators to have a single shared abstract class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -14,7 +14,7 @@ import io.strimzi.operator.cluster.model.UnsupportedVersionException;
 import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.AbstractResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractNamespacedResourceOperator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -369,16 +369,16 @@ public class ClusterOperatorConfig {
     private static Set<String> parseNamespaceList(String namespacesList)   {
         Set<String> namespaces;
         if (namespacesList == null || namespacesList.isEmpty()) {
-            namespaces = Collections.singleton(AbstractResourceOperator.ANY_NAMESPACE);
+            namespaces = Collections.singleton(AbstractNamespacedResourceOperator.ANY_NAMESPACE);
         } else {
-            if (namespacesList.trim().equals(AbstractResourceOperator.ANY_NAMESPACE)) {
-                namespaces = Collections.singleton(AbstractResourceOperator.ANY_NAMESPACE);
+            if (namespacesList.trim().equals(AbstractNamespacedResourceOperator.ANY_NAMESPACE)) {
+                namespaces = Collections.singleton(AbstractNamespacedResourceOperator.ANY_NAMESPACE);
             } else if (namespacesList.matches("(\\s*[a-z0-9.-]+\\s*,)*\\s*[a-z0-9.-]+\\s*")) {
                 namespaces = new HashSet<>(asList(namespacesList.trim().split("\\s*,+\\s*")));
             } else {
                 throw new InvalidConfigurationException(STRIMZI_NAMESPACE
                         + " is not a valid list of namespaces nor the 'any namespace' wildcard "
-                        + AbstractResourceOperator.ANY_NAMESPACE);
+                        + AbstractNamespacedResourceOperator.ANY_NAMESPACE);
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -20,7 +20,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.AbstractOperator;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
@@ -44,7 +44,7 @@ import java.util.List;
  */
 public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T extends CustomResource<P, S>,
         L extends KubernetesResourceList<T>, R extends Resource<T>, P extends Spec, S extends Status>
-    extends AbstractOperator<T, P, S, AbstractWatchableStatusedResourceOperator<C, T, L, R>> {
+    extends AbstractOperator<T, P, S, AbstractWatchableStatusedNamespacedResourceOperator<C, T, L, R>> {
     protected final PlatformFeaturesAvailability pfa;
     protected final SecretOperator secretOperations;
     protected final CertManager certManager;
@@ -72,7 +72,7 @@ public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T ext
      */
     protected AbstractAssemblyOperator(Vertx vertx, PlatformFeaturesAvailability pfa, String kind,
                                        CertManager certManager, PasswordGenerator passwordGenerator,
-                                       AbstractWatchableStatusedResourceOperator<C, T, L, R> resourceOperator,
+                                       AbstractWatchableStatusedNamespacedResourceOperator<C, T, L, R> resourceOperator,
                                        ResourceOperatorSupplier supplier,
                                        ClusterOperatorConfig config) {
         super(vertx, kind, resourceOperator, supplier.metricsProvider, config.getCustomResourceSelector());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -52,7 +52,7 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
@@ -150,7 +150,7 @@ import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_REBALANCE_A
  */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaRebalanceAssemblyOperator
-       extends AbstractOperator<KafkaRebalance, KafkaRebalanceSpec, KafkaRebalanceStatus, AbstractWatchableStatusedResourceOperator<KubernetesClient, KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>>> {
+       extends AbstractOperator<KafkaRebalance, KafkaRebalanceSpec, KafkaRebalanceStatus, AbstractWatchableStatusedNamespacedResourceOperator<KubernetesClient, KafkaRebalance, KafkaRebalanceList, Resource<KafkaRebalance>>> {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaRebalanceAssemblyOperator.class.getName());
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ManualPodCleaner.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ManualPodCleaner.java
@@ -17,7 +17,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractScalableNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.vertx.core.CompositeFuture;
@@ -128,7 +128,7 @@ public class ManualPodCleaner {
                     // Only one pod per reconciliation is rolled
                     Pod podToClean = pods
                             .stream()
-                            .filter(pod -> Annotations.booleanAnnotation(pod, AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, false))
+                            .filter(pod -> Annotations.booleanAnnotation(pod, AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, false))
                             .findFirst()
                             .orElse(null);
 
@@ -302,7 +302,7 @@ public class ManualPodCleaner {
 
                     for (PersistentVolumeClaim pvc : deletePvcs)    {
                         String pvcName = pvc.getMetadata().getName();
-                        LOGGER.debugCr(reconciliation, "Deleting PVC {} for Pod {} based on {} annotation", pvcName, podName, AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC);
+                        LOGGER.debugCr(reconciliation, "Deleting PVC {} for Pod {} based on {} annotation", pvcName, podName, AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC);
                         deleteResults.add(pvcOperator.deleteAsync(reconciliation, reconciliation.namespace(), pvcName, true));
                     }
                     return CompositeFuture.join(deleteResults);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -15,7 +15,7 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractScalableNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.CompositeFuture;
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Operations for {@code StatefulSets}s
  */
-public class StatefulSetOperator extends AbstractScalableResourceOperator<KubernetesClient, StatefulSet, StatefulSetList, RollableScalableResource<StatefulSet>> {
+public class StatefulSetOperator extends AbstractScalableNamespacedResourceOperator<KubernetesClient, StatefulSet, StatefulSetList, RollableScalableResource<StatefulSet>> {
     private static final int NO_GENERATION = -1;
     private static final int INIT_GENERATION = 0;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ManualPodCleanerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ManualPodCleanerTest.java
@@ -22,7 +22,7 @@ import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractScalableNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.vertx.core.Future;
@@ -68,7 +68,7 @@ public class ManualPodCleanerTest {
     private void manualPodCleanupOnePod(VertxTestContext context, boolean useStrimziPodSets)    {
         List<Pod> pods = List.of(
                 podWithName(CONTROLLER_NAME + "-0"),
-                podWithNameAndAnnotations(CONTROLLER_NAME + "-1", Collections.singletonMap(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true")),
+                podWithNameAndAnnotations(CONTROLLER_NAME + "-1", Collections.singletonMap(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true")),
                 podWithName(CONTROLLER_NAME + "-2")
         );
 
@@ -94,7 +94,7 @@ public class ManualPodCleanerTest {
     private void manualPodCleanupJbod(VertxTestContext context, boolean useStrimziPodSets)    {
         List<Pod> pods = List.of(
                 podWithName(CONTROLLER_NAME + "-0"),
-                podWithNameAndAnnotations(CONTROLLER_NAME + "-1", Collections.singletonMap(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true")),
+                podWithNameAndAnnotations(CONTROLLER_NAME + "-1", Collections.singletonMap(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true")),
                 podWithName(CONTROLLER_NAME + "-2")
         );
 
@@ -123,8 +123,8 @@ public class ManualPodCleanerTest {
     private void manualPodCleanupMultiplePods(VertxTestContext context, boolean useStrimziPodSets)    {
         List<Pod> pods = List.of(
                 podWithName(CONTROLLER_NAME + "-0"),
-                podWithNameAndAnnotations(CONTROLLER_NAME + "-1", Collections.singletonMap(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true")),
-                podWithNameAndAnnotations(CONTROLLER_NAME + "-2", Collections.singletonMap(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true"))
+                podWithNameAndAnnotations(CONTROLLER_NAME + "-1", Collections.singletonMap(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true")),
+                podWithNameAndAnnotations(CONTROLLER_NAME + "-2", Collections.singletonMap(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_DELETE_POD_AND_PVC, "true"))
         );
 
         List<PersistentVolumeClaim> pvcs = List.of(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.operator.resource.AbstractResourceOperatorTest;
-import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractNamespacedResourceOperatorTest;
+import io.strimzi.operator.common.operator.resource.AbstractScalableNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.ScalableResourceOperatorTest;
@@ -71,14 +71,14 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
     protected StatefulSet resource(String name) {
         return new StatefulSetBuilder()
                 .withNewMetadata()
-                    .withNamespace(AbstractResourceOperatorTest.NAMESPACE)
+                    .withNamespace(AbstractNamespacedResourceOperatorTest.NAMESPACE)
                     .withName(name)
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(3)
                     .withNewTemplate()
                         .withNewMetadata()
-                            .addToAnnotations(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_GENERATION, "1")
+                            .addToAnnotations(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_GENERATION, "1")
                         .endMetadata()
                     .endTemplate()
                 .endSpec()
@@ -92,7 +92,7 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
                     .withReplicas(5)
                     .withNewTemplate()
                         .withNewMetadata()
-                            .addToAnnotations(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_GENERATION, "2")
+                            .addToAnnotations(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_GENERATION, "2")
                         .endMetadata()
                         .withNewSpec()
                             .withHostname("new-hostname")
@@ -155,8 +155,8 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
     public void testInternalReplace(VertxTestContext context)   {
         StatefulSet sts1 = new StatefulSetBuilder()
                 .withNewMetadata()
-                    .withNamespace(AbstractResourceOperatorTest.NAMESPACE)
-                    .withName(AbstractResourceOperatorTest.RESOURCE_NAME)
+                    .withNamespace(AbstractNamespacedResourceOperatorTest.NAMESPACE)
+                    .withName(AbstractNamespacedResourceOperatorTest.RESOURCE_NAME)
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(3)
@@ -185,8 +185,8 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
 
         StatefulSet sts2 = new StatefulSetBuilder()
                 .withNewMetadata()
-                    .withNamespace(AbstractResourceOperatorTest.NAMESPACE)
-                    .withName(AbstractResourceOperatorTest.RESOURCE_NAME)
+                    .withNamespace(AbstractNamespacedResourceOperatorTest.NAMESPACE)
+                    .withName(AbstractNamespacedResourceOperatorTest.RESOURCE_NAME)
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(3)
@@ -228,7 +228,7 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
         KubernetesClient mockClient = mock(KubernetesClient.class);
         mocker(mockClient, mockCms);
 
-        StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
+        StatefulSetOperator op = new StatefulSetOperator(AbstractNamespacedResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
             @Override
             protected boolean shouldIncrementGeneration(Reconciliation reconciliation, StatefulSetDiff diff) {
                 return true;
@@ -274,7 +274,7 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
         KubernetesClient mockClient = mock(KubernetesClient.class);
         mocker(mockClient, mockCms);
 
-        StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
+        StatefulSetOperator op = new StatefulSetOperator(AbstractNamespacedResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
             @Override
             protected boolean shouldIncrementGeneration(Reconciliation reconciliation, StatefulSetDiff diff) {
                 return true;
@@ -314,7 +314,7 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
         KubernetesClient mockClient = mock(KubernetesClient.class);
         mocker(mockClient, mockCms);
 
-        StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
+        StatefulSetOperator op = new StatefulSetOperator(AbstractNamespacedResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
             @Override
             protected boolean shouldIncrementGeneration(Reconciliation reconciliation, StatefulSetDiff diff) {
                 return true;
@@ -348,7 +348,7 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
         KubernetesClient mockClient = mock(KubernetesClient.class);
         mocker(mockClient, mockCms);
 
-        StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
+        StatefulSetOperator op = new StatefulSetOperator(AbstractNamespacedResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
             @Override
             protected boolean shouldIncrementGeneration(Reconciliation reconciliation, StatefulSetDiff diff) {
                 return true;
@@ -383,7 +383,7 @@ public class StatefulSetOperatorTest extends ScalableResourceOperatorTest<Kubern
         KubernetesClient mockClient = mock(KubernetesClient.class);
         mocker(mockClient, mockCms);
 
-        StatefulSetOperator op = new StatefulSetOperator(AbstractResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
+        StatefulSetOperator op = new StatefulSetOperator(AbstractNamespacedResourceOperatorTest.vertx, mockClient, 5_000L, podOperator) {
             @Override
             protected boolean shouldIncrementGeneration(Reconciliation reconciliation, StatefulSetDiff diff) {
                 return true;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsStatefulSetsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsStatefulSetsMockTest.java
@@ -41,7 +41,7 @@ import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.MockCertManager;
-import io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractScalableNamespacedResourceOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube2.MockKube2;
@@ -76,7 +76,7 @@ import static io.strimzi.operator.cluster.model.RestartReason.MANUAL_ROLLING_UPD
 import static io.strimzi.operator.cluster.model.RestartReason.POD_HAS_OLD_GENERATION;
 import static io.strimzi.operator.cluster.model.RestartReason.POD_STUCK;
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE;
-import static io.strimzi.operator.common.operator.resource.AbstractScalableResourceOperator.ANNO_STRIMZI_IO_GENERATION;
+import static io.strimzi.operator.common.operator.resource.AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_GENERATION;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -174,7 +174,7 @@ public class KubernetesRestartEventsStatefulSetsMockTest {
         StatefulSet kafkaSet = stsOps().withLabel(appName, "kafka").list().getItems().get(0);
         int statefulSetGen = StatefulSetOperator.getStsGeneration(kafkaSet);
 
-        patchKafkaPodWithAnnotation(AbstractScalableResourceOperator.ANNO_STRIMZI_IO_GENERATION, String.valueOf(statefulSetGen - 1));
+        patchKafkaPodWithAnnotation(AbstractScalableNamespacedResourceOperator.ANNO_STRIMZI_IO_GENERATION, String.valueOf(statefulSetGen - 1));
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_HAS_OLD_GENERATION, context));
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -21,7 +21,7 @@ import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
-import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.strimzi.operator.common.operator.resource.TimeoutException;
 import io.vertx.core.AsyncResult;
@@ -63,7 +63,7 @@ public abstract class AbstractOperator<
         T extends CustomResource<P, S>,
         P extends Spec,
         S extends Status,
-        O extends AbstractWatchableStatusedResourceOperator<?, T, ?, ?>>
+        O extends AbstractWatchableStatusedNamespacedResourceOperator<?, T, ?, ?>>
             implements Operator {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractOperator.class);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract resource creation, for a generic resource type {@code R}.
+ * This class applies the template method pattern, first checking whether the resource exists,
+ * and creating it if it does not. It is not an error if the resource did already exist.
+ * @param <C> The type of client used to interact with kubernetes.
+ * @param <T> The Kubernetes resource type.
+ * @param <L> The list variant of the Kubernetes resource type.
+ * @param <R> The resource operations.
+ */
+public abstract class AbstractNamespacedResourceOperator<C extends KubernetesClient,
+            T extends HasMetadata,
+            L extends KubernetesResourceList<T>,
+            R extends Resource<T>>
+        extends AbstractResourceOperator<C, T, L, R> {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractNamespacedResourceOperator.class);
+
+    /**
+     * Marker for indication "all namesapces" => this is used for example when creating watches to create a cluster
+     * wide watch.
+     */
+    public final static String ANY_NAMESPACE = "*";
+
+    /**
+     * Constructor.
+     * @param vertx The vertx instance.
+     * @param client The kubernetes client.
+     * @param resourceKind The mind of Kubernetes resource (used for logging).
+     */
+    public AbstractNamespacedResourceOperator(Vertx vertx, C client, String resourceKind) {
+        super(vertx, client, resourceKind);
+    }
+
+    protected abstract MixedOperation<T, L, R> operation();
+
+    /**
+     * Asynchronously create or update the given {@code resource} depending on whether it already exists,
+     * returning a future for the outcome.
+     * If the resource with that name already exists the future completes successfully.
+     * @param reconciliation The reconciliation
+     * @param resource The resource to create.
+     * @return A future which completes with the outcome.
+     */
+    public Future<ReconcileResult<T>> createOrUpdate(Reconciliation reconciliation, T resource) {
+        if (resource == null) {
+            throw new NullPointerException();
+        }
+        return reconcile(reconciliation, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), resource);
+    }
+
+    /**
+     * Asynchronously reconciles the resource with the given namespace and name to match the given
+     * desired resource, returning a future for the result.
+     * @param reconciliation Reconciliation object
+     * @param namespace The namespace of the resource to reconcile
+     * @param name The name of the resource to reconcile
+     * @param desired The desired state of the resource.
+     * @return A future which completes when the resource has been updated.
+     */
+    public Future<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String namespace, String name, T desired) {
+        if (desired != null && !namespace.equals(desired.getMetadata().getNamespace())) {
+            return Future.failedFuture("Given namespace " + namespace + " incompatible with desired namespace " + desired.getMetadata().getNamespace());
+        } else if (desired != null && !name.equals(desired.getMetadata().getName())) {
+            return Future.failedFuture("Given name " + name + " incompatible with desired name " + desired.getMetadata().getName());
+        }
+
+        Promise<ReconcileResult<T>> promise = Promise.promise();
+        vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
+            future -> {
+                T current = operation().inNamespace(namespace).withName(name).get();
+                if (desired != null) {
+                    if (current == null) {
+                        LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, creating it", resourceKind, namespace, name);
+                        internalCreate(reconciliation, namespace, name, desired).onComplete(future);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "{} {}/{} already exists, patching it", resourceKind, namespace, name);
+                        internalPatch(reconciliation, namespace, name, current, desired).onComplete(future);
+                    }
+                } else {
+                    if (current != null) {
+                        // Deletion is desired
+                        LOGGER.debugCr(reconciliation, "{} {}/{} exist, deleting it", resourceKind, namespace, name);
+                        internalDelete(reconciliation, namespace, name).onComplete(future);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, noop", resourceKind, namespace, name);
+                        future.complete(ReconcileResult.noop(null));
+                    }
+                }
+
+            },
+            false,
+            promise
+        );
+        return promise.future();
+    }
+
+    /**
+     * Does a batch reconciliation of resources. It takes a list with desired resources and a selector for getting all
+     * resources. It will compare the desired resources against the actual resources based on the selector and decides
+     * which need to be created, modified or deleted. This is useful in situations when we need to manage list of
+     * resources per operand and not just single resource which either exists or not. The reconciliation of the
+     * individual resources delegates to the regular reconcile(...) methods for a single resource.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param namespace         Namespace where the resources should be reconciled
+     * @param desired           List of desired resources
+     * @param selector          Selector for getting a list of current resource
+     *
+     * @return  Future which completes when the lists are reconciled
+     */
+    public Future<Void> batchReconcile(Reconciliation reconciliation, String namespace, List<T> desired, Labels selector)  {
+        return listAsync(namespace, selector)
+                .compose(current -> {
+                    @SuppressWarnings({ "rawtypes" }) // Has to use Raw type because of the CompositeFuture
+                    List<Future> futures = new ArrayList<>(desired.size());
+                    List<String> currentNames = current.stream().map(ingress -> ingress.getMetadata().getName()).collect(Collectors.toList());
+
+                    LOGGER.debugCr(reconciliation, "Reconciling existing {} resources {} against the desired {} resources", resourceKind, currentNames, resourceKind);
+
+                    // Update desired resources which should be created or already exist and are still desired
+                    for (T desiredResource : desired) {
+                        String name = desiredResource.getMetadata().getName();
+                        currentNames.remove(name);
+                        futures.add(reconcile(reconciliation, namespace, name, desiredResource));
+                    }
+
+                    LOGGER.debugCr(reconciliation, "{} {}/{} should be deleted", resourceKind, namespace, currentNames);
+
+                    // Delete resources which match our selector but are not desired anymore
+                    for (String name : currentNames) {
+                        futures.add(reconcile(reconciliation, namespace, name, null));
+                    }
+
+                    return CompositeFuture
+                            .join(futures)
+                            .map((Void) null);
+                });
+    }
+
+    /**
+     * Deletes the resource with the given namespace and name and completes the given future accordingly.
+     * This method will do a cascading delete.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace Namespace of the resource which should be deleted
+     * @param name Name of the resource which should be deleted
+     *
+     * @return A future which will be completed on the context thread
+     *         once the resource has been deleted.
+     */
+    protected Future<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name) {
+        return internalDelete(reconciliation, namespace, name, true);
+    }
+
+    /**
+     * Asynchronously deletes the resource in the given {@code namespace} with the given {@code name},
+     * returning a Future which completes once the resource
+     * is observed to have been deleted.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace Namespace of the resource which should be deleted
+     * @param name Name of the resource which should be deleted
+     * @param cascading Defines whether the delete should be cascading or not (e.g. whether a STS deletion should delete pods etc.)
+     *
+     * @return A future which will be completed on the context thread
+     *         once the resource has been deleted.
+     */
+    protected Future<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
+        R resourceOp = operation().inNamespace(namespace).withName(name);
+
+        Future<ReconcileResult<T>> watchForDeleteFuture = resourceSupport.selfClosingWatch(
+            reconciliation,
+            resourceOp,
+            resourceOp,
+            deleteTimeoutMs(),
+            "observe deletion of " + resourceKind + " " + namespace + "/" + name,
+            (action, resource) -> {
+                if (action == Watcher.Action.DELETED) {
+                    LOGGER.debugCr(reconciliation, "{} {}/{} has been deleted", resourceKind, namespace, name);
+                    return ReconcileResult.deleted();
+                } else {
+                    return null;
+                }
+            },
+            resource -> {
+                if (resource == null) {
+                    LOGGER.debugCr(reconciliation, "{} {}/{} has been already deleted in pre-check", resourceKind, namespace, name);
+                    return ReconcileResult.deleted();
+                } else {
+                    return null;
+                }
+            });
+
+        Future<Void> deleteFuture = resourceSupport.deleteAsync(resourceOp.withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L));
+
+        return CompositeFuture.join(watchForDeleteFuture, deleteFuture).map(ReconcileResult.deleted());
+    }
+
+    /**
+     * Patches the resource with the given namespace and name to match the given desired resource
+     * and completes the given future accordingly.
+     */
+    protected Future<ReconcileResult<T>> internalPatch(Reconciliation reconciliation, String namespace, String name, T current, T desired) {
+        if (needsPatching(reconciliation, name, current, desired))  {
+            try {
+                T result = operation().inNamespace(namespace).withName(name).patch(PatchContext.of(PatchType.JSON), desired);
+                LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been patched", resourceKind, name, namespace);
+                return Future.succeededFuture(wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result));
+            } catch (Exception e) {
+                LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
+                return Future.failedFuture(e);
+            }
+        } else {
+            LOGGER.debugCr(reconciliation, "{} {} in namespace {} did not changed and doesn't need patching", resourceKind, name, namespace);
+            return Future.succeededFuture(ReconcileResult.noop(current));
+        }
+    }
+
+    /**
+     * Creates a resource with the given namespace and name with the given desired state
+     * and completes the given future accordingly.
+     */
+    protected Future<ReconcileResult<T>> internalCreate(Reconciliation reconciliation, String namespace, String name, T desired) {
+        try {
+            ReconcileResult<T> result = ReconcileResult.created(operation().inNamespace(namespace).resource(desired).create());
+            LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been created", resourceKind, name, namespace);
+            return Future.succeededFuture(result);
+        } catch (Exception e) {
+            LOGGER.debugCr(reconciliation, "Caught exception while creating {} {} in namespace {}", resourceKind, name, namespace, e);
+            return Future.failedFuture(e);
+        }
+    }
+
+    /**
+     * Synchronously gets the resource with the given {@code name} in the given {@code namespace}.
+     * @param namespace The namespace.
+     * @param name The name.
+     * @return The resource, or null if it doesn't exist.
+     */
+    public T get(String namespace, String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
+        return operation().inNamespace(namespace).withName(name).get();
+    }
+
+    /**
+     * Asynchronously gets the resource with the given {@code name} in the given {@code namespace}.
+     * @param namespace The namespace.
+     * @param name The name.
+     * @return A Future for the result.
+     */
+    public Future<T> getAsync(String namespace, String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
+        return resourceSupport.getAsync(operation().inNamespace(namespace).withName(name));
+    }
+
+    /**
+     * Synchronously list the resources in the given {@code namespace} with the given {@code selector}.
+     * @param namespace The namespace.
+     * @param selector The selector.
+     * @return A list of matching resources.
+     */
+    public List<T> list(String namespace, Labels selector) {
+        return list(applySelector(applyNamespace(namespace), selector));
+    }
+
+    /**
+     * Applies the namespace on the operation. Depending on the value of the namespace parameter, it returns either
+     * operation for working in all namespaces or in the selected namespace.
+     *
+     * @param namespace     Namespace which should be applied or * for all namespaces
+     *
+     * @return  Operation with applied namespace
+     */
+    private FilterWatchListDeletable<T, L, R> applyNamespace(String namespace)  {
+        if (ANY_NAMESPACE.equals(namespace))  {
+            return operation().inAnyNamespace();
+        } else {
+            return operation().inNamespace(namespace);
+        }
+    }
+
+    /**
+     * Asynchronously lists the resource with the given {@code selector} in the given {@code namespace}.
+     *
+     * @param namespace The namespace.
+     * @param selector The selector.
+     * @return A Future with a list of matching resources.
+     */
+    public Future<List<T>> listAsync(String namespace, Labels selector) {
+        return listAsync(applySelector(applyNamespace(namespace), selector));
+    }
+
+    /**
+     * Asynchronously lists the resource with the given {@code selector} in the given {@code namespace}.
+     *
+     * @param namespace     Namespace where the resources should be listed
+     * @param selector      Label selector for selecting only some of the resources
+     *
+     * @return A Future with a list of matching resources.
+     */
+    public Future<List<T>> listAsync(String namespace, Optional<LabelSelector> selector) {
+        return listAsync(applySelector(applyNamespace(namespace), selector));
+    }
+
+    /**
+     * Returns a future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace The namespace.
+     * @param name The resource name.
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
+     * @param predicate The predicate.
+     * @return A future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     */
+    public Future<Void> waitFor(Reconciliation reconciliation, String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+        return waitFor(reconciliation, namespace, name, "ready", pollIntervalMs, timeoutMs, predicate);
+    }
+
+    /**
+     * Returns a future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace The namespace.
+     * @param name The resource name.
+     * @param logState The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
+     * @param predicate The predicate.
+     * @return A future that completes when the resource identified by the given {@code namespace} and {@code name}
+     * is ready.
+     */
+    public Future<Void> waitFor(Reconciliation reconciliation, String namespace, String name, String logState, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+        return Util.waitFor(reconciliation, vertx,
+            String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
+            logState,
+            pollIntervalMs,
+            timeoutMs,
+            () -> predicate.test(namespace, name));
+    }
+
+    /**
+     * Asynchronously deletes the resource with the given {@code name} in the given {@code namespace}.
+     *
+     * @param reconciliation    The reconciliation
+     * @param namespace         Namespace of the resource which should be deleted
+     * @param name              Name of the resource which should be deleted
+     * @param cascading         Defines whether the deletion should be cascading or not
+     *
+     * @return                  A Future with True if the deletion succeeded and False when it failed.
+     */
+    public Future<Void> deleteAsync(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
+        return internalDelete(reconciliation, namespace, name, cascading).map((Void) null);
+    }
+
+    /**
+     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide).
+     *
+     * @param namespace Namespace on which to inform
+     *
+     * @return          Informer instance
+     */
+    public SharedIndexInformer<T> informer(String namespace)   {
+        if (ANY_NAMESPACE.equals(namespace))    {
+            return operation().inAnyNamespace().inform();
+        } else {
+            return operation().inNamespace(namespace).inform();
+        }
+    }
+
+    /**
+     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
+     * matching the selector.
+     *
+     * @param namespace         Namespace on which to inform
+     * @param selectorLabels    Selector which should be matched by the resources
+     *
+     * @return                  Informer instance
+     */
+    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels)   {
+        if (ANY_NAMESPACE.equals(namespace))    {
+            return operation().inAnyNamespace().withLabels(selectorLabels).inform();
+        } else {
+            return operation().inNamespace(namespace).withLabels(selectorLabels).inform();
+        }
+    }
+
+    /**
+     * Returns the Kubernetes client for given resource type
+     *
+     * @return  Kubernetes client instance for given resource
+     */
+    public MixedOperation<T, L, R> client() {
+        return operation();
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractReadyNamespacedResourceOperator.java
@@ -13,7 +13,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 /**
- * Specializes {@link AbstractResourceOperator} for resources which also have a notion
+ * Specializes {@link AbstractNamespacedResourceOperator} for resources which also have a notion
  * of being "ready".
  *
  * @param <C> The type of client used to interact with kubernetes.
@@ -21,11 +21,11 @@ import io.vertx.core.Vertx;
  * @param <L> The list variant of the Kubernetes resource type.
  * @param <R> The resource operations.
  */
-public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
+public abstract class AbstractReadyNamespacedResourceOperator<C extends KubernetesClient,
             T extends HasMetadata,
             L extends KubernetesResourceList<T>,
             R extends Resource<T>>
-        extends AbstractResourceOperator<C, T, L, R> {
+        extends AbstractNamespacedResourceOperator<C, T, L, R> {
 
     /**
      * Constructor.
@@ -34,7 +34,7 @@ public abstract class AbstractReadyResourceOperator<C extends KubernetesClient,
      * @param client       The kubernetes client.
      * @param resourceKind The mind of Kubernetes resource (used for logging).
      */
-    public AbstractReadyResourceOperator(Vertx vertx, C client, String resourceKind) {
+    public AbstractReadyNamespacedResourceOperator(Vertx vertx, C client, String resourceKind) {
         super(vertx, client, resourceKind);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -4,37 +4,22 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.AnyNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Listable;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.PatchContext;
-import io.fabric8.kubernetes.client.dsl.base.PatchType;
-import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Abstract resource creation, for a generic resource type {@code R}.
@@ -50,20 +35,10 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
         L extends KubernetesResourceList<T>,
         R extends Resource<T>> {
     /**
-     * Marker for indication "all namesapces" => this is used for example when creating watches to create a cluster
-     * wide watch.
+     * Default reconciliation timeout
      */
-    public final static String ANY_NAMESPACE = "*";
+    private static final long DEFAULT_TIMEOUT_MS = 300_000;
 
-    protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
-            "^(/metadata/managedFields" +
-                    "|/metadata/creationTimestamp" +
-                    "|/metadata/resourceVersion" +
-                    "|/metadata/generation" +
-                    "|/metadata/uid" +
-                    "|/status)$");
-
-    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractResourceOperator.class);
     protected final Vertx vertx;
     protected final C client;
     protected final String resourceKind;
@@ -82,180 +57,18 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
         this.resourceKind = resourceKind;
     }
 
-    protected abstract MixedOperation<T, L, R> operation();
-
     /**
-     * Asynchronously create or update the given {@code resource} depending on whether it already exists,
-     * returning a future for the outcome.
-     * If the resource with that name already exists the future completes successfully.
-     * @param reconciliation The reconciliation
-     * @param resource The resource to create.
-     * @return A future which completes with the outcome.
+     * @return  Default timeout for deleting resources
      */
-    public Future<ReconcileResult<T>> createOrUpdate(Reconciliation reconciliation, T resource) {
-        if (resource == null) {
-            throw new NullPointerException();
-        }
-        return reconcile(reconciliation, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), resource);
-    }
-
-    /**
-     * Asynchronously reconciles the resource with the given namespace and name to match the given
-     * desired resource, returning a future for the result.
-     * @param reconciliation Reconciliation object
-     * @param namespace The namespace of the resource to reconcile
-     * @param name The name of the resource to reconcile
-     * @param desired The desired state of the resource.
-     * @return A future which completes when the resource has been updated.
-     */
-    public Future<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String namespace, String name, T desired) {
-        if (desired != null && !namespace.equals(desired.getMetadata().getNamespace())) {
-            return Future.failedFuture("Given namespace " + namespace + " incompatible with desired namespace " + desired.getMetadata().getNamespace());
-        } else if (desired != null && !name.equals(desired.getMetadata().getName())) {
-            return Future.failedFuture("Given name " + name + " incompatible with desired name " + desired.getMetadata().getName());
-        }
-
-        Promise<ReconcileResult<T>> promise = Promise.promise();
-        vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-            future -> {
-                T current = operation().inNamespace(namespace).withName(name).get();
-                if (desired != null) {
-                    if (current == null) {
-                        LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, creating it", resourceKind, namespace, name);
-                        internalCreate(reconciliation, namespace, name, desired).onComplete(future);
-                    } else {
-                        LOGGER.debugCr(reconciliation, "{} {}/{} already exists, patching it", resourceKind, namespace, name);
-                        internalPatch(reconciliation, namespace, name, current, desired).onComplete(future);
-                    }
-                } else {
-                    if (current != null) {
-                        // Deletion is desired
-                        LOGGER.debugCr(reconciliation, "{} {}/{} exist, deleting it", resourceKind, namespace, name);
-                        internalDelete(reconciliation, namespace, name).onComplete(future);
-                    } else {
-                        LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, noop", resourceKind, namespace, name);
-                        future.complete(ReconcileResult.noop(null));
-                    }
-                }
-
-            },
-            false,
-            promise
-        );
-        return promise.future();
-    }
-
-    /**
-     * Does a batch reconciliation of resources. It takes a list with desired resources and a selector for getting all
-     * resources. It will compare the desired resources against the actual resources based on the selector and decides
-     * which need to be created, modified or deleted. This is useful in situations when we need to manage list of
-     * resources per operand and not just single resource which either exists or not. The reconciliation of the
-     * individual resources delegates to the regular reconcile(...) methods for a single resource.
-     *
-     * @param reconciliation    Reconciliation marker
-     * @param namespace         Namespace where the resources should be reconciled
-     * @param desired           List of desired resources
-     * @param selector          Selector for getting a list of current resource
-     *
-     * @return  Future which completes when the lists are reconciled
-     */
-    public Future<Void> batchReconcile(Reconciliation reconciliation, String namespace, List<T> desired, Labels selector)  {
-        return listAsync(namespace, selector)
-                .compose(current -> {
-                    @SuppressWarnings({ "rawtypes" }) // Has to use Raw type because of the CompositeFuture
-                    List<Future> futures = new ArrayList<>(desired.size());
-                    List<String> currentNames = current.stream().map(ingress -> ingress.getMetadata().getName()).collect(Collectors.toList());
-
-                    LOGGER.debugCr(reconciliation, "Reconciling existing {} resources {} against the desired {} resources", resourceKind, currentNames, resourceKind);
-
-                    // Update desired resources which should be created or already exist and are still desired
-                    for (T desiredResource : desired) {
-                        String name = desiredResource.getMetadata().getName();
-                        currentNames.remove(name);
-                        futures.add(reconcile(reconciliation, namespace, name, desiredResource));
-                    }
-
-                    LOGGER.debugCr(reconciliation, "{} {}/{} should be deleted", resourceKind, namespace, currentNames);
-
-                    // Delete resources which match our selector but are not desired anymore
-                    for (String name : currentNames) {
-                        futures.add(reconcile(reconciliation, namespace, name, null));
-                    }
-
-                    return CompositeFuture
-                            .join(futures)
-                            .map((Void) null);
-                });
-    }
-
-    /**
-     * Deletes the resource with the given namespace and name and completes the given future accordingly.
-     * This method will do a cascading delete.
-     *
-     * @param reconciliation The reconciliation
-     * @param namespace Namespace of the resource which should be deleted
-     * @param name Name of the resource which should be deleted
-     *
-     * @return A future which will be completed on the context thread
-     *         once the resource has been deleted.
-     */
-    protected Future<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name) {
-        return internalDelete(reconciliation, namespace, name, true);
-    }
-
-    /**
-     * Asynchronously deletes the resource in the given {@code namespace} with the given {@code name},
-     * returning a Future which completes once the resource
-     * is observed to have been deleted.
-     *
-     * @param reconciliation The reconciliation
-     * @param namespace Namespace of the resource which should be deleted
-     * @param name Name of the resource which should be deleted
-     * @param cascading Defines whether the delete should be cascading or not (e.g. whether a STS deletion should delete pods etc.)
-     *
-     * @return A future which will be completed on the context thread
-     *         once the resource has been deleted.
-     */
-    protected Future<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
-        R resourceOp = operation().inNamespace(namespace).withName(name);
-
-        Future<ReconcileResult<T>> watchForDeleteFuture = resourceSupport.selfClosingWatch(
-            reconciliation,
-            resourceOp,
-            resourceOp,
-            deleteTimeoutMs(),
-            "observe deletion of " + resourceKind + " " + namespace + "/" + name,
-            (action, resource) -> {
-                if (action == Watcher.Action.DELETED) {
-                    LOGGER.debugCr(reconciliation, "{} {}/{} has been deleted", resourceKind, namespace, name);
-                    return ReconcileResult.deleted();
-                } else {
-                    return null;
-                }
-            },
-            resource -> {
-                if (resource == null) {
-                    LOGGER.debugCr(reconciliation, "{} {}/{} has been already deleted in pre-check", resourceKind, namespace, name);
-                    return ReconcileResult.deleted();
-                } else {
-                    return null;
-                }
-            });
-
-        Future<Void> deleteFuture = resourceSupport.deleteAsync(resourceOp.withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L));
-
-        return CompositeFuture.join(watchForDeleteFuture, deleteFuture).map(ReconcileResult.deleted());
-    }
-
     protected long deleteTimeoutMs() {
-        return ResourceSupport.DEFAULT_TIMEOUT_MS;
+        return DEFAULT_TIMEOUT_MS;
     }
 
     /**
      * @return  Returns the Pattern for matching paths which can be ignored in the resource diff
      */
     protected Pattern ignorablePaths() {
-        return IGNORABLE_PATHS;
+        return ResourceDiff.DEFAULT_IGNORABLE_PATHS;
     }
 
     /**
@@ -287,25 +100,13 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
     }
 
     /**
-     * Patches the resource with the given namespace and name to match the given desired resource
-     * and completes the given future accordingly.
+     * Compares two resources and decides whether they changed or not based on their resource versions form metadata.
+     *
+     * @param oldVersion    Old resource
+     * @param newVersion    New resource
+     *
+     * @return  True if the resource changed. False otherwise.
      */
-    protected Future<ReconcileResult<T>> internalPatch(Reconciliation reconciliation, String namespace, String name, T current, T desired) {
-        if (needsPatching(reconciliation, name, current, desired))  {
-            try {
-                T result = operation().inNamespace(namespace).withName(name).patch(PatchContext.of(PatchType.JSON), desired);
-                LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been patched", resourceKind, name, namespace);
-                return Future.succeededFuture(wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result));
-            } catch (Exception e) {
-                LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
-                return Future.failedFuture(e);
-            }
-        } else {
-            LOGGER.debugCr(reconciliation, "{} {} in namespace {} did not changed and doesn't need patching", resourceKind, name, namespace);
-            return Future.succeededFuture(ReconcileResult.noop(current));
-        }
-    }
-
     protected boolean wasChanged(T oldVersion, T newVersion) {
         if (oldVersion != null
                 && oldVersion.getMetadata() != null
@@ -318,229 +119,58 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
     }
 
     /**
-     * Creates a resource with the given namespace and name with the given desired state
-     * and completes the given future accordingly.
-     */
-    protected Future<ReconcileResult<T>> internalCreate(Reconciliation reconciliation, String namespace, String name, T desired) {
-        try {
-            ReconcileResult<T> result = ReconcileResult.created(operation().inNamespace(namespace).resource(desired).create());
-            LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been created", resourceKind, name, namespace);
-            return Future.succeededFuture(result);
-        } catch (Exception e) {
-            LOGGER.debugCr(reconciliation, "Caught exception while creating {} {} in namespace {}", resourceKind, name, namespace, e);
-            return Future.failedFuture(e);
-        }
-    }
-
-    /**
-     * Synchronously gets the resource with the given {@code name} in the given {@code namespace}.
-     * @param namespace The namespace.
-     * @param name The name.
-     * @return The resource, or null if it doesn't exist.
-     */
-    public T get(String namespace, String name) {
-        if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
-        }
-        return operation().inNamespace(namespace).withName(name).get();
-    }
-
-    /**
-     * Asynchronously gets the resource with the given {@code name} in the given {@code namespace}.
-     * @param namespace The namespace.
-     * @param name The name.
-     * @return A Future for the result.
-     */
-    public Future<T> getAsync(String namespace, String name) {
-        if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
-        }
-        return resourceSupport.getAsync(operation().inNamespace(namespace).withName(name));
-    }
-
-    /**
-     * Synchronously list the resources in the given {@code namespace} with the given {@code selector}.
-     * @param namespace The namespace.
-     * @param selector The selector.
-     * @return A list of matching resources.
-     */
-    public List<T> list(String namespace, Labels selector) {
-        if (ANY_NAMESPACE.equals(namespace))  {
-            return listInAnyNamespace(selector);
-        } else {
-            return listInNamespace(namespace, selector);
-        }
-    }
-
-    protected List<T> listInAnyNamespace(Labels selector) {
-        AnyNamespaceOperation<T, L, R> operation = operation().inAnyNamespace();
-
-        if (selector != null) {
-            Map<String, String> labels = selector.toMap();
-            FilterWatchListDeletable<T, L, R> tlBooleanWatchWatcherFilterWatchListDeletable = operation.withLabels(labels);
-            return tlBooleanWatchWatcherFilterWatchListDeletable
-                    .list()
-                    .getItems();
-        } else {
-            return operation
-                    .list()
-                    .getItems();
-        }
-    }
-
-    protected List<T> listInNamespace(String namespace, Labels selector) {
-        NonNamespaceOperation<T, L, R> tldrNonNamespaceOperation = operation().inNamespace(namespace);
-
-        if (selector != null) {
-            Map<String, String> labels = selector.toMap();
-            FilterWatchListDeletable<T, L, R> tlBooleanWatchWatcherFilterWatchListDeletable = tldrNonNamespaceOperation.withLabels(labels);
-            return tlBooleanWatchWatcherFilterWatchListDeletable
-                    .list()
-                    .getItems();
-        } else {
-            return tldrNonNamespaceOperation
-                    .list()
-                    .getItems();
-        }
-    }
-
-    /**
-     * Asynchronously lists the resource with the given {@code selector} in the given {@code namespace}.
+     * Applies the selector to the operation. If the selector is specified, it will return an operation with the applied
+     * selector. If it is not specified, it will return the original operation.
      *
-     * @param namespace The namespace.
-     * @param selector The selector.
-     * @return A Future with a list of matching resources.
+     * @param filterable    Filterable operation on which we can apply the selector
+     * @param selector      Selector
+     *
+     * @return  Filtered operation
      */
-    public Future<List<T>> listAsync(String namespace, Labels selector) {
-        FilterWatchListDeletable<T, L, R> x;
-
-        if (ANY_NAMESPACE.equals(namespace))  {
-            x = operation().inAnyNamespace();
-        } else {
-            x = operation().inNamespace(namespace);
-        }
+    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, Labels selector)  {
         if (selector != null) {
-            x = x.withLabels(selector.toMap());
+            return filterable.withLabels(selector.toMap());
+        } else {
+            return filterable;
         }
-
-        return resourceSupport.listAsync(x);
     }
 
     /**
-     * Asynchronously lists the resource with the given {@code selector} in the given {@code namespace}.
+     * Applies the selector to the operation. If the selector is specified, it will return an operation with the applied
+     * selector. If it is not specified, it will return the original operation.
      *
-     * @param namespace     Namespace where the resources should be listed
-     * @param selector      Label selector for selecting only some of the resources
+     * @param filterable    Filterable operation on which we can apply the selector
+     * @param selector      Selector
      *
-     * @return A Future with a list of matching resources.
+     * @return  Filtered operation
      */
-    public Future<List<T>> listAsync(String namespace, Optional<LabelSelector> selector) {
-        FilterWatchListDeletable<T, L, R> x;
-
-        if (ANY_NAMESPACE.equals(namespace))  {
-            x = operation().inAnyNamespace();
-        } else {
-            x = operation().inNamespace(namespace);
-        }
+    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, Optional<LabelSelector> selector)  {
         if (selector.isPresent()) {
-            x = x.withLabelSelector(selector.get());
-        }
-
-        return resourceSupport.listAsync(x);
-    }
-
-    /**
-     * Returns a future that completes when the resource identified by the given {@code namespace} and {@code name}
-     * is ready.
-     *
-     * @param reconciliation The reconciliation
-     * @param namespace The namespace.
-     * @param name The resource name.
-     * @param pollIntervalMs The poll interval in milliseconds.
-     * @param timeoutMs The timeout, in milliseconds.
-     * @param predicate The predicate.
-     * @return A future that completes when the resource identified by the given {@code namespace} and {@code name}
-     * is ready.
-     */
-    public Future<Void> waitFor(Reconciliation reconciliation, String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
-        return waitFor(reconciliation, namespace, name, "ready", pollIntervalMs, timeoutMs, predicate);
-    }
-
-    /**
-     * Returns a future that completes when the resource identified by the given {@code namespace} and {@code name}
-     * is ready.
-     *
-     * @param reconciliation The reconciliation
-     * @param namespace The namespace.
-     * @param name The resource name.
-     * @param logState The state we are waiting for use in log messages
-     * @param pollIntervalMs The poll interval in milliseconds.
-     * @param timeoutMs The timeout, in milliseconds.
-     * @param predicate The predicate.
-     * @return A future that completes when the resource identified by the given {@code namespace} and {@code name}
-     * is ready.
-     */
-    public Future<Void> waitFor(Reconciliation reconciliation, String namespace, String name, String logState, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
-        return Util.waitFor(reconciliation, vertx,
-            String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
-            logState,
-            pollIntervalMs,
-            timeoutMs,
-            () -> predicate.test(namespace, name));
-    }
-
-    /**
-     * Asynchronously deletes the resource with the given {@code name} in the given {@code namespace}.
-     *
-     * @param reconciliation    The reconciliation
-     * @param namespace         Namespace of the resource which should be deleted
-     * @param name              Name of the resource which should be deleted
-     * @param cascading         Defines whether the deletion should be cascading or not
-     *
-     * @return                  A Future with True if the deletion succeeded and False when it failed.
-     */
-    public Future<Void> deleteAsync(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
-        return internalDelete(reconciliation, namespace, name, cascading).map((Void) null);
-    }
-
-    /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide).
-     *
-     * @param namespace Namespace on which to inform
-     *
-     * @return          Informer instance
-     */
-    public SharedIndexInformer<T> informer(String namespace)   {
-        if (ANY_NAMESPACE.equals(namespace))    {
-            return operation().inAnyNamespace().inform();
+            return filterable.withLabelSelector(selector.get());
         } else {
-            return operation().inNamespace(namespace).inform();
+            return filterable;
         }
     }
 
     /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
-     * matching the selector.
+     * List the resources and returns Java list with all found resources.
      *
-     * @param namespace         Namespace on which to inform
-     * @param selectorLabels    Selector which should be matched by the resources
+     * @param listable  Listable operation
      *
-     * @return                  Informer instance
+     * @return  List of resources
      */
-    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels)   {
-        if (ANY_NAMESPACE.equals(namespace))    {
-            return operation().inAnyNamespace().withLabels(selectorLabels).inform();
-        } else {
-            return operation().inNamespace(namespace).withLabels(selectorLabels).inform();
-        }
+    protected List<T> list(Listable<L> listable)    {
+        return listable.list().getItems();
     }
 
     /**
-     * Returns the Kubernetes client for given resource type
+     * List the resources and returns Java list with all found resources in asynchronous way.
      *
-     * @return  Kubernetes client instance for given resource
+     * @param listable  Listable operation
+     *
+     * @return  Future with the list of resources
      */
-    public MixedOperation<T, L, R> client() {
-        return operation();
+    protected Future<List<T>> listAsync(Listable<L> listable) {
+        return resourceSupport.listAsync(listable);
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableNamespacedResourceOperator.java
@@ -16,19 +16,19 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 /**
- * An {@link AbstractResourceOperator} that can be scaled up and down in addition to the usual operations.
+ * An {@link AbstractNamespacedResourceOperator} that can be scaled up and down in addition to the usual operations.
  * @param <C> The type of client used to interact with kubernetes.
  * @param <T> The Kubernetes resource type.
  * @param <L> The list variant of the Kubernetes resource type.
  * @param <R> The resource operations.
  */
-public abstract class AbstractScalableResourceOperator<C extends KubernetesClient,
+public abstract class AbstractScalableNamespacedResourceOperator<C extends KubernetesClient,
             T extends HasMetadata,
             L extends KubernetesResourceList<T>,
             R extends ScalableResource<T>>
-        extends AbstractReadyResourceOperator<C, T, L, R> {
+        extends AbstractReadyNamespacedResourceOperator<C, T, L, R> {
 
-    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractScalableResourceOperator.class);
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractScalableNamespacedResourceOperator.class);
 
     /**
      * Annotation key for indicating the resource generation
@@ -46,7 +46,7 @@ public abstract class AbstractScalableResourceOperator<C extends KubernetesClien
      * @param client The Kubernetes client
      * @param resourceKind The kind of resource.
      */
-    public AbstractScalableResourceOperator(Vertx vertx, C client, String resourceKind) {
+    public AbstractScalableNamespacedResourceOperator(Vertx vertx, C client, String resourceKind) {
         super(vertx, client, resourceKind);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableNamespacedResourceOperator.java
@@ -24,12 +24,12 @@ import java.util.Optional;
  * @param <L> The list variant of the Kubernetes resource type.
  * @param <R> The resource operations.
  */
-public abstract class AbstractWatchableResourceOperator<
+public abstract class AbstractWatchableNamespacedResourceOperator<
         C extends KubernetesClient,
         T extends HasMetadata,
         L extends KubernetesResourceList<T>,
         R extends Resource<T>>
-        extends AbstractResourceOperator<C, T, L, R> {
+        extends AbstractNamespacedResourceOperator<C, T, L, R> {
     /**
      * Constructor.
      *
@@ -37,7 +37,7 @@ public abstract class AbstractWatchableResourceOperator<
      * @param client       The kubernetes client.
      * @param resourceKind The mind of Kubernetes resource (used for logging).
      */
-    public AbstractWatchableResourceOperator(Vertx vertx, C client, String resourceKind) {
+    public AbstractWatchableNamespacedResourceOperator(Vertx vertx, C client, String resourceKind) {
         super(vertx, client, resourceKind);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableStatusedNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableStatusedNamespacedResourceOperator.java
@@ -21,12 +21,12 @@ import io.vertx.core.Vertx;
  * @param <L>   Kubernetes resource list
  * @param <R>   Kubernetes Reasource
  */
-public abstract class AbstractWatchableStatusedResourceOperator<
+public abstract class AbstractWatchableStatusedNamespacedResourceOperator<
         C extends KubernetesClient,
         T extends HasMetadata,
         L extends KubernetesResourceList<T>,
         R extends Resource<T>>
-        extends AbstractWatchableResourceOperator<C, T, L, R> {
+        extends AbstractWatchableNamespacedResourceOperator<C, T, L, R> {
     /**
      * Constructor.
      *
@@ -34,7 +34,7 @@ public abstract class AbstractWatchableStatusedResourceOperator<
      * @param client       The kubernetes client.
      * @param resourceKind The mind of Kubernetes resource (used for logging).
      */
-    public AbstractWatchableStatusedResourceOperator(Vertx vertx, C client, String resourceKind) {
+    public AbstractWatchableStatusedNamespacedResourceOperator(Vertx vertx, C client, String resourceKind) {
         super(vertx, client, resourceKind);
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
@@ -19,7 +19,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code BuildConfig}s.
  */
-public class BuildConfigOperator extends AbstractResourceOperator<OpenShiftClient, BuildConfig, BuildConfigList, BuildConfigResource<BuildConfig, Void, Build>> {
+public class BuildConfigOperator extends AbstractNamespacedResourceOperator<OpenShiftClient, BuildConfig, BuildConfigList, BuildConfigResource<BuildConfig, Void, Build>> {
     /**
      * Constructor
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Build}s.
  */
-public class BuildOperator extends AbstractResourceOperator<OpenShiftClient, Build, BuildList, BuildResource> {
+public class BuildOperator extends AbstractNamespacedResourceOperator<OpenShiftClient, Build, BuildList, BuildResource> {
     /**
      * Constructor
      *

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 /**
  * Operations for {@code ConfigMap}s.
  */
-public class ConfigMapOperator extends AbstractResourceOperator<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> {
+public class ConfigMapOperator extends AbstractNamespacedResourceOperator<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ConfigMapOperator.class);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -33,7 +33,7 @@ import io.vertx.core.Vertx;
 public class CrdOperator<C extends KubernetesClient,
             T extends CustomResource,
             L extends DefaultKubernetesResourceList<T>>
-        extends AbstractWatchableStatusedResourceOperator<C, T, L, Resource<T>> {
+        extends AbstractWatchableStatusedNamespacedResourceOperator<C, T, L, Resource<T>> {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(CrdOperator.class);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -17,7 +17,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code DeploymentConfigs}s.
  */
-public class DeploymentConfigOperator extends AbstractScalableResourceOperator<OpenShiftClient, DeploymentConfig,
+public class DeploymentConfigOperator extends AbstractScalableNamespacedResourceOperator<OpenShiftClient, DeploymentConfig,
         DeploymentConfigList, DeployableScalableResource<DeploymentConfig>> {
     /**
      * Constructor

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -19,7 +19,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Deployment}s.
  */
-public class DeploymentOperator extends AbstractScalableResourceOperator<KubernetesClient, Deployment, DeploymentList, RollableScalableResource<Deployment>> {
+public class DeploymentOperator extends AbstractScalableNamespacedResourceOperator<KubernetesClient, Deployment, DeploymentList, RollableScalableResource<Deployment>> {
 
     private final PodOperator podOperations;
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/EndpointOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/EndpointOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Endpoint}s.
  */
-public class EndpointOperator extends AbstractReadyResourceOperator<KubernetesClient, Endpoints, EndpointsList, Resource<Endpoints>> {
+public class EndpointOperator extends AbstractReadyNamespacedResourceOperator<KubernetesClient, Endpoints, EndpointsList, Resource<Endpoints>> {
     /**
      * Constructor
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ImageStreamOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ImageStreamOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code ImageStream}s.
  */
-public class ImageStreamOperator extends AbstractResourceOperator<OpenShiftClient, ImageStream, ImageStreamList, Resource<ImageStream>> {
+public class ImageStreamOperator extends AbstractNamespacedResourceOperator<OpenShiftClient, ImageStream, ImageStreamList, Resource<ImageStream>> {
     /**
      * Constructor
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
@@ -16,7 +16,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Ingress}es.
  */
-public class IngressOperator extends AbstractResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
+public class IngressOperator extends AbstractNamespacedResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
 
     /**
      * Constructor

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
@@ -16,8 +16,8 @@ import java.util.regex.Pattern;
 /**
  * Operator for managing network policies
  */
-public class NetworkPolicyOperator extends AbstractResourceOperator<KubernetesClient, NetworkPolicy, NetworkPolicyList, Resource<NetworkPolicy>> {
-    protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
+public class NetworkPolicyOperator extends AbstractNamespacedResourceOperator<KubernetesClient, NetworkPolicy, NetworkPolicyList, Resource<NetworkPolicy>> {
+    private static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
                     "|/metadata/creationTimestamp" +
                     "|/metadata/resourceVersion" +

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operator for managing Pod Disruption Budgets
  */
-public class PodDisruptionBudgetOperator extends AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
+public class PodDisruptionBudgetOperator extends AbstractNamespacedResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
     /**
      * Constructs the PDB operator
      *

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetV1Beta1Operator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetV1Beta1Operator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operator for managing Pod Disruption Budgets of API version v1beta1
  */
-public class PodDisruptionBudgetV1Beta1Operator extends AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
+public class PodDisruptionBudgetV1Beta1Operator extends AbstractNamespacedResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
     /**
      * Constructs the PDB v1beta1 operator
      *

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PodOperator.java
@@ -19,7 +19,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Pod}s, which support {@link #isReady(String, String)}.
  */
-public class PodOperator extends AbstractReadyResourceOperator<KubernetesClient, Pod, PodList, PodResource> {
+public class PodOperator extends AbstractReadyNamespacedResourceOperator<KubernetesClient, Pod, PodList, PodResource> {
 
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(PodOperator.class);
     private static final String NO_UID = "NULL";

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -19,9 +19,9 @@ import java.util.regex.Pattern;
 /**
  * Operations for {@code PersistentVolumeClaim}s.
  */
-public class PvcOperator extends AbstractResourceOperator<KubernetesClient, PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> {
+public class PvcOperator extends AbstractNamespacedResourceOperator<KubernetesClient, PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(PvcOperator.class);
-    protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
+    private static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
                     "|/metadata/annotations/pv.kubernetes.io~1bind-completed" +
                     "|/metadata/finalizers" +

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -31,10 +31,6 @@ import java.util.function.Function;
  * Utility method for working with Kubernetes resources
  */
 public class ResourceSupport {
-    /**
-     * Default reconciliation timeout
-     */
-    public static final long DEFAULT_TIMEOUT_MS = 300_000;
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ResourceSupport.class);
 
     private final Vertx vertx;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleBindingOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleBindingOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operator for managing Role Bindings
  */
-public class RoleBindingOperator extends AbstractResourceOperator<KubernetesClient, RoleBinding,
+public class RoleBindingOperator extends AbstractNamespacedResourceOperator<KubernetesClient, RoleBinding,
         RoleBindingList,
         Resource<RoleBinding>> {
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RoleOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operator for managing Roles
  */
-public class RoleOperator extends AbstractResourceOperator<
+public class RoleOperator extends AbstractNamespacedResourceOperator<
         KubernetesClient,
         Role,
         RoleList,

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/RouteOperator.java
@@ -16,7 +16,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Route}s.
  */
-public class RouteOperator extends AbstractResourceOperator<OpenShiftClient, Route, RouteList, Resource<Route>> {
+public class RouteOperator extends AbstractNamespacedResourceOperator<OpenShiftClient, Route, RouteList, Resource<Route>> {
     /**
      * Constructor
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/SecretOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/SecretOperator.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 /**
  * Operations for {@code Secret}s.
  */
-public class SecretOperator extends AbstractResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> {
+public class SecretOperator extends AbstractNamespacedResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> {
 
     /**
      * Constructor

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -16,7 +16,7 @@ import io.vertx.core.Vertx;
 /**
  * Operator for managing Service Accounts
  */
-public class ServiceAccountOperator extends AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
+public class ServiceAccountOperator extends AbstractNamespacedResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
     /**
      * Constructor
      * @param vertx The Vertx instance

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -26,9 +26,9 @@ import java.util.stream.Collectors;
 /**
  * Operations for {@code Service}s.
  */
-public class ServiceOperator extends AbstractResourceOperator<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
+public class ServiceOperator extends AbstractNamespacedResourceOperator<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ServiceOperator.class);
-    protected static final Pattern IGNORABLE_PATHS = Pattern.compile(
+    private static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
                     "|/metadata/creationTimestamp" +
                     "|/metadata/resourceVersion" +

--- a/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/AbstractOperatorTest.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.model.Spec;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedNamespacedResourceOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -214,7 +214,7 @@ class AbstractOperatorTest {
             T extends CustomResource<P, S>,
             P extends Spec,
             S extends Status,
-            O extends AbstractWatchableStatusedResourceOperator<?, T, ?, ?>>
+            O extends AbstractWatchableStatusedNamespacedResourceOperator<?, T, ?, ?>>
                 extends AbstractOperator<T, P, S, O> {
 
         public DefaultOperator(Vertx vertx, String kind, O resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
@@ -250,7 +250,7 @@ class AbstractOperatorTest {
             T extends HasMetadata,
             L extends KubernetesResourceList<T>,
             R extends Resource<T>>
-                extends AbstractWatchableStatusedResourceOperator<C, T, L, R> {
+                extends AbstractWatchableStatusedNamespacedResourceOperator<C, T, L, R> {
 
         public DefaultWatchableStatusedResourceOperator(Vertx vertx, C client, String resourceKind) {
             super(vertx, client, resourceKind);

--- a/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/OperatorMetricsTest.java
@@ -17,7 +17,7 @@ import io.strimzi.api.kafka.model.Spec;
 import io.strimzi.api.kafka.model.status.Status;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
-import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedResourceOperator;
+import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedNamespacedResourceOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -68,7 +68,7 @@ public class OperatorMetricsTest {
     public void successfulReconcile(VertxTestContext context, Labels selectorLabels)  {
         MetricsProvider metricsProvider = createCleanMetricsProvider();
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithSelectorLabel(selectorLabels);
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithSelectorLabel(selectorLabels);
 
         AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metricsProvider, selectorLabels) {
             @Override
@@ -130,7 +130,7 @@ public class OperatorMetricsTest {
     public void failingReconcile(VertxTestContext context, Labels selectorLabels)  {
         MetricsProvider metricsProvider = createCleanMetricsProvider();
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithSelectorLabel(selectorLabels);
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithSelectorLabel(selectorLabels);
 
         AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metricsProvider, selectorLabels) {
             @Override
@@ -194,7 +194,7 @@ public class OperatorMetricsTest {
     public void testPauseReconcile(VertxTestContext context)  {
         MetricsProvider metricsProvider = createCleanMetricsProvider();
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingPausedResource();
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = resourceOperatorWithExistingPausedResource();
 
         AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metricsProvider, null) {
             @Override
@@ -244,7 +244,7 @@ public class OperatorMetricsTest {
     public void testFailingWithLockReconcile(VertxTestContext context)  {
         MetricsProvider metricsProvider = createCleanMetricsProvider();
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithoutSelectorLabel();
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithoutSelectorLabel();
 
         AbstractOperator operator = new AbstractOperator(vertx, "TestResource", resourceOperator, metricsProvider, null) {
             @Override
@@ -281,7 +281,7 @@ public class OperatorMetricsTest {
     public void testDeleteCountsReconcile(VertxTestContext context)  {
         MetricsProvider metricsProvider = createCleanMetricsProvider();
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = new AbstractWatchableStatusedResourceOperator(vertx, null, "TestResource") {
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = new AbstractWatchableStatusedNamespacedResourceOperator(vertx, null, "TestResource") {
             @Override
             protected MixedOperation operation() {
                 return null;
@@ -349,7 +349,7 @@ public class OperatorMetricsTest {
         resources.add(new NamespaceAndName("my-namespace", "vtid"));
         resources.add(new NamespaceAndName("my-namespace", "utv"));
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithoutSelectorLabel();
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithoutSelectorLabel();
         AbstractOperator operator = new ReconcileAllMockOperator(vertx, "TestResource", resourceOperator, metrics, null);
 
         Promise<Void> reconcileAllPromise = Promise.promise();
@@ -400,7 +400,7 @@ public class OperatorMetricsTest {
         updatedResources.add(new NamespaceAndName("my-namespace", "avfc"));
         updatedResources.add(new NamespaceAndName("my-namespace", "vtid"));
 
-        AbstractWatchableStatusedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithoutSelectorLabel();
+        AbstractWatchableStatusedNamespacedResourceOperator resourceOperator = resourceOperatorWithExistingResourceWithoutSelectorLabel();
 
         AbstractOperator operator = new ReconcileAllMockOperator(vertx, "TestResource", resourceOperator, metrics, null);
 
@@ -489,8 +489,8 @@ public class OperatorMetricsTest {
     protected abstract static class MyResource extends CustomResource {
     }
 
-    protected AbstractWatchableStatusedResourceOperator resourceOperatorWithExistingResource(Labels selectorLabels)    {
-        return new AbstractWatchableStatusedResourceOperator(vertx, null, "TestResource") {
+    protected AbstractWatchableStatusedNamespacedResourceOperator resourceOperatorWithExistingResource(Labels selectorLabels)    {
+        return new AbstractWatchableStatusedNamespacedResourceOperator(vertx, null, "TestResource") {
             @Override
             public Future updateStatusAsync(Reconciliation reconciliation, HasMetadata resource) {
                 return null;
@@ -515,16 +515,16 @@ public class OperatorMetricsTest {
         };
     }
 
-    private AbstractWatchableStatusedResourceOperator resourceOperatorWithExistingResourceWithoutSelectorLabel() {
+    private AbstractWatchableStatusedNamespacedResourceOperator resourceOperatorWithExistingResourceWithoutSelectorLabel() {
         return resourceOperatorWithExistingResource(null);
     }
 
-    private AbstractWatchableStatusedResourceOperator resourceOperatorWithExistingResourceWithSelectorLabel(Labels selectorLabel) {
+    private AbstractWatchableStatusedNamespacedResourceOperator resourceOperatorWithExistingResourceWithSelectorLabel(Labels selectorLabel) {
         return resourceOperatorWithExistingResource(selectorLabel);
     }
 
-    private AbstractWatchableStatusedResourceOperator resourceOperatorWithExistingPausedResource() {
-        return new AbstractWatchableStatusedResourceOperator(vertx, null, "TestResource") {
+    private AbstractWatchableStatusedNamespacedResourceOperator resourceOperatorWithExistingPausedResource() {
+        return new AbstractWatchableStatusedNamespacedResourceOperator(vertx, null, "TestResource") {
             @Override
             public Future updateStatusAsync(Reconciliation reconciliation, HasMetadata resource) {
                 return Future.succeededFuture();
@@ -561,7 +561,7 @@ public class OperatorMetricsTest {
     static class ReconcileAllMockOperator extends  AbstractOperator  {
         private Set<NamespaceAndName> resources;
 
-        public ReconcileAllMockOperator(Vertx vertx, String kind, AbstractWatchableStatusedResourceOperator resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
+        public ReconcileAllMockOperator(Vertx vertx, String kind, AbstractWatchableStatusedNamespacedResourceOperator resourceOperator, MetricsProvider metrics, Labels selectorLabels) {
             super(vertx, kind, resourceOperator, metrics, selectorLabels);
         }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorIT.java
@@ -43,11 +43,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
  * test them against real clusters.
  */
 @ExtendWith(VertxExtension.class)
-public abstract class AbstractResourceOperatorIT<C extends KubernetesClient,
+public abstract class AbstractNamespacedResourceOperatorIT<C extends KubernetesClient,
         T extends HasMetadata,
         L extends KubernetesResourceList<T>,
         R extends Resource<T>> {
-    protected static final Logger LOGGER = LogManager.getLogger(AbstractResourceOperatorIT.class);
+    protected static final Logger LOGGER = LogManager.getLogger(AbstractNamespacedResourceOperatorIT.class);
     public static final String RESOURCE_NAME = "my-test-resource";
     private static WorkerExecutor sharedWorkerExecutor;
     protected String resourceName;
@@ -94,7 +94,7 @@ public abstract class AbstractResourceOperatorIT<C extends KubernetesClient,
         }
     }
 
-    abstract AbstractResourceOperator<C, T, L, R> operator();
+    abstract AbstractNamespacedResourceOperator<C, T, L, R> operator();
     abstract T getOriginal();
     abstract T getModified();
     abstract void assertResources(VertxTestContext context, T expected, T actual);
@@ -102,7 +102,7 @@ public abstract class AbstractResourceOperatorIT<C extends KubernetesClient,
     @Test
     public void testCreateModifyDelete(VertxTestContext context)    {
         Checkpoint async = context.checkpoint();
-        AbstractResourceOperator<C, T, L, R> op = operator();
+        AbstractNamespacedResourceOperator<C, T, L, R> op = operator();
 
         T newResource = getOriginal();
         T modResource = getModified();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
-public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T extends HasMetadata,
+public abstract class AbstractNamespacedResourceOperatorTest<C extends KubernetesClient, T extends HasMetadata,
         L extends KubernetesResourceList<T>, R extends Resource<T>> {
 
     public static final String RESOURCE_NAME = "my-resource";
@@ -115,10 +115,10 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
     protected abstract void mocker(C mockClient, MixedOperation op);
 
     /** Create the subclass of ResourceOperation to be tested */
-    protected abstract AbstractResourceOperator<C, T, L, R> createResourceOperations(Vertx vertx, C mockClient);
+    protected abstract AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperations(Vertx vertx, C mockClient);
 
     /** Create the subclass of ResourceOperation to be tested with mocked readiness checks*/
-    protected AbstractResourceOperator<C, T, L, R> createResourceOperationsWithMockedReadiness(Vertx vertx, C mockClient)    {
+    protected AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperationsWithMockedReadiness(Vertx vertx, C mockClient)    {
         return createResourceOperations(vertx, mockClient);
     }
 
@@ -143,7 +143,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, modifiedResource()).onComplete(context.succeeding(rr -> context.verify(() -> {
@@ -176,7 +176,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource()).onComplete(context.succeeding(rr -> context.verify(() -> {
@@ -205,7 +205,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource).onComplete(context.failing(e -> context.verify(() -> {
@@ -232,7 +232,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperationsWithMockedReadiness(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperationsWithMockedReadiness(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource).onComplete(context.succeeding(rr -> context.verify(() -> {
@@ -261,7 +261,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource).onComplete(context.failing(e -> {
@@ -284,7 +284,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -325,7 +325,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -365,7 +365,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -405,7 +405,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -446,7 +446,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -499,7 +499,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
@@ -570,7 +570,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.batchReconcile(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, List.of(resource2Mod, resource3), Labels.fromMap(selector)).onComplete(context.succeeding(i -> context.verify(() -> {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractReadyResourceOperatorTest.java
@@ -29,10 +29,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClient, T extends HasMetadata,
-        L extends KubernetesResourceList<T>, R extends Resource<T>> extends AbstractResourceOperatorTest<C, T, L, R> {
+        L extends KubernetesResourceList<T>, R extends Resource<T>> extends AbstractNamespacedResourceOperatorTest<C, T, L, R> {
 
     @Override
-    protected abstract AbstractReadyResourceOperator<C, T, L, R> createResourceOperations(Vertx vertx, C mockClient);
+    protected abstract AbstractReadyNamespacedResourceOperator<C, T, L, R> createResourceOperations(Vertx vertx, C mockClient);
 
     @Test
     public void testReadinessThrowsWhenResourceDoesNotExist(VertxTestContext context) {
@@ -49,7 +49,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractReadyResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractReadyNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
         Checkpoint async = context.checkpoint();
         op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
             .onComplete(context.failing(e -> context.verify(() -> {
@@ -78,7 +78,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractReadyResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractReadyNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
@@ -130,7 +130,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractReadyResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractReadyNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 5_000)
@@ -157,7 +157,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractReadyResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractReadyNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)
@@ -188,7 +188,7 @@ public abstract class AbstractReadyResourceOperatorTest<C extends KubernetesClie
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractReadyResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
+        AbstractReadyNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(vertx, mockClient);
 
         Checkpoint async = context.checkpoint();
         op.readiness(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, 20, 100)

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildConfigOperatorTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.when;
 
-public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenShiftClient, BuildConfig,
+public class BuildConfigOperatorTest extends AbstractNamespacedResourceOperatorTest<OpenShiftClient, BuildConfig,
         BuildConfigList, BuildConfigResource<BuildConfig, Void, Build>> {
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/BuildOperatorTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 
 import static org.mockito.Mockito.when;
 
-public class BuildOperatorTest extends AbstractResourceOperatorTest<OpenShiftClient, Build, BuildList, BuildResource> {
+public class BuildOperatorTest extends AbstractNamespacedResourceOperatorTest<OpenShiftClient, Build, BuildList, BuildResource> {
 
     @Override
     protected void mocker(OpenShiftClient mockClient, MixedOperation mockCms) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ConfigMapOperatorTest.java
@@ -15,7 +15,7 @@ import io.vertx.core.Vertx;
 import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.when;
 
-public class ConfigMapOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> {
+public class ConfigMapOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> {
 
     @Override
     protected void  mocker(KubernetesClient mockClient, MixedOperation mockCms) {
@@ -23,7 +23,7 @@ public class ConfigMapOperatorTest extends AbstractResourceOperatorTest<Kubernet
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, ConfigMap, ConfigMapList, Resource<ConfigMap>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new ConfigMapOperator(vertx, mockClient);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ImageStreamOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ImageStreamOperatorTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 
 import static org.mockito.Mockito.when;
 
-public class ImageStreamOperatorTest extends AbstractResourceOperatorTest<OpenShiftClient, ImageStream, ImageStreamList, Resource<ImageStream>> {
+public class ImageStreamOperatorTest extends AbstractNamespacedResourceOperatorTest<OpenShiftClient, ImageStream, ImageStreamList, Resource<ImageStream>> {
 
     @Override
     protected Class<OpenShiftClient> clientType() {
@@ -53,7 +53,7 @@ public class ImageStreamOperatorTest extends AbstractResourceOperatorTest<OpenSh
     }
 
     @Override
-    protected AbstractResourceOperator<OpenShiftClient, ImageStream, ImageStreamList, Resource<ImageStream>> createResourceOperations(Vertx vertx, OpenShiftClient mockClient) {
+    protected AbstractNamespacedResourceOperator<OpenShiftClient, ImageStream, ImageStreamList, Resource<ImageStream>> createResourceOperations(Vertx vertx, OpenShiftClient mockClient) {
         return new ImageStreamOperator(vertx, mockClient);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/IngressOperatorTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class IngressOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
+public class IngressOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, Ingress, IngressList, Resource<Ingress>> {
     @Override
     protected Class<KubernetesClient> clientType() {
         return KubernetesClient.class;
@@ -65,7 +65,7 @@ public class IngressOperatorTest extends AbstractResourceOperatorTest<Kubernetes
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Ingress, IngressList, Resource<Ingress>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new IngressOperator(vertx, mockClient);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/KafkaCrdOperatorTest.java
@@ -29,7 +29,7 @@ import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class KafkaCrdOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Kafka, KafkaList, Resource<Kafka>> {
+public class KafkaCrdOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, Kafka, KafkaList, Resource<Kafka>> {
 
     @Override
     protected Class<KubernetesClient> clientType() {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetOperatorTest.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
+public class PodDisruptionBudgetOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
 
     @Override
     protected void  mocker(KubernetesClient mockClient, MixedOperation op) {
@@ -30,7 +30,7 @@ public class PodDisruptionBudgetOperatorTest extends AbstractResourceOperatorTes
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new PodDisruptionBudgetOperator(vertx, mockClient);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetV1Beta1OperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PodDisruptionBudgetV1Beta1OperatorTest.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PodDisruptionBudgetV1Beta1OperatorTest extends AbstractResourceOperatorTest<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
+public class PodDisruptionBudgetV1Beta1OperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> {
 
     @Override
     protected void  mocker(KubernetesClient mockClient, MixedOperation op) {
@@ -30,7 +30,7 @@ public class PodDisruptionBudgetV1Beta1OperatorTest extends AbstractResourceOper
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, PodDisruptionBudget, PodDisruptionBudgetList, Resource<PodDisruptionBudget>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new PodDisruptionBudgetV1Beta1Operator(vertx, mockClient);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/PvcOperatorTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PvcOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> {
+public class PvcOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, PersistentVolumeClaim, PersistentVolumeClaimList, Resource<PersistentVolumeClaim>> {
 
     @Override
     protected Class<KubernetesClient> clientType() {

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorIT.java
@@ -23,10 +23,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static java.util.Collections.singletonMap;
 
 @ExtendWith(VertxExtension.class)
-public class RoleBindingOperatorIT extends AbstractResourceOperatorIT<KubernetesClient, RoleBinding, RoleBindingList, Resource<RoleBinding>> {
+public class RoleBindingOperatorIT extends AbstractNamespacedResourceOperatorIT<KubernetesClient, RoleBinding, RoleBindingList, Resource<RoleBinding>> {
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, RoleBinding, RoleBindingList, Resource<RoleBinding>> operator() {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, RoleBinding, RoleBindingList, Resource<RoleBinding>> operator() {
         return new RoleBindingOperator(vertx, client);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleBindingOperatorTest.java
@@ -22,7 +22,7 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RoleBindingOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, RoleBinding, RoleBindingList, Resource<RoleBinding>> {
+public class RoleBindingOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, RoleBinding, RoleBindingList, Resource<RoleBinding>> {
 
 
     @Override
@@ -81,8 +81,8 @@ public class RoleBindingOperatorTest extends AbstractResourceOperatorTest<Kubern
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, RoleBinding, RoleBindingList,
-            Resource<RoleBinding>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, RoleBinding, RoleBindingList,
+                Resource<RoleBinding>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new RoleBindingOperator(vertx, mockClient);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorIT.java
@@ -20,18 +20,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(VertxExtension.class)
-public class RoleOperatorIT extends AbstractResourceOperatorIT<
+public class RoleOperatorIT extends AbstractNamespacedResourceOperatorIT<
         KubernetesClient,
         Role,
         RoleList,
         Resource<Role>> {
 
     @Override
-    protected AbstractResourceOperator<
-            KubernetesClient,
-            Role,
-            RoleList,
-            Resource<Role>> operator() {
+    protected AbstractNamespacedResourceOperator<
+                KubernetesClient,
+                Role,
+                RoleList,
+                Resource<Role>> operator() {
         return new RoleOperator(vertx, client);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RoleOperatorTest.java
@@ -19,7 +19,7 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RoleOperatorTest extends AbstractResourceOperatorTest<
+public class RoleOperatorTest extends AbstractNamespacedResourceOperatorTest<
         KubernetesClient,
         Role,
         RoleList,
@@ -72,7 +72,7 @@ public class RoleOperatorTest extends AbstractResourceOperatorTest<
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, Role, RoleList, Resource<Role>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Role, RoleList, Resource<Role>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new RoleOperator(vertx, mockClient);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/RouteOperatorTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 
 import static org.mockito.Mockito.when;
 
-public class RouteOperatorTest extends AbstractResourceOperatorTest<OpenShiftClient, Route, RouteList, Resource<Route>> {
+public class RouteOperatorTest extends AbstractNamespacedResourceOperatorTest<OpenShiftClient, Route, RouteList, Resource<Route>> {
     @Override
     protected Class<OpenShiftClient> clientType() {
         return OpenShiftClient.class;
@@ -52,7 +52,7 @@ public class RouteOperatorTest extends AbstractResourceOperatorTest<OpenShiftCli
     }
 
     @Override
-    protected AbstractResourceOperator<OpenShiftClient, Route, RouteList, Resource<Route>> createResourceOperations(Vertx vertx, OpenShiftClient mockClient) {
+    protected AbstractNamespacedResourceOperator<OpenShiftClient, Route, RouteList, Resource<Route>> createResourceOperations(Vertx vertx, OpenShiftClient mockClient) {
         return new RouteOperator(vertx, mockClient);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/SecretOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/SecretOperatorTest.java
@@ -15,7 +15,7 @@ import io.vertx.core.Vertx;
 import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.when;
 
-public class SecretOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Secret, SecretList, Resource<Secret>> {
+public class SecretOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, Secret, SecretList, Resource<Secret>> {
 
 
     @Override
@@ -53,7 +53,7 @@ public class SecretOperatorTest extends AbstractResourceOperatorTest<KubernetesC
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new SecretOperator(vertx, mockClient);
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
@@ -25,9 +25,9 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @ExtendWith(VertxExtension.class)
-public class ServiceAccountOperatorIT extends AbstractResourceOperatorIT<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
+public class ServiceAccountOperatorIT extends AbstractNamespacedResourceOperatorIT<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
     @Override
-    protected AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> operator() {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> operator() {
         return new ServiceAccountOperator(vertx, client);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
+public class ServiceAccountOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> {
 
 
     @Override
@@ -80,7 +80,7 @@ public class ServiceAccountOperatorTest extends AbstractResourceOperatorTest<Kub
     }
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
         return new ServiceAccountOperator(vertx, mockClient);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorIT.java
@@ -20,11 +20,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(VertxExtension.class)
-public class ServiceOperatorIT extends AbstractResourceOperatorIT<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
+public class ServiceOperatorIT extends AbstractNamespacedResourceOperatorIT<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
 
     @Override
-    protected AbstractResourceOperator<KubernetesClient, Service, ServiceList,
-            ServiceResource<Service>> operator() {
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Service, ServiceList,
+                ServiceResource<Service>> operator() {
         return new ServiceOperator(vertx, client);
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
-public class ServiceOperatorTest extends AbstractResourceOperatorTest<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
+public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, Service, ServiceList, ServiceResource<Service>> {
 
     @Override
     protected Class<KubernetesClient> clientType() {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Today, the resource operators we have in `operator-common` do not have a single common ancestor. Instead, there is `AbstractNonNamespacedOperator` for non-namespaced resources and `AbstractResourceOperator` for namespaced resources. While these for two separate inheritance trees, they obviously share many common aspects.

This PR restructures them. It renames the `AbstractResourceOperator` to `AbstractNamespacedResourceOperator` and creates a _new_ `AbstractResourceOperator` whihc is used as an abstract parent for both `AbstractNamespacedResourceOperator` and `AbstractNonNamespacedOperator` and moves the shared code to it.

It also refactors the methods for listing resources to have the _list_ logic copied in less different places which should make it easier to add `ListOptions` to the `list(...)` calls. This is related to #7794 to make it easier to configure the `LIST` operation to optimise the consumed resources on the Kubernetes control plane side. (However, this PR itself does not change ayn of the `list` call options => that would be subject to some later PR)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging