### PR TITLE
[systemtest] Add pull secret to Scraper pod if appropriate env variable is set

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
@@ -31,7 +31,7 @@ public class ScraperTemplates {
 
         PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
 
-        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isBlank()) {
             List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
             podSpecBuilder.withImagePullSecrets(imagePullSecrets);
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/ScraperTemplates.java
@@ -5,6 +5,8 @@
 package io.strimzi.systemtest.templates.specific;
 
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
@@ -12,7 +14,9 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.enums.DeploymentTypes;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ScraperTemplates {
@@ -24,6 +28,13 @@ public class ScraperTemplates {
 
         label.put(Constants.SCRAPER_LABEL_KEY, Constants.SCRAPER_LABEL_VALUE);
         label.put(Constants.DEPLOYMENT_TYPE, DeploymentTypes.Scraper.name());
+
+        PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            List<LocalObjectReference> imagePullSecrets = Collections.singletonList(new LocalObjectReference(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET));
+            podSpecBuilder.withImagePullSecrets(imagePullSecrets);
+        }
 
         return new DeploymentBuilder()
             .withNewMetadata()
@@ -42,7 +53,7 @@ public class ScraperTemplates {
                         .addToLabels("app", podName)
                         .addToLabels(label)
                     .endMetadata()
-                    .withNewSpec()
+                    .withNewSpecLike(podSpecBuilder.build())
                         .withContainers(
                             new ContainerBuilder()
                                 .withName(podName)


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

As it is mentioned in #7822 , we are not passing the pull secret specified in `SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET` env variable to the Scraper pod template, so if the user wants to run STs with custom images in some private registry, all of the tests which are using Scraper pod will simply fail.

Fixes #7822 

### Checklist

- [x] Make sure all tests pass

