### PR TITLE
Updated canary Deployment to latest 0.6.0 release

### DIFF
--- a/.checksums
+++ b/.checksums
@@ -14,7 +14,7 @@ HELM_CHART_CHECKSUM="fba5991eedd41bf0d668d483a60bbc8c03deda43  -"
 # if this checksum has changed as part of any non-release specific changes, please apply your changes to the
 #   development version of the helm charts in ./packaging/install
 ### IMPORTANT ###
-INSTALL_CHECKSUM="3bd3591dcae31c95f429529a8f60a740dc1c0247  -"
+INSTALL_CHECKSUM="8b6fd60b87ba97f28c1edf4fca50bca4349cc201  -"
 
 ### IMPORTANT ###
 # if the below line has changed, this means the ./examples directory has changed

--- a/install/canary/020-Deployment.yaml
+++ b/install/canary/020-Deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-canary
       containers:
       - name: strimzi-canary
-        image: quay.io/strimzi/canary:0.5.0
+        image: quay.io/strimzi/canary:0.6.0
         env:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092

--- a/packaging/install/canary/020-Deployment.yaml
+++ b/packaging/install/canary/020-Deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-canary
       containers:
       - name: strimzi-canary
-        image: quay.io/strimzi/canary:0.5.0
+        image: quay.io/strimzi/canary:0.6.0
         env:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: my-cluster-kafka-bootstrap:9092


### PR DESCRIPTION
Trivial PR just for updating the canary Deployment to use the latest 0.6.0 release.