### PR TITLE
KafkaRebalanceOperator now checks for cluster readiness before creating KafkaRebalance resources

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1405,7 +1405,7 @@ public class KafkaRebalanceAssemblyOperator
          * Kafka Cluster is not ready
          *
          */
-        kafkaClusterNotReady("Creating Kafka Cluster");
+        kafkaClusterNotReady("Kafka cluster is not Ready");
 
         public String getReason() {
             return reason;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1160,13 +1160,14 @@ public class KafkaRebalanceAssemblyOperator
                                 new NoSuchResourceException("Kafka resource '" + clusterName
                                         + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL
                                         + "' does not exist in namespace " + clusterNamespace + ".")).mapEmpty();
-                    } else if (kafka.getStatus().getConditions().stream().noneMatch(condition -> condition.getType().equals("Ready") && condition.getStatus().equals("True"))) {
+                    } else if (kafka.getStatus() == null
+                            || kafka.getStatus().getConditions() == null
+                            || kafka.getStatus().getConditions().stream().noneMatch(condition -> condition.getType().equals("Ready") && condition.getStatus().equals("True"))) {
                         String errorString = "Kafka cluster is being deployed";
                         LOGGER.warnCr(reconciliation, errorString);
                         KafkaRebalanceStatus status = new KafkaRebalanceStatus();
-                        status.addCondition(StatusUtils.buildWarningCondition(CruiseControlIssues.kafkaClusterNotReady.getReason(), errorString));
                         return updateStatus(reconciliation, kafkaRebalance, status,
-                                new RuntimeException("Secret " + clusterNamespace + "/my-cluster-cruise-control-certs does not exist")).mapEmpty();
+                                new RuntimeException(CruiseControlIssues.kafkaClusterNotReady.getReason())).mapEmpty();
                     } else if (!Util.matchesSelector(kafkaSelector, kafka)) {
                         LOGGER.debugCr(reconciliation, "{} {} in namespace {} belongs to a Kafka cluster {} which does not match label selector {} and will be ignored", kind(), kafkaRebalance.getMetadata().getName(), clusterNamespace, clusterName, kafkaSelector.get().getMatchLabels());
                         return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1163,7 +1163,7 @@ public class KafkaRebalanceAssemblyOperator
                     } else if (kafka.getStatus() == null
                             || kafka.getStatus().getConditions() == null
                             || kafka.getStatus().getConditions().stream().noneMatch(condition -> condition.getType().equals("Ready") && condition.getStatus().equals("True"))) {
-                        String errorString = "Kafka cluster is being deployed";
+                        String errorString = "Kafka cluster is not Ready";
                         LOGGER.warnCr(reconciliation, errorString);
                         KafkaRebalanceStatus status = new KafkaRebalanceStatus();
                         return updateStatus(reconciliation, kafkaRebalance, status,
@@ -1404,7 +1404,6 @@ public class KafkaRebalanceAssemblyOperator
 
         /**
          * Kafka Cluster is not ready
-         *
          */
         kafkaClusterNotReady("Kafka cluster is not Ready");
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1160,6 +1160,13 @@ public class KafkaRebalanceAssemblyOperator
                                 new NoSuchResourceException("Kafka resource '" + clusterName
                                         + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL
                                         + "' does not exist in namespace " + clusterNamespace + ".")).mapEmpty();
+                    } else if (kafka.getStatus().getConditions().stream().noneMatch(condition -> condition.getType().equals("Ready") && condition.getStatus().equals("True"))) {
+                        String errorString = "Kafka cluster is being deployed";
+                        LOGGER.warnCr(reconciliation, errorString);
+                        KafkaRebalanceStatus status = new KafkaRebalanceStatus();
+                        status.addCondition(StatusUtils.buildWarningCondition(CruiseControlIssues.kafkaClusterNotReady.getReason(), errorString));
+                        return updateStatus(reconciliation, kafkaRebalance, status,
+                                new RuntimeException("Secret " + clusterNamespace + "/my-cluster-cruise-control-certs does not exist")).mapEmpty();
                     } else if (!Util.matchesSelector(kafkaSelector, kafka)) {
                         LOGGER.debugCr(reconciliation, "{} {} in namespace {} belongs to a Kafka cluster {} which does not match label selector {} and will be ignored", kind(), kafkaRebalance.getMetadata().getName(), clusterNamespace, clusterName, kafkaSelector.get().getMatchLabels());
                         return Future.succeededFuture();
@@ -1392,7 +1399,13 @@ public class KafkaRebalanceAssemblyOperator
         /**
          * Cruise Control was not declared in the Kafka Resource
          */
-        cruiseControlDisabled("Cruise Control disabled");
+        cruiseControlDisabled("Cruise Control disabled"),
+
+        /**
+         * Kafka Cluster is not ready
+         *
+         */
+        kafkaClusterNotReady("Creating Kafka Cluster");
 
         public String getReason() {
             return reason;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -19,10 +19,9 @@ import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpecBuilder;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceMode;
-import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.*;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
-import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
@@ -126,6 +125,13 @@ public class KafkaRebalanceAssemblyOperatorTest {
                             .withImage(ccImage)
                         .endCruiseControl()
                     .endSpec()
+                    .withNewStatus()
+                        .withObservedGeneration(1L)
+                        .withConditions(new ConditionBuilder()
+                                .withType("Ready")
+                                .withStatus("True")
+                                .build())
+                    .endStatus()
                     .build();
 
     @BeforeAll
@@ -1386,10 +1392,17 @@ public class KafkaRebalanceAssemblyOperatorTest {
         Kafka kafka =
                 new KafkaBuilder(ResourceUtils.createKafka(CLUSTER_NAMESPACE, CLUSTER_NAME, replicas, image, healthDelay, healthTimeout))
                         .editSpec()
-                        .editKafka()
-                        .withVersion(version)
-                        .endKafka()
+                            .editKafka()
+                            .withVersion(version)
+                            .endKafka()
                         .endSpec()
+                        .withNewStatus()
+                            .withObservedGeneration(1L)
+                            .withConditions(new ConditionBuilder()
+                                    .withType("Ready")
+                                    .withStatus("True")
+                                    .build())
+                        .endStatus()
                         .build();
 
         KafkaRebalance kr =
@@ -1423,6 +1436,13 @@ public class KafkaRebalanceAssemblyOperatorTest {
                                 .withVersion(version)
                             .endKafka()
                         .endSpec()
+                        .withNewStatus()
+                            .withObservedGeneration(1L)
+                            .withConditions(new ConditionBuilder()
+                                    .withType("Ready")
+                                    .withStatus("True")
+                                    .build())
+                        .endStatus()
                         .build();
 
         KafkaRebalance kr =

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -19,7 +19,9 @@ import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpecBuilder;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceMode;
-import io.strimzi.api.kafka.model.status.*;
+import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.KafkaRebalanceStatus;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -1393,7 +1395,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 new KafkaBuilder(ResourceUtils.createKafka(CLUSTER_NAMESPACE, CLUSTER_NAME, replicas, image, healthDelay, healthTimeout))
                         .editSpec()
                             .editKafka()
-                            .withVersion(version)
+                                .withVersion(version)
                             .endKafka()
                         .endSpec()
                         .withNewStatus()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1481,6 +1481,13 @@ public class KafkaRebalanceAssemblyOperatorTest {
                                     .withImage(ccImage)
                                 .endCruiseControl()
                             .endSpec()
+                            .withNewStatus()
+                            .withObservedGeneration(1L)
+                            .withConditions(new ConditionBuilder()
+                                    .withType("Ready")
+                                    .withStatus("True")
+                                    .build())
+                            .endStatus()
                             .build();
 
                     when(mockKafkaOps.getAsync(CLUSTER_NAMESPACE, CLUSTER_NAME)).thenReturn(Future.succeededFuture(kafkaPatch));


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

- Bugfix

### Description

This PR fixes #7643. This PR adds a check for Cluster readiness. If the user applies a KafkaRebalance resource before the creation of Kafka Cluster, We get the desired warning and errors in the KafkaRebalance Status.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

