### PR TITLE
Make the CC logs when Rebalance resource is applied more understandable

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -65,6 +65,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.HashSet;
 import java.util.Arrays;
 import java.util.Collections;
@@ -396,7 +397,7 @@ public class KafkaRebalanceAssemblyOperator
                                    CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
                                    KafkaRebalanceState currentState, KafkaRebalanceAnnotation rebalanceAnnotation) {
 
-        LOGGER.infoCr(reconciliation, "Rebalance action from state [{}]", currentState);
+        LOGGER.infoCr(reconciliation, "Rebalance action is performed and KafkaRebalance resource is currently in [{}] state", currentState);
 
         if (Annotations.isReconciliationPausedWithAnnotation(kafkaRebalance)) {
             // we need to do this check again because it was triggered by a watcher
@@ -431,13 +432,16 @@ public class KafkaRebalanceAssemblyOperator
                                                 kafkaRebalance.getMetadata().getName(), desiredStatusAndMap.getLoadMap())
                                                 .compose(i -> updateStatus(reconciliation, currentKafkaRebalance, desiredStatusAndMap.getStatus(), null))
                                                 .compose(updatedKafkaRebalance -> {
-                                                    String message = "State updated to [{}] ";
+                                                    String message = "KafkaRebalance resource is in [{}] state";
+                                                    if (!Objects.equals(rebalanceStateConditionType(currentKafkaRebalance.getStatus()), rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
+                                                        message = "KafkaRebalance state is now updated to [{}]";
+                                                    }
                                                     if (rawRebalanceAnnotation(updatedKafkaRebalance) == null) {
-                                                        LOGGER.infoCr(reconciliation, message + "and annotation {} is not set ",
+                                                        LOGGER.infoCr(reconciliation, message + " and no annotation {} is applied on the KafkaRebalance resource",
                                                                 rebalanceStateConditionType(updatedKafkaRebalance.getStatus()),
                                                                 ANNO_STRIMZI_IO_REBALANCE);
                                                     } else {
-                                                        LOGGER.infoCr(reconciliation, message + "with annotation {}={} ",
+                                                        LOGGER.infoCr(reconciliation, message + " with annotation {}={} applied on the KafkaRebalance resource",
                                                                 rebalanceStateConditionType(updatedKafkaRebalance.getStatus()),
                                                                 ANNO_STRIMZI_IO_REBALANCE,
                                                                 rawRebalanceAnnotation(updatedKafkaRebalance)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -65,7 +65,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.HashSet;
 import java.util.Arrays;
 import java.util.Collections;
@@ -403,7 +402,7 @@ public class KafkaRebalanceAssemblyOperator
                 && rawRebalanceAnnotation(kafkaRebalance) == null) {
             LOGGER.infoCr(reconciliation, "Rebalancing is completed. You can use the  `refresh` annotation to ask for a new rebalance request");
         } else {
-                LOGGER.infoCr(reconciliation, "Rebalance action is performed and KafkaRebalance resource is currently in [{}] state", currentState);
+            LOGGER.infoCr(reconciliation, "Rebalance action is performed and KafkaRebalance resource is currently in [{}] state", currentState);
         }
 
         if (Annotations.isReconciliationPausedWithAnnotation(kafkaRebalance)) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -433,7 +433,9 @@ public class KafkaRebalanceAssemblyOperator
                                                 .compose(i -> updateStatus(reconciliation, currentKafkaRebalance, desiredStatusAndMap.getStatus(), null))
                                                 .compose(updatedKafkaRebalance -> {
                                                     String message = "KafkaRebalance resource is in [{}] state";
-                                                    if (!Objects.equals(rebalanceStateConditionType(currentKafkaRebalance.getStatus()), rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
+                                                    if (currentKafkaRebalance.getStatus() != null
+                                                            && updatedKafkaRebalance.getStatus() != null
+                                                            && !Objects.equals(rebalanceStateConditionType(currentKafkaRebalance.getStatus()), rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
                                                         message = "KafkaRebalance state is now updated to [{}]";
                                                     }
                                                     if (rawRebalanceAnnotation(updatedKafkaRebalance) == null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -399,9 +399,9 @@ public class KafkaRebalanceAssemblyOperator
 
 
         if (kafkaRebalance != null && kafkaRebalance.getStatus() != null
-                && Objects.equals(rebalanceStateConditionType(kafkaRebalance.getStatus()), "Ready")
+                && "Ready".equals(rebalanceStateConditionType(kafkaRebalance.getStatus()))
                 && rawRebalanceAnnotation(kafkaRebalance) == null) {
-            LOGGER.infoCr(reconciliation, "Rebalancing is completed. You can use the  `refresh` annotation to ask for a new rebalance request", currentState);
+            LOGGER.infoCr(reconciliation, "Rebalancing is completed. You can use the  `refresh` annotation to ask for a new rebalance request");
         } else {
                 LOGGER.infoCr(reconciliation, "Rebalance action is performed and KafkaRebalance resource is currently in [{}] state", currentState);
         }
@@ -442,7 +442,7 @@ public class KafkaRebalanceAssemblyOperator
                                                     String message = "";
                                                     if (currentKafkaRebalance.getStatus() != null
                                                             && updatedKafkaRebalance.getStatus() != null
-                                                            && !Objects.equals(rebalanceStateConditionType(currentKafkaRebalance.getStatus()), rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
+                                                            && !rebalanceStateConditionType(currentKafkaRebalance.getStatus()).equals(rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
                                                         message = "KafkaRebalance state is now updated to [{}]";
                                                     }
                                                     if (rawRebalanceAnnotation(updatedKafkaRebalance) != null) {


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

_Select the type of your PR_

- Task

### Description

This PR fixes #7873. This PR tries to make the logs when Rebalance resource is applied more understandable and remove the confusion.

Here is how the logs look when we don't add any annotation and there is no update of the Kafka Rebalance resource state :-

```
2023-01-06 11:35:56 INFO  KafkaRebalanceAssemblyOperator:400 - Reconciliation #34(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Rebalance action is performed and KafkaRebalance resource is currently in [New] state
2023-01-06 11:35:56 INFO  KafkaRebalanceAssemblyOperator:1251 - Reconciliation #34(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Requesting Cruise Control rebalance [dryrun=true]
2023-01-06 11:35:56 INFO  CrdOperator:133 - Reconciliation #34(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Status of KafkaRebalance my-rebalance in namespace myproject has been updated
2023-01-06 11:35:56 INFO  KafkaRebalanceAssemblyOperator:400 - Reconciliation #35(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Rebalance action is performed and KafkaRebalance resource is currently in [ProposalReady] state
2023-01-06 11:35:56 INFO  KafkaRebalanceAssemblyOperator:440 - Reconciliation #35(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): KafkaRebalance resource is in [ProposalReady] state and no annotation strimzi.io/rebalance is applied on the KafkaRebalance resource 
```

Here is how the logs look when we add an annotation and there is update of the Kafka Rebalance resource state :-

```
2023-01-06 11:39:02 INFO  KafkaRebalanceAssemblyOperator:400 - Reconciliation #38(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Rebalance action is performed and KafkaRebalance resource is currently in [ProposalReady] state
2023-01-06 11:39:02 INFO  KafkaRebalanceAssemblyOperator:1251 - Reconciliation #38(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Requesting Cruise Control rebalance [dryrun=false]
2023-01-06 11:39:02 INFO  CrdOperator:133 - Reconciliation #38(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Status of KafkaRebalance my-rebalance in namespace myproject has been updated
2023-01-06 11:39:02 INFO  KafkaRebalanceAssemblyOperator:444 - Reconciliation #38(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): KafkaRebalance state is now updated to [Rebalancing]  with annotation strimzi.io/rebalance=approve
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

