### PR TITLE
Use longer passwords to make tests pass in FIPS environments

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1276,7 +1276,7 @@ class ConnectIsolatedST extends AbstractST {
                     .withName("custom-pwd-secret")
                     .withNamespace(namespaceName)
                 .endMetadata()
-                .addToData("pwd", "MTIzNDU2Nzg5")
+                .addToStringData("pwd", "completely_secret_password_long_enough_for_fips")
                 .build();
 
         kubeClient(namespaceName).createSecret(passwordSecret);
@@ -1321,13 +1321,12 @@ class ConnectIsolatedST extends AbstractST {
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(namespaceName, kafkaConnectPodName);
 
         Map<String, String> connectSnapshot = DeploymentUtils.depSnapshot(namespaceName, KafkaConnectResources.deploymentName(clusterName));
-        String newPassword = "bmVjb0ppbmVob05lelNwcmF2bnlQYXNzd29yZA==";
         Secret newPasswordSecret = new SecretBuilder()
                 .withNewMetadata()
                     .withName("new-custom-pwd-secret")
                     .withNamespace(namespaceName)
                 .endMetadata()
-                .addToData("pwd", newPassword)
+                .addToStringData("pwd", "completely_different_secret_password")
                 .build();
 
         kubeClient(namespaceName).createSecret(newPasswordSecret);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2154,7 +2154,8 @@ public class ListenersST extends AbstractST {
     void testMessagesTlsScramShaWithPredefinedPassword(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
 
-        final String firstUnencodedPassword = "completely_secret_password";
+        // FIPS needs the passwords at least 32 characters long
+        final String firstUnencodedPassword = "completely_secret_password_long_enough_for_fips";
         final String secondUnencodedPassword = "completely_different_secret_password";
 
         final String firstEncodedPassword = Base64.getEncoder().encodeToString(firstUnencodedPassword.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some system tests seem to rely on passwords which are part of the test directly. This is correct as it supports the tested scenario. But in some places, the passwords are too short and cause failures when run against FIPS enabled environments. This PR updates the passwords to be more then 32 characters long and make them work on FIPS.