### PR TITLE
Remove some leftovers after `v1beta1` `Ingress` support from `KafkaCluster` class and its tests

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1042,62 +1042,6 @@ public class KafkaCluster extends AbstractModel {
     }
 
     /**
-     * Generates a list of bootstrap ingress which can be used to bootstrap clients outside of Kubernetes.
-     *
-     * @return The list of generated Ingresses
-     */
-    public List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> generateExternalBootstrapIngressesV1Beta1() {
-        List<GenericKafkaListener> ingressListeners = ListenersUtils.ingressListeners(listeners);
-        List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingresses = new ArrayList<>(ingressListeners.size());
-
-        for (GenericKafkaListener listener : ingressListeners)   {
-            String ingressName = ListenersUtils.backwardsCompatibleBootstrapRouteOrIngressName(cluster, listener);
-            String serviceName = ListenersUtils.backwardsCompatibleBootstrapServiceName(cluster, listener);
-
-            String host = ListenersUtils.bootstrapHost(listener);
-            String ingressClass = ListenersUtils.controllerClass(listener);
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
-                    .withPath("/")
-                    .withNewBackend()
-                        .withNewServicePort(listener.getPort())
-                        .withServiceName(serviceName)
-                    .endBackend()
-                    .build();
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule rule = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRuleBuilder()
-                    .withHost(host)
-                    .withNewHttp()
-                        .withPaths(path)
-                    .endHttp()
-                    .build();
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS tls = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLSBuilder()
-                    .withHosts(host)
-                    .build();
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingress = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
-                    .withNewMetadata()
-                        .withName(ingressName)
-                        .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templateExternalBootstrapIngressLabels, ListenersUtils.bootstrapLabels(listener))).toMap())
-                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), templateExternalBootstrapIngressAnnotations, ListenersUtils.bootstrapAnnotations(listener)))
-                        .withNamespace(namespace)
-                        .withOwnerReferences(ownerReference)
-                    .endMetadata()
-                    .withNewSpec()
-                        .withIngressClassName(ingressClass)
-                        .withRules(rule)
-                        .withTls(tls)
-                    .endSpec()
-                    .build();
-
-            ingresses.add(ingress);
-        }
-
-        return ingresses;
-    }
-
-    /**
      * Generates list of ingress for pod. This ingress is used for exposing it externally using Nginx Ingress.
      *
      * @param pod Number of the pod for which this ingress should be generated
@@ -1137,61 +1081,6 @@ public class KafkaCluster extends AbstractModel {
                     .build();
 
             Ingress ingress = new IngressBuilder()
-                    .withNewMetadata()
-                        .withName(ingressName)
-                        .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())
-                        .withAnnotations(Util.mergeLabelsOrAnnotations(generateInternalIngressAnnotations(), templatePerPodIngressAnnotations, ListenersUtils.brokerAnnotations(listener, pod)))
-                        .withNamespace(namespace)
-                        .withOwnerReferences(ownerReference)
-                    .endMetadata()
-                    .withNewSpec()
-                        .withIngressClassName(ingressClass)
-                        .withRules(rule)
-                        .withTls(tls)
-                    .endSpec()
-                    .build();
-
-            ingresses.add(ingress);
-        }
-
-        return ingresses;
-    }
-
-    /**
-     * Generates list of ingress for pod. This ingress is used for exposing it externally using Nginx Ingress.
-     *
-     * @param pod Number of the pod for which this ingress should be generated
-     * @return The list of generated Ingresses
-     */
-    public List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> generateExternalIngressesV1Beta1(int pod) {
-        List<GenericKafkaListener> ingressListeners = ListenersUtils.ingressListeners(listeners);
-        List<io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress> ingresses = new ArrayList<>(ingressListeners.size());
-
-        for (GenericKafkaListener listener : ingressListeners)   {
-            String ingressName = ListenersUtils.backwardsCompatibleBrokerServiceName(cluster, pod, listener);
-            String host = ListenersUtils.brokerHost(listener, pod);
-            String ingressClass = ListenersUtils.controllerClass(listener);
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath path = new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder()
-                    .withPath("/")
-                    .withNewBackend()
-                        .withNewServicePort(listener.getPort())
-                        .withServiceName(ingressName)
-                    .endBackend()
-                    .build();
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule rule = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRuleBuilder()
-                    .withHost(host)
-                    .withNewHttp()
-                        .withPaths(path)
-                    .endHttp()
-                    .build();
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS tls = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLSBuilder()
-                    .withHosts(host)
-                    .build();
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingress = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
                     .withNewMetadata()
                         .withName(ingressName)
                         .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(templatePerPodIngressLabels, ListenersUtils.brokerLabels(listener, pod))).toMap())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3043,22 +3043,6 @@ public class KafkaClusterTest {
         assertThat(bing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
         TestUtils.checkOwnerReference(bing, KAFKA);
 
-        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress bingV1Beta1 = kc.generateExternalBootstrapIngressesV1Beta1().get(0);
-        assertThat(bingV1Beta1.getMetadata().getName(), is(KafkaResources.bootstrapServiceName(CLUSTER)));
-        assertThat(bingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
-        assertThat(bingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-bootstrap.com"));
-        assertThat(bingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
-        assertThat(bingV1Beta1.getSpec().getTls().size(), is(1));
-        assertThat(bingV1Beta1.getSpec().getTls().get(0).getHosts().size(), is(1));
-        assertThat(bingV1Beta1.getSpec().getTls().get(0).getHosts().get(0), is("my-kafka-bootstrap.com"));
-        assertThat(bingV1Beta1.getSpec().getRules().size(), is(1));
-        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHost(), is("my-kafka-bootstrap.com"));
-        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
-        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
-        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaResources.externalBootstrapServiceName(CLUSTER)));
-        assertThat(bingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
-        TestUtils.checkOwnerReference(bingV1Beta1, KAFKA);
-
         // Check per pod ingress
         for (int i = 0; i < REPLICAS; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
@@ -3076,22 +3060,6 @@ public class KafkaClusterTest {
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(ing.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber(), is(9094));
             TestUtils.checkOwnerReference(ing, KAFKA);
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
-            assertThat(ingV1Beta1.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
-            assertThat(ingV1Beta1.getSpec().getIngressClassName(), is(nullValue()));
-            assertThat(ingV1Beta1.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
-            assertThat(ingV1Beta1.getMetadata().getLabels().get("label"), is("label-value"));
-            assertThat(ingV1Beta1.getSpec().getTls().size(), is(1));
-            assertThat(ingV1Beta1.getSpec().getTls().get(0).getHosts().size(), is(1));
-            assertThat(ingV1Beta1.getSpec().getTls().get(0).getHosts().get(0), is(String.format("my-broker-kafka-%d.com", i)));
-            assertThat(ingV1Beta1.getSpec().getRules().size(), is(1));
-            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHost(), is(String.format("my-broker-kafka-%d.com", i)));
-            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().size(), is(1));
-            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), is("/"));
-            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
-            assertThat(ingV1Beta1.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort(), is(new IntOrString(9094)));
-            TestUtils.checkOwnerReference(ingV1Beta1, KAFKA);
         }
     }
 
@@ -3139,16 +3107,10 @@ public class KafkaClusterTest {
         Ingress bing = kc.generateExternalBootstrapIngresses().get(0);
         assertThat(bing.getSpec().getIngressClassName(), is("nginx-internal"));
 
-        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress bingV1Beta1 = kc.generateExternalBootstrapIngressesV1Beta1().get(0);
-        assertThat(bingV1Beta1.getSpec().getIngressClassName(), is("nginx-internal"));
-
         // Check per pod ingress
         for (int i = 0; i < REPLICAS; i++)  {
             Ingress ing = kc.generateExternalIngresses(i).get(0);
             assertThat(ing.getSpec().getIngressClassName(), is("nginx-internal"));
-
-            io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingV1Beta1 = kc.generateExternalIngressesV1Beta1(i).get(0);
-            assertThat(ingV1Beta1.getSpec().getIngressClassName(), is("nginx-internal"));
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

PR #7395 removed our support for `v1beta1` version of the `Ingress` resource as we moved to support only Kubernetes 1.19+ in Strimzi 0.32. But it looks like it left some code in the `KafkaCluster` class and its test class. This PR removes these leftovers.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally