### PR TITLE
Reset the auto-restart status if the connector is running after the restart

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -8,6 +8,7 @@ package io.strimzi.operator.common.operator.resource;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.kafka.model.Spec;
 import io.strimzi.api.kafka.model.status.AutoRestartStatus;
+import io.strimzi.api.kafka.model.status.AutoRestartStatusBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
 import io.strimzi.api.kafka.model.status.Status;
@@ -302,12 +303,18 @@ public class StatusUtils {
      * @return the AutoRestart status updated or a new one if it was null
      */
     public static AutoRestartStatus incrementAutoRestartStatus(AutoRestartStatus autoRestart)  {
+        AutoRestartStatus newStatus;
+
         if (autoRestart == null)  {
-            autoRestart = new AutoRestartStatus();
-            autoRestart.setCount(0);
+            newStatus = new AutoRestartStatus();
+            newStatus.setCount(1);
+        } else {
+            newStatus = new AutoRestartStatusBuilder(autoRestart).build();
+            newStatus.setCount(autoRestart.getCount() + 1);
         }
-        autoRestart.setCount(autoRestart.getCount() + 1);
-        autoRestart.setLastRestartTimestamp(iso8601Now());
-        return autoRestart;
+
+        newStatus.setLastRestartTimestamp(iso8601Now());
+
+        return newStatus;
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #7891, we currently never reset the auto-restart status during normal operations. The only changing the configuration resets the status. So after your connector is restarted 7 times - regardless of during which period, it could be even weeks or months - it will not be restarted anymore until some configuration change happens and resets it. This PR adds functionality to reset the auto-restart status when the connector is running some time after the restart. 

Instead of an interval configurable in the auto-restart spec as originally suggested in the issue, it uses the same back-off mechanism as used for the restart. For example:
* if the connector was restarted just once, then the auto-restart status will be reset if it is running at least 2 minutes after the restart
* if the connector was restarted already trice, then the auto-restart status will be reset if it is running at least 12 minutes after the restart

Currently, the reset mechanism does not check that the connector is running the whole back-off interval. It checks only that it is in a running state in the next reconciliation after the corresponding back-off interval is over. I tried to implement it, but it is prone to cycle the operator with misbehaving connectors which are often changing the status as it ends up looping through updating the status fields tracking for how long it runs without interruption. That is why I in the end decided to abandon this and simply check if it is running after the interval. I think the solution implemented here at the end offers a good combination of simplicity, and fault-tolerance and at the same time delivers value in most use cases.
This should close #7891

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging