### PR TITLE
[DOC] Fix the Cruise Control auto-approve annotation

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -164,7 +164,7 @@ metadata:
   labels:
     strimzi.io/cluster: my-cluster
   annotations:
-    strimzi.io/rebalance-auto-approval: true
+    strimzi.io/rebalance-auto-approval: "true"
 spec:
   mode: # any mode
   # ...

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -158,7 +158,7 @@ metadata:
   labels:
     strimzi.io/cluster: my-cluster
   annotations:
-    strimzi.io/rebalance-auto-approval: true
+    strimzi.io/rebalance-auto-approval: "true"
 spec:
   goals:
     - RackAwareGoal


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

In our docs, we list the annotation to enable auto approval of Cruise Control and its KafkaRebalance proposal as `strimzi.io/rebalance-auto-approval: true`. However, that is wrong because the annotations can be only strings and not booleans (and `true` would be interpreted as boolean). To make it string, it should be `strimzi.io/rebalance-auto-approval: "true"`.

This PR fixes the docs.