### PR TITLE
docs(events): Change to callouts used in example events output

### DIFF
--- a/documentation/modules/deploying/proc-operator-restart-events.adoc
+++ b/documentation/modules/deploying/proc-operator-restart-events.adoc
@@ -58,13 +58,13 @@ items:
 - action: StrimziInitiatedPodRestart
   apiVersion: v1
   eventTime: "2022-05-13T00:22:34.168086Z"
-  firstTimestamp: null <1>
+  firstTimestamp: null
   involvedObject:
       kind: Pod
       name: strimzi-cluster-kafka-1
       namespace: kafka
   kind: Event
-  lastTimestamp: null <1>
+  lastTimestamp: null
   message: Pod needs to be forcibly restarted due to an error
   metadata:
       creationTimestamp: "2022-05-13T00:22:34Z"
@@ -76,11 +76,16 @@ items:
   reason: PodForceRestartOnError
   reportingController: strimzi.io/cluster-operator
   reportingInstance: strimzi-cluster-operator-6458cfb4c6-6bpdp
-  source: {} <1>
+  source: {}
   type: Normal
 kind: List
 metadata:
   resourceVersion: ""
   selfLink: ""
 ----
-<1> These fields are deprecated, and will be removed in Kubernetes 1.25. As such, they are not populated for these events.
+
+The following fields are deprecated, so they are not populated for these events:
+
+* `firstTimestamp`
+* `lastTimestamp`
+* `source`


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Removes and replaces the callouts from the  example showing detailed events output.
The callouts don't render correctly if building the doc locally.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

