### PR TITLE
Simplify `OwnerReference` handling in model classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -238,7 +238,6 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.setJvmOptions(ccSpec.getJvmOptions());
 
             cruiseControl.setResources(ccSpec.getResources());
-            cruiseControl.setOwnerReference(kafkaCr);
 
             if (ccSpec.getTemplate() != null) {
                 CruiseControlTemplate template = ccSpec.getTemplate();
@@ -510,7 +509,7 @@ public class CruiseControl extends AbstractModel {
      * @return The generated Secret.
      */
     public Secret generateApiSecret() {
-        return ModelUtils.createSecret(CruiseControlResources.apiSecretName(cluster), namespace, labels, createOwnerReference(), generateCruiseControlApiCredentials(), Collections.emptyMap(), Collections.emptyMap());
+        return ModelUtils.createSecret(CruiseControlResources.apiSecretName(cluster), namespace, labels, ownerReference, generateCruiseControlApiCredentials(), Collections.emptyMap(), Collections.emptyMap());
     }
 
     /**
@@ -596,7 +595,7 @@ public class CruiseControl extends AbstractModel {
                     .withName(CruiseControlResources.networkPolicyName(cluster))
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())
-                    .withOwnerReferences(createOwnerReference())
+                    .withOwnerReferences(ownerReference)
                 .endMetadata()
                 .withNewSpec()
                     .withNewPodSelector()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -122,8 +122,6 @@ public class EntityOperator extends AbstractModel {
                 && (entityOperatorSpec.getUserOperator() != null || entityOperatorSpec.getTopicOperator() != null)) {
             EntityOperator result = new EntityOperator(reconciliation, kafkaAssembly);
 
-            result.setOwnerReference(kafkaAssembly);
-
             EntityTopicOperator topicOperator = EntityTopicOperator.fromCrd(reconciliation, kafkaAssembly);
             EntityUserOperator userOperator = EntityUserOperator.fromCrd(reconciliation, kafkaAssembly, kraftEnabled);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -124,7 +124,6 @@ public class EntityTopicOperator extends AbstractModel {
             EntityTopicOperatorSpec topicOperatorSpec = kafkaAssembly.getSpec().getEntityOperator().getTopicOperator();
             EntityTopicOperator result = new EntityTopicOperator(reconciliation, kafkaAssembly);
 
-            result.setOwnerReference(kafkaAssembly);
             String image = topicOperatorSpec.getImage();
             if (image == null) {
                 image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE, "quay.io/strimzi/operator:latest");
@@ -275,7 +274,7 @@ public class EntityTopicOperator extends AbstractModel {
     public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret secret = clusterCa.entityTopicOperatorSecret();
         return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, KafkaResources.entityTopicOperatorSecretName(cluster), componentName,
-            CERT_SECRET_KEY_NAME, labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
+            CERT_SECRET_KEY_NAME, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -125,8 +125,6 @@ public class EntityUserOperator extends AbstractModel {
             EntityUserOperatorSpec userOperatorSpec = kafkaAssembly.getSpec().getEntityOperator().getUserOperator();
             EntityUserOperator result = new EntityUserOperator(reconciliation, kafkaAssembly);
 
-            result.setOwnerReference(kafkaAssembly);
-
             String image = userOperatorSpec.getImage();
             if (image == null) {
                 image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_USER_OPERATOR_IMAGE, "quay.io/strimzi/operator:latest");
@@ -312,7 +310,7 @@ public class EntityUserOperator extends AbstractModel {
     public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret secret = clusterCa.entityUserOperatorSecret();
         return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, KafkaResources.entityUserOperatorSecretName(cluster), componentName,
-            CERT_SECRET_KEY_NAME, labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
+            CERT_SECRET_KEY_NAME, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -149,8 +149,6 @@ public class JmxTrans extends AbstractModel {
             }
             result.setImage(image);
 
-            result.setOwnerReference(kafkaAssembly);
-
             if (jmxTransSpec.getTemplate() != null) {
                 JmxTransTemplate template = jmxTransSpec.getTemplate();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -230,7 +230,6 @@ public class KafkaBridgeCluster extends AbstractModel {
             LOGGER.warnCr(reconciliation, "The spec.http property is missing.");
             throw new InvalidResourceException("The HTTP configuration for the bridge is not specified.");
         }
-        kafkaBridgeCluster.setOwnerReference(kafkaBridge);
 
         return kafkaBridgeCluster;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -317,8 +317,6 @@ public class KafkaCluster extends AbstractModel {
         // This also validates that the Kafka version is supported
         result.kafkaVersion = versions.supportedVersion(kafkaClusterSpec.getVersion());
 
-        result.setOwnerReference(kafkaAssembly);
-
         result.setReplicas(kafkaClusterSpec.getReplicas());
 
         // Configures KRaft and KRaft cluster ID
@@ -910,7 +908,7 @@ public class KafkaCluster extends AbstractModel {
                         .withLabels(Util.mergeLabelsOrAnnotations(labels.withAdditionalLabels(templateExternalBootstrapRouteLabels).toMap(), ListenersUtils.bootstrapLabels(listener)))
                         .withAnnotations(Util.mergeLabelsOrAnnotations(templateExternalBootstrapRouteAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
                         .withNamespace(namespace)
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withNewTo()
@@ -955,7 +953,7 @@ public class KafkaCluster extends AbstractModel {
                         .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templatePerPodRouteLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(templatePerPodRouteAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
                         .withNamespace(namespace)
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withNewTo()
@@ -1028,7 +1026,7 @@ public class KafkaCluster extends AbstractModel {
                         .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templateExternalBootstrapIngressLabels, ListenersUtils.bootstrapLabels(listener))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), templateExternalBootstrapIngressAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
                         .withNamespace(namespace)
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withIngressClassName(ingressClass)
@@ -1084,7 +1082,7 @@ public class KafkaCluster extends AbstractModel {
                         .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templateExternalBootstrapIngressLabels, ListenersUtils.bootstrapLabels(listener))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), templateExternalBootstrapIngressAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
                         .withNamespace(namespace)
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withIngressClassName(ingressClass)
@@ -1144,7 +1142,7 @@ public class KafkaCluster extends AbstractModel {
                         .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), templatePerPodIngressAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
                         .withNamespace(namespace)
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withIngressClassName(ingressClass)
@@ -1199,7 +1197,7 @@ public class KafkaCluster extends AbstractModel {
                         .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
                         .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), templatePerPodIngressAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
                         .withNamespace(namespace)
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withIngressClassName(ingressClass)
@@ -1860,7 +1858,7 @@ public class KafkaCluster extends AbstractModel {
                     .withName(KafkaResources.kafkaNetworkPolicyName(cluster))
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())
-                    .withOwnerReferences(createOwnerReference())
+                    .withOwnerReferences(ownerReference)
                 .endMetadata()
                 .withNewSpec()
                     .withNewPodSelector()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -102,8 +102,6 @@ public class KafkaConnectBuild extends AbstractModel {
             throw new InvalidResourceException("Required .spec section is missing.");
         }
 
-        build.setOwnerReference(kafkaConnect);
-
         if (spec.getBuild() != null)    {
             validateBuildConfiguration(spec.getBuild());
 
@@ -418,7 +416,7 @@ public class KafkaConnectBuild extends AbstractModel {
                     .withLabels(labels.withAdditionalLabels(templateBuildConfigLabels).toMap())
                     .withAnnotations(templateBuildConfigAnnotations)
                     .withNamespace(namespace)
-                    .withOwnerReferences(createOwnerReference())
+                    .withOwnerReferences(ownerReference)
                 .endMetadata()
                 .withNewSpec()
                     .withOutput(output)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -202,8 +202,6 @@ public class KafkaConnectCluster extends AbstractModel {
         KafkaConnectCluster cluster = fromSpec(reconciliation, kafkaConnect.getSpec(), versions,
                 new KafkaConnectCluster(reconciliation, kafkaConnect));
 
-        cluster.setOwnerReference(kafkaConnect);
-
         return cluster;
     }
 
@@ -858,7 +856,7 @@ public class KafkaConnectCluster extends AbstractModel {
                         .withName(componentName)
                         .withNamespace(namespace)
                         .withLabels(labels.toMap())
-                        .withOwnerReferences(createOwnerReference())
+                        .withOwnerReferences(ownerReference)
                     .endMetadata()
                     .withNewSpec()
                         .withNewPodSelector()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -168,7 +168,6 @@ public class KafkaExporter extends AbstractModel {
             }
 
             kafkaExporter.version = versions.supportedVersion(kafkaAssembly.getSpec().getKafka().getVersion()).version();
-            kafkaExporter.setOwnerReference(kafkaAssembly);
 
             return kafkaExporter;
         } else {
@@ -294,6 +293,6 @@ public class KafkaExporter extends AbstractModel {
     public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret secret = clusterCa.kafkaExporterSecret();
         return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, KafkaExporterResources.secretName(cluster), componentName,
-                "kafka-exporter", labels, createOwnerReference(), isMaintenanceTimeWindowsSatisfied);
+                "kafka-exporter", labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -97,7 +97,6 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                                                    KafkaVersion.Lookup versions) {
         KafkaMirrorMaker2Cluster cluster = new KafkaMirrorMaker2Cluster(reconciliation, kafkaMirrorMaker2);
         KafkaMirrorMaker2Spec spec = kafkaMirrorMaker2.getSpec();
-        cluster.setOwnerReference(kafkaMirrorMaker2);
 
         cluster.setImage(versions.kafkaMirrorMaker2Version(spec.getImage(), spec.getVersion()));
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -229,8 +229,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
         }
         kafkaMirrorMakerCluster.templatePodLabels = Util.mergeLabelsOrAnnotations(kafkaMirrorMakerCluster.templatePodLabels, DEFAULT_POD_LABELS);
 
-        kafkaMirrorMakerCluster.setOwnerReference(kafkaMirrorMaker);
-
         return kafkaMirrorMakerCluster;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -190,7 +190,6 @@ public class ZookeeperCluster extends AbstractModel {
     @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     public static ZookeeperCluster fromCrd(Reconciliation reconciliation, Kafka kafkaAssembly, KafkaVersion.Lookup versions, Storage oldStorage, int oldReplicas) {
         ZookeeperCluster zk = new ZookeeperCluster(reconciliation, kafkaAssembly);
-        zk.setOwnerReference(kafkaAssembly);
         ZookeeperClusterSpec zookeeperClusterSpec = kafkaAssembly.getSpec().getZookeeper();
 
         int replicas = zookeeperClusterSpec.getReplicas();
@@ -443,7 +442,7 @@ public class ZookeeperCluster extends AbstractModel {
                     .withName(KafkaResources.zookeeperNetworkPolicyName(cluster))
                     .withNamespace(namespace)
                     .withLabels(labels.toMap())
-                    .withOwnerReferences(createOwnerReference())
+                    .withOwnerReferences(ownerReference)
                 .endMetadata()
                 .withNewSpec()
                     .withPodSelector(labelSelector2)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -92,13 +92,13 @@ public class AbstractModelTest {
                 .withNewMetadata()
                     .withName("my-cluster")
                     .withNamespace("my-namespace")
+                    .withUid("6d92db8a-a1f9-4c18-a663-d88731bd52bb")
                 .endMetadata()
                 .build();
 
         AbstractModel am = new Model(kafka);
-        am.setOwnerReference(kafka);
 
-        OwnerReference ref = am.createOwnerReference();
+        OwnerReference ref = am.ownerReference;
 
         assertThat(ref.getApiVersion(), is(kafka.getApiVersion()));
         assertThat(ref.getKind(), is(kafka.getKind()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -139,7 +139,8 @@ public class CruiseControlTest {
             .endTemplate()
             .build();
 
-    private final CruiseControl cc = createCruiseControl(createKafka(cruiseControlSpec));
+    private final Kafka kafka = createKafka(cruiseControlSpec);
+    private final CruiseControl cc = createCruiseControl(kafka);
 
     private CruiseControl createCruiseControl(Kafka kafkaAssembly) {
         return CruiseControl.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS, kafkaAssembly.getSpec().getKafka().getStorage());
@@ -368,8 +369,7 @@ public class CruiseControlTest {
 
         assertThat(dep.getMetadata().getName(), is(CruiseControlResources.deploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        assertThat(dep.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(dep.getMetadata().getOwnerReferences().get(0), is(cc.createOwnerReference()));
+        TestUtils.checkOwnerReference(dep, kafka);
 
         // checks on the main Cruise Control container
         Container ccContainer = containers.stream().filter(container -> ccImage.equals(container.getImage())).findFirst().orElseThrow();
@@ -535,7 +535,7 @@ public class CruiseControlTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
 
-        TestUtils.checkOwnerReference(cc.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, kafka);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -130,8 +130,7 @@ public class EntityOperatorTest {
         assertThat(dep.getMetadata().getName(), is(KafkaResources.entityOperatorDeploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
         assertThat(dep.getSpec().getReplicas(), is(EntityOperatorSpec.DEFAULT_REPLICAS));
-        assertThat(dep.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(dep.getMetadata().getOwnerReferences().get(0), is(entityOperator.createOwnerReference()));
+        TestUtils.checkOwnerReference(dep, resource);
 
         assertThat(containers.size(), is(3));
         // just check names of topic and user operators (their containers are tested in the related unit test classes)
@@ -1064,7 +1063,7 @@ public class EntityOperatorTest {
         EntityOperator eo =  EntityOperator.fromCrd(new Reconciliation("test", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()), resource, VERSIONS, true);
         Role role = eo.generateRole(namespace, namespace);
 
-        assertThat(role.getMetadata().getOwnerReferences().get(0), is(entityOperator.createOwnerReference()));
+        TestUtils.checkOwnerReference(role, resource);
 
         role = eo.generateRole(namespace, "some-other-namespace");
         assertThat(role.getMetadata().getOwnerReferences().size(), is(0));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -188,8 +188,7 @@ public class JmxTransTest {
 
         assertThat(dep.getMetadata().getName(), is(JmxTransResources.deploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        assertThat(dep.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(dep.getMetadata().getOwnerReferences().get(0), is(jmxTrans.createOwnerReference()));
+        TestUtils.checkOwnerReference(dep, kafkaAssembly);
 
         // checks on the main Exporter container
         assertThat(containers.get(0).getImage(), is(image));
@@ -247,8 +246,7 @@ public class JmxTransTest {
 
         assertThat(cm.getMetadata().getName(), is(JmxTransResources.configMapName(cluster)));
         assertThat(cm.getMetadata().getNamespace(), is(namespace));
-        assertThat(cm.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(cm.getMetadata().getOwnerReferences().get(0), is(jmxTrans.createOwnerReference()));
+        TestUtils.checkOwnerReference(cm, kafkaAssembly);
 
         assertThat(cm.getData().getOrDefault(JmxTrans.JMXTRANS_CONFIGMAP_KEY, ""), is("{\"servers\":[{\"host\":\"foo-kafka-0.foo-kafka-brokers\",\"port\":9999,\"username\":\"${kafka.username}\",\"password\":\"${kafka.password}\",\"queries\":[{\"obj\":\"kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=*\",\"attr\":[\"Count\"],\"outputWriters\":[{\"@class\":\"com.googlecode.jmxtrans.model.output.StdOutWriter\"}]}]},{\"host\":\"foo-kafka-1.foo-kafka-brokers\",\"port\":9999,\"username\":\"${kafka.username}\",\"password\":\"${kafka.password}\",\"queries\":[{\"obj\":\"kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=*\",\"attr\":[\"Count\"],\"outputWriters\":[{\"@class\":\"com.googlecode.jmxtrans.model.output.StdOutWriter\"}]}]},{\"host\":\"foo-kafka-2.foo-kafka-brokers\",\"port\":9999,\"username\":\"${kafka.username}\",\"password\":\"${kafka.password}\",\"queries\":[{\"obj\":\"kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=*\",\"attr\":[\"Count\"],\"outputWriters\":[{\"@class\":\"com.googlecode.jmxtrans.model.output.StdOutWriter\"}]}]}]}"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -9,13 +9,11 @@ import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KeyToPath;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -188,7 +186,7 @@ public class KafkaBridgeClusterTest {
 
         assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(KafkaBridgeCluster.DEFAULT_REST_API_PORT)));
 
-        checkOwnerReference(kbc.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @ParallelTest
@@ -222,7 +220,7 @@ public class KafkaBridgeClusterTest {
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
             .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
-        checkOwnerReference(kbc.createOwnerReference(), dep);
+        TestUtils.checkOwnerReference(dep, resource);
     }
 
     @ParallelTest
@@ -531,11 +529,6 @@ public class KafkaBridgeClusterTest {
         ServiceAccount sa = kbc.generateServiceAccount();
         assertThat(sa.getMetadata().getLabels().entrySet().containsAll(saLabels.entrySet()), is(true));
         assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnots.entrySet()), is(true));
-    }
-
-    public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
     @ParallelTest
@@ -1214,7 +1207,7 @@ public class KafkaBridgeClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaBridgeCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(1874)));
-        checkOwnerReference(kbc.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -109,8 +109,7 @@ public class KafkaClusterPodSetTest {
         assertThat(ps.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(kc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
         assertThat(ps.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withDeleteClaim(false).build()).build())));
-        assertThat(ps.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(ps.getMetadata().getOwnerReferences().get(0), is(kc.createOwnerReference()));
+        TestUtils.checkOwnerReference(ps, KAFKA);
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
@@ -197,7 +197,7 @@ public class KafkaClusterStatefulSetTest {
         // We expect a single statefulSet ...
         StatefulSet sts = KC.generateStatefulSet(true, null, null, null);
         checkStatefulSet(sts, KAFKA);
-        checkOwnerReference(KC.createOwnerReference(), sts);
+        TestUtils.checkOwnerReference(sts, KAFKA);
 
         // Check Volumes
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().size(), is(6));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -215,8 +215,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/dockerfile"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is("docker-credentials"));
         assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/kaniko/.docker"));
-        assertThat(pod.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(pod.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
+        TestUtils.checkOwnerReference(pod, kc);
     }
 
     @ParallelTest
@@ -278,8 +277,7 @@ public class KafkaConnectBuildTest {
         assertThat(cm.getMetadata().getName(), is(KafkaConnectResources.dockerFileConfigMapName(cluster)));
         assertThat(cm.getMetadata().getNamespace(), is(namespace));
         assertThat(cm.getData().get("Dockerfile"), is(dockerfile.getDockerfile()));
-        assertThat(cm.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(cm.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
+        TestUtils.checkOwnerReference(cm, kc);
     }
 
     @ParallelTest
@@ -334,8 +332,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getSpec().getStrategy().getDockerStrategy(), is(notNullValue()));
         assertThat(bc.getSpec().getResources().getLimits(), is(limit));
         assertThat(bc.getSpec().getResources().getRequests(), is(request));
-        assertThat(bc.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(bc.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
+        TestUtils.checkOwnerReference(bc, kc);
     }
 
     @ParallelTest
@@ -377,8 +374,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getSpec().getOutput().getTo().getKind(), is("ImageStreamTag"));
         assertThat(bc.getSpec().getOutput().getTo().getName(), is("my-image:latest"));
         assertThat(bc.getSpec().getStrategy().getDockerStrategy(), is(notNullValue()));
-        assertThat(bc.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(bc.getMetadata().getOwnerReferences().get(0), is(build.createOwnerReference()));
+        TestUtils.checkOwnerReference(bc, kc);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -10,13 +10,11 @@ import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.HostAliasBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -238,7 +236,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
 
-        checkOwnerReference(kc.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @ParallelTest
@@ -263,7 +261,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getMetadata().getAnnotations().containsKey("prometheus.io/scrape"), is(false));
         assertThat(svc.getMetadata().getAnnotations().containsKey("prometheus.io/path"), is(false));
 
-        checkOwnerReference(kc.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @ParallelTest
@@ -1781,13 +1779,8 @@ public class KafkaConnectClusterTest {
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
             .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
-        checkOwnerReference(kc.createOwnerReference(), dep);
+        TestUtils.checkOwnerReference(dep, resource);
         checkRack(dep, resource);
-    }
-
-    private void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
     private void checkRack(Deployment deployment, KafkaConnect resource) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -160,8 +160,7 @@ public class KafkaExporterTest {
 
         assertThat(dep.getMetadata().getName(), is(KafkaExporterResources.deploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        assertThat(dep.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(dep.getMetadata().getOwnerReferences().get(0), is(ke.createOwnerReference()));
+        TestUtils.checkOwnerReference(dep, resource);
 
         // checks on the main Exporter container
         assertThat(containers.get(0).getImage(), is(ke.image));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -10,12 +10,10 @@ import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.HostAliasBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
@@ -247,7 +245,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
 
-        checkOwnerReference(kmm2.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @ParallelTest
@@ -272,7 +270,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getMetadata().getAnnotations().containsKey("prometheus.io/scrape"), is(false));
         assertThat(svc.getMetadata().getAnnotations().containsKey("prometheus.io/path"), is(false));
 
-        checkOwnerReference(kmm2.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, resource);
     }
 
     @ParallelTest
@@ -308,7 +306,7 @@ public class KafkaMirrorMaker2ClusterTest {
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
             .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
-        checkOwnerReference(kmm2.createOwnerReference(), dep);
+        TestUtils.checkOwnerReference(dep, resource);
     }
 
     @ParallelTest
@@ -976,11 +974,6 @@ public class KafkaMirrorMaker2ClusterTest {
         ServiceAccount sa = kmm2.generateServiceAccount();
         assertThat(sa.getMetadata().getLabels().entrySet().containsAll(saLabels.entrySet()), is(true));
         assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnots.entrySet()), is(true));
-    }
-
-    public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -9,12 +9,10 @@ import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.HostAliasBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
@@ -279,7 +277,7 @@ public class KafkaMirrorMakerClusterTest {
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
             .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
-        checkOwnerReference(mm.createOwnerReference(), dep);
+        TestUtils.checkOwnerReference(dep, resource);
     }
 
     @ParallelTest
@@ -560,11 +558,6 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_SASL_MECHANISM_CONSUMER), is("plain"));
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_SASL_PASSWORD_FILE_CONSUMER), is("consumer-secret/password"));
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaMirrorMakerCluster.ENV_VAR_KAFKA_MIRRORMAKER_SASL_USERNAME_CONSUMER), is("consumer"));
-    }
-
-    public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -93,8 +93,7 @@ public class ZookeeperClusterPodSetTest {
         assertThat(ps.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(zc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
         assertThat(ps.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new PersistentClaimStorageBuilder().withSize("100Gi").withDeleteClaim(false).build())));
-        assertThat(ps.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(ps.getMetadata().getOwnerReferences().get(0), is(zc.createOwnerReference()));
+        TestUtils.checkOwnerReference(ps, KAFKA);
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(zc.getSelectorLabels().toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterStatefulSetTest.java
@@ -5,12 +5,10 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.HostAliasBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
@@ -146,11 +144,6 @@ public class ZookeeperClusterStatefulSetTest {
                 .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
     }
 
-    public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
-    }
-
     //////////
     // Tests
     //////////
@@ -160,7 +153,7 @@ public class ZookeeperClusterStatefulSetTest {
         // We expect a single statefulSet ...
         StatefulSet sts = ZC.generateStatefulSet(true, null, null);
         checkStatefulSet(sts);
-        checkOwnerReference(ZC.createOwnerReference(), sts);
+        TestUtils.checkOwnerReference(sts, KAFKA);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -9,10 +9,8 @@ import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -146,11 +144,6 @@ public class ZookeeperClusterTest {
         assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
     }
 
-    public void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
-        assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
-    }
-
     private Secret generateCertificatesSecret() {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
         clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, true);
@@ -180,7 +173,7 @@ public class ZookeeperClusterTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
 
         ConfigMap brokerCm = zc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCm, null));
-        checkOwnerReference(zc.createOwnerReference(), brokerCm);
+        TestUtils.checkOwnerReference(brokerCm, KAFKA);
         assertThat(brokerCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS), is("{\"animal\":\"wombat\"}"));
     }
 
@@ -198,7 +191,7 @@ public class ZookeeperClusterTest {
         assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
         assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
 
-        checkOwnerReference(ZC.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, KAFKA);
     }
 
     @ParallelTest
@@ -222,14 +215,14 @@ public class ZookeeperClusterTest {
 
         assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
 
-        checkOwnerReference(zc.createOwnerReference(), svc);
+        TestUtils.checkOwnerReference(svc, KAFKA);
     }
 
     @ParallelTest
     public void testGenerateHeadlessService() {
         Service headless = ZC.generateHeadlessService();
         checkHeadlessService(headless);
-        checkOwnerReference(ZC.createOwnerReference(), headless);
+        TestUtils.checkOwnerReference(headless, KAFKA);
     }
 
     @ParallelTest
@@ -262,7 +255,7 @@ public class ZookeeperClusterTest {
         assertThat(headless.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
 
-        checkOwnerReference(zc.createOwnerReference(), headless);
+        TestUtils.checkOwnerReference(headless, KAFKA);
     }
 
     @ParallelTest

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -368,9 +368,17 @@ public final class TestUtils {
         }
     }
 
-    public static void checkOwnerReference(OwnerReference ownerRef, HasMetadata resource)  {
+    public static void checkOwnerReference(HasMetadata resource, HasMetadata parent)  {
         assertThat(resource.getMetadata().getOwnerReferences().size(), is(1));
-        assertThat(resource.getMetadata().getOwnerReferences().get(0), is(ownerRef));
+
+        OwnerReference or = resource.getMetadata().getOwnerReferences().get(0);
+
+        assertThat(or.getApiVersion(), is(parent.getApiVersion()));
+        assertThat(or.getKind(), is(parent.getKind()));
+        assertThat(or.getName(), is(parent.getMetadata().getName()));
+        assertThat(or.getUid(), is(parent.getMetadata().getUid()));
+        assertThat(or.getBlockOwnerDeletion(), is(false));
+        assertThat(or.getController(), is(false));
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues refactoring the `AbstractModel` class and its subclasses. It moves the creation of the OwnerReference to the `AbstractModel` constructor instead of calling the `createOwnerReference` method again and again to build the same reference. This also removes the need to call the `setOwnerReference` method from every subclass (not sure why we did it like that - maybe some regression failures will remind me 🤔).

Since the owner reference is now stored just as a field, it could be more easily passed to static methods for generating the resources in the future.

As part of these changes, I also slightly improved the tests to use one shared method for checking the owner reference and to compere it against the custom resource rather than just comparing the same field against each other.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally