### PR TITLE
Using one HttpClient for asking user task status and rebalance per `KafkaRebalance` reconcile

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -761,7 +761,8 @@ public class KafkaRebalanceAssemblyOperator
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> onNew(Reconciliation reconciliation,
                                                                         String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                                                        AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                                        AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                        HttpClient httpClient) {
         return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder, httpClient);
     }
 
@@ -782,7 +783,8 @@ public class KafkaRebalanceAssemblyOperator
                                                                              String host, CruiseControlApi apiClient,
                                                                              KafkaRebalance kafkaRebalance,
                                                                              KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                                             AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                                             AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                             HttpClient httpClient) {
 
         if (shouldRenewRebalance(kafkaRebalance, rebalanceAnnotation)) {
             // CC is activated from the disabled state or the user has fixed the error on the resource and want to 'refresh'
@@ -839,7 +841,8 @@ public class KafkaRebalanceAssemblyOperator
                                                                     String host, CruiseControlApi apiClient,
                                                                     KafkaRebalance kafkaRebalance,
                                                                     KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                                    AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                                    AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                    HttpClient httpClient) {
         Promise<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> p = Promise.promise();
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.none) {
             LOGGER.debugCr(reconciliation, "Starting Cruise Control rebalance proposal request timer");
@@ -924,7 +927,8 @@ public class KafkaRebalanceAssemblyOperator
                                                                       String host, CruiseControlApi apiClient,
                                                                       KafkaRebalance kafkaRebalance,
                                                                       KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                                      AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                                      AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                      HttpClient httpClient) {
         if (Annotations.booleanAnnotation(kafkaRebalance, ANNO_STRIMZI_IO_REBALANCE_AUTOAPPROVAL, false)) {
             LOGGER.infoCr(reconciliation, "Auto-approval set on the KafkaRebalance resource");
             return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, httpClient);
@@ -969,7 +973,8 @@ public class KafkaRebalanceAssemblyOperator
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> onRebalancing(Reconciliation reconciliation,
                                                                                 String host, CruiseControlApi apiClient,
                                                                                 KafkaRebalance kafkaRebalance,
-                                                                                KafkaRebalanceAnnotation rebalanceAnnotation, HttpClient httpClient) {
+                                                                                KafkaRebalanceAnnotation rebalanceAnnotation,
+                                                                                HttpClient httpClient) {
         Promise<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> p = Promise.promise();
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.none) {
             LOGGER.infoCr(reconciliation, "Starting Cruise Control rebalance user task status timer");
@@ -1099,7 +1104,8 @@ public class KafkaRebalanceAssemblyOperator
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> onStop(Reconciliation reconciliation,
                                                                  String host, CruiseControlApi apiClient,
                                                                  KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                                 AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                                 AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                 HttpClient httpClient) {
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
             return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder, httpClient);
         } else {
@@ -1126,7 +1132,8 @@ public class KafkaRebalanceAssemblyOperator
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> onReady(Reconciliation reconciliation,
                                                                     String host, CruiseControlApi apiClient,
                                                                     KafkaRebalance kafkaRebalance, KafkaRebalanceAnnotation rebalanceAnnotation,
-                                                                    AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                                    AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                    HttpClient httpClient) {
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.refresh) {
             return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder, httpClient);
         } else {
@@ -1217,7 +1224,6 @@ public class KafkaRebalanceAssemblyOperator
                                 CruiseControlApi apiClient = cruiseControlClientProvider(ccSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);
 
                                 HttpClientOptions httpOptions = getHttpClientOptions(apiSslEnabled, ccSecret);
-
                                 HttpClient httpClient = vertx.createHttpClient(httpOptions);
 
                                 // get latest KafkaRebalance state as it may have changed
@@ -1268,14 +1274,16 @@ public class KafkaRebalanceAssemblyOperator
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation,
                                                           String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                                          boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, HttpClient httpClient) {
+                                                          boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                          HttpClient httpClient) {
         return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, dryrun, rebalanceOptionsBuilder, null, httpClient);
     }
 
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation, String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
                                                                                    boolean dryrun,
-                                                                                   AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, String userTaskID, HttpClient httpClient) {
+                                                                                   AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, String userTaskID,
+                                                                                   HttpClient httpClient) {
 
         LOGGER.infoCr(reconciliation, "Requesting Cruise Control rebalance [dryrun={}]", dryrun);
         rebalanceOptionsBuilder.withVerboseResponse();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/HttpClientUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/HttpClientUtils.java
@@ -39,4 +39,23 @@ public class HttpClientUtils {
                 return Future.failedFuture(error);
             });
     }
+
+    /**
+     * Perform the given operation, which completes the promise, using an HTTP client instance,
+     * and the future for the promise returned.
+     * @param httpClient Any client that should be applied.
+     * @param operation The operation to perform.
+     * @param <T> The type of the result
+     * @return A future which is completed with the result performed by the operation
+     */
+    public static <T> Future<T> withHttpClientCruiseControl(HttpClient httpClient, BiConsumer<HttpClient, Promise<T>> operation) {
+        Promise<T> promise = Promise.promise();
+        operation.accept(httpClient, promise);
+        return promise.future().compose(
+                Future::succeededFuture,
+                error -> {
+                    httpClient.close();
+                    return Future.failedFuture(error);
+                });
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import io.vertx.core.Future;
+import io.vertx.core.http.HttpClient;
 
 /**
  * Cruise Control REST API interface definition
@@ -44,14 +45,15 @@ public interface CruiseControlApi {
      * @param userTaskId This is the unique ID of a previous rebalance request. If a previous request had not been
      *                   completed when the response was returned then this ID can be used to retrieve the results of that
      *                   request.
+     * @param httpClient An HTTP client instance
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> rebalance(String host, int port, RebalanceOptions options, String userTaskId);
+    Future<CruiseControlRebalanceResponse> rebalance(String host, int port, RebalanceOptions options, String userTaskId, HttpClient httpClient);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when adding new brokers.
      * This method allows to move replicas from existing brokers to the new ones and avoids to run a full rebalance
-     * across all brokers in the cluster as done by {@link #rebalance(String, int, RebalanceOptions, String)}.
+     * across all brokers in the cluster as done by {@link #rebalance(String, int, RebalanceOptions, String, HttpClient)}.
      *
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
@@ -59,9 +61,10 @@ public interface CruiseControlApi {
      * @param userTaskId This is the unique ID of a previous addBroker request. If a previous request had not been
      *                   completed when the response was returned then this ID can be used to retrieve the results of that
      *                   request.
+     * @param httpClient An HTTP client instance
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> addBroker(String host, int port, AddBrokerOptions options, String userTaskId);
+    Future<CruiseControlRebalanceResponse> addBroker(String host, int port, AddBrokerOptions options, String userTaskId, HttpClient httpClient);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when removing existing brokers.
@@ -73,9 +76,10 @@ public interface CruiseControlApi {
      * @param userTaskId This is the unique ID of a previous removeBroker request. If a previous request had not been
      *                   completed when the response was returned then this ID can be used to retrieve the results of that
      *                   request.
+     * @param httpClient An HTTP client instance
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> removeBroker(String host, int port, RemoveBrokerOptions options, String userTaskId);
+    Future<CruiseControlRebalanceResponse> removeBroker(String host, int port, RemoveBrokerOptions options, String userTaskId, HttpClient httpClient);
 
     /**
      *  Get the state of a specific task (e.g. a rebalance) from the Cruise Control server.
@@ -84,9 +88,10 @@ public interface CruiseControlApi {
      * @param port The port the Cruise Control Server is listening on.
      * @param userTaskID This is the unique ID of a previous rebalance request or other task supported by Cruise Control.
      *                   This is used to retrieve the task's current state.
+     * @param httpClient An HTTP client instance.
      * @return A future for the state of the specified task.
      */
-    Future<CruiseControlResponse> getUserTaskStatus(String host, int port, String userTaskID);
+    Future<CruiseControlResponse> getUserTaskStatus(String host, int port, String userTaskID, HttpClient httpClient);
 
     /**
      *  Issue a stop command to the Cruise Control server. This will halt any task (e.g. a rebalance) which is currently
@@ -94,8 +99,9 @@ public interface CruiseControlApi {
      *
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
+     * @param httpClient An HTTP client instance
      * @return A furture for the response from the Cruise Control server indicating if the stop command was issued.
      */
-    Future<CruiseControlResponse> stopExecution(String host, int port);
+    Future<CruiseControlResponse> stopExecution(String host, int port, HttpClient httpClient);
 }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.AfterAll;
