### PR TITLE
Move PDB creation to `PodDisruptionBudgetUtils` class

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/template/BuildConfigTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/BuildConfigTemplate.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "pullSecret"})
 @EqualsAndHashCode
-public class BuildConfigTemplate implements Serializable, UnknownPropertyPreserving {
+public class BuildConfigTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/DeploymentTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/DeploymentTemplate.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "deploymentStrategy"})
 @EqualsAndHashCode
-public class DeploymentTemplate implements Serializable, UnknownPropertyPreserving {
+public class DeploymentTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/HasMetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/HasMetadataTemplate.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.template;
+
+/**
+ * Interface used for template objects which allow to configure Kubernetes metadata. This is used to have a shard
+ * methods for getting the template values.
+ */
+public interface HasMetadataTemplate {
+    MetadataTemplate getMetadata();
+    void setMetadata(MetadataTemplate metadata);
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/HasMetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/HasMetadataTemplate.java
@@ -9,6 +9,17 @@ package io.strimzi.api.kafka.model.template;
  * methods for getting the template values.
  */
 public interface HasMetadataTemplate {
+    /**
+     * Gets the metadata template
+     *
+     * @return  Metadata template
+     */
     MetadataTemplate getMetadata();
+
+    /**
+     * Sets the metadata template
+     *
+     * @param metadata  Metadata template
+     */
     void setMetadata(MetadataTemplate metadata);
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "ipFamilyPolicy", "ipFamilies"})
 @EqualsAndHashCode
-public class InternalServiceTemplate implements Serializable, UnknownPropertyPreserving {
+public class InternalServiceTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodDisruptionBudgetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodDisruptionBudgetTemplate.java
@@ -30,7 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "maxUnavailable"})
 @DescriptionFile
 @EqualsAndHashCode
-public class PodDisruptionBudgetTemplate implements Serializable, UnknownPropertyPreserving {
+public class PodDisruptionBudgetTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -40,7 +40,7 @@ import java.util.Map;
     "tolerations", "topologySpreadConstraint", "priorityClassName", "schedulerName", "hostAliases", "tmpDirSizeLimit"})
 @EqualsAndHashCode
 @DescriptionFile
-public class PodTemplate implements Serializable, UnknownPropertyPreserving {
+public class PodTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/ResourceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/ResourceTemplate.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata"})
 @EqualsAndHashCode
-public class ResourceTemplate implements Serializable, UnknownPropertyPreserving {
+public class ResourceTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/StatefulSetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/StatefulSetTemplate.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "podManagementPolicy"})
 @EqualsAndHashCode
-public class StatefulSetTemplate implements Serializable, UnknownPropertyPreserving {
+public class StatefulSetTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private MetadataTemplate metadata;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -50,8 +50,6 @@ import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetUpdateStrategyBuilder;
-import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudgetBuilder;
-import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
@@ -294,9 +292,6 @@ public abstract class AbstractModel {
     protected int templateTerminationGracePeriodSeconds = 30;
     protected Map<String, String> templatePersistentVolumeClaimLabels;
     protected Map<String, String> templatePersistentVolumeClaimAnnotations;
-    protected Map<String, String> templatePodDisruptionBudgetLabels;
-    protected Map<String, String> templatePodDisruptionBudgetAnnotations;
-    protected int templatePodDisruptionBudgetMaxUnavailable = 1;
     protected String templatePodPriorityClassName;
     protected String templatePodSchedulerName;
     protected List<HostAlias> templatePodHostAliases;
@@ -1427,98 +1422,6 @@ public abstract class AbstractModel {
      */
     public JvmOptions getJvmOptions() {
         return jvmOptions;
-    }
-
-    /**
-     * Creates the PodDisruptionBudget
-     *
-     * @return The default PodDisruptionBudget
-     */
-    protected PodDisruptionBudget createPodDisruptionBudget()   {
-        return new PodDisruptionBudgetBuilder()
-                .withNewMetadata()
-                    .withName(componentName)
-                    .withLabels(labels.withAdditionalLabels(templatePodDisruptionBudgetLabels).toMap())
-                    .withNamespace(namespace)
-                    .withAnnotations(templatePodDisruptionBudgetAnnotations)
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewMaxUnavailable(templatePodDisruptionBudgetMaxUnavailable)
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels().toMap()).build())
-                .endSpec()
-                .build();
-    }
-
-    /**
-     * Creates the PodDisruptionBudgetV1Beta1
-     *
-     * @return The default PodDisruptionBudgetV1Beta1
-     */
-    protected io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget createPodDisruptionBudgetV1Beta1()   {
-        return new io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudgetBuilder()
-                .withNewMetadata()
-                    .withName(componentName)
-                    .withLabels(labels.withAdditionalLabels(templatePodDisruptionBudgetLabels).toMap())
-                    .withNamespace(namespace)
-                    .withAnnotations(templatePodDisruptionBudgetAnnotations)
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewMaxUnavailable(templatePodDisruptionBudgetMaxUnavailable)
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels().toMap()).build())
-                .endSpec()
-                .build();
-    }
-
-    /**
-     * Creates a PodDisruptionBudget for use with custom pod controller (such as StrimziPodSetController). Unlike
-     * built-in controllers (Deployments, StatefulSets, Jobs, DaemonSets, ...), custom pod controllers can use only PDBs
-     * with minAvailable in absolute numbers (i.e. no percentages).
-     * See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors for more
-     * details.
-     *
-     * @return The default PodDisruptionBudget
-     */
-    protected PodDisruptionBudget createCustomControllerPodDisruptionBudget()   {
-        return new PodDisruptionBudgetBuilder()
-                .withNewMetadata()
-                    .withName(componentName)
-                    .withLabels(labels.withAdditionalLabels(templatePodDisruptionBudgetLabels).toMap())
-                    .withNamespace(namespace)
-                    .withAnnotations(templatePodDisruptionBudgetAnnotations)
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withMinAvailable(new IntOrString(replicas - templatePodDisruptionBudgetMaxUnavailable))
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels().toMap()).build())
-                .endSpec()
-                .build();
-    }
-
-    /**
-     * Creates a PodDisruptionBudget V1Beta1 for use with custom pod controller (such as StrimziPodSetController). Unlike
-     * built-in controllers (Deployments, StatefulSets, Jobs, DaemonSets, ...), custom pod controllers can use only PDBs
-     * with minAvailable in absolute numbers (i.e. no percentages).
-     * See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors for more
-     * details.
-     *
-     * @return The default PodDisruptionBudget V1Beta1
-     */
-    protected io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget createCustomControllerPodDisruptionBudgetV1Beta1()   {
-        return new io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudgetBuilder()
-                .withNewMetadata()
-                    .withName(componentName)
-                    .withLabels(labels.withAdditionalLabels(templatePodDisruptionBudgetLabels).toMap())
-                    .withNamespace(namespace)
-                    .withAnnotations(templatePodDisruptionBudgetAnnotations)
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withMinAvailable(new IntOrString(replicas - templatePodDisruptionBudgetMaxUnavailable))
-                    .withSelector(new LabelSelectorBuilder().withMatchLabels(getSelectorLabels().toMap()).build())
-                .endSpec()
-                .build();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -26,7 +26,6 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
-import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
@@ -262,8 +261,6 @@ public class CruiseControl extends AbstractModel {
                     cruiseControl.templateServiceAccountLabels = template.getServiceAccount().getMetadata().getLabels();
                     cruiseControl.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
                 }
-
-                ModelUtils.parsePodDisruptionBudgetTemplate(cruiseControl, template.getPodDisruptionBudget());
             }
 
             cruiseControl.templatePodLabels = Util.mergeLabelsOrAnnotations(cruiseControl.templatePodLabels, DEFAULT_POD_LABELS);
@@ -447,24 +444,6 @@ public class CruiseControl extends AbstractModel {
         addContainerEnvsToExistingEnvs(varList, templateCruiseControlContainerEnvVars);
 
         return varList;
-    }
-
-    /**
-     * Generates the PodDisruptionBudget.
-     *
-     * @return The PodDisruptionBudget.
-     */
-    public PodDisruptionBudget generatePodDisruptionBudget() {
-        return createPodDisruptionBudget();
-    }
-
-    /**
-     * Generates the PodDisruptionBudgetV1Beta1.
-     *
-     * @return The PodDisruptionBudgetV1Beta1.
-     */
-    public io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget generatePodDisruptionBudgetV1Beta1() {
-        return createPodDisruptionBudgetV1Beta1();
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -39,6 +39,7 @@ import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.Rack;
 import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.template.KafkaBridgeTemplate;
+import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.tracing.Tracing;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.securityprofiles.ContainerSecurityProviderContextImpl;
@@ -128,6 +129,8 @@ public class KafkaBridgeCluster extends AbstractModel {
     private List<ContainerEnvVar> templateInitContainerEnvVars;
     private SecurityContext templateContainerSecurityContext;
 
+    // Templates
+    private PodDisruptionBudgetTemplate templatePodDisruptionBudget;
     private SecurityContext templateInitContainerSecurityContext;
 
     private Tracing tracing;
@@ -267,7 +270,7 @@ public class KafkaBridgeCluster extends AbstractModel {
             kafkaBridgeCluster.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
         }
 
-        ModelUtils.parsePodDisruptionBudgetTemplate(kafkaBridgeCluster, template.getPodDisruptionBudget());
+        kafkaBridgeCluster.templatePodDisruptionBudget = template.getPodDisruptionBudget();
     }
 
     /**
@@ -500,7 +503,7 @@ public class KafkaBridgeCluster extends AbstractModel {
      * @return The pod disruption budget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
-        return createPodDisruptionBudget();
+        return PodDisruptionBudgetUtils.createPodDisruptionBudget(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
     /**
@@ -509,7 +512,7 @@ public class KafkaBridgeCluster extends AbstractModel {
      * @return The pod disruption budget V1Beta1.
      */
     public io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget generatePodDisruptionBudgetV1Beta1() {
-        return createPodDisruptionBudgetV1Beta1();
+        return PodDisruptionBudgetUtils.createPodDisruptionBudgetV1Beta1(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -53,6 +53,7 @@ import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnv;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationEnvVarSource;
 import io.strimzi.api.kafka.model.connect.ExternalConfigurationVolumeSource;
 import io.strimzi.api.kafka.model.template.KafkaConnectTemplate;
+import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
@@ -145,6 +146,9 @@ public class KafkaConnectCluster extends AbstractModel {
 
     private boolean isJmxEnabled;
     private boolean isJmxAuthenticated;
+
+    // Templates
+    protected PodDisruptionBudgetTemplate templatePodDisruptionBudget;
 
     private static final Map<String, String> DEFAULT_POD_LABELS = new HashMap<>();
     static {
@@ -320,7 +324,7 @@ public class KafkaConnectCluster extends AbstractModel {
                 kafkaConnect.templateJmxSecretAnnotations = template.getJmxSecret().getMetadata().getAnnotations();
             }
 
-            ModelUtils.parsePodDisruptionBudgetTemplate(kafkaConnect, template.getPodDisruptionBudget());
+            kafkaConnect.templatePodDisruptionBudget = template.getPodDisruptionBudget();
         }
 
         if (spec.getExternalConfiguration() != null)    {
@@ -710,19 +714,19 @@ public class KafkaConnectCluster extends AbstractModel {
     /**
      * Generates the PodDisruptionBudget
      *
-     * @return The PodDisruptionBudget.
+     * @return The pod disruption budget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
-        return createPodDisruptionBudget();
+        return PodDisruptionBudgetUtils.createPodDisruptionBudget(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
     /**
      * Generates the PodDisruptionBudgetV1Beta1
      *
-     * @return The PodDisruptionBudgetV1Beta1.
+     * @return The pod disruption budget V1Beta1.
      */
     public io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget generatePodDisruptionBudgetV1Beta1() {
-        return createPodDisruptionBudgetV1Beta1();
+        return PodDisruptionBudgetUtils.createPodDisruptionBudgetV1Beta1(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -25,6 +25,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerSpec;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.template.KafkaMirrorMakerTemplate;
+import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.tracing.Tracing;
@@ -111,6 +112,9 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
     protected KafkaMirrorMakerProducerSpec producer;
     protected KafkaMirrorMakerConsumerSpec consumer;
+
+    // Templates
+    private PodDisruptionBudgetTemplate templatePodDisruptionBudget;
     protected List<ContainerEnvVar> templateContainerEnvVars;
     protected SecurityContext templateContainerSecurityContext;
 
@@ -222,7 +226,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
 
                 ModelUtils.parseDeploymentTemplate(kafkaMirrorMakerCluster, template.getDeployment());
                 ModelUtils.parsePodTemplate(kafkaMirrorMakerCluster, template.getPod());
-                ModelUtils.parsePodDisruptionBudgetTemplate(kafkaMirrorMakerCluster, template.getPodDisruptionBudget());
+                kafkaMirrorMakerCluster.templatePodDisruptionBudget = template.getPodDisruptionBudget();
             }
 
             kafkaMirrorMakerCluster.tracing = spec.getTracing();
@@ -467,21 +471,21 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     }
 
     /**
-     * Generates the PodDisruptionBudget.
+     * Generates the PodDisruptionBudget
      *
-     * @return The PodDisruptionBudget.
+     * @return The pod disruption budget.
      */
     public PodDisruptionBudget generatePodDisruptionBudget() {
-        return createPodDisruptionBudget();
+        return PodDisruptionBudgetUtils.createPodDisruptionBudget(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
     /**
-     * Generates the PodDisruptionBudgetV1Beta1.
+     * Generates the PodDisruptionBudgetV1Beta1
      *
-     * @return The PodDisruptionBudgetV1Beta1.
+     * @return The pod disruption budget V1Beta1.
      */
     public io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget generatePodDisruptionBudgetV1Beta1() {
-        return createPodDisruptionBudgetV1Beta1();
+        return PodDisruptionBudgetUtils.createPodDisruptionBudgetV1Beta1(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -32,7 +32,6 @@ import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
-import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.Annotations;
@@ -229,23 +228,6 @@ public class ModelUtils {
                     .withType("Opaque")
                     .withData(data)
                     .build();
-        }
-    }
-
-    /**
-     * Parses the values from the PodDisruptionBudgetTemplate in CRD model into the component model
-     *
-     * @param model AbstractModel class where the values from the PodDisruptionBudgetTemplate should be set
-     * @param pdb PodDisruptionBudgetTemplate with the values form the CRD
-     */
-    public static void parsePodDisruptionBudgetTemplate(AbstractModel model, PodDisruptionBudgetTemplate pdb)   {
-        if (pdb != null)  {
-            if (pdb.getMetadata() != null) {
-                model.templatePodDisruptionBudgetLabels = pdb.getMetadata().getLabels();
-                model.templatePodDisruptionBudgetAnnotations = pdb.getMetadata().getAnnotations();
-            }
-
-            model.templatePodDisruptionBudgetMaxUnavailable = pdb.getMaxUnavailable();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtils.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudgetBuilder;
+import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
+import io.strimzi.operator.common.model.Labels;
+
+/**
+ * Shared methods for working with PodDisruptionBudgets (PDB)
+ */
+public class PodDisruptionBudgetUtils {
+    private static final int DEFAULT_MAX_UNAVAILABLE = 1;
+
+    /**
+     * Creates the PodDisruptionBudget
+     *
+     * @param name              Name of the PDB
+     * @param namespace         Namespace of the PDB
+     * @param labels            Labels of the PDB
+     * @param ownerReference    OwnerReference of the PDB
+     * @param template          PDB template with user's custom configuration
+     *
+     * @return The generated PodDisruptionBudget
+     */
+    public static PodDisruptionBudget createPodDisruptionBudget(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            PodDisruptionBudgetTemplate template
+    )   {
+        return new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(TemplateUtils.annotations(template))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE)
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates the v1beta1 PodDisruptionBudget
+     *
+     * @param name              Name of the PDB
+     * @param namespace         Namespace of the PDB
+     * @param labels            Labels of the PDB
+     * @param ownerReference    OwnerReference of the PDB
+     * @param template          PDB template with user's custom configuration
+     *
+     * @return The generated v1beta1 PodDisruptionBudget
+     */
+    public static io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget createPodDisruptionBudgetV1Beta1(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            PodDisruptionBudgetTemplate template
+    )   {
+        return new io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(TemplateUtils.annotations(template))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewMaxUnavailable(template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE)
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates a PodDisruptionBudget for use with custom pod controller (such as StrimziPodSetController). Unlike
+     * built-in controllers (Deployments, StatefulSets, Jobs, DaemonSets, ...), custom pod controllers can use only PDBs
+     * with minAvailable in absolute numbers (i.e. no percentages).
+     * <p>
+     * See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors for more
+     * details.
+     *
+     * @param name              Name of the PDB
+     * @param namespace         Namespace of the PDB
+     * @param labels            Labels of the PDB
+     * @param ownerReference    OwnerReference of the PDB
+     * @param template          PDB template with user's custom configuration
+     * @param replicas          Number of replicas in the resource(s) which this PDB covers
+     *
+     * @return The generated PodDisruptionBudget
+     */
+    public static PodDisruptionBudget createCustomControllerPodDisruptionBudget(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            PodDisruptionBudgetTemplate template,
+            int replicas
+    )   {
+        return new PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(TemplateUtils.annotations(template))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withMinAvailable(new IntOrString(replicas - (template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE)))
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates a PodDisruptionBudget V1Beta1 for use with custom pod controller (such as StrimziPodSetController). Unlike
+     * built-in controllers (Deployments, StatefulSets, Jobs, DaemonSets, ...), custom pod controllers can use only PDBs
+     * with minAvailable in absolute numbers (i.e. no percentages).
+     * <p>
+     * See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors for more
+     * details.
+     *
+     * @param name              Name of the PDB
+     * @param namespace         Namespace of the PDB
+     * @param labels            Labels of the PDB
+     * @param ownerReference    OwnerReference of the PDB
+     * @param template          PDB template with user's custom configuration
+     * @param replicas          Number of replicas in the resource(s) which this PDB covers
+     *
+     * @return The generated v1beta1 PodDisruptionBudget
+     */
+    public static io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget createCustomControllerPodDisruptionBudgetV1Beta1(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            PodDisruptionBudgetTemplate template,
+            int replicas
+    )   {
+        return new io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudgetBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(TemplateUtils.annotations(template))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withMinAvailable(new IntOrString(replicas - (template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE)))
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
+                .endSpec()
+                .build();
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.template.HasMetadataTemplate;
+
+import java.util.Map;
+
+/**
+ * Shared methods for working with Strimzi API templates
+ */
+public class TemplateUtils {
+    /**
+     * Extracts custom labels configured through the Strimzi API resource templates. This method deals the null checks
+     * and makes the code using it more eas to read.
+     *
+     * @param template  The resource template
+     *
+     * @return  Map with custom labels from the template or null if not set
+     */
+    public static Map<String, String> labels(HasMetadataTemplate template)   {
+        if (template != null
+                && template.getMetadata() != null) {
+            return template.getMetadata().getLabels();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Extracts custom annotations configured through the Strimzi API resource templates. This method deals the null
+     * checks and makes the code using it more eas to read.
+     *
+     * @param template  The resource template
+     *
+     * @return  Map with custom annotations from the template or null if not set
+     */
+    public static Map<String, String> annotations(HasMetadataTemplate template)   {
+        if (template != null
+                && template.getMetadata() != null) {
+            return template.getMetadata().getAnnotations();
+        } else {
+            return null;
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class TemplateUtils {
     /**
      * Extracts custom labels configured through the Strimzi API resource templates. This method deals the null checks
-     * and makes the code using it more eas to read.
+     * and makes the code using it more easy to read.
      *
      * @param template  The resource template
      *
@@ -31,7 +31,7 @@ public class TemplateUtils {
 
     /**
      * Extracts custom annotations configured through the Strimzi API resource templates. This method deals the null
-     * checks and makes the code using it more eas to read.
+     * checks and makes the code using it more easy to read.
      *
      * @param template  The resource template
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -774,15 +773,8 @@ public class KafkaReconciler {
         if (!pfa.hasPodDisruptionBudgetV1()) {
             return Future.succeededFuture();
         } else {
-            PodDisruptionBudget pdb;
-
-            if (featureGates.useStrimziPodSetsEnabled()) {
-                pdb = kafka.generateCustomControllerPodDisruptionBudget();
-            } else {
-                pdb = kafka.generatePodDisruptionBudget();
-            }
-
-            return podDisruptionBudgetOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaStatefulSetName(reconciliation.name()), pdb)
+            return podDisruptionBudgetOperator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaStatefulSetName(reconciliation.name()), kafka.generatePodDisruptionBudget(featureGates.useStrimziPodSetsEnabled()))
                     .map((Void) null);
         }
     }
@@ -796,15 +788,8 @@ public class KafkaReconciler {
         if (pfa.hasPodDisruptionBudgetV1()) {
             return Future.succeededFuture();
         } else {
-            io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdb;
-
-            if (featureGates.useStrimziPodSetsEnabled()) {
-                pdb = kafka.generateCustomControllerPodDisruptionBudgetV1Beta1();
-            } else {
-                pdb = kafka.generatePodDisruptionBudgetV1Beta1();
-            }
-
-            return podDisruptionBudgetV1Beta1Operator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaStatefulSetName(reconciliation.name()), pdb)
+            return podDisruptionBudgetV1Beta1Operator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaStatefulSetName(reconciliation.name()), kafka.generatePodDisruptionBudgetV1Beta1(featureGates.useStrimziPodSetsEnabled()))
                     .map((Void) null);
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.StrimziPodSet;
@@ -488,15 +487,8 @@ public class ZooKeeperReconciler {
         if (!pfa.hasPodDisruptionBudgetV1()) {
             return Future.succeededFuture();
         } else {
-            PodDisruptionBudget pdb;
-
-            if (featureGates.useStrimziPodSetsEnabled()) {
-                pdb = zk.generateCustomControllerPodDisruptionBudget();
-            } else {
-                pdb = zk.generatePodDisruptionBudget();
-            }
-
-            return podDisruptionBudgetOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.zookeeperStatefulSetName(reconciliation.name()), pdb)
+            return podDisruptionBudgetOperator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.zookeeperStatefulSetName(reconciliation.name()), zk.generatePodDisruptionBudget(featureGates.useStrimziPodSetsEnabled()))
                     .map((Void) null);
         }
     }
@@ -510,15 +502,8 @@ public class ZooKeeperReconciler {
         if (pfa.hasPodDisruptionBudgetV1()) {
             return Future.succeededFuture();
         } else {
-            io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdb;
-
-            if (featureGates.useStrimziPodSetsEnabled()) {
-                pdb = zk.generateCustomControllerPodDisruptionBudgetV1Beta1();
-            } else {
-                pdb = zk.generatePodDisruptionBudgetV1Beta1();
-            }
-
-            return podDisruptionBudgetV1Beta1Operator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.zookeeperStatefulSetName(reconciliation.name()), pdb)
+            return podDisruptionBudgetV1Beta1Operator
+                    .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.zookeeperStatefulSetName(reconciliation.name()), zk.generatePodDisruptionBudgetV1Beta1(featureGates.useStrimziPodSetsEnabled()))
                     .map((Void) null);
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -30,7 +30,6 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
-import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
@@ -650,29 +649,6 @@ public class CruiseControlTest {
         ServiceAccount sa = cc.generateServiceAccount();
         assertThat(sa.getMetadata().getLabels().entrySet().containsAll(saLabels.entrySet()), is(true));
         assertThat(sa.getMetadata().getAnnotations().entrySet().containsAll(saAnots.entrySet()), is(true));
-    }
-
-    @ParallelTest
-    public void testPodDisruptionBudget() {
-        int maxUnavailable = 2;
-        CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
-                .withImage(ccImage)
-                    .withNewTemplate()
-                        .withNewPodDisruptionBudget()
-                        .withMaxUnavailable(maxUnavailable)
-                    .endPodDisruptionBudget()
-                .endTemplate()
-                .build();
-
-        Kafka resource = createKafka(cruiseControlSpec);
-
-        CruiseControl cc = createCruiseControl(resource);
-
-        PodDisruptionBudget pdb = cc.generatePodDisruptionBudget();
-        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(maxUnavailable)));
-
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = cc.generatePodDisruptionBudgetV1Beta1();
-        assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(new IntOrString(maxUnavailable)));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -601,12 +601,12 @@ public class KafkaClusterTest {
         assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(perPodRouteAnnotations.entrySet()), is(true));
 
         // Check PodDisruptionBudget
-        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget(false);
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
         // Check PodDisruptionBudget V1Beta1
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1(false);
         assertThat(pdbV1Beta1.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
@@ -2530,7 +2530,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget(false);
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
@@ -2549,7 +2549,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1(false);
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
     }
 
@@ -2559,7 +2559,7 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget(false);
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
@@ -2569,20 +2569,20 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1(false);
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
     @ParallelTest
     public void testDefaultCustomControllerPodDisruptionBudget()   {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
-        PodDisruptionBudget pdb = kc.generateCustomControllerPodDisruptionBudget();
+        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget(true);
         assertThat(pdb.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER)));
         assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
         assertThat(pdb.getSpec().getMinAvailable().getIntVal(), is(2));
         assertThat(pdb.getSpec().getSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
 
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generateCustomControllerPodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kc.generatePodDisruptionBudgetV1Beta1(true);
         assertThat(pdbV1Beta1.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER)));
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(nullValue()));
         assertThat(pdbV1Beta1.getSpec().getMinAvailable().getIntVal(), is(2));
@@ -2611,7 +2611,7 @@ public class KafkaClusterTest {
                 .build();
 
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        PodDisruptionBudget pdb = kc.generateCustomControllerPodDisruptionBudget();
+        PodDisruptionBudget pdb = kc.generatePodDisruptionBudget(true);
 
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnos.entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -44,8 +44,6 @@ import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.template.InternalServiceTemplateBuilder;
 import io.strimzi.api.kafka.model.template.IpFamily;
 import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
-import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
-import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplateBuilder;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplateBuilder;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -108,48 +106,6 @@ public class ModelUtilsTest {
         assertThat(m.get("discovery.3scale.net/port"), is("8080"));
         assertThat(m.get("discovery.3scale.net/path"), is("path/"));
         assertThat(m.get("discovery.3scale.net/description-path"), is("oapi/"));
-    }
-
-    @Test
-    public void testParsePodDisruptionBudgetTemplate()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                    .withName("my-cluster")
-                    .withNamespace("my-namespace")
-                .endMetadata()
-                .build();
-
-        PodDisruptionBudgetTemplate template = new PodDisruptionBudgetTemplateBuilder()
-                .withNewMetadata()
-                .withAnnotations(Collections.singletonMap("annoKey", "annoValue"))
-                .withLabels(Collections.singletonMap("labelKey", "labelValue"))
-                .endMetadata()
-                .withMaxUnavailable(2)
-                .build();
-
-        Model model = new Model(Reconciliation.DUMMY_RECONCILIATION, kafka);
-
-        ModelUtils.parsePodDisruptionBudgetTemplate(model, template);
-        assertThat(model.templatePodDisruptionBudgetLabels, is(Collections.singletonMap("labelKey", "labelValue")));
-        assertThat(model.templatePodDisruptionBudgetAnnotations, is(Collections.singletonMap("annoKey", "annoValue")));
-        assertThat(model.templatePodDisruptionBudgetMaxUnavailable, is(2));
-    }
-
-    @Test
-    public void testParseNullPodDisruptionBudgetTemplate()  {
-        Kafka kafka = new KafkaBuilder()
-                .withNewMetadata()
-                    .withName("my-cluster")
-                    .withNamespace("my-namespace")
-                .endMetadata()
-                .build();
-
-        Model model = new Model(Reconciliation.DUMMY_RECONCILIATION, kafka);
-
-        ModelUtils.parsePodDisruptionBudgetTemplate(model, null);
-        assertThat(model.templatePodDisruptionBudgetLabels, is(nullValue()));
-        assertThat(model.templatePodDisruptionBudgetAnnotations, is(nullValue()));
-        assertThat(model.templatePodDisruptionBudgetMaxUnavailable, is(1));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtilsTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
+import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplateBuilder;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class PodDisruptionBudgetUtilsTest {
+    private final static String NAME = "my-pdb";
+    private final static String NAMESPACE = "my-namespace";
+    private final static int REPLICAS = 5;
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-name")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+    private final static PodDisruptionBudgetTemplate TEMPLATE = new PodDisruptionBudgetTemplateBuilder()
+            .withNewMetadata()
+                .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+            .endMetadata()
+            .withMaxUnavailable(2)
+            .build();
+
+    @ParallelTest
+    public void testPdbWithoutTemplate() {
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
+        assertThat(pdb.getSpec().getMinAvailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testPdbWithTemplate() {
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
+        assertThat(pdb.getSpec().getMinAvailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testCustomControllerPdbWithoutTemplate() {
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, REPLICAS);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(4)));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testCustomControllerPdbWithTemplate() {
+        PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudget(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, REPLICAS);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(3)));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testV1Beta1PdbWithoutTemplate() {
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudgetV1Beta1(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
+        assertThat(pdb.getSpec().getMinAvailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testV1Beta1PdbWithTemplate() {
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createPodDisruptionBudgetV1Beta1(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
+        assertThat(pdb.getSpec().getMinAvailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testV1Beta1CustomControllerPdbWithoutTemplate() {
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudgetV1Beta1(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, REPLICAS);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(4)));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @ParallelTest
+    public void testV1Beta1CustomControllerPdbWithTemplate() {
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdb = PodDisruptionBudgetUtils.createCustomControllerPodDisruptionBudgetV1Beta1(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, REPLICAS);
+
+        assertThat(pdb.getMetadata().getName(), is(NAME));
+        assertThat(pdb.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pdb.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pdb.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pdb.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
+        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(3)));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(pdb.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class TemplateUtilsTest {
+    @ParallelTest
+    public void testMetadataWithNullTemplate() {
+        assertThat(TemplateUtils.annotations(null), is(nullValue()));
+        assertThat(TemplateUtils.labels(null), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testMetadataWithEmptyMetadataTemplate() {
+        ResourceTemplate template = new ResourceTemplateBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .build();
+
+        assertThat(TemplateUtils.annotations(template), is(Map.of()));
+        assertThat(TemplateUtils.labels(template), is(Map.of()));
+    }
+
+    @ParallelTest
+    public void testAnnotations() {
+        ResourceTemplate template = new ResourceTemplateBuilder()
+                .withNewMetadata()
+                    .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                .endMetadata()
+                .build();
+
+        assertThat(TemplateUtils.annotations(template), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+    }
+
+    @ParallelTest
+    public void testLabels() {
+        ResourceTemplate template = new ResourceTemplateBuilder()
+                .withNewMetadata()
+                    .withLabels(Map.of("label-1", "value-1", "label-2", "value-2"))
+                .endMetadata()
+                .build();
+
+        assertThat(TemplateUtils.labels(template), is(Map.of("label-1", "value-1", "label-2", "value-2")));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -496,12 +496,12 @@ public class ZookeeperClusterTest {
         assertThat(svc.getSpec().getIpFamilies(), contains("IPv6"));
 
         // Check PodDisruptionBudget
-        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget(false);
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
         // Check PodDisruptionBudgetV1Beta1
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generatePodDisruptionBudgetV1Beta1(false);
         assertThat(pdbV1Beta1.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnotations.entrySet()), is(true));
 
@@ -526,10 +526,10 @@ public class ZookeeperClusterTest {
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget(false);
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
 
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generatePodDisruptionBudgetV1Beta1(false);
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(new IntOrString(2)));        
     }
 
@@ -539,7 +539,7 @@ public class ZookeeperClusterTest {
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget(false);
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
     }
 
@@ -1043,8 +1043,8 @@ public class ZookeeperClusterTest {
 
     @ParallelTest
     public void testDefaultCustomControllerPodDisruptionBudget()   {
-        PodDisruptionBudget pdb = ZC.generateCustomControllerPodDisruptionBudget();
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = ZC.generateCustomControllerPodDisruptionBudgetV1Beta1();
+        PodDisruptionBudget pdb = ZC.generatePodDisruptionBudget(true);
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = ZC.generatePodDisruptionBudgetV1Beta1(true);
 
         assertThat(pdb.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
@@ -1079,8 +1079,8 @@ public class ZookeeperClusterTest {
                 .build();
 
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        PodDisruptionBudget pdb = zc.generateCustomControllerPodDisruptionBudget();
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generateCustomControllerPodDisruptionBudgetV1Beta1();
+        PodDisruptionBudget pdb = zc.generatePodDisruptionBudget(true);
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = zc.generatePodDisruptionBudgetV1Beta1(true);
 
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnnos.entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1137,8 +1137,8 @@ public class KafkaAssemblyOperatorTest {
         when(mockPolicyOps.get(clusterNamespace, KafkaResources.zookeeperNetworkPolicyName(clusterName))).thenReturn(originalZookeeperCluster.generateNetworkPolicy(null, null));
 
         // Mock PodDisruptionBudget get
-        when(mockPdbOps.get(clusterNamespace, KafkaResources.kafkaStatefulSetName(clusterName))).thenReturn(originalKafkaCluster.generatePodDisruptionBudget());
-        when(mockPdbOps.get(clusterNamespace, KafkaResources.zookeeperStatefulSetName(clusterName))).thenReturn(originalZookeeperCluster.generatePodDisruptionBudget());
+        when(mockPdbOps.get(clusterNamespace, KafkaResources.kafkaStatefulSetName(clusterName))).thenReturn(originalKafkaCluster.generatePodDisruptionBudget(false));
+        when(mockPdbOps.get(clusterNamespace, KafkaResources.zookeeperStatefulSetName(clusterName))).thenReturn(originalZookeeperCluster.generatePodDisruptionBudget(false));
 
         // Mock StrimziPodSets
         AtomicReference<StrimziPodSet> zooPodSetRef = new AtomicReference<>();


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues refactoring the `AbstractModel` class and its subclasses. It moves the creation of Pod Disruption Budgets into static methods in a new class `PodDisruptionBudgetUtils`. The new methods take the full `PodDisruptionBudgetTemplate` object, so it is not necessary anymore to parse it in the `fromCrd` methods and we can also optimize the fields used to hold the PDB options in the model classes.

To make dealing with labels and annotations from the template easier, this PR also introduces a new interface `HasMetadataTemplate` which is used for all the template objects which have the metadata template. That allows us to create a new `TemplateUtils` class with static methods for parsing the labels and annotations out of the different templates. These handle all the null checks and make the code in the methods using them easier to read since it does not have to deal with them.

The Cruise Control model seemed to have the methods for using PDBs. But it actually does not use PDB. So these were removed without replacement.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally