### PR TITLE
[systemtest] Add smoke test for testing all supported Kafka versions during regression pipeline

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -376,7 +376,7 @@
             <id>azp_kafka_oauth</id>
             <properties>
                 <skipTests>false</skipTests>
-                <groups>regression</groups>
+                <groups>regression,kafkasmoke</groups>
                 <it.test>
                     kafka/**/*ST,
                     !kafka/listeners/*ST,

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -206,6 +206,11 @@ public interface Constants {
     String SMOKE = "smoke";
 
     /**
+     * Tag for Kafka smoke tests
+     */
+    String KAFKA_SMOKE = "kafkasmoke";
+
+    /**
      * Tag for sanity tests
      */
     String SANITY = "sanity";

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.kafka;
+
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.annotations.ParallelSuite;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static io.strimzi.systemtest.Constants.KAFKA_SMOKE;
+
+@ParallelSuite
+@Tag(KAFKA_SMOKE)
+public class KafkaVersionsST extends AbstractST {
+
+    private static final Logger LOGGER = LogManager.getLogger(KafkaVersionsST.class);
+
+    @ParameterizedTest(name = "Kafka version: {0}.version()")
+    @MethodSource("io.strimzi.systemtest.utils.TestKafkaVersion#getSupportedKafkaVersions")
+    void testKafkaWithVersion(TestKafkaVersion testKafkaVersion, ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext);
+
+        LOGGER.info("Deploying Kafka with version: {}", testKafkaVersion.version());
+
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3)
+            .editOrNewSpec()
+                .editOrNewKafka()
+                    .withVersion(testKafkaVersion.version())
+                    .addToConfig("inter.broker.protocol.version", testKafkaVersion.protocolVersion())
+                    .addToConfig("log.message.format.version", testKafkaVersion.messageVersion())
+                .endKafka()
+            .endSpec()
+            .build()
+        );
+
+        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(testStorage).build());
+
+        LOGGER.info("Sending and receiving messages via PLAIN");
+
+        KafkaClients kafkaClients = new KafkaClientsBuilder()
+            .withTopicName(testStorage.getTopicName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withMessageCount(testStorage.getMessageCount())
+            .build();
+
+        resourceManager.createResource(extensionContext,
+            kafkaClients.producerStrimzi(),
+            kafkaClients.consumerStrimzi()
+        );
+
+        ClientUtils.waitForClientsSuccess(testStorage);
+
+        LOGGER.info("Sending and receiving messages via TLS");
+
+        kafkaClients = new KafkaClientsBuilder(kafkaClients)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withUserName(testStorage.getUserName())
+            .build();
+
+        resourceManager.createResource(extensionContext,
+            kafkaClients.producerTlsStrimzi(testStorage.getClusterName()),
+            kafkaClients.consumerTlsStrimzi(testStorage.getClusterName())
+        );
+
+        ClientUtils.waitForClientsSuccess(testStorage);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -4,13 +4,19 @@
  */
 package io.strimzi.systemtest.kafka;
 
+import io.strimzi.api.kafka.model.AclOperation;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaUser;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
@@ -29,10 +35,26 @@ public class KafkaVersionsST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaVersionsST.class);
 
+    /**
+     * Test checking basic functionality for each supported Kafka version.
+     * Ensures that for every Kafka version:
+     *     - Kafka cluster is deployed without an issue
+     *       - with TopicOperator, UserOperator, 3 Zookeeper and Kafka pods
+     *     - TopicOperator is working - because of the KafkaTopic creation
+     *     - UserOperator is working - because of SCRAM-SHA, ACLs and overall KafkaUser creations
+     *     - Sending and receiving messages is working to PLAIN (with SCRAM-SHA) and TLS listeners
+     * @param testKafkaVersion TestKafkaVersion added for each iteration of the parametrized test
+     * @param extensionContext context in which the current test is being executed
+     */
     @ParameterizedTest(name = "Kafka version: {0}.version()")
     @MethodSource("io.strimzi.systemtest.utils.TestKafkaVersion#getSupportedKafkaVersions")
-    void testKafkaWithVersion(TestKafkaVersion testKafkaVersion, ExtensionContext extensionContext) {
+    void testKafkaWithVersion(final TestKafkaVersion testKafkaVersion, ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
+
+        final String kafkaUserRead = testStorage.getUserName() + "-read";
+        final String kafkaUserWrite = testStorage.getUserName() + "-write";
+        final String kafkaUserReadWriteTls = testStorage.getUserName() + "-read-write";
+        final String readConsumerGroup = ClientUtils.generateRandomConsumerGroup();
 
         LOGGER.info("Deploying Kafka with version: {}", testKafkaVersion.version());
 
@@ -42,14 +64,90 @@ public class KafkaVersionsST extends AbstractST {
                     .withVersion(testKafkaVersion.version())
                     .addToConfig("inter.broker.protocol.version", testKafkaVersion.protocolVersion())
                     .addToConfig("log.message.format.version", testKafkaVersion.messageVersion())
+                    .withNewKafkaAuthorizationSimple()
+                    .endKafkaAuthorizationSimple()
+                    .withListeners(
+                            new GenericKafkaListenerBuilder()
+                                    .withName(Constants.PLAIN_LISTENER_DEFAULT_NAME)
+                                    .withPort(9092)
+                                    .withType(KafkaListenerType.INTERNAL)
+                                    .withTls(false)
+                                    .withNewKafkaListenerAuthenticationScramSha512Auth()
+                                    .endKafkaListenerAuthenticationScramSha512Auth()
+                                    .build(),
+                            new GenericKafkaListenerBuilder()
+                                    .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                                    .withPort(9093)
+                                    .withType(KafkaListenerType.INTERNAL)
+                                    .withTls(true)
+                                    .withNewKafkaListenerAuthenticationTlsAuth()
+                                    .endKafkaListenerAuthenticationTlsAuth()
+                                    .build()
+                    )
                 .endKafka()
             .endSpec()
             .build()
         );
 
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(testStorage).build());
+        KafkaUser writeUser = KafkaUserTemplates.scramShaUser(testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaUserWrite)
+            .editSpec()
+                .withNewKafkaUserAuthorizationSimple()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(testStorage.getTopicName())
+                        .endAclRuleTopicResource()
+                        .withOperations(AclOperation.WRITE, AclOperation.DESCRIBE)
+                    .endAcl()
+                .endKafkaUserAuthorizationSimple()
+            .endSpec()
+            .build();
 
-        LOGGER.info("Sending and receiving messages via PLAIN");
+        KafkaUser readUser = KafkaUserTemplates.scramShaUser(testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaUserRead)
+            .editSpec()
+                .withNewKafkaUserAuthorizationSimple()
+                    .addNewAcl()
+                        .withNewAclRuleTopicResource()
+                            .withName(testStorage.getTopicName())
+                        .endAclRuleTopicResource()
+                        .withOperations(AclOperation.READ, AclOperation.DESCRIBE)
+                    .endAcl()
+                    .addNewAcl()
+                        .withNewAclRuleGroupResource()
+                            .withName(readConsumerGroup)
+                        .endAclRuleGroupResource()
+                        .withOperations(AclOperation.READ)
+                    .endAcl()
+                .endKafkaUserAuthorizationSimple()
+            .endSpec()
+            .build();
+
+        KafkaUser tlsReadWriteUser = KafkaUserTemplates.tlsUser(testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaUserReadWriteTls)
+                .editSpec()
+                    .withNewKafkaUserAuthorizationSimple()
+                        .addNewAcl()
+                            .withNewAclRuleTopicResource()
+                                .withName(testStorage.getTopicName())
+                            .endAclRuleTopicResource()
+                            .withOperations(AclOperation.WRITE, AclOperation.READ, AclOperation.DESCRIBE)
+                        .endAcl()
+                        .addNewAcl()
+                            .withNewAclRuleGroupResource()
+                                .withName(readConsumerGroup)
+                            .endAclRuleGroupResource()
+                            .withOperations(AclOperation.READ)
+                        .endAcl()
+                    .endKafkaUserAuthorizationSimple()
+                .endSpec()
+                .build();
+
+        resourceManager.createResource(extensionContext,
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build(),
+            readUser,
+            writeUser,
+            tlsReadWriteUser
+        );
+
+        LOGGER.info("Sending and receiving messages via PLAIN -> SCRAM-SHA");
 
         KafkaClients kafkaClients = new KafkaClientsBuilder()
             .withTopicName(testStorage.getTopicName())
@@ -58,20 +156,25 @@ public class KafkaVersionsST extends AbstractST {
             .withProducerName(testStorage.getProducerName())
             .withConsumerName(testStorage.getConsumerName())
             .withMessageCount(testStorage.getMessageCount())
+            .withUserName(kafkaUserWrite)
+            .withConsumerGroup(readConsumerGroup)
             .build();
 
-        resourceManager.createResource(extensionContext,
-            kafkaClients.producerStrimzi(),
-            kafkaClients.consumerStrimzi()
-        );
+        resourceManager.createResource(extensionContext, kafkaClients.producerScramShaPlainStrimzi());
+        ClientUtils.waitForProducerClientSuccess(testStorage);
 
-        ClientUtils.waitForClientsSuccess(testStorage);
+        kafkaClients = new KafkaClientsBuilder(kafkaClients)
+                .withUserName(kafkaUserRead)
+                .build();
+
+        resourceManager.createResource(extensionContext, kafkaClients.consumerScramShaPlainStrimzi());
+        ClientUtils.waitForConsumerClientSuccess(testStorage);
 
         LOGGER.info("Sending and receiving messages via TLS");
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withUserName(testStorage.getUserName())
+            .withUserName(kafkaUserReadWriteTls)
             .build();
 
         resourceManager.createResource(extensionContext,


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- New test

### Description

This PR adds simple smoke test for testing all supported Kafka versions - inside the `kafka-versions.yaml`.
This way we can test (at least basic functionality like sending and receiving messages) all supported versions in AZP regression pipelines, as we are now running all the tests just with the latest Kafka.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