@@ -182,7 +183,9 @@ public class KafkaRebalanceStateMachineTest {
         when(mockRebalanceOps.get(CLUSTER_NAMESPACE, RESOURCE_NAME)).thenReturn(kcRebalance);
         when(mockRebalanceOps.getAsync(CLUSTER_NAMESPACE, RESOURCE_NAME)).thenReturn(Future.succeededFuture(kcRebalance));
 
-        return kcrao.computeNextStatus(recon, HOST, client, kcRebalance, currentState, initialAnnotation, rbOptions)
+        HttpClient httpClient =  vertx.createHttpClient(KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET));
+
+        return kcrao.computeNextStatus(recon, HOST, client, kcRebalance, currentState, initialAnnotation, rbOptions, httpClient)
                 .compose(result -> {
                     context.verify(() -> {
                         assertThat(result.getStatus().getConditions(), StateMatchers.hasStateInConditions(nextState));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -4,14 +4,10 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
-import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator;
-import io.strimzi.operator.common.Util;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.net.PemTrustOptions;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -29,7 +25,6 @@ import java.util.function.Consumer;
 
 import static io.strimzi.operator.cluster.JSONObjectMatchers.hasEntry;
 import static io.strimzi.operator.cluster.JSONObjectMatchers.hasKeys;
-import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl.HTTP_CLIENT_ACTIVITY_LOGGING;
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl.HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -127,8 +127,8 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         HttpClientOptions httpOptions = KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET);
-
         HttpClient httpClient = vertx.createHttpClient(httpOptions);
+
         String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID;
 
         Checkpoint checkpoint = context.checkpoint();
@@ -260,7 +260,6 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         HttpClientOptions httpOptions = KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET);
-
         HttpClient httpClient = vertx.createHttpClient(httpOptions);
 
         Checkpoint checkpoint = context.checkpoint();
@@ -298,7 +297,6 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         HttpClientOptions httpOptions = KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET);
-
         HttpClient httpClient = vertx.createHttpClient(httpOptions);
 
         Checkpoint checkpoint = context.checkpoint();
@@ -336,7 +334,6 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         HttpClientOptions httpOptions = KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET);
-
         HttpClient httpClient = vertx.createHttpClient(httpOptions);
 
         Checkpoint checkpoint = context.checkpoint();
@@ -374,7 +371,6 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         HttpClientOptions httpOptions = KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET);
-
         HttpClient httpClient = vertx.createHttpClient(httpOptions);
 
         Checkpoint checkpoint = context.checkpoint();
@@ -412,7 +408,6 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         HttpClientOptions httpOptions = KafkaRebalanceAssemblyOperator.getHttpClientOptions(true, MockCruiseControl.CC_SECRET);
-
         HttpClient httpClient = vertx.createHttpClient(httpOptions);
 
         Checkpoint checkpoint = context.checkpoint();


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

- Enhancement / new feature

### Description

This PR fixes #6739. With these changes we will no longer have to create the HttpClient every time we ask for a rebalance or we need to check the user task status hence saving resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

