### PR TITLE
Update docs and CHANGELOG with new StrimziPodSet graduation schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Changes, deprecations and removals
 
-* The `UseStrimziPodSet` feature gate will ove to GA in Strimzi 0.35.
+* The `UseStrimziPodSet` feature gate will move to GA in Strimzi 0.35.
   Support for StatefulSets will be removed from Strimzi right after the 0.34 release.
   Please use the Strimzi 0.33 release to test StrimziPodSets in your environment and report any major or blocking issues before the StatefulSet support is removed.
 * The default length of any new SCRAM-SHA-512 passwords will be 32 characters instead of 12 characters used in the previous Strimzi versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Changes, deprecations and removals
 
+* The `UseStrimziPodSet` feature gate will ove to GA in Strimzi 0.35.
+  Support for StatefulSets will be removed from Strimzi right after the 0.34 release.
+  Please use the Strimzi 0.33 release to test StrimziPodSets in your environment and report any major or blocking issues before the StatefulSet support is removed.
 * The default length of any new SCRAM-SHA-512 passwords will be 32 characters instead of 12 characters used in the previous Strimzi versions.
   Existing passwords will not be affected by this change until they are regenerated (for example because the user secret is deleted).
   If you want to keep using the original password length, you can set it using the `STRIMZI_SCRAM_SHA_PASSWORD_LENGTH` environment variable in `.spec.entityOperator.template.userOperatorContainer.env` in the `Kafka` custom resource or in the `Deployment` of the standalone User Operator.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -19,7 +19,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 
 * The `ControlPlaneListener` feature gate moved to GA stage in Strimzi 0.32. It is now permanently enabled and cannot be disabled.
 * The `ServiceAccountPatching` feature gate moved to GA stage in Strimzi 0.30. It is now permanently enabled and cannot be disabled.
-* The `UseStrimziPodSets` feature gate moved to beta stage in Strimzi 0.30 and is expected to remain in the beta stage until Strimzi 0.33.
+* The `UseStrimziPodSets` feature gate moved to beta stage in Strimzi 0.30.
+  It will move to GA in Strimzi 0.35 when the support for StatefulSets will be completely removed.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
@@ -46,7 +47,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`UseStrimziPodSets`
 ¦0.28
 ¦0.30
-¦ -
+¦0.35 (plan)
 
 ¦`UseKRaft`
 ¦0.29

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -20,7 +20,7 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `ControlPlaneListener` feature gate moved to GA stage in Strimzi 0.32. It is now permanently enabled and cannot be disabled.
 * The `ServiceAccountPatching` feature gate moved to GA stage in Strimzi 0.30. It is now permanently enabled and cannot be disabled.
 * The `UseStrimziPodSets` feature gate moved to beta stage in Strimzi 0.30.
-  It will move to GA in Strimzi 0.35 when the support for StatefulSets will be completely removed.
+  It moves to GA in Strimzi 0.35 when the support for StatefulSets is completely removed.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
@@ -47,7 +47,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`UseStrimziPodSets`
 ¦0.28
 ¦0.30
-¦0.35 (plan)
+¦0.35 (planned)
 
 ¦`UseKRaft`
 ¦0.29


### PR DESCRIPTION
### Type of change

- Documentation

### Description

[SP-44](https://github.com/strimzi/proposals/blob/main/044-StrimziPodSets-graduation.md) approved a new schedule for the graduation of the `UseStrimziPodSets` feature gate. This PR updates the docs and the CHANGELOG.md with it. In the CHANGELOG, it also encourages the testing in Strimzi 0.33.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md