### PR TITLE
docs(tls): Clarifies config for mTLS

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -268,7 +268,7 @@ The TLS property is required.
 By default, TLS encryption is not enabled.
 To enable it, set the `tls` property to `true`.
 
-TLS encryption is always used with `route` listeners.
+For `route` and `ingress` type listeners, TLS encryption must be enabled.
 
 === `authentication`
 

--- a/documentation/assemblies/security/assembly-securing-kafka-clients.adoc
+++ b/documentation/assemblies/security/assembly-securing-kafka-clients.adoc
@@ -20,7 +20,7 @@ The authentication and authorization mechanisms must match the xref:proc-securin
 For more information on configuring a `KafkaUser` resource to access Kafka brokers securely, see the following sections:
 
 * xref:proc-configuring-kafka-user-str[Securing user access to Kafka]
-* link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^]
+* link:{BookURLDeploying}#setup-external-clients-str[Setting up client access to a Kafka cluster using listeners^]
 
 include::../../modules/security/con-securing-client-labels.adoc[leveloffset=+1]
 include::../../modules/security/con-securing-client-authentication.adoc[leveloffset=+1]

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -103,7 +103,7 @@ spec:
 <2> Name to identify the listener. Must be unique within the Kafka cluster.
 <3> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <4> External listener type specified as `route`, `loadbalancer`, `nodeport` or `ingress`. An internal listener is specified as `internal` or `cluster-ip`.
-<5> TLS encryption on the listener. Default is `false`. For mTLS authentication, the configuration also enables server authentication. TLS encryption is not required for `route` listeners.  
+<5> Required. TLS encryption on the listener. For `route` and `ingress` type listeners it must be set to `true`. For mTLS authentication, also use the `authentication` property. 
 <6> Client authentication mechanism on the listener. For server and client authentication using mTLS, you specify `tls: true` and `authentication.type: tls`. 
 <7> (Optional) Depending on the requirements of the listener type, you can specify additional link:{BookURLUsing}#type-GenericKafkaListenerConfiguration-reference[listener configuration^].
 <8> Authorization specified as `simple`, which uses the `AclAuthorizer` Kafka plugin.

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -103,8 +103,8 @@ spec:
 <2> Name to identify the listener. Must be unique within the Kafka cluster.
 <3> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <4> External listener type specified as `route`, `loadbalancer`, `nodeport` or `ingress`. An internal listener is specified as `internal` or `cluster-ip`.
-<5> Enables TLS encryption on the listener. Default is `false`. TLS encryption is not required for `route` listeners.
-<6> Authentication specified as mutual `tls`.
+<5> TLS encryption on the listener. Default is `false`. For mTLS authentication, the configuration also enables server authentication. TLS encryption is not required for `route` listeners.  
+<6> Client authentication mechanism on the listener. For server and client authentication using mTLS, you specify `tls: true` and `authentication.type: tls`. 
 <7> (Optional) Depending on the requirements of the listener type, you can specify additional link:{BookURLUsing}#type-GenericKafkaListenerConfiguration-reference[listener configuration^].
 <8> Authorization specified as `simple`, which uses the `AclAuthorizer` Kafka plugin.
 <9> (Optional) Super users can access all brokers regardless of any access restrictions defined in ACLs.

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -63,7 +63,7 @@ spec:
       - name: external
         port: 9094
         type: ingress
-        tls: true
+        tls: true # <1>
         authentication:
           type: tls
         configuration:
@@ -76,12 +76,13 @@ spec:
             host: broker-1.myingress.com
           - broker: 2
             host: broker-2.myingress.com
-          class: nginx  # <1>
+          class: nginx  # <2>
     # ...
   zookeeper:
     # ...
 ----
-<1> (Optional) Class that specifies the ingress controller to use. You might need to add a class if you have not set up a default and a class name is missing in the ingresses created. 
+<1> For `ingress` type listeners, TLS encryption must be enabled (`true`).
+<2> (Optional) Class that specifies the ingress controller to use. You might need to add a class if you have not set up a default and a class name is missing in the ingresses created. 
 
 . Create or update the resource.
 +

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -59,12 +59,13 @@ spec:
       - name: listener1
         port: 9094
         type: route
-        tls: true
+        tls: true # <1>
         # ...
     # ...
   zookeeper:
     # ...
 ----
+<1> For `route` type listeners, TLS encryption must be enabled (`true`).
 
 . Create or update the resource.
 +

--- a/documentation/modules/security/proc-configuring-secure-kafka-user.adoc
+++ b/documentation/modules/security/proc-configuring-secure-kafka-user.adoc
@@ -73,4 +73,4 @@ kubectl apply -f _<user_config_file>_
 The user is created, as well as a Secret with the same name as the `KafkaUser` resource.
 The Secret contains a private and public key for mTLS authentication.
 
-For information on configuring a Kafka client with properties for secure connection to Kafka brokers, see link:{BookURLDeploying}#setup-external-clients-str[Setting up access for clients outside of Kubernetes^].
+For information on configuring a Kafka client with properties for secure connection to Kafka brokers, see link:{BookURLDeploying}#setup-external-clients-str[Setting up client access to a Kafka cluster using listeners^].


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Change to [Setting up client access to a Kafka cluster using listeners](https://strimzi.io/docs/operators/in-development/deploying.html#setup-external-clients-str) to describe the config for mTLS. And why there are two `tls` configs, which can be confusing. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

