### PR TITLE
Update Azure Pipelines to Ubuntu 22.04 and try to use pre-installed Java

### DIFF
--- a/.azure/templates/jobs/build/build_containers.yaml
+++ b/.azure/templates/jobs/build/build_containers.yaml
@@ -11,7 +11,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       # Install Prerequisites

--- a/.azure/templates/jobs/build/build_docs.yaml
+++ b/.azure/templates/jobs/build/build_docs.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: Ubuntu-20.04
+      vmImage: Ubuntu-22.04
     # Pipeline steps
     steps:
       # Install Prerequisites

--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -6,13 +6,12 @@ jobs:
       matrix:
         'build_strimzi_java-17':
           jdk_version: '17'
-          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: Ubuntu-20.04
+      vmImage: Ubuntu-22.04
     # Pipeline steps
     steps:
       # Get cached Maven repository
@@ -21,6 +20,7 @@ jobs:
         inputs:
           key: '"kafka-binaries" | kafka-versions.yaml'
           path: docker-images/artifacts/binaries/kafka/archives
+        displayName: Kafka binaries cache
 
       # Install Prerequisites
       - template: "../../steps/prerequisites/install_yq.yaml"
@@ -28,7 +28,6 @@ jobs:
       - template: "../../steps/prerequisites/install_helm.yaml"
       - template: '../../steps/prerequisites/install_java.yaml'
         parameters:
-          JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
 
       # Build the Java code without tests

--- a/.azure/templates/jobs/build/deploy_strimzi_java.yaml
+++ b/.azure/templates/jobs/build/deploy_strimzi_java.yaml
@@ -6,13 +6,12 @@ jobs:
       matrix:
         'deploy_strimzi_java-17':
           jdk_version: '17'
-          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       # Get cached Maven repository
@@ -22,7 +21,6 @@ jobs:
       - template: "../../steps/prerequisites/install_yq.yaml"
       - template: '../../steps/prerequisites/install_java.yaml'
         parameters:
-          JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
 
       # Deploy Java artifacts

--- a/.azure/templates/jobs/build/publish_docs.yaml
+++ b/.azure/templates/jobs/build/publish_docs.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       # Unpack the docs

--- a/.azure/templates/jobs/build/push_containers.yaml
+++ b/.azure/templates/jobs/build/push_containers.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       # Install Prerequisites

--- a/.azure/templates/jobs/build/release_artifacts.yaml
+++ b/.azure/templates/jobs/build/release_artifacts.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       # Install Prerequisites

--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -6,13 +6,12 @@ jobs:
       matrix:
         'test_strimzi_java-17':
           jdk_version: '17'
-          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 70
     # Base system
     pool:
-      vmImage: Ubuntu-20.04
+      vmImage: Ubuntu-22.04
     # Pipeline steps
     steps:
       # Get cached Maven repository
@@ -24,7 +23,6 @@ jobs:
       - template: '../../steps/prerequisites/install_minikube.yaml'
       - template: '../../steps/prerequisites/install_java.yaml'
         parameters:
-          JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
 
       # Run the unit and integration tests

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -1,25 +1,11 @@
-# Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (currently, only 17 is used). Images are based on Java 17
+# Step to configure JAVA on the agent
 parameters:
-  - name: JDK_PATH
-    default: '/usr/lib/jvm/java-17-openjdk-amd64'
   - name: JDK_VERSION
     default: '17'
 steps:
-  - bash: |
-      sudo apt-get update
-    displayName: 'Update package list'
-  - bash: |
-      sudo apt-get install openjdk-17-jdk
-    displayName: 'Install openjdk17'
-    condition: eq(variables['JDK_VERSION'], '17')
-  - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]17"
-    displayName: 'Setup JAVA_VERSION=17'
-    condition: eq(variables['JDK_VERSION'], '17')
-  - bash: |
-      echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
-      echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"
-      echo "##vso[task.setvariable variable=PATH]$(jdk_path)/bin:$(PATH)"
-    displayName: 'Setup JAVA_HOME'
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: $(JDK_VERSION)
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+    displayName: 'Configure Java'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -21,10 +21,9 @@ jobs:
     matrix:
       ${{ parameters.name }}:
         jdk_version: '17'
-        jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
   # Base system
   pool:
-    vmImage: 'Ubuntu-20.04'
+    vmImage: 'Ubuntu-22.04'
   # Environment variables
   variables:
     - template: 'default_variables.yaml'
@@ -48,6 +47,7 @@ jobs:
       inputs:
         key: '"kafka-binaries" | kafka-versions.yaml'
         path: docker-images/artifacts/binaries/kafka/archives
+      displayName: Kafka binaries cache
 
     # Install Prerequisites
     - template: "./prerequisites/install_yq.yaml"
@@ -57,7 +57,6 @@ jobs:
     - template: './prerequisites/install_minikube.yaml'
     - template: './prerequisites/install_java.yaml'
       parameters:
-        JDK_PATH: $(jdk_path)
         JDK_VERSION: $(jdk_version)
 
     # Build Strimzi and its images => used when running STs against PR or main branch where container images should be built

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -246,10 +246,7 @@ Commonly used Make targets:
 
 ### Java versions
 
-To use different Java version for the Maven build, you can specify the environment variable `JAVA_VERSION_BUILD` and set
-it to the desired Java version. For example, for building with Java 17 you can use `export JAVA_VERSION_BUILD=17`.
-
-> *Note*: Strimzi currently developed and tested with Java 17.
+Strimzi currently developed and tested with Java 17.
 
 ### Building Docker images
 
@@ -278,12 +275,6 @@ To configure the `docker_tag` and `docker_push` targets you can set following en
 ### Docker build options
 
 When building the Docker images you can use an alternative JRE or use an alternate base image.
-
-#### Alternative Docker image JRE
-
-The docker images can be built with an alternative Java version by setting the environment variable `JAVA_VERSION`. For
-example, to build docker images that have the Java 19 JRE installed use `JAVA_VERSION=19 make docker_build`. If not
-present, the container images will use Java **17** by default.
 
 #### Alternative `docker` command
 

--- a/docker-images/kafka-based/build.sh
+++ b/docker-images/kafka-based/build.sh
@@ -44,7 +44,6 @@ function build {
     
     local targets=$*
     local tag="${DOCKER_TAG:-latest}"
-    local java_version="${JAVA_VERSION:-11}"
 
     for kafka_version in "${!version_checksums[@]}"
     do
@@ -58,7 +57,7 @@ function build {
         for image in $kafka_images
         do
             make -C "$image" "$targets" \
-                DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg JAVA_VERSION=${java_version} --build-arg KAFKA_VERSION=${kafka_version} --build-arg KAFKA_DIST_DIR=${relative_dist_dir} --build-arg THIRD_PARTY_LIBS=${lib_directory} $(alternate_base "$image")" \
+                DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg KAFKA_VERSION=${kafka_version} --build-arg KAFKA_DIST_DIR=${relative_dist_dir} --build-arg THIRD_PARTY_LIBS=${lib_directory} $(alternate_base "$image")" \
                 DOCKER_TAG="${tag}-kafka-${kafka_version}" \
                 BUILD_TAG="build-kafka-${kafka_version}" \
                 KAFKA_VERSION="${kafka_version}" \


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Lately, we had a lot of issues with the installation of OpenJDK in our pipelines. This PR moves to use Ubuntu 22.04 and the pre-installed OpenJDK which is already there. That should solve the issues. While doing this, it also cleans up some of the unused variables around the Java version configuration and removes them from the developer docs.