### PR TITLE
docs(listeners): Updates ingress and route listener procedures

### DIFF
--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -3,48 +3,47 @@
 // assembly-configuring-kafka-listeners.adoc
 
 [id='proc-accessing-kafka-using-ingress-{context}']
-= Accessing Kafka using ingresses
+= Accessing Kafka using an Ingress NGINX Controller for Kubernetes
 
 [role="_abstract"]
 Use an {NginxIngressController} to access a Strimzi Kafka cluster from clients outside the Kubernetes cluster. 
-The Nginx Ingress Controller supports connections from HTTP and HTTPS-based applications.
 
-To be able to use an Nginx Ingress Controller, add configuration for an `ingress` type listener in the `Kafka` custom resource. 
+To be able to use an Ingress NGINX Controller for Kubernetes, add configuration for an `ingress` type listener in the `Kafka` custom resource. 
 When applied, the configuration creates a dedicated ingress and service for an external bootstrap and each broker in the cluster. 
 Clients connect to the bootstrap ingress, which routes them through the bootstrap service to connect to a broker. 
 Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific ingresses and services.
 
-To connect to a broker, you specify a hostname (advertised address) for the ingress bootstrap address, as well as the certificate used for authentication.
+To connect to a broker, you specify a hostname for the ingress bootstrap address, as well as the TLS certificate.
+Authentication is optional.
 
-For access using an ingress, the port is always 443.
+For access using an ingress, the port used in the Kafka client is typically 443.
 
 .TLS passthrough
 
-Make sure that you enable TLS passthrough in your NGINX Ingress Controller deployment.
-Kafka uses a binary protocol over TCP, but the NGINX Ingress Controller is designed to work with a HTTP protocol. 
-To be able to route traffic through ingresses, Strimzi uses TLS passthrough with Server Name Indication (SNI).
+Make sure that you enable TLS passthrough in your Ingress NGINX Controller for Kubernetes deployment.
+Kafka uses a binary protocol over TCP, but the Ingress NGINX Controller for Kubernetes is designed to work with a HTTP protocol. 
+To be able to route TCP traffic through ingresses, Strimzi uses TLS passthrough with Server Name Indication (SNI).
 
 SNI helps with identifying and passing connection to Kafka brokers.
 In passthrough mode, TLS encryption is always used.
-Because connection passes to the brokers, the listeners use the TLS certificates signed by the internal cluster CA.
+Because the connection passes to the brokers, the listeners use the TLS certificates signed by the internal cluster CA and not the ingrress certificates.
 To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property]. 
 
 For more information about enabling TLS passthrough, see the {NginxIngressControllerTLSPassthrough}.
 
 .Prerequisites
 
-* An NGINX Ingress Controller is running with TLS passthrough enabled
+* An Ingress NGINX Controller for Kubernetes is running with TLS passthrough enabled
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-
-NOTE: You can install and use the NGINX Ingress Operator to deploy an NGINX Ingress Controller.
 
 .Procedure
 
 . Configure a `Kafka` resource with an external listener set to the `ingress` type.
 +
 Specify an ingress hostname for the bootstrap service and each of the Kafka brokers in the Kafka cluster.
+Add any hostname to the `bootstrap` and `broker-<index>` prefixes that identify the bootstrap and brokers.
 +
 For example:
 +
@@ -77,15 +76,12 @@ spec:
             host: broker-1.myingress.com
           - broker: 2
             host: broker-2.myingress.com
-          class: nginx  
+          class: nginx  # <1>
     # ...
   zookeeper:
     # ...
 ----
-+
-Add any hostname to the `bootstrap` and `broker-<index>` prefixes that identify the bootstrap and brokers.
-+
-NOTE: You might need to add `nginx` as the class if it is missing in the ingresses created. 
+<1> (Optional) Class that specifies the ingress controller to use. You might need to add a class if you have not set up a default and a class name is missing in the ingresses created. 
 
 . Create or update the resource.
 +
