### PR TITLE
[ST] Fix SKIP_TEARDOWN when creating / deleting namespaces

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -147,7 +147,7 @@ public class KubeClusterResource {
         bindingsNamespaces = namespaces;
         for (String namespace: namespaces) {
 
-            if (kubeClient().getNamespace(namespace) != null && !System.getenv("SKIP_TEARDOWN").equals("true")) {
+            if (kubeClient().getNamespace(namespace) != null && (System.getenv("SKIP_TEARDOWN") == null || !System.getenv("SKIP_TEARDOWN").equals("true"))) {
                 LOGGER.warn("Namespace {} is already created, going to delete it", namespace);
                 kubeClient().deleteNamespace(namespace);
                 cmdKubeClient().waitForResourceDeletion("Namespace", namespace);

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -147,7 +147,7 @@ public class KubeClusterResource {
         bindingsNamespaces = namespaces;
         for (String namespace: namespaces) {
 
-            if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") != "true") {
+            if (kubeClient().getNamespace(namespace) != null && !System.getenv("SKIP_TEARDOWN").equals("true")) {
                 LOGGER.warn("Namespace {} is already created, going to delete it", namespace);
                 kubeClient().deleteNamespace(namespace);
                 cmdKubeClient().waitForResourceDeletion("Namespace", namespace);

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -147,7 +147,7 @@ public class KubeClusterResource {
         bindingsNamespaces = namespaces;
         for (String namespace: namespaces) {
 
-            if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") == null) {
+            if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") != "true") {
                 LOGGER.warn("Namespace {} is already created, going to delete it", namespace);
                 kubeClient().deleteNamespace(namespace);
                 cmdKubeClient().waitForResourceDeletion("Namespace", namespace);


### PR DESCRIPTION
Signed-off-by: jkalinic <jkalinic@redhat.com>

### Type of change

- Bugfix

### Description

This pr fixes problems with namespaces being stuck and not replaced with newly created one. When SKIP_TEARDOWN == null everything works as expected, but when this env is set to false, namespace isn't deleted and this pr should fix this.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

