### PR TITLE
Move PVC creation out of `AbstractModel` class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.strimzi.api.kafka.model.storage.JbodStorage;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverride;
+import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
+import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared methods for working with Persistent Volume Claims
+ */
+public class PersistentVolumeClaimUtils {
+    /**
+     * Creates list of PersistentVolumeClaims required by stateful deployments (Kafka and Zoo). This method calls itself
+     * recursively to handle volumes inside JBOD storage. When it calls itself to handle the volumes inside JBOD array,
+     * the {@code jbod} flag should be set to {@code true}. When called from outside, it should be set to {@code false}.
+     *
+     * @param componentName             Name of the Strimzi component to which these PVCs belong. It is used to generate
+     *                                  the PVC names.
+     * @param namespace                 Namespace of the PVC
+     * @param replicas                  Number of replicas this component has
+     * @param storage                   The user supplied configuration of the PersistentClaimStorage
+     * @param jbod                      Indicator whether the {@code storage} is part of JBOD array or not
+     * @param labels                    Labels of the PVC
+     * @param ownerReference            OwnerReference of the PVC
+     * @param template                  PVC template with user's custom configuration
+     * @param statefulSetTemplateLabels User configured labels from StatefulSet template. These are added to the PVC
+     *                                  labels for historical reasons. This should be removed when removing StatefulSet support.
+     *
+     * @return  List with Persistent Volume Claims
+     */
+    public static List<PersistentVolumeClaim> createPersistentVolumeClaims(
+            String componentName,
+            String namespace,
+            int replicas,
+            Storage storage,
+            boolean jbod,
+            Labels labels,
+            OwnerReference ownerReference,
+            ResourceTemplate template,
+            Map<String, String> statefulSetTemplateLabels
+    )   {
+        List<PersistentVolumeClaim> pvcs = new ArrayList<>();
+
+        if (storage != null) {
+            if (storage instanceof PersistentClaimStorage persistentStorage) {
+                String pvcBaseName = VolumeUtils.createVolumePrefix(persistentStorage.getId(), jbod) + "-" + componentName;
+
+                for (int brokerId = 0; brokerId < replicas; brokerId++) {
+                    pvcs.add(createPersistentVolumeClaim(pvcBaseName + "-" + brokerId, namespace, brokerId, persistentStorage, labels, ownerReference, template, statefulSetTemplateLabels));
+                }
+            } else if (storage instanceof JbodStorage jbodStorage) {
+                for (SingleVolumeStorage volume : jbodStorage.getVolumes()) {
+                    // it's called recursively for setting the information from the current volume
+                    pvcs.addAll(createPersistentVolumeClaims(componentName, namespace, replicas, volume, true, labels, ownerReference, template, statefulSetTemplateLabels));
+                }
+            }
+        }
+
+        return pvcs;
+    }
+
+    /**
+     * Gets the storage class configured for given PVC. This either the regularly configured storage class or the
+     * storage class from the per-broker configuration overrides. If not storage class is specified, it returns null
+     * and the default storage class will be used.
+     *
+     * @param brokerId          ID of the broker to which this PVC belongs. It is used to find configuration overrides
+     *                          for Storage class.
+     * @param storage           The user supplied configuration of the PersistentClaimStorage
+     *
+     * @return  Storage class which should be used for this PVC
+     */
+    private static String storageClassNameForBrokerId(int brokerId, PersistentClaimStorage storage)    {
+        String storageClass = storage.getStorageClass();
+
+        if (storage.getOverrides() != null) {
+            storageClass = storage.getOverrides().stream()
+                    .filter(broker -> broker != null
+                            && broker.getBroker() != null
+                            && broker.getBroker() == brokerId
+                            && broker.getStorageClass() != null)
+                    .map(PersistentClaimStorageOverride::getStorageClass)
+                    .findAny()
+                    // if none are found for broker do not change storage class from overrides
+                    .orElse(storageClass);
+        }
+
+        return storageClass;
+    }
+
+    /**
+     * Generates a persistent volume claim for a given broker ID.
+     *
+     * @param name                      Name of the PVC
+     * @param namespace                 Namespace of the PVC
+     * @param brokerId                  ID of the broker to which this PVC belongs. It is used to find configuration
+     *                                  overrides for Storage class.
+     * @param storage                   The user supplied configuration of the PersistentClaimStorage
+     * @param labels                    Labels of the PVC
+     * @param ownerReference            OwnerReference of the PVC
+     * @param template                  PVC template with user's custom configuration
+     * @param statefulSetTemplateLabels User configured labels from StatefulSet template. These are added to the PVC
+     *                                  labels for historical reasons. This should be removed when removing StatefulSet support.
+     *
+     * @return  Generated PersistentVolumeClaim
+     */
+    private static PersistentVolumeClaim createPersistentVolumeClaim(
+            String name,
+            String namespace,
+            int brokerId,
+            PersistentClaimStorage storage,
+            Labels labels,
+            OwnerReference ownerReference,
+            ResourceTemplate template,
+            Map<String, String> statefulSetTemplateLabels
+    ) {
+        Map<String, Quantity> requests = new HashMap<>(1);
+        requests.put("storage", new Quantity(storage.getSize(), null));
+
+        LabelSelector storageSelector = null;
+        if (storage.getSelector() != null && !storage.getSelector().isEmpty()) {
+            storageSelector = new LabelSelector(null, storage.getSelector());
+        }
+
+        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(TemplateUtils.labels(template), statefulSetTemplateLabels)).toMap())
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, Boolean.toString(storage.isDeleteClaim())), TemplateUtils.annotations(template)))
+                .endMetadata()
+                .withNewSpec()
+                    .withAccessModes("ReadWriteOnce")
+                    .withNewResources()
+                        .withRequests(requests)
+                    .endResources()
+                    .withStorageClassName(storageClassNameForBrokerId(brokerId, storage))
+                    .withSelector(storageSelector)
+                    .withVolumeMode("Filesystem")
+                .endSpec()
+                .build();
+
+        // if the persistent volume claim has to be deleted when the cluster is un-deployed then set an owner reference of the CR
+        if (storage.isDeleteClaim())    {
+            pvc.getMetadata().setOwnerReferences(Collections.singletonList(ownerReference));
+        }
+
+        return pvc;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -48,8 +48,6 @@ import io.vertx.core.Vertx;
 
 import java.time.Clock;
 
