### PR TITLE
Fix kafka pod address used to check if replication port is listening

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -800,7 +800,7 @@ public class KafkaRoller {
             try {
                 LOGGER.debugCr(reconciliation, "Probing TCP port due to previous problems connecting to pod {}", podRef);
                 // do a tcp connect and close (with a short connect timeout)
-                tcpProbe(podRef.getPodName(), KafkaCluster.REPLICATION_PORT);
+                tcpProbe(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), podRef.getPodName()), KafkaCluster.REPLICATION_PORT);
             } catch (IOException connectionException) {
                 throw new ForceableProblem("Unable to connect to " + podRef.getPodName() + ":" + KafkaCluster.REPLICATION_PORT, executionException.getCause(), true);
             }
@@ -817,7 +817,7 @@ public class KafkaRoller {
      * @param port The port
      * @throws IOException if anything went wrong.
      */
-    void tcpProbe(String hostname, int port) throws IOException {
+    /*test*/ void tcpProbe(String hostname, int port) throws IOException {
         Socket socket = new Socket();
         try {
             socket.connect(new InetSocketAddress(hostname, port), 5_000);


### PR DESCRIPTION
Fixes #7798

### Type of change

- Bugfix

### Description

The KafkaRoller was trying to connect to `${podName}:${replicaPort}` which doesn't resolve to anything from the operator.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

