### PR TITLE
Update Fabric8 and other dependencies (Jackson, Vert.x)

### DIFF
--- a/mockkube/src/main/java/io/strimzi/test/mockkube2/MockKube2.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube2/MockKube2.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube2.controllers.AbstractMockController;
@@ -185,7 +186,7 @@ public class MockKube2 {
          * @return  MockKube builder instance
          */
         public MockKube2Builder withKafkaUserCrd()  {
-            mock.registerCrd("kafka.strimzi.io/v1beta2", "KafkaUser", KafkaRebalance.class, TestUtils.CRD_KAFKA_USER);
+            mock.registerCrd("kafka.strimzi.io/v1beta2", "KafkaUser", KafkaUser.class, TestUtils.CRD_KAFKA_USER);
             return this;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,19 +103,19 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.2.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.2.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.2.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.3.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.3.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.3.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <fasterxml.jackson-core.version>2.13.4</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.13.4.1</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.13.4</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.13.4</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-core.version>2.14.1</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.14.1</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.14.1</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.14.1</fasterxml.jackson-annotations.version>
         <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once jackson-dataformat-yaml uses it out of the box -->
         <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
         <snakeyaml.version>1.33</snakeyaml.version>
-        <vertx.version>4.3.5</vertx.version>
-        <vertx-junit5.version>4.3.5</vertx-junit5.version>
+        <vertx.version>4.3.6</vertx.version>
+        <vertx-junit5.version>4.3.6</vertx-junit5.version>
         <kafka.version>3.3.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <scala-library.version>2.13.9</scala-library.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Fabric8 Kubernetes client to 6.3.1. It also updates some other dependencies -> Jackson to 2.14.1 to sync it with Fabric8. It also bumps Vert.x to 4.3.6 (just a patch release).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally