### PR TITLE
[Enhancement] Add new interBrokerTls boolean flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `ImageStream` validation for Kafka Connect builds on OpenShift
 * Support for configuring the metadata for the Role / RoleBinding of Entity Operator
 * Add liveness and readiness probes specifically for nodes running in KRaft combined mode
+* Add new interBrokerTls boolean flag [#2266](https://github.com/strimzi/strimzi-kafka-operator/issues/2266)
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -35,7 +35,8 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "version", "replicas", "image", "listeners", "config", "storage", "authorization", "rack", "brokerRackInitImage",
-    "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig", "logging", "template"})
+    "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig", "logging", "template",
+    "interBrokerTls"})
 @EqualsAndHashCode
 public class KafkaClusterSpec implements HasConfigurableMetrics, UnknownPropertyPreserving, Serializable {
 
@@ -71,6 +72,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, UnknownProperty
     private List<GenericKafkaListener> listeners;
     private KafkaAuthorization authorization;
     private KafkaClusterTemplate template;
+    private boolean interBrokerTls = true;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The kafka broker version. Defaults to {DefaultKafkaVersion}. " +
@@ -249,6 +251,16 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, UnknownProperty
 
     public void setTemplate(KafkaClusterTemplate template) {
         this.template = template;
+    }
+
+    @Description("Inter-broker communication should be over TLS. Defaults to 'true'." +
+            "Affects CONTROLPLANE and REPLICATION listener creation.")
+    public boolean getInterBrokerTls() {
+        return interBrokerTls;
+    }
+
+    public void setInterBrokerTls(boolean interBrokerTls) {
+        this.interBrokerTls = interBrokerTls;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -223,6 +223,7 @@ public class KafkaCluster extends AbstractModel {
     private boolean isJmxAuthenticated;
     private boolean useKRaft = false;
     private String clusterId;
+    private boolean interBrokerTls;
 
     // Templates
     protected Map<String, String> templateExternalBootstrapServiceLabels;
@@ -528,6 +529,8 @@ public class KafkaCluster extends AbstractModel {
         // Should run at the end when everything is set
         KafkaSpecChecker specChecker = new KafkaSpecChecker(kafkaSpec, versions, result);
         result.warningConditions.addAll(specChecker.run());
+
+        result.interBrokerTls = kafkaSpec.getKafka().getInterBrokerTls();
 
         return result;
     }
@@ -2103,7 +2106,8 @@ public class KafkaCluster extends AbstractModel {
                             () -> getPodName(brokerId),
                             listenerId -> advertisedHostnames.get(brokerId).get(listenerId),
                             listenerId -> advertisedPorts.get(brokerId).get(listenerId),
-                            true)
+                            true,
+                            interBrokerTls)
                     .withAuthorization(cluster, authorization, true)
                     .withCruiseControl(cluster, cruiseControlSpec, ccNumPartitions, ccReplicationFactor, ccMinInSyncReplicas)
                     .withUserConfiguration(configuration)
@@ -2120,7 +2124,8 @@ public class KafkaCluster extends AbstractModel {
                             () -> getPodName(brokerId),
                             listenerId -> advertisedHostnames.get(brokerId).get(listenerId),
                             listenerId -> advertisedPorts.get(brokerId).get(listenerId),
-                            false)
+                            false,
+                            interBrokerTls)
                     .withAuthorization(cluster, authorization, false)
                     .withCruiseControl(cluster, cruiseControlSpec, ccNumPartitions, ccReplicationFactor, ccMinInSyncReplicas)
                     .withUserConfiguration(configuration)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -710,7 +710,12 @@ public class KafkaBrokerConfigurationBuilderTest {
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
                 .withBrokerId("2")
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2", listenerId -> "my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc", listenerId -> "9092", false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2",
+                    listenerId -> "my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc",
+                    listenerId -> "9092",
+                    false,
+                    true
+                )
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=2",
@@ -750,7 +755,12 @@ public class KafkaBrokerConfigurationBuilderTest {
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
                 .withBrokerId("2")
                 .withKRaft("my-cluster", "my-namespace", 3)
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2", listenerId -> "my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc", listenerId -> "9092", true)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2",
+                    listenerId -> "my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc",
+                    listenerId -> "9092",
+                    true,
+                    true
+                )
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=2",
@@ -775,6 +785,39 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092",
                 "advertised.listeners=REPLICATION-9091://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9091,PLAIN-9092://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9092",
                 "listener.security.protocol.map=CONTROLPLANE-9090:SSL,REPLICATION-9091:SSL,PLAIN-9092:PLAINTEXT",
+                "inter.broker.listener.name=REPLICATION-9091",
+                "sasl.enabled.mechanisms=",
+                "ssl.endpoint.identification.algorithm=HTTPS"));
+    }
+
+    @ParallelTest
+    public void testKraftListenersInterBrokerTlsDisabled() {
+        GenericKafkaListener listener = new GenericKafkaListenerBuilder()
+                .withName("plain")
+                .withPort(9092)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(false)
+                .build();
+
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
+                .withBrokerId("2")
+                .withKRaft("my-cluster", "my-namespace", 3)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2",
+                    listenerId -> "my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc",
+                    listenerId -> "9092",
+                    true,
+                    false
+                )
+                .build();
+
+        assertThat(configuration, isEquivalent("broker.id=2",
+                "node.id=2",
+                "process.roles=broker,controller",
+                "controller.listener.names=CONTROLPLANE-9090",
+                "controller.quorum.voters=0@my-cluster-kafka-0.my-cluster-kafka-brokers.my-namespace.svc.cluster.local:9090,1@my-cluster-kafka-1.my-cluster-kafka-brokers.my-namespace.svc.cluster.local:9090,2@my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc.cluster.local:9090",
+                "listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092",
+                "advertised.listeners=REPLICATION-9091://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9091,PLAIN-9092://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9092",
+                "listener.security.protocol.map=CONTROLPLANE-9090:PLAINTEXT,REPLICATION-9091:PLAINTEXT,PLAIN-9092:PLAINTEXT",
                 "inter.broker.listener.name=REPLICATION-9091",
                 "sasl.enabled.mechanisms=",
                 "ssl.endpoint.identification.algorithm=HTTPS"));