-import static io.strimzi.operator.cluster.model.AbstractModel.ANNO_STRIMZI_IO_STORAGE;
-
 /**
  * <p>Assembly operator for a "Kafka" assembly, which manages:</p>
  * <ul>
@@ -296,7 +294,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             Storage storage = null;
 
             if (sts != null)    {
-                String jsonStorage = Annotations.stringAnnotation(sts, ANNO_STRIMZI_IO_STORAGE, null);
+                String jsonStorage = Annotations.stringAnnotation(sts, Annotations.ANNO_STRIMZI_IO_STORAGE, null);
 
                 if (jsonStorage != null)    {
                     storage = ModelUtils.decodeStorageFromJson(jsonStorage);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -92,7 +92,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.strimzi.operator.cluster.model.AbstractModel.ANNO_STRIMZI_IO_STORAGE;
 import static io.strimzi.operator.cluster.model.KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION;
 
 /**
@@ -817,7 +816,7 @@ public class KafkaReconciler {
 
         // Storage annotation on Pods is used only for StatefulSets
         if (storageAnnotation) {
-            podAnnotations.put(ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(kafka.getStorage()));
+            podAnnotations.put(Annotations.ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(kafka.getStorage()));
         }
 
         return podAnnotations;
@@ -958,7 +957,7 @@ public class KafkaReconciler {
     private RestartReasons needsRestartBecauseAddedOrRemovedJbodVolumes(Pod pod, JbodStorage desiredStorage, int currentReplicas, int desiredReplicas)  {
         if (pod != null
                 && pod.getMetadata() != null) {
-            String jsonStorage = Annotations.stringAnnotation(pod, ANNO_STRIMZI_IO_STORAGE, null);
+            String jsonStorage = Annotations.stringAnnotation(pod, Annotations.ANNO_STRIMZI_IO_STORAGE, null);
 
             if (jsonStorage != null) {
                 Storage currentStorage = ModelUtils.decodeStorageFromJson(jsonStorage);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -174,7 +173,7 @@ public class PvcReconciler {
     private Future<Void> considerPersistentClaimDeletion(String pvcName)   {
         return pvcOperator.getAsync(reconciliation.namespace(), pvcName)
                 .compose(pvc -> {
-                    if (Annotations.booleanAnnotation(pvc, AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM, false)) {
+                    if (Annotations.booleanAnnotation(pvc, Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, false)) {
                         LOGGER.infoCr(reconciliation, "Deleting PVC {}", pvcName);
                         return pvcOperator.reconcile(reconciliation, reconciliation.namespace(), pvcName, null)
                                 .map((Void) null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -36,6 +36,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.platform.KubernetesVersion;
@@ -108,7 +109,7 @@ public class KafkaClusterPodSetTest {
 
         assertThat(ps.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(kc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
-        assertThat(ps.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withDeleteClaim(false).build()).build())));
+        assertThat(ps.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").withDeleteClaim(false).build()).build())));
         TestUtils.checkOwnerReference(ps, KAFKA);
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(kc.getSelectorLabels().toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
@@ -33,6 +33,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.template.PodManagementPolicy;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.platform.KubernetesVersion;
@@ -121,7 +122,7 @@ public class KafkaClusterStatefulSetTest {
         assertThat(sts.getMetadata().getNamespace(), is(NAMESPACE));
         // ... with these labels
         assertThat(sts.getMetadata().getLabels(), is(expectedLabels()));
-        assertThat(sts.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(kafka.getSpec().getKafka().getStorage())));
+        assertThat(sts.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(kafka.getSpec().getKafka().getStorage())));
         assertThat(sts.getSpec().getSelector().getMatchLabels(), is(expectedSelectorLabels()));
 
         assertThat(sts.getSpec().getTemplate().getSpec().getSchedulerName(), is("default-scheduler"));
@@ -590,7 +591,7 @@ public class KafkaClusterStatefulSetTest {
 
         // Check Storage annotation on STS
         StatefulSet sts = kc.generateStatefulSet(true, ImagePullPolicy.NEVER, null, null);
-        assertThat(sts.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
+        assertThat(sts.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(kafkaAssembly.getSpec().getKafka().getStorage())));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream().filter(v -> "data".equals(v.getName())).findFirst().orElseThrow().getEmptyDir(), is(notNullValue()));
 
         // Check PVCs

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -68,6 +68,7 @@ import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
@@ -804,7 +805,7 @@ public class KafkaClusterTest {
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
     }
 
@@ -829,7 +830,7 @@ public class KafkaClusterTest {
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
     }
 
@@ -870,7 +871,7 @@ public class KafkaClusterTest {
 
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
     }
 
@@ -916,7 +917,7 @@ public class KafkaClusterTest {
 
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
 
         for (int i = 3; i < 6; i++) {
@@ -931,7 +932,7 @@ public class KafkaClusterTest {
 
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
     }
 
@@ -960,7 +961,7 @@ public class KafkaClusterTest {
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
 
         for (int i = 3; i < 6; i++) {
@@ -969,7 +970,7 @@ public class KafkaClusterTest {
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-st1"));
             assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.strimzi.api.kafka.model.storage.EphemeralStorage;
+import io.strimzi.api.kafka.model.storage.JbodStorage;
+import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverrideBuilder;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class PersistentVolumeClaimUtilsTest {
+    private final static String NAME = "my-cluster-kafka";
+    private final static String NAMESPACE = "my-namespace";
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-cluster")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-cluster-kafka")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+    private final static ResourceTemplate TEMPLATE = new ResourceTemplateBuilder()
+            .withNewMetadata()
+                .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+            .endMetadata()
+            .build();
+    private final static PersistentClaimStorage PERSISTENT_CLAIM_STORAGE = new PersistentClaimStorageBuilder()
+            .withStorageClass("my-storage-class")
+            .withSize("100Gi")
+            .build();
+
+    @ParallelTest
+    public void testEphemeralStorage()  {
+        assertThat(
+                PersistentVolumeClaimUtils
+                        .createPersistentVolumeClaims(NAME, NAMESPACE, 3, new EphemeralStorage(), false, LABELS, OWNER_REFERENCE, null, null),
+                is(List.of())
+        );
+    }
+
+    @ParallelTest
+    public void testEphemeralJbodStorage()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new EphemeralStorage(), new EphemeralStorage())
+                .build();
+
+        assertThat(
+                PersistentVolumeClaimUtils
+                        .createPersistentVolumeClaims(NAME, NAMESPACE, 3, jbod, false, LABELS, OWNER_REFERENCE, null, null),
+                is(List.of())
+        );
+    }
+
+    @ParallelTest
+    public void testPersistentClaimStorage()  {
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, PERSISTENT_CLAIM_STORAGE, false, LABELS, OWNER_REFERENCE, null, null);
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testJbodStorage()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, null);
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testTemplate()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, TEMPLATE, null);
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false", "anno-1", "value-1", "anno-2", "value-2")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testTemplateAndStatefulSetLabels()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, TEMPLATE, Map.of("sts-labela-1", "value-from-sts-1"));
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4", "sts-labela-1", "value-from-sts-1")).toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false", "anno-1", "value-1", "anno-2", "value-2")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testWithoutTemplateButWithStatefulSetLabels()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, Map.of("sts-labela-1", "value-from-sts-1"));
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("sts-labela-1", "value-from-sts-1")).toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testWithSelector()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .withSelector(Map.of("pv-label", "pv-value"))
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, null);
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector().getMatchLabels(), is(Map.of("pv-label", "pv-value")));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testJbodStorageWithDeleteClaim()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .withDeleteClaim(true)
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, null);
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "true")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
+    }
+
+    @ParallelTest
+    public void testWithStorageClassOverrides()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                        .withId(0)
+                        .withStorageClass("my-storage-class")
+                        .withSize("100Gi")
+                        .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build())
+                        .build())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, null);
+
+        assertThat(pvcs.size(), is(1));
+
+        assertThat(pvcs.get(0).getMetadata().getName(), is("data-0-my-cluster-kafka-0"));
+        assertThat(pvcs.get(0).getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pvcs.get(0).getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pvcs.get(0).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
+        assertThat(pvcs.get(0).getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(pvcs.get(0).getSpec().getVolumeMode(), is("Filesystem"));
+        assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+        assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
+        assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("special-storage-class"));
+    }
+
+    @ParallelTest
+    public void testJbodWithClassOverridesAndDeleteClaims()  {
+        JbodStorage jbod = new JbodStorageBuilder()
+                .withVolumes(
+                        new PersistentClaimStorageBuilder()
+                                .withId(0)
+                                .withStorageClass("my-storage-class")
+                                .withSize("100Gi")
+                                .withDeleteClaim(false)
+                                .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build())
+                                .build(),
+                        new PersistentClaimStorageBuilder()
+                                .withId(1)
+                                .withStorageClass("my-storage-class2")
+                                .withSize("200Gi")
+                                .withDeleteClaim(true)
+                                .build(),
+                        new EphemeralStorage())
+                .build();
+
+        List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 3, jbod, false, LABELS, OWNER_REFERENCE, null, null);
+
+        assertThat(pvcs.size(), is(6));
+
+        for (int i = 0; i < 3; i++)  {
+            assertThat(pvcs.get(i).getMetadata().getName(), is("data-0-my-cluster-kafka-" + i));
+            assertThat(pvcs.get(i).getMetadata().getNamespace(), is(NAMESPACE));
+            assertThat(pvcs.get(i).getMetadata().getLabels(), is(LABELS.toMap()));
+            assertThat(pvcs.get(i).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "false")));
+            assertThat(pvcs.get(i).getMetadata().getOwnerReferences(), is(List.of()));
+            assertThat(pvcs.get(i).getSpec().getVolumeMode(), is("Filesystem"));
+            assertThat(pvcs.get(i).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+            assertThat(pvcs.get(i).getSpec().getSelector(), is(nullValue()));
+            assertThat(pvcs.get(i).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
+            assertThat(pvcs.get(i).getSpec().getStorageClassName(), is(i == 0 ? "special-storage-class" : "my-storage-class"));
+        }
+
+        for (int i = 3; i < 6; i++)  {
+            assertThat(pvcs.get(i).getMetadata().getName(), is("data-1-my-cluster-kafka-" + i % 3));
+            assertThat(pvcs.get(i).getMetadata().getNamespace(), is(NAMESPACE));
+            assertThat(pvcs.get(i).getMetadata().getLabels(), is(LABELS.toMap()));
+            assertThat(pvcs.get(i).getMetadata().getAnnotations(), is(Map.of("strimzi.io/delete-claim", "true")));
+            assertThat(pvcs.get(i).getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+            assertThat(pvcs.get(i).getSpec().getVolumeMode(), is("Filesystem"));
+            assertThat(pvcs.get(i).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
+            assertThat(pvcs.get(i).getSpec().getSelector(), is(nullValue()));
+            assertThat(pvcs.get(i).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("200Gi", null))));
+            assertThat(pvcs.get(i).getSpec().getStorageClassName(), is("my-storage-class2"));
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -32,6 +32,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.platform.KubernetesVersion;
@@ -92,7 +93,7 @@ public class ZookeeperClusterPodSetTest {
 
         assertThat(ps.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(zc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
-        assertThat(ps.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new PersistentClaimStorageBuilder().withSize("100Gi").withDeleteClaim(false).build())));
+        assertThat(ps.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(new PersistentClaimStorageBuilder().withSize("100Gi").withDeleteClaim(false).build())));
         TestUtils.checkOwnerReference(ps, KAFKA);
         assertThat(ps.getSpec().getSelector().getMatchLabels(), is(zc.getSelectorLabels().toMap()));
         assertThat(ps.getSpec().getPods().size(), is(3));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterStatefulSetTest.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.template.PodManagementPolicy;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
@@ -108,7 +109,7 @@ public class ZookeeperClusterStatefulSetTest {
         assertThat(sts.getMetadata().getNamespace(), is(NAMESPACE));
         // ... with these labels
         assertThat(sts.getMetadata().getLabels(), is(expectedLabels()));
-        assertThat(sts.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(KAFKA.getSpec().getZookeeper().getStorage())));
+        assertThat(sts.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_STORAGE), is(ModelUtils.encodeStorageToJson(KAFKA.getSpec().getZookeeper().getStorage())));
 
         assertThat(sts.getSpec().getSelector().getMatchLabels(), is(expectedSelectorLabels()));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -44,6 +44,7 @@ import io.strimzi.api.kafka.model.template.IpFamily;
 import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
@@ -666,7 +667,7 @@ public class ZookeeperClusterTest {
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
             assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
     }
 
@@ -691,7 +692,7 @@ public class ZookeeperClusterTest {
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
             assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
     }
 
@@ -732,7 +733,7 @@ public class ZookeeperClusterTest {
 
             assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
-            assertThat(pvc.getMetadata().getAnnotations().get(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
+            assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -179,7 +179,7 @@ public class JbodStorageMockTest {
                             PersistentVolumeClaim pvc = matchingPvcs.get(0);
                             boolean isDeleteClaim = ((PersistentClaimStorage) volume).isDeleteClaim();
                             assertThat("deleteClaim value did not match for volume : " + volume,
-                                    Annotations.booleanAnnotation(pvc, AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM,
+                                    Annotations.booleanAnnotation(pvc, Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM,
                                             false),
                                     is(isDeleteClaim));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperator;
@@ -31,7 +32,6 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.model.Ca;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
@@ -484,7 +484,7 @@ public class KafkaAssemblyOperatorMockTest {
                 for (String pvcName: kafkaPvcs.get()) {
                     assertThat(client.persistentVolumeClaims().inNamespace(NAMESPACE).withName(pvcName).get()
                                     .getMetadata().getAnnotations(),
-                            hasEntry(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM, String.valueOf(!originalKafkaDeleteClaim.get())));
+                            hasEntry(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, String.valueOf(!originalKafkaDeleteClaim.get())));
                 }
                 kafkaAssembly(NAMESPACE, CLUSTER_NAME).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
                 LOGGER.info("Reconciling again -> delete");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -49,6 +49,7 @@ import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.JmxTransOutputDefinitionTemplateBuilder;
 import io.strimzi.api.kafka.model.template.JmxTransQueryTemplateBuilder;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperator;
@@ -729,7 +730,7 @@ public class KafkaAssemblyOperatorTest {
                 assertThat(pvcCaptor.getAllValues().stream().map(pvc -> pvc.getMetadata().getName()).collect(Collectors.toSet()),
                         is(expectedPvcs));
                 for (PersistentVolumeClaim pvc : pvcCaptor.getAllValues()) {
-                    assertThat(pvc.getMetadata().getAnnotations(), hasKey(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM));
+                    assertThat(pvc.getMetadata().getAnnotations(), hasKey(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM));
                 }
 
                 // Verify deleted routes

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PvcReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PvcReconcilerTest.java
@@ -12,8 +12,8 @@ import io.fabric8.kubernetes.api.model.storage.StorageClass;
 import io.fabric8.kubernetes.api.model.storage.StorageClassBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.operator.resource.PvcOperator;
 import io.strimzi.operator.common.operator.resource.StorageClassOperator;
@@ -523,7 +523,7 @@ public class PvcReconcilerTest {
     public void testVolumesDeletion(VertxTestContext context)  {
         PersistentVolumeClaim pvcWithDeleteClaim = new PersistentVolumeClaimBuilder(createPvc("data-pod-3"))
                 .editMetadata()
-                    .withAnnotations(Map.of(AbstractModel.ANNO_STRIMZI_IO_DELETE_CLAIM, "true"))
+                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, "true"))
                 .endMetadata()
                 .build();
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -125,6 +125,16 @@ public class Annotations {
         ">\\d+)$");
 
     /**
+     * Annotation on PVCs storing the original configuration. It is used to revert any illegal changes.
+     */
+    public static final String ANNO_STRIMZI_IO_STORAGE = STRIMZI_DOMAIN + "storage";
+
+    /**
+     * Annotation for storing the information whether the PVC should be deleted when the node is scaled down or when the cluster is deleted.
+     */
+    public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = STRIMZI_DOMAIN + "delete-claim";
+
+    /**
      * Annotation for tracking Deployment revisions
      */
     public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues to refactor `AbstractModel` and its subclasses. It moves the methods used to generate PVCs which are used only by the Kafka and ZooKeeper clusters into a separate utils class. It also moves the Storage annotations from the `AbstractModel` to the `Annotations` class where most of our other annotations are and does some smaller improvements to other methods dealing with storage in `AsbtractModel` (such as using new Java 17 features to simplify the code).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally