### PR TITLE
Use separate log level for OkHttp3

### DIFF
--- a/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityTopicOperatorDefaultLoggingProperties
@@ -17,3 +17,8 @@ logger.clients.additivity = false
 logger.streams.name = org.apache.kafka.streams
 logger.streams.level = INFO
 logger.streams.additivity = false
+
+# Keeps separate log level for OkHttp client
+logger.okhttp3.name = okhttp3
+logger.okhttp3.level = INFO
+logger.okhttp3.additivity = false

--- a/cluster-operator/src/main/resources/entityUserOperatorDefaultLoggingProperties
+++ b/cluster-operator/src/main/resources/entityUserOperatorDefaultLoggingProperties
@@ -11,5 +11,11 @@ rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
 # Keeps separate level for Jetty
-logger.jetty.name = org.eclipse.jetty.server
+logger.jetty.name = org.eclipse.jetty
 logger.jetty.level = INFO
+logger.jetty.additivity = false
+
+# Keeps separate log level for OkHttp client
+logger.okhttp3.name = okhttp3
+logger.okhttp3.level = INFO
+logger.okhttp3.additivity = false

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -37,4 +37,8 @@ data:
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
+
+    # Keeps separate log level for OkHttp client
+    logger.okhttp3.name = okhttp3
+    logger.okhttp3.level = INFO
     {{- end }}

--- a/packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -29,3 +29,7 @@ data:
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
+
+    # Keeps separate log level for OkHttp client
+    logger.okhttp3.name = okhttp3
+    logger.okhttp3.level = INFO


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#7792 properly integrated the logging of the OkHttp client into the operator logs. That is useful if you have some issues with OkHttp and want to see its debug or trace logs. However, in most cases, you want the DEBUG level for just the operator debug logs and do not want to have them full of some OkHttp logs about the HTTP2 connections. This PR adds separate OkHttp logger to the logging configurations of the operators. That allows it to be easily configurable if needed but not get in the way when not needed.

In also changes slightly the Jetty loger in the User Operator configuration to cover some additional Jetty classes which log some (mostly) useless messages.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally