### PR TITLE
Fix the javadoc link of function `waitTillComponentHasRolled()` in `PodUtils.java`

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -107,7 +107,7 @@ public class PodUtils {
      * The method to wait when all pods of specific prefix will be deleted
      * To wait for the cluster to be updated, the following methods must be used:
      * {@link io.strimzi.systemtest.utils.RollingUpdateUtils#componentHasRolled(String, LabelSelector, Map)},
-     * {@link io.strimzi.systemtest.utils.RollingUpdateUtils#waitTillComponentHasRolled(LabelSelector, int, Map)} )}
+     * {@link io.strimzi.systemtest.utils.RollingUpdateUtils#waitTillComponentHasRolled(String, LabelSelector, int, Map)} )}
      * @param podsNamePrefix Cluster name where pods should be deleted
      */
     public static void waitForPodsWithPrefixDeletion(String podsNamePrefix) {


### PR DESCRIPTION
Signed-off-by: Kun-Lu <kun.lu@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

`mvn clean install -DskipTests` command failed on s390x CI due to the following warning/failure:

```bash
[WARNING] /home/jenkins/workspace/strimzi-kafka-operator/Strimzi_Kafka_Operator_ST/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java:110: warning: Tag @link: reference not found: io.strimzi.systemtest.utils.RollingUpdateUtils#waitTillComponentHasRolled(LabelSelector, int, Map)
[WARNING] * {@link io.strimzi.systemtest.utils.RollingUpdateUtils#waitTillComponentHasRolled(LabelSelector, int, Map)} )}
[WARNING] ^
```

The cause of this failure is that PR #7555 had removed an overloaded function `waitTillComponentHasRolled()` with the following signature from `systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java`:
```bash
 public static Map<String, String> waitTillComponentHasRolled(LabelSelector selector, int expectedPods, Map<String, String> snapshot) {
```
, but the javadoc link of this function in `PodUtils.java` remains unchanged: https://github.com/strimzi/strimzi-kafka-operator/blob/a32fd2318b753260ce446f2701ab996ed6aaec64/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java#L110

Thus when `mvn clean install -DskipTests` command is called without the`-Dmaven.javadoc.skip=true` flag, the above issue would occur. It's a potential bug on Intel platform as well.

This PR fixed this issue by updating the out-of-date javadoc link of the function `waitTillComponentHasRolled()` in `PodUtils.java`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

