### PR TITLE
Added field to configure metadata of EO Role/Rolebinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Kafka Exporter support for `Recreate` deployment strategy
 * `ImageStream` validation for Kafka Connect builds on OpenShift
+* Support for configuring the metadata for the Role/Rolebinding of Entity Operator
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Kafka Exporter support for `Recreate` deployment strategy
 * `ImageStream` validation for Kafka Connect builds on OpenShift
-* Support for configuring the metadata for the Role/Rolebinding of Entity Operator
+* Support for configuring the metadata for the Role/ Rolebinding of Entity Operator
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Kafka Exporter support for `Recreate` deployment strategy
 * `ImageStream` validation for Kafka Connect builds on OpenShift
-* Support for configuring the metadata for the Role/ Rolebinding of Entity Operator
+* Support for configuring the metadata for the Role / RoleBinding of Entity Operator
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "entityOperatorRole", "entityOperatorRoleBinding", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount"})
+@JsonPropertyOrder({"deployment", "pod", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount", "entityOperatorRole", "entityOperatorRoleBinding"})
 @EqualsAndHashCode
 public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -68,7 +68,7 @@ public class EntityOperatorTemplate implements Serializable, UnknownPropertyPres
         this.entityOperatorRole = entityOperatorRole;
     }
 
-    @Description("Template for the Entity operator RoleBinding")
+    @Description("Template for the Entity Operator RoleBinding")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ResourceTemplate getEntityOperatorRoleBinding() {
         return entityOperatorRoleBinding;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -24,13 +24,14 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount"})
+@JsonPropertyOrder({"deployment", "pod", "entityOperatorRoleBinding", "entityOperatorRole", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount"})
 @EqualsAndHashCode
 public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
-
     private ResourceTemplate deployment;
     private PodTemplate pod;
+    private ResourceTemplate entityOperatorRole;
+    private ResourceTemplate entityOperatorRoleBinding;
     private ContainerTemplate topicOperatorContainer;
     private ContainerTemplate userOperatorContainer;
     private ContainerTemplate tlsSidecarContainer;
@@ -55,6 +56,26 @@ public class EntityOperatorTemplate implements Serializable, UnknownPropertyPres
 
     public void setPod(PodTemplate pod) {
         this.pod = pod;
+    }
+
+    @Description("Template for the Entity Operator Role")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getEntityOperatorRole() {
+        return entityOperatorRole;
+    }
+
+    public void setEntityOperatorRole(ResourceTemplate entityOperatorRole) {
+        this.entityOperatorRole = entityOperatorRole;
+    }
+
+    @Description("Template for the Entity operator RoleBinding")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getEntityOperatorRoleBinding() {
+        return entityOperatorRoleBinding;
+    }
+
+    public void setEntityOperatorRoleBinding(ResourceTemplate entityOperatorRoleBinding) {
+        this.entityOperatorRoleBinding = entityOperatorRoleBinding;
     }
 
     @Description("Template for the Entity Topic Operator container")

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "entityOperatorRoleBinding", "entityOperatorRole", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount"})
+@JsonPropertyOrder({"deployment", "pod", "entityOperatorRole", "entityOperatorRoleBinding", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount"})
 @EqualsAndHashCode
 public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -310,6 +310,13 @@ public abstract class AbstractModel {
     protected Boolean templatePodEnableServiceLinks;
     protected Map<String, String> templateClusterRoleBindingLabels;
     protected Map<String, String> templateClusterRoleBindingAnnotations;
+
+
+    protected Map<String, String> templateEntityOperatorRoleBindingLabels;
+    protected Map<String, String> templateEntityOperatorRoleBindingAnnotations;
+    protected Map<String, String> templateEntityOperatorRoleLabels;
+    protected Map<String, String> templateEntityOperatorRoleAnnotations;
+
     protected Map<String, String> templateServiceAccountLabels;
     protected Map<String, String> templateServiceAccountAnnotations;
     protected Map<String, String> templateJmxSecretLabels;
@@ -1669,7 +1676,8 @@ public abstract class AbstractModel {
                     .withName(getRoleName())
                     .withNamespace(namespace)
                     .withOwnerReferences(createOwnerReference())
-                    .addToLabels(labels.toMap())
+                    .addToLabels(labels.withAdditionalLabels(templateEntityOperatorRoleLabels).toMap())
+                    .addToAnnotations(templateEntityOperatorRoleAnnotations)
                 .endMetadata()
                 .withRules(rules)
                 .build();
@@ -1689,7 +1697,8 @@ public abstract class AbstractModel {
                     .withName(name)
                     .withNamespace(namespace)
                     .withOwnerReferences(createOwnerReference())
-                    .withLabels(labels.toMap())
+                    .withLabels(labels.withAdditionalLabels(templateEntityOperatorRoleBindingLabels).toMap())
+                    .withAnnotations(templateEntityOperatorRoleBindingAnnotations)
                 .endMetadata()
                 .withRoleRef(roleRef)
                 .withSubjects(subjects)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -310,13 +310,10 @@ public abstract class AbstractModel {
     protected Boolean templatePodEnableServiceLinks;
     protected Map<String, String> templateClusterRoleBindingLabels;
     protected Map<String, String> templateClusterRoleBindingAnnotations;
-
-
     protected Map<String, String> templateEntityOperatorRoleBindingLabels;
     protected Map<String, String> templateEntityOperatorRoleBindingAnnotations;
     protected Map<String, String> templateEntityOperatorRoleLabels;
     protected Map<String, String> templateEntityOperatorRoleAnnotations;
-
     protected Map<String, String> templateServiceAccountLabels;
     protected Map<String, String> templateServiceAccountAnnotations;
     protected Map<String, String> templateJmxSecretLabels;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -148,6 +148,16 @@ public class EntityOperator extends AbstractModel {
 
                 ModelUtils.parsePodTemplate(result, template.getPod());
 
+                if (template.getEntityOperatorRole() != null && template.getEntityOperatorRole().getMetadata() != null) {
+                    result.templateEntityOperatorRoleLabels = template.getEntityOperatorRole().getMetadata().getLabels();
+                    result.templateEntityOperatorRoleAnnotations = template.getEntityOperatorRole().getMetadata().getAnnotations();
+                }
+
+                if (template.getEntityOperatorRoleBinding() != null && template.getEntityOperatorRoleBinding().getMetadata() != null) {
+                    result.templateEntityOperatorRoleBindingAnnotations = template.getEntityOperatorRoleBinding().getMetadata().getLabels();
+                    result.templateEntityOperatorRoleBindingAnnotations = template.getEntityOperatorRoleBinding().getMetadata().getAnnotations();
+                }
+
                 if (template.getTopicOperatorContainer() != null && template.getTopicOperatorContainer().getEnv() != null) {
                     topicOperator.templateContainerEnvVars = template.getTopicOperatorContainer().getEnv();
                 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -154,7 +154,7 @@ public class EntityOperator extends AbstractModel {
                 }
 
                 if (template.getEntityOperatorRoleBinding() != null && template.getEntityOperatorRoleBinding().getMetadata() != null) {
-                    result.templateEntityOperatorRoleBindingAnnotations = template.getEntityOperatorRoleBinding().getMetadata().getLabels();
+                    result.templateEntityOperatorRoleBindingLabels = template.getEntityOperatorRoleBinding().getMetadata().getLabels();
                     result.templateEntityOperatorRoleBindingAnnotations = template.getEntityOperatorRoleBinding().getMetadata().getAnnotations();
                 }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -233,6 +233,9 @@ public class EntityOperatorTest {
         Map<String, String> saLabels = TestUtils.map("l5", "v5", "l6", "v6");
         Map<String, String> saAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
 
+        Map<String, String> rbLabels = TestUtils.map("l9", "v9", "l10", "v10");
+        Map<String, String> rbAnots = TestUtils.map("a9", "v9", "a10", "v10");
+
         Toleration toleration = new TolerationBuilder()
                 .withEffect("NoSchedule")
                 .withValue("")
@@ -281,6 +284,12 @@ public class EntityOperatorTest {
                                         .withTopologySpreadConstraints(tsc1, tsc2)
                                         .withEnableServiceLinks(false)
                                     .endPod()
+                                    .withNewEntityOperatorRole()
+                                        .withNewMetadata()
+                                            .withLabels(rbLabels)
+                                            .withAnnotations(rbAnots)
+                                        .endMetadata()
+                                    .endEntityOperatorRole()
                                     .withNewServiceAccount()
                                         .withNewMetadata()
                                             .withLabels(saLabels)
@@ -306,6 +315,11 @@ public class EntityOperatorTest {
         assertThat(dep.getSpec().getTemplate().getSpec().getTopologySpreadConstraints(), containsInAnyOrder(tsc1, tsc2));
         assertThat(dep.getSpec().getTemplate().getSpec().getEnableServiceLinks(), is(false));
         assertThat(dep.getSpec().getTemplate().getSpec().getTolerations(), is(singletonList(assertToleration)));
+
+        // Generate Role metadata
+        Role crb = entityOperator.generateRole(null, namespace);
+        assertThat(crb.getMetadata().getLabels().entrySet().containsAll(rbLabels.entrySet()), is(true));
+        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(rbAnots.entrySet()), is(true));
 
         // Check Service Account
         ServiceAccount sa = entityOperator.generateServiceAccount();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -236,6 +236,9 @@ public class EntityOperatorTest {
         Map<String, String> saLabels = TestUtils.map("l5", "v5", "l6", "v6");
         Map<String, String> saAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
 
+        Map<String, String> rLabels = TestUtils.map("l7", "v7", "l8", "v8");
+        Map<String, String> rAnots = TestUtils.map("a7", "v7", "a8", "v8");
+
         Map<String, String> rbLabels = TestUtils.map("l9", "v9", "l10", "v10");
         Map<String, String> rbAnots = TestUtils.map("a9", "v9", "a10", "v10");
 
@@ -289,8 +292,8 @@ public class EntityOperatorTest {
                                     .endPod()
                                     .withNewEntityOperatorRole()
                                         .withNewMetadata()
-                                            .withLabels(rbLabels)
-                                            .withAnnotations(rbAnots)
+                                            .withLabels(rLabels)
+                                            .withAnnotations(rAnots)
                                         .endMetadata()
                                     .endEntityOperatorRole()
                                     .withNewEntityOperatorRoleBinding()
@@ -327,8 +330,8 @@ public class EntityOperatorTest {
 
         // Generate Role metadata
         Role crb = entityOperator.generateRole(null, namespace);
-        assertThat(crb.getMetadata().getLabels().entrySet().containsAll(rbLabels.entrySet()), is(true));
-        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(rbAnots.entrySet()), is(true));
+        assertThat(crb.getMetadata().getLabels().entrySet().containsAll(rLabels.entrySet()), is(true));
+        assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(rAnots.entrySet()), is(true));
 
         // Generate RoleBinding metadata
         RoleBinding binding = entityOperator.generateRoleBinding(namespace, namespace, new RoleRef(), new ArrayList<>());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -23,6 +23,8 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
@@ -71,6 +73,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasProperty;
 
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 @ParallelSuite
 public class EntityOperatorTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
@@ -290,6 +293,12 @@ public class EntityOperatorTest {
                                             .withAnnotations(rbAnots)
                                         .endMetadata()
                                     .endEntityOperatorRole()
+                                    .withNewEntityOperatorRoleBinding()
+                                        .withNewMetadata()
+                                            .withLabels(rbLabels)
+                                            .withAnnotations(rbAnots)
+                                        .endMetadata()
+                                    .endEntityOperatorRoleBinding()
                                     .withNewServiceAccount()
                                         .withNewMetadata()
                                             .withLabels(saLabels)
@@ -320,6 +329,11 @@ public class EntityOperatorTest {
         Role crb = entityOperator.generateRole(null, namespace);
         assertThat(crb.getMetadata().getLabels().entrySet().containsAll(rbLabels.entrySet()), is(true));
         assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(rbAnots.entrySet()), is(true));
+
+        // Generate RoleBinding metadata
+        RoleBinding binding = entityOperator.generateRoleBinding(namespace, namespace, new RoleRef(), new ArrayList<>());
+        assertThat(binding.getMetadata().getLabels().entrySet().containsAll(rbLabels.entrySet()), is(true));
+        assertThat(binding.getMetadata().getAnnotations().entrySet().containsAll(rbAnots.entrySet()), is(true));
 
         // Check Service Account
         ServiceAccount sa = entityOperator.generateServiceAccount();

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1271,18 +1271,22 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 
 [options="header"]
 |====
-|Property                       |Description
-|deployment              1.2+<.<a|Template for Entity Operator `Deployment`.
+|Property                          |Description
+|deployment                 1.2+<.<a|Template for Entity Operator `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod                     1.2+<.<a|Template for Entity Operator `Pods`.
+|pod                        1.2+<.<a|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|topicOperatorContainer  1.2+<.<a|Template for the Entity Topic Operator container.
+|entityOperatorRoleBinding  1.2+<.<a|Template for the Entity operator RoleBinding.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|entityOperatorRole         1.2+<.<a|Template for the Entity Operator Role.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|topicOperatorContainer     1.2+<.<a|Template for the Entity Topic Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|userOperatorContainer   1.2+<.<a|Template for the Entity User Operator container.
+|userOperatorContainer      1.2+<.<a|Template for the Entity User Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|tlsSidecarContainer     1.2+<.<a|Template for the Entity Operator TLS sidecar container.
+|tlsSidecarContainer        1.2+<.<a|Template for the Entity Operator TLS sidecar container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|serviceAccount          1.2+<.<a|Template for the Entity Operator service account.
+|serviceAccount             1.2+<.<a|Template for the Entity Operator service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1276,10 +1276,6 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |pod                        1.2+<.<a|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|entityOperatorRole         1.2+<.<a|Template for the Entity Operator Role.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|entityOperatorRoleBinding  1.2+<.<a|Template for the Entity operator RoleBinding.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |topicOperatorContainer     1.2+<.<a|Template for the Entity Topic Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |userOperatorContainer      1.2+<.<a|Template for the Entity User Operator container.
@@ -1287,6 +1283,10 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |tlsSidecarContainer        1.2+<.<a|Template for the Entity Operator TLS sidecar container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |serviceAccount             1.2+<.<a|Template for the Entity Operator service account.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|entityOperatorRole         1.2+<.<a|Template for the Entity Operator Role.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|entityOperatorRoleBinding  1.2+<.<a|Template for the Entity Operator RoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1276,9 +1276,9 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |pod                        1.2+<.<a|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|entityOperatorRoleBinding  1.2+<.<a|Template for the Entity operator RoleBinding.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |entityOperatorRole         1.2+<.<a|Template for the Entity Operator Role.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|entityOperatorRoleBinding  1.2+<.<a|Template for the Entity operator RoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |topicOperatorContainer     1.2+<.<a|Template for the Entity Topic Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -3505,6 +3505,38 @@ spec:
                                     type: string
                               description: The pod's topology spread constraints.
                           description: Template for Entity Operator `Pods`.
+                        entityOperatorRole:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              description: Metadata applied to the resource.
+                          description: Template for the Entity Operator Role.
+                        entityOperatorRoleBinding:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              description: Metadata applied to the resource.
+                          description: Template for the Entity operator RoleBinding.
                         topicOperatorContainer:
                           type: object
                           properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -3505,38 +3505,6 @@ spec:
                                     type: string
                               description: The pod's topology spread constraints.
                           description: Template for Entity Operator `Pods`.
-                        entityOperatorRole:
-                          type: object
-                          properties:
-                            metadata:
-                              type: object
-                              properties:
-                                labels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                                annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                              description: Metadata applied to the resource.
-                          description: Template for the Entity Operator Role.
-                        entityOperatorRoleBinding:
-                          type: object
-                          properties:
-                            metadata:
-                              type: object
-                              properties:
-                                labels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                                annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                              description: Metadata applied to the resource.
-                          description: Template for the Entity operator RoleBinding.
                         topicOperatorContainer:
                           type: object
                           properties:
@@ -3775,6 +3743,38 @@ spec:
                                   description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                               description: Metadata applied to the resource.
                           description: Template for the Entity Operator service account.
+                        entityOperatorRole:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              description: Metadata applied to the resource.
+                          description: Template for the Entity Operator Role.
+                        entityOperatorRoleBinding:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              description: Metadata applied to the resource.
+                          description: Template for the Entity Operator RoleBinding.
                       description: Template for Entity Operator resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
                   description: Configuration of the Entity Operator.
                 clusterCa:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -3504,6 +3504,38 @@ spec:
                                   type: string
                             description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
+                      entityOperatorRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity operator RoleBinding.
+                      entityOperatorRole:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Operator Role.
                       topicOperatorContainer:
                         type: object
                         properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -3504,38 +3504,6 @@ spec:
                                   type: string
                             description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
-                      entityOperatorRole:
-                        type: object
-                        properties:
-                          metadata:
-                            type: object
-                            properties:
-                              labels:
-                                x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                              annotations:
-                                x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                            description: Metadata applied to the resource.
-                        description: Template for the Entity Operator Role.
-                      entityOperatorRoleBinding:
-                        type: object
-                        properties:
-                          metadata:
-                            type: object
-                            properties:
-                              labels:
-                                x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                              annotations:
-                                x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                            description: Metadata applied to the resource.
-                        description: Template for the Entity operator RoleBinding.
                       topicOperatorContainer:
                         type: object
                         properties:
@@ -3774,6 +3742,38 @@ spec:
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
                         description: Template for the Entity Operator service account.
+                      entityOperatorRole:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Operator Role.
+                      entityOperatorRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Operator RoleBinding.
                     description: Template for Entity Operator resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
                 description: Configuration of the Entity Operator.
               clusterCa:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -3504,22 +3504,6 @@ spec:
                                   type: string
                             description: The pod's topology spread constraints.
                         description: Template for Entity Operator `Pods`.
-                      entityOperatorRoleBinding:
-                        type: object
-                        properties:
-                          metadata:
-                            type: object
-                            properties:
-                              labels:
-                                x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                              annotations:
-                                x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                            description: Metadata applied to the resource.
-                        description: Template for the Entity operator RoleBinding.
                       entityOperatorRole:
                         type: object
                         properties:
@@ -3536,6 +3520,22 @@ spec:
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
                         description: Template for the Entity Operator Role.
+                      entityOperatorRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity operator RoleBinding.
                       topicOperatorContainer:
                         type: object
                         properties:


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds field `entityOperatorRoleBinding` and `entityOperatorRole` to configure the metadata of the EntityOperator like lable and annotation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