@@ -98,7 +94,7 @@ A cluster CA certificate to verify the identity of the kafka brokers is created 
 +
 `ClusterIP` type services are created for each Kafka broker, as well as an external bootstrap service.
 +
-An `ingress` is also created for each service, with a DNS address to expose them using the NGINX Ingress Controller.
+An `ingress` is also created for each service, with a DNS address to expose them using the Ingress NGINX Controller for Kubernetes.
 +
 .Ingresses created for the bootstrap and brokers
 [source,shell]
@@ -126,7 +122,7 @@ status:
 +
 [source,shell]
 ----
-openssl s_client -connect my-cluster-kafka-0:443 -servername my-cluster-kafka-0 -showcerts
+openssl s_client -connect broker-0.myingress.com:443 -servername broker-0.myingress.com -showcerts
 ----
 +
 The server name is the SNI for passing the connection to the broker. 

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -26,7 +26,7 @@ To be able to route TCP traffic through ingresses, Strimzi uses TLS passthrough 
 
 SNI helps with identifying and passing connection to Kafka brokers.
 In passthrough mode, TLS encryption is always used.
-Because the connection passes to the brokers, the listeners use the TLS certificates signed by the internal cluster CA and not the ingrress certificates.
+Because the connection passes to the brokers, the listeners use the TLS certificates signed by the internal cluster CA and not the ingress certificates.
 To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property]. 
 
 For more information about enabling TLS passthrough, see the {NginxIngressControllerTLSPassthrough}.

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -3,36 +3,48 @@
 // assembly-configuring-kafka-listeners.adoc
 
 [id='proc-accessing-kafka-using-ingress-{context}']
-= Accessing Kafka using ingress
+= Accessing Kafka using ingresses
 
-This procedure shows how to access a Strimzi Kafka cluster from an external client outside of Kubernetes using Nginx Ingress.
+[role="_abstract"]
+Use an {NginxIngressController} to access a Strimzi Kafka cluster from clients outside the Kubernetes cluster. 
+The Nginx Ingress Controller supports connections from HTTP and HTTPS-based applications.
 
-To connect to a broker, you need a hostname (advertised address) for the Ingress _bootstrap address_,
-as well as the certificate used for authentication.
+To be able to use an Nginx Ingress Controller, add configuration for an `ingress` type listener in the `Kafka` custom resource. 
+When applied, the configuration creates a dedicated ingress and service for an external bootstrap and each broker in the cluster. 
+Clients connect to the bootstrap ingress, which routes them through the bootstrap service to connect to a broker. 
+Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific ingresses and services.
 
-For access using Ingress, the port is always 443.
+To connect to a broker, you specify a hostname (advertised address) for the ingress bootstrap address, as well as the certificate used for authentication.
+
+For access using an ingress, the port is always 443.
 
 .TLS passthrough
 
-Kafka uses a binary protocol over TCP, but the {NginxIngressController} is designed to work with the HTTP protocol.
-To be able to pass the Kafka connections through the Ingress, Strimzi uses the TLS passthrough feature of the {NginxIngressController}.
-Ensure TLS passthrough is enabled in your {NginxIngressController} deployment.
+Make sure that you enable TLS passthrough in your NGINX Ingress Controller deployment.
+Kafka uses a binary protocol over TCP, but the NGINX Ingress Controller is designed to work with a HTTP protocol. 
+To be able to route traffic through ingresses, Strimzi uses TLS passthrough with Server Name Indication (SNI).
 
-Because it is using the TLS passthrough functionality, TLS encryption cannot be disabled when exposing Kafka using `Ingress`.
+SNI helps with identifying and passing connection to Kafka brokers.
+In passthrough mode, TLS encryption is always used.
+Because connection passes to the brokers, the listeners use the TLS certificates signed by the internal cluster CA.
+To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property]. 
 
