### PR TITLE
Suppress deprecation warning in Azure for STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -74,6 +74,8 @@ public class SystemTestCertAndKeyBuilder {
     private X500Name issuer;
     private X500Name subject;
 
+    // Suppresses the deprecation warning about getSubjectDN()
+    @SuppressWarnings("deprecation")
     private SystemTestCertAndKeyBuilder(KeyPair keyPair, SystemTestCertAndKey caCert, List<Extension> extensions) {
         this.keyPair = keyPair;
         this.caCert = caCert;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The STs are currently in the `SystemTestCertAndKeyBuilder` class using deprecated `getSubjectDN()` method. The change to use some undeprecated method is tracked in #7698. However, the deprecation warning is showing up in the Azure CI:

![Screenshot 2022-12-15 at 17 04 32](https://user-images.githubusercontent.com/5658439/207910507-402f676b-f1f2-47a2-8b18-a8f597256394.png)

This PR suppresses the dperecation to get rid of the unnecessary warning in the Azure Pipelines UI.