### PR TITLE
Sample Prometheus configuration change

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -28,18 +28,6 @@ NOTE: By default, the Prometheus Operator only supports jobs that include an `en
 
 .Procedure
 
-. Modify the Prometheus installation file (`prometheus.yaml`) according to the namespace Prometheus is going to be installed into:
-+
-On Linux, use:
-+
-[source,shell,subs="+quotes,attributes"]
-sed -i 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
-+
-On MacOS, use:
-+
-[source,shell,subs="+quotes,attributes"]
-sed -i '' 's/namespace: .*/namespace: _my-namespace_/' prometheus.yaml
-
 . Edit the `PodMonitor` resource in `strimzi-pod-monitor.yaml` to define Prometheus jobs that will scrape the metrics data from pods.
 +
 Update the `namespaceSelector.matchNames` property with the namespace where the pods to scrape the metrics from are running.

--- a/examples/metrics/prometheus-install/prometheus.yaml
+++ b/examples/metrics/prometheus-install/prometheus.yaml
@@ -43,7 +43,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: prometheus-server
-    namespace: myproject
 
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/examples/metrics/prometheus-install/prometheus.yaml
+++ b/examples/metrics/prometheus-install/prometheus.yaml
@@ -43,6 +43,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: prometheus-server
+    namespace: default
 
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -68,7 +69,7 @@ spec:
       app: strimzi
   alerting:
     alertmanagers:
-    - namespace: myproject
+    - namespace: default
       name: alertmanager
       port: alertmanager
   additionalScrapeConfigs:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the sample Prometheus configuration, ServiceAcount `prometheus-server` is created without namespace specified, but it's used with namespace `myproject`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

