### PR TITLE
Bump test-clients version to 0.4.2

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -171,7 +171,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.3.1";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.4.1";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.4.2";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     /**
      * Set values


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This PR bumps version of test-clients to 0.4.2, which brings support for Java 17 and also more FIPS compliance - so we will be able to run the tests on FIPS enabled environment 

### Checklist

- [x] Make sure all tests pass