-For more information about enabling TLS passthrough, see {NginxIngressControllerTLSPassthrough}.
+For more information about enabling TLS passthrough, see the {NginxIngressControllerTLSPassthrough}.
 
 .Prerequisites
 
-* Kubernetes cluster
-* Deployed {NginxIngressController} with TLS passthrough enabled
+* An NGINX Ingress Controller is running with TLS passthrough enabled
 * A running Cluster Operator
+
+In this procedure, the Kafka cluster name is `my-cluster`.
+
+NOTE: You can install and use the NGINX Ingress Operator to deploy an NGINX Ingress Controller.
 
 .Procedure
 
 . Configure a `Kafka` resource with an external listener set to the `ingress` type.
 +
-Specify the Ingress hosts for the bootstrap service and Kafka brokers.
+Specify an ingress hostname for the bootstrap service and each of the Kafka brokers in the Kafka cluster.
 +
 For example:
 +
@@ -40,6 +52,11 @@ For example:
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
 spec:
   kafka:
     # ...
@@ -50,7 +67,7 @@ spec:
         tls: true
         authentication:
           type: tls
-        configuration: <1>
+        configuration:
           bootstrap:
             host: bootstrap.myingress.com
           brokers:
@@ -60,30 +77,85 @@ spec:
             host: broker-1.myingress.com
           - broker: 2
             host: broker-2.myingress.com
+          class: nginx  
     # ...
   zookeeper:
     # ...
 ----
-<1> Ingress hosts for the bootstrap service and Kafka brokers.
++
+Add any hostname to the `bootstrap` and `broker-<index>` prefixes that identify the bootstrap and brokers.
++
+NOTE: You might need to add `nginx` as the class if it is missing in the ingresses created. 
 
 . Create or update the resource.
 +
 [source,shell,subs=+quotes]
+----
 kubectl apply -f _<kafka_configuration_file>_
+----
 +
-`ClusterIP` type services are created for each Kafka broker, as well as an additional _bootstrap service_.
-These services are used by the Ingress controller to route traffic to the Kafka brokers.
-An `Ingress` resource is also created for each service to expose them using the Ingress controller.
-The Ingress hosts are propagated to the `status` of each service.
+A cluster CA certificate to verify the identity of the kafka brokers is created in the secret `my-cluster-cluster-ca-cert`.
 +
-The cluster CA certificate to verify the identity of the kafka brokers is also created in the secret `_<cluster_name>_-cluster-ca-cert`.
+`ClusterIP` type services are created for each Kafka broker, as well as an external bootstrap service.
 +
-Use the address for the bootstrap host you specified in the `configuration` and port 443 (_BOOTSTRAP-HOST:443_) in your Kafka client as the _bootstrap address_ to connect to the Kafka cluster.
+An `ingress` is also created for each service, with a DNS address to expose them using the NGINX Ingress Controller.
++
+.Ingresses created for the bootstrap and brokers
+[source,shell]
+----
+NAME                        CLASS  HOSTS                    ADDRESS               PORTS
+my-cluster-kafka-0          nginx  broker-0.myingress.com   external.ingress.com  80,443
+my-cluster-kafka-1          nginx  broker-1.myingress.com   external.ingress.com  80,443
+my-cluster-kafka-2          nginx  broker-2.myingress.com   external.ingress.com  80,443
+my-cluster-kafka-bootstrap  nginx  bootstrap.myingress.com  external.ingress.com  80,443
+----
++
+The DNS addresses used for client connection are propagated to the `status` of each ingress.
++
+.Status for the bootstrap ingress
+[source,yaml]
+----
+status:
+  loadBalancer:
+    ingress:
+      - hostname: external.ingress.com
+ # ...
+----
 
