### PR TITLE
KRaft liveness and readiness phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Kafka Exporter support for `Recreate` deployment strategy
 * `ImageStream` validation for Kafka Connect builds on OpenShift
 * Support for configuring the metadata for the Role / RoleBinding of Entity Operator
+* Add liveness and readiness probes specifically for nodes running in KRaft combined mode
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1656,8 +1656,7 @@ public class KafkaCluster extends AbstractModel {
                         .endExec().build())
                 .withReadinessProbe(ProbeGenerator.defaultBuilder(readinessProbeOptions)
                         .withNewExec()
-                            // The kafka-agent will create /var/opt/kafka/kafka-ready in the container
-                            .withCommand("test", "-f", "/var/opt/kafka/kafka-ready")
+                            .withCommand("/opt/kafka/kafka_readiness.sh")
                         .endExec().build())
                 .withResources(getResources())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, getImage()))

--- a/docker-images/kafka-based/kafka/scripts/kafka_controller_liveness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_controller_liveness.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+for proc in /proc/*[0-9];
+  do if readlink -f "$proc"/exe | grep -q java; then exit 0; fi;
+done
+
+exit 1

--- a/docker-images/kafka-based/kafka/scripts/kafka_liveness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_liveness.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -f /var/opt/kafka/kafka-ready ] ; then
-  rm -f /var/opt/kafka/zk-connected 2&> /dev/null
-  # Test listening on replication port 9091
-  netstat -lnt | grep -Eq 'tcp6?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9091.*LISTEN[[:space:]]*'
+if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
+  # Test KRaft controller process is running
+  . ./kafka_controller_liveness.sh
 else
-  # Not yet ready, so test ZK connected state
-  test -f /var/opt/kafka/zk-connected
+  # Test ZK-based broker liveness
+  # We expect that either the broker is ready and listening on 9091 (replication port)
+  # or it has a ZK session
+  if [ -f /var/opt/kafka/kafka-ready ] ; then
+    rm -f /var/opt/kafka/zk-connected 2&> /dev/null
+    # Test listening on replication port 9091
+    netstat -lnt | grep -Eq 'tcp6?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9091.*LISTEN[[:space:]]*'
+  else
+    # Not yet ready, so test ZK connected state
+    test -f /var/opt/kafka/zk-connected
+  fi
 fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
+  # Test KRaft controller process is running
+  # This is the best check we can do in a combined node until KafkaRoller is updated
+  # See proposal 046 for more details
+  . ./kafka_controller_liveness.sh
+else
+  # Test ZK-based broker readiness
+  # The kafka-agent will create /var/opt/kafka/kafka-ready in the container when the broker
+  # state is >= 3 && != 127 (UNKNOWN state)
+  test -f /var/opt/kafka/kafka-ready
+fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -63,8 +63,6 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
     echo "Kraft storage is already formatted"
   fi
 
-  touch /var/opt/kafka/kafka-ready
-  touch /var/opt/kafka/zk-connected
 else
   rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
   KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -32,6 +32,9 @@ public class KafkaAgent {
     // KafkaYammerMetrics class in Kafka 3.2-
     private static final String YAMMER_METRICS_IN_KAFKA_3_2_AND_EARLIER = "kafka.metrics.KafkaYammerMetrics";
 
+    private static final Integer BROKER_RUNNING_STATE = 3;
+    private static final Integer BROKER_UNKNOWN_STATE = 127;
+
     private final File sessionConnectedFile;
     private final File brokerReadyFile;
     private MetricName brokerStateName;
@@ -159,17 +162,15 @@ public class KafkaAgent {
             boolean handleBrokerState() {
                 LOGGER.trace("Polling {}", brokerStateName);
                 boolean ready = false;
-                Integer runningState = 3;
-                Integer unknownState = 127;
                 Object observedState = brokerState.value();
 
                 boolean stateIsRunning = false;
                 if (observedState instanceof Integer) {
-                    stateIsRunning = runningState.compareTo((Integer) observedState) <= 0 && !unknownState.equals(observedState);
+                    stateIsRunning = BROKER_RUNNING_STATE.compareTo((Integer) observedState) <= 0 && !BROKER_UNKNOWN_STATE.equals(observedState);
                 }
                 if (observedState instanceof Byte) {
                     int intValue = ((Byte) observedState).intValue();
-                    stateIsRunning = runningState <= intValue && !unknownState.equals(intValue);
+                    stateIsRunning = BROKER_RUNNING_STATE <= intValue && !BROKER_UNKNOWN_STATE.equals(intValue);
                 }
                 if (stateIsRunning) {
                     try {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

KRaft liveness and readiness phase 1
* If KRaft mode enabled, check controller process is running for both liveness and readiness.
* Move Kafka readiness logic to kafka_readiness.sh script.
* Update KafkaAgent to create ready file only if broker state is > 3 and != 127.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

