### PR TITLE
filter v character

### DIFF
--- a/tools/prerequisites-check.sh
+++ b/tools/prerequisites-check.sh
@@ -20,7 +20,7 @@ check_command_present shellcheck
 # After version 3.3.1, yq --version sends the string to STDERR instead of STDOUT
 YQ_VERSION="$(yq --version 2>&1 | ${SED} -r 's/^.* v?//g')"
 
-IFS="." read -r -a YQ_ARRAY <<< "$YQ_VERSION"
+IFS="." read -r -a YQ_ARRAY <<< "${YQ_VERSION#v}"
 
 yq_err_msg="${RED}yq version is ${YQ_VERSION}, version must be 4.2.1 or above. Please download the latest version from https://github.com/mikefarah/yq/releases${NO_COLOUR}"
 


### PR DESCRIPTION
when using yq > v4.30, its version number prefix character v 

Signed-off-by: hubert-he <hzh512@126.com>

### Type of change
- Bugfix

### Description

fix issure:
when using yq(v4.30), got make failed #7824

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [N] Write tests
- [Y] Make sure all tests pass
- [N] Update documentation
- [N] Check RBAC rights for Kubernetes / OpenShift roles
- [N] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [N] Reference relevant issue(s) and close them after merging
- [N] Update CHANGELOG.md
- [N] Supply screenshots for visual changes, such as Grafana dashboards

