### PR TITLE
docs(metrics): Use the same name as used in ConfigMap for name/key in configMapKeyRef

### DIFF
--- a/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
+++ b/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
@@ -70,8 +70,8 @@ spec:
       type: jmxPrometheusExporter
       valueFrom:
         configMapKeyRef:
-          name: my-config-map
-          key: my-key
+          name: kafka-metrics
+          key: kafka-metrics-config.yml
 ---
 kind: ConfigMap <2>
 apiVersion: v1


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The sample yaml in metrics doc uses different name/key for ConfigMap and Kafka configuration.
It's better to use the same name/key.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