@@ -1173,7 +1216,12 @@ public class KafkaBrokerConfigurationBuilderTest {
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
                 .withBrokerId("2")
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2", listenerId -> "my-lb.com", listenerId -> "9094", false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2",
+                    listenerId -> "my-lb.com",
+                    listenerId -> "9094",
+                    false,
+                    true
+                )
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=2",
@@ -1195,6 +1243,39 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,EXTERNAL-9094://0.0.0.0:9094",
                 "advertised.listeners=CONTROLPLANE-9090://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9090,REPLICATION-9091://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9091,EXTERNAL-9094://my-lb.com:9094",
                 "listener.security.protocol.map=CONTROLPLANE-9090:SSL,REPLICATION-9091:SSL,EXTERNAL-9094:SSL",
+                "control.plane.listener.name=CONTROLPLANE-9090",
+                "inter.broker.listener.name=REPLICATION-9091",
+                "sasl.enabled.mechanisms=",
+                "ssl.endpoint.identification.algorithm=HTTPS",
+                "listener.name.external-9094.ssl.keystore.location=/tmp/kafka/cluster.keystore.p12",
+                "listener.name.external-9094.ssl.keystore.password=${CERTS_STORE_PASSWORD}",
+                "listener.name.external-9094.ssl.keystore.type=PKCS12"));
+    }
+
+    @ParallelTest
+    public void testPerBrokerWithExternalListenersInterBrokerTlsDisabled() {
+        GenericKafkaListener listener = new GenericKafkaListenerBuilder()
+                .withName("external")
+                .withPort(9094)
+                .withType(KafkaListenerType.LOADBALANCER)
+                .withTls(true)
+                .build();
+
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
+                .withBrokerId("2")
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2",
+                    listenerId -> "my-lb.com",
+                    listenerId -> "9094",
+                    false,
+                    false
+                )
+                .build();
+
+        assertThat(configuration, isEquivalent("broker.id=2",
+                "node.id=2",
+                "listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,EXTERNAL-9094://0.0.0.0:9094",
+                "advertised.listeners=CONTROLPLANE-9090://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9090,REPLICATION-9091://my-cluster-kafka-2.my-cluster-kafka-brokers.my-namespace.svc:9091,EXTERNAL-9094://my-lb.com:9094",
+                "listener.security.protocol.map=CONTROLPLANE-9090:PLAINTEXT,REPLICATION-9091:PLAINTEXT,EXTERNAL-9094:SSL",
                 "control.plane.listener.name=CONTROLPLANE-9090",
                 "inter.broker.listener.name=REPLICATION-9091",
                 "sasl.enabled.mechanisms=",
@@ -1326,7 +1407,12 @@ public class KafkaBrokerConfigurationBuilderTest {
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION)
                 .withBrokerId("2")
-                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2", listenerId -> "${STRIMZI_NODEPORT_DEFAULT_ADDRESS}", listenerId -> "31234", false)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), () -> "my-cluster-kafka-2",
+                    listenerId -> "${STRIMZI_NODEPORT_DEFAULT_ADDRESS}",
+                    listenerId -> "31234",
+                    false,
+                    true
+                )
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=2",

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -95,6 +95,8 @@ include::../api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc[leveloffset=+1]
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
 |template             1.2+<.<a|Template for Kafka cluster resources. The template allows users to specify how the `StatefulSet`, `Pods`, and `Services` are generated.
 |xref:type-KafkaClusterTemplate-{context}[`KafkaClusterTemplate`]
+|interBrokerTls       1.2+<.<a|Inter-broker communication should be over TLS. Defaults to 'true'.Affects CONTROLPLANE and REPLICATION listener creation.
+|boolean
 |====
 
 [id='type-GenericKafkaListener-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1717,6 +1717,9 @@ spec:
                               description: Metadata applied to the resource.
                           description: Template for Kafka `StrimziPodSet` resource.
                       description: "Template for Kafka cluster resources. The template allows users to specify how the `StatefulSet`, `Pods`, and `Services` are generated."
+                    interBrokerTls:
+                      type: boolean
+                      description: Inter-broker communication should be over TLS. Defaults to 'true'.Affects CONTROLPLANE and REPLICATION listener creation.
                   required:
                     - replicas
                     - listeners

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1716,6 +1716,9 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for Kafka `StrimziPodSet` resource.
                     description: "Template for Kafka cluster resources. The template allows users to specify how the `StatefulSet`, `Pods`, and `Services` are generated."
+                  interBrokerTls:
+                    type: boolean
+                    description: Inter-broker communication should be over TLS. Defaults to 'true'.Affects CONTROLPLANE and REPLICATION listener creation.
                 required:
                 - replicas
                 - listeners


### PR DESCRIPTION
The new flag defaults to 'true' to preserve the existing behavior of configuring the ControlPlane and Replication listeners with TLS. When set to 'false', they are created in PLAINTEXT protocol mode.

https://github.com/strimzi/strimzi-kafka-operator/issues/2266