-. Extract the public certificate of the broker certificate authority.
+. Use a target broker to check the client-server TLS connection on port 443 using the OpenSSL `s_client`.  
++
+[source,shell]
+----
+openssl s_client -connect my-cluster-kafka-0:443 -servername my-cluster-kafka-0 -showcerts
+----
++
+The server name is the SNI for passing the connection to the broker. 
++
+If the connection is successful, the certificates for the broker are returned.
++
+.Certificates for the broker
+[source,shell,subs=attributes+]
+----
+Certificate chain
+ 0 s:O = io.strimzi, CN = my-cluster-kafka
+   i:O = io.strimzi, CN = cluster-ca v0
+----
+
+. Extract the cluster CA certificate.
 +
 [source,shell,subs=+quotes]
-kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+
+
+. Configure your client to connect to the brokers.
+
+.. Specify the bootstrap host (from the listener `configuration`) and port 443 in your Kafka client as the bootstrap address to connect to the Kafka cluster. For example, `bootstrap.myingress.com:443`.
+
+.. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
 +
-Use the extracted certificate in your Kafka client to configure the TLS connection.
 If you enabled any authentication, you will also need to configure it in your client.
+
+NOTE: If you are using your own listener certificates, check whether you need to add the CA certificate to the client's truststore configuration. 
+If it is a public (external) CA, you usually won't need to add it.
+
+

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -5,17 +5,38 @@
 [id='proc-accessing-kafka-using-routes-{context}']
 = Accessing Kafka using OpenShift routes
 
-This procedure describes how to access a Strimzi Kafka cluster from an external client outside of OpenShift using routes.
+[role="_abstract"]
+Use OpenShift routes to access a Strimzi Kafka cluster from clients outside the OpenShift cluster.
+Routes support connections from from HTTP and HTTPS-based applications.
 
-To connect to a broker, you need a hostname for the route _bootstrap address_,
-as well as the certificate used for TLS encryption.
+To be able to use routes, add configuration for a `route` type listener in the `Kafka` custom resource. 
+When applied, the configuration creates a dedicated route and service for an external bootstrap and each broker in the cluster. 
+Clients connect to the bootstrap route, which routes them through the bootstrap service to connect to a broker. 
+Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific routes and services.
+
+To connect to a broker, you specify a hostname for the route bootstrap address, as well as the certificate used for authentication.
 
 For access using routes, the port is always 443.
 
+WARNING: An OpenShift route address comprises the name of the Kafka cluster, the name of the listener, and the name of the project it is created in.
+For example, `my-cluster-kafka-listener1-bootstrap-myproject` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
+
+.TLS passthrough
+
+TLS passthrough is enabled for routes created by AMQ Streams.
+Kafka uses a binary protocol over TCP, but routes are designed to work with a HTTP protocol. 
+To be able to route traffic through routes, Strimzi uses TLS passthrough with Server Name Indication (SNI).
+
+SNI helps with identifying and passing connection to Kafka brokers.
+In passthrough mode, TLS encryption is always used.
+Because connection passes to the brokers, the listeners use TLS certificates signed by the internal cluster CA.
+To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property].
+
 .Prerequisites
 
-* An OpenShift cluster
 * A running Cluster Operator
+
+In this procedure, the Kafka cluster name is `my-cluster`.
 
 .Procedure
 
@@ -45,36 +66,90 @@ spec:
   zookeeper:
     # ...
 ----
-+
-WARNING: An OpenShift Route address comprises the name of the Kafka cluster, the name of the listener, and the name of the namespace it is created in.
-For example, `my-cluster-kafka-listener1-bootstrap-myproject` (_CLUSTER-NAME_-kafka-_LISTENER-NAME_-bootstrap-_NAMESPACE_). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
 
 . Create or update the resource.
 +
 [source,shell,subs=+quotes]
+----
 kubectl apply -f _<kafka_configuration_file>_
+----
 +
-`ClusterIP` type services are created for each Kafka broker, as well as an external _bootstrap service_.
-The services route the traffic from the OpenShift Routes to the Kafka brokers.
-An OpenShift `Route` resource is also created for each service to expose them using the HAProxy load balancer.
-DNS addresses used for connection are propagated to the `status` of each service.
+A cluster CA certificate to verify the identity of the kafka brokers is created in the secret `my-cluster-cluster-ca-cert`.
 +
-The cluster CA certificate to verify the identity of the kafka brokers is also created in the secret `_<cluster_name>_-cluster-ca-cert`.
+`ClusterIP` type services are created for each Kafka broker, as well as an external bootstrap service.
++
+A `route` is also created for each service, with a DNS address (host/port) to expose them using the default OpenShift HAProxy router.
++
+The routes are preconfigured with TLS passthrough. 
++
+.Routes created for the bootstraps and brokers
+[source,shell]
+----
+NAME                                  HOST/PORT                                                   SERVICES                              PORT  TERMINATION
+my-cluster-kafka-listener1-0          my-cluster-kafka-listener1-0-my-project.router.com          my-cluster-kafka-listener1-0          9094  passthrough
+my-cluster-kafka-listener1-1          my-cluster-kafka-listener1-1-my-project.router.com          my-cluster-kafka-listener1-1          9094  passthrough
+my-cluster-kafka-listener1-2          my-cluster-kafka-listener1-2-my-project.router.com          my-cluster-kafka-listener1-2          9094  passthrough
+my-cluster-kafka-listener1-bootstrap  my-cluster-kafka-listener1-bootstrap-my-project.router.com  my-cluster-kafka-listener1-bootstrap  9094  passthrough
+----
++
+The DNS addresses used for client connection are propagated to the `status` of each route.
++
+.Example status for the bootstrap route
+[source,yaml]
+----
+status:
+  ingress:
+    - host: >-
+        my-cluster-kafka-listener1-bootstrap-my-project.router.com
+ # ...
+----
 
-. Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
+. Use a target broker to check the client-server TLS connection on port 443 using the OpenSSL `s_client`.  
++
+[source,shell]
+----
+openssl s_client -connect my-cluster-kafka-0:443 -servername my-cluster-kafka-0 -showcerts
+----
++
+The server name is the SNI for passing the connection to the broker. 
++
+If the connection is successful, the certificates for the broker are returned.
++
+.Certificates for the broker
+[source,shell,subs=attributes+]
+----
+Certificate chain
+ 0 s:O = io.strimzi, CN = my-cluster-kafka
+   i:O = io.strimzi, CN = cluster-ca v0
+----
+
+. Retrieve the address of the bootstrap service from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
-+
-For example:
-+
-[source,shell,subs=+quotes]
+----
 kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="listener1")].bootstrapServers}{"\n"}'
 
-. Extract the public certificate of the broker certification authority.
+my-cluster-kafka-listener1-bootstrap-my-project.router.com:443
+----
 +
-[source,shell,subs=+quotes]
-kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+The address comprises the cluster name, the listener name, the project name and the domain of the router (`router.com` in this example).
+
+. Extract the cluster CA certificate.
 +
-Use the extracted certificate in your Kafka client to configure TLS connection.
+[source,shell]
+----
+kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+
+. Configure your client to connect to the brokers.
+
+.. Specify the address for the bootstrap service and port 443 in your Kafka client as the bootstrap address to connect to the Kafka cluster.
+
+.. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
++
 If you enabled any authentication, you will also need to configure it in your client.
+
+NOTE: If you are using your own listener certificates, check whether you need to add the CA certificate to the client's truststore configuration. 
+If it is a public (external) CA, you usually won't need to add it.
+
+

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -28,7 +28,7 @@ To be able to route TCP traffic through routes, Strimzi uses TLS passthrough wit
 
 SNI helps with identifying and passing connection to Kafka brokers.
 In passthrough mode, TLS encryption is always used.
-Because the connection passes to the brokers, the listeners use TLS certificates signed by the internal cluster CA and not the ingrress certificates.
+Because the connection passes to the brokers, the listeners use TLS certificates signed by the internal cluster CA and not the ingress certificates.
 To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property].
 
 .Prerequisites

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -7,7 +7,6 @@
 
 [role="_abstract"]
 Use OpenShift routes to access a Strimzi Kafka cluster from clients outside the OpenShift cluster.
-Routes support connections from from HTTP and HTTPS-based applications.
 
 To be able to use routes, add configuration for a `route` type listener in the `Kafka` custom resource. 
 When applied, the configuration creates a dedicated route and service for an external bootstrap and each broker in the cluster. 
@@ -23,13 +22,13 @@ For example, `my-cluster-kafka-listener1-bootstrap-myproject` (<cluster_name>-ka
 
 .TLS passthrough
 
-TLS passthrough is enabled for routes created by AMQ Streams.
+TLS passthrough is enabled for routes created by Strimzi.
 Kafka uses a binary protocol over TCP, but routes are designed to work with a HTTP protocol. 
-To be able to route traffic through routes, Strimzi uses TLS passthrough with Server Name Indication (SNI).
+To be able to route TCP traffic through routes, Strimzi uses TLS passthrough with Server Name Indication (SNI).
 
 SNI helps with identifying and passing connection to Kafka brokers.
 In passthrough mode, TLS encryption is always used.
-Because connection passes to the brokers, the listeners use TLS certificates signed by the internal cluster CA.
+Because the connection passes to the brokers, the listeners use TLS certificates signed by the internal cluster CA and not the ingrress certificates.
 To configure listeners to use your own listener certificates, xref:proc-installing-certs-per-listener-{context}[use the `brokerCertChainAndKey` property].
 
 .Prerequisites
@@ -108,7 +107,7 @@ status:
 +
 [source,shell]
 ----
-openssl s_client -connect my-cluster-kafka-0:443 -servername my-cluster-kafka-0 -showcerts
+openssl s_client -connect my-cluster-kafka-listener1-0-my-project.router.com:443 -servername my-cluster-kafka-listener1-0-my-project.router.com -showcerts
 ----
 +
 The server name is the SNI for passing the connection to the broker. 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -84,7 +84,7 @@
 :K8sDockerSecret: link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^]
 :MavenCentral: https://mvnrepository.com/repos/central[Maven Central repository^]
 :Minikube: link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Install and start Minikube]
-:NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[NGINX Ingress Controller^]
+:NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[Ingress NGINX Controller for Kubernetes^]
 :NginxIngressControllerTLSPassthrough: link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough[TLS passthrough documentation]
 :KubernetesExternalDNS: link:https://github.com/kubernetes-incubator/external-dns[External DNS^]
 :ApacheKafkaBrokerConfig: link:https://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation^]

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -84,7 +84,7 @@
 :K8sDockerSecret: link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials[Create a Secret based on existing Docker credentials^]
 :MavenCentral: https://mvnrepository.com/repos/central[Maven Central repository^]
 :Minikube: link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Install and start Minikube]
-:NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[NGINX Ingress Controller for Kubernetes^]
+:NginxIngressController: link:https://github.com/kubernetes/ingress-nginx[NGINX Ingress Controller^]
 :NginxIngressControllerTLSPassthrough: link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough[TLS passthrough documentation]
 :KubernetesExternalDNS: link:https://github.com/kubernetes-incubator/external-dns[External DNS^]
 :ApacheKafkaBrokerConfig: link:https://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation^]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates the following procedures for Accessing Kafka outside of the Kubernetes cluster:

- [Accessing Kafka using ingress](https://strimzi.io/docs/operators/in-development/configuring.html#proc-accessing-kafka-using-ingress-str)
- [Accessing Kafka using OpenShift routes](https://strimzi.io/docs/operators/in-development/configuring.html#proc-accessing-kafka-using-routes-str)

- Describes why TLS passthrough and SNI is used
- Explains what this means for certificates
- Updates steps with more detail and verification

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

