### PR TITLE
Move RBAC resources creation from `AbstractModel` to separate utility class

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -24,14 +24,15 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount", "entityOperatorRole", "entityOperatorRoleBinding"})
+@JsonPropertyOrder({"deployment", "pod", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount", "entityOperatorRole", "topicOperatorRoleBinding", "userOperatorRoleBinding"})
 @EqualsAndHashCode
 public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
     private ResourceTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate entityOperatorRole;
-    private ResourceTemplate entityOperatorRoleBinding;
+    private ResourceTemplate topicOperatorRoleBinding;
+    private ResourceTemplate userOperatorRoleBinding;
     private ContainerTemplate topicOperatorContainer;
     private ContainerTemplate userOperatorContainer;
     private ContainerTemplate tlsSidecarContainer;
@@ -68,14 +69,24 @@ public class EntityOperatorTemplate implements Serializable, UnknownPropertyPres
         this.entityOperatorRole = entityOperatorRole;
     }
 
-    @Description("Template for the Entity Operator RoleBinding")
+    @Description("Template for the Entity Topic Operator RoleBinding")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getEntityOperatorRoleBinding() {
-        return entityOperatorRoleBinding;
+    public ResourceTemplate getTopicOperatorRoleBinding() {
+        return topicOperatorRoleBinding;
     }
 
-    public void setEntityOperatorRoleBinding(ResourceTemplate entityOperatorRoleBinding) {
-        this.entityOperatorRoleBinding = entityOperatorRoleBinding;
+    public void setTopicOperatorRoleBinding(ResourceTemplate topicOperatorRoleBinding) {
+        this.topicOperatorRoleBinding = topicOperatorRoleBinding;
+    }
+
+    @Description("Template for the Entity Topic Operator RoleBinding")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getUserOperatorRoleBinding() {
+        return userOperatorRoleBinding;
+    }
+
+    public void setUserOperatorRoleBinding(ResourceTemplate userOperatorRoleBinding) {
+        this.userOperatorRoleBinding = userOperatorRoleBinding;
     }
 
     @Description("Template for the Entity Topic Operator container")

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaBridgeTemplate.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "bridgeContainer", "serviceAccount", "initContainer"})
+@JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "bridgeContainer", "clusterRoleBinding", "serviceAccount", "initContainer"})
 @EqualsAndHashCode
 public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -35,6 +35,7 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate bridgeContainer;
     private ContainerTemplate initContainer;
+    private ResourceTemplate clusterRoleBinding;
     private ResourceTemplate serviceAccount;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -96,6 +97,16 @@ public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserv
 
     public void setInitContainer(ContainerTemplate initContainer) {
         this.initContainer = initContainer;
+    }
+
+    @Description("Template for the Kafka Bridge ClusterRoleBinding.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getClusterRoleBinding() {
+        return clusterRoleBinding;
+    }
+
+    public void setClusterRoleBinding(ResourceTemplate clusterRoleBinding) {
+        this.clusterRoleBinding = clusterRoleBinding;
     }
 
     @Description("Template for the Kafka Bridge service account.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -47,15 +47,6 @@ import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetUpdateStrategyBuilder;
-import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
-import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
-import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
-import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
-import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
-import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
-import io.fabric8.kubernetes.api.model.rbac.RoleRef;
-import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.ExternalLogging;
 import io.strimzi.api.kafka.model.InlineLogging;
@@ -280,12 +271,6 @@ public abstract class AbstractModel {
     protected List<TopologySpreadConstraint> templatePodTopologySpreadConstraints;
     protected PodManagementPolicy templatePodManagementPolicy = PodManagementPolicy.PARALLEL;
     protected Boolean templatePodEnableServiceLinks;
-    protected Map<String, String> templateClusterRoleBindingLabels;
-    protected Map<String, String> templateClusterRoleBindingAnnotations;
-    protected Map<String, String> templateEntityOperatorRoleBindingLabels;
-    protected Map<String, String> templateEntityOperatorRoleBindingAnnotations;
-    protected Map<String, String> templateEntityOperatorRoleLabels;
-    protected Map<String, String> templateEntityOperatorRoleAnnotations;
     protected Map<String, String> templateServiceAccountLabels;
     protected Map<String, String> templateServiceAccountAnnotations;
     protected Map<String, String> templateJmxSecretLabels;
@@ -736,13 +721,6 @@ public abstract class AbstractModel {
      */
     protected String getServiceAccountName() {
         return null;
-    }
-
-    /**
-     * @return the name of the role used by the service account for the deployed cluster for Kubernetes API operations.
-     */
-    protected String getRoleName() {
-        throw new RuntimeException("Unsupported method: this method should be overridden");
     }
 
     /**
@@ -1378,47 +1356,6 @@ public abstract class AbstractModel {
     }
 
     /**
-     * @param namespace The namespace the role will be deployed into
-     * @param rules the list of rules associated with this role
-     *
-     * @return The role for the component.
-     */
-    public Role generateRole(String namespace, List<PolicyRule> rules) {
-        return new RoleBuilder()
-                .withNewMetadata()
-                    .withName(getRoleName())
-                    .withNamespace(namespace)
-                    .withOwnerReferences(ownerReference)
-                    .addToLabels(labels.withAdditionalLabels(templateEntityOperatorRoleLabels).toMap())
-                    .addToAnnotations(templateEntityOperatorRoleAnnotations)
-                .endMetadata()
-                .withRules(rules)
-                .build();
-    }
-
-    /**
-     * @param name The name of the rolebinding
-     * @param namespace The namespace the rolebinding will be deployed into
-     * @param roleRef a reference to a Role to bind to
-     * @param subjects a list of subject ServiceAccounts to bind the role to
-     *
-     * @return The RoleBinding for the component with the given name and namespace.
-     */
-    public RoleBinding generateRoleBinding(String name, String namespace, RoleRef roleRef, List<Subject> subjects) {
-        return new RoleBindingBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                    .withNamespace(namespace)
-                    .withOwnerReferences(ownerReference)
-                    .withLabels(labels.withAdditionalLabels(templateEntityOperatorRoleBindingLabels).toMap())
-                    .withAnnotations(templateEntityOperatorRoleBindingAnnotations)
-                .endMetadata()
-                .withRoleRef(roleRef)
-                .withSubjects(subjects)
-                .build();
-    }
-
-    /**
      * Adds the supplied list of user configured container environment variables {@see io.strimzi.api.kafka.model.ContainerEnvVar} to the
      * supplied list of fabric8 environment variables {@see io.fabric8.kubernetes.api.model.EnvVar},
      * checking first if the environment variable key has already been set in the existing list and then converts them.
@@ -1447,18 +1384,6 @@ public abstract class AbstractModel {
                 }
             }
         }
-    }
-
-    protected ClusterRoleBinding getClusterRoleBinding(String name, Subject subject, RoleRef roleRef) {
-        return new ClusterRoleBindingBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                    .withLabels(labels.withAdditionalLabels(templateClusterRoleBindingLabels).toMap())
-                    .withAnnotations(templateClusterRoleBindingAnnotations)
-                .endMetadata()
-                .withSubjects(subject)
-                .withRoleRef(roleRef)
-                .build();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RbacUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RbacUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
+import io.fabric8.kubernetes.api.model.rbac.Subject;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.List;
+
+/**
+ * Shared methods for working with RBAC resources
+ */
+public class RbacUtils {
+    /**
+     * Creates a Role with rules passed as parameter
+     *
+     * @param name              Name of the Role
+     * @param namespace         Namespace of the Role
+     * @param rules             The list of rules associated with this role
+     * @param labels            Labels of the Role
+     * @param ownerReference    OwnerReference of the Role
+     * @param template          PDB template with user's custom configuration
+     *
+     * @return The role for the component.
+     */
+    public static Role createRole(String name, String namespace, List<PolicyRule> rules, Labels labels, OwnerReference ownerReference, ResourceTemplate template) {
+        return new RoleBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withOwnerReferences(ownerReference)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withAnnotations(TemplateUtils.annotations(template))
+                .endMetadata()
+                .withRules(rules)
+                .build();
+    }
+
+    /**
+     * Creates RoleBinding for a role and subjects passed as parameters
+     *
+     * @param name              Name of the RoleBinding
+     * @param namespace         Namespace of the RoleBinding
+     * @param roleRef           Role reference
+     * @param subjects          Subjects which should be bound
+     * @param labels            Labels of the RoleBinding
+     * @param ownerReference    OwnerReference of the RoleBinding
+     * @param template          PDB template with user's custom configuration
+     *
+     * @return  The RoleBinding with the given name, namespace, role reference and subjects
+     */
+    public static RoleBinding createRoleBinding(String name, String namespace, RoleRef roleRef, List<Subject> subjects, Labels labels, OwnerReference ownerReference, ResourceTemplate template) {
+        return new RoleBindingBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withOwnerReferences(ownerReference)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withAnnotations(TemplateUtils.annotations(template))
+                .endMetadata()
+                .withRoleRef(roleRef)
+                .withSubjects(subjects)
+                .build();
+    }
+
+    /**
+     * Creates ClusterRoleBinding for a role and subjects passed as parameters
+     *
+     * @param name      Name of the ClusterRoleBinding
+     * @param roleRef   Role reference
+     * @param subjects  Subjects which should be bound
+     * @param labels    Labels of the ClusterRoleBinding
+     * @param template  PDB template with user's custom configuration
+     *
+     * @return The RoleBinding with the given name, namespace, role reference and subjects
+     */
+    public static ClusterRoleBinding createClusterRoleBinding(String name, RoleRef roleRef, List<Subject> subjects, Labels labels, ResourceTemplate template) {
+        return new ClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withAnnotations(TemplateUtils.annotations(template))
+                .endMetadata()
+                .withSubjects(subjects)
+                .withRoleRef(roleRef)
+                .build();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -23,8 +23,6 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
-import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
@@ -295,12 +293,6 @@ public class EntityOperatorTest {
                                             .withAnnotations(rAnots)
                                         .endMetadata()
                                     .endEntityOperatorRole()
-                                    .withNewEntityOperatorRoleBinding()
-                                        .withNewMetadata()
-                                            .withLabels(rbLabels)
-                                            .withAnnotations(rbAnots)
-                                        .endMetadata()
-                                    .endEntityOperatorRoleBinding()
                                     .withNewServiceAccount()
                                         .withNewMetadata()
                                             .withLabels(saLabels)
@@ -331,11 +323,6 @@ public class EntityOperatorTest {
         Role crb = entityOperator.generateRole(null, namespace);
         assertThat(crb.getMetadata().getLabels().entrySet().containsAll(rLabels.entrySet()), is(true));
         assertThat(crb.getMetadata().getAnnotations().entrySet().containsAll(rAnots.entrySet()), is(true));
-
-        // Generate RoleBinding metadata
-        RoleBinding binding = entityOperator.generateRoleBinding(namespace, namespace, new RoleRef(), new ArrayList<>());
-        assertThat(binding.getMetadata().getLabels().entrySet().containsAll(rbLabels.entrySet()), is(true));
-        assertThat(binding.getMetadata().getAnnotations().entrySet().containsAll(rbAnots.entrySet()), is(true));
 
         // Check Service Account
         ServiceAccount sa = entityOperator.generateServiceAccount();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.SystemPropertyBuilder;
+import io.strimzi.api.kafka.model.template.EntityOperatorTemplateBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -27,6 +28,7 @@ import io.strimzi.test.annotations.ParallelTest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static io.strimzi.test.TestUtils.map;
 import static org.hamcrest.CoreMatchers.is;
@@ -92,6 +94,14 @@ public class EntityTopicOperatorTest {
 
     private final EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder()
             .withTopicOperator(entityTopicOperatorSpec)
+            .withTemplate(new EntityOperatorTemplateBuilder()
+                    .withNewTopicOperatorRoleBinding()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-1", "value-1"))
+                            .withAnnotations(Map.of("anno-1", "value-1"))
+                        .endMetadata()
+                    .endTopicOperatorRoleBinding()
+                    .build())
             .build();
 
     private final Kafka resource =
@@ -268,6 +278,8 @@ public class EntityTopicOperatorTest {
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(toWatchedNamespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
+        assertThat(binding.getMetadata().getLabels().get("label-1"), is("value-1"));
+        assertThat(binding.getMetadata().getAnnotations().get("anno-1"), is("value-1"));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
@@ -280,6 +292,8 @@ public class EntityTopicOperatorTest {
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
+        assertThat(binding.getMetadata().getLabels().get("label-1"), is("value-1"));
+        assertThat(binding.getMetadata().getAnnotations().get("anno-1"), is("value-1"));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -26,6 +26,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.SystemPropertyBuilder;
+import io.strimzi.api.kafka.model.template.EntityOperatorTemplateBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -34,6 +35,7 @@ import io.strimzi.test.annotations.ParallelTest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static io.strimzi.test.TestUtils.map;
 import static java.util.Collections.emptyMap;
@@ -101,6 +103,14 @@ public class EntityUserOperatorTest {
 
     private final EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpecBuilder()
             .withUserOperator(entityUserOperatorSpec)
+            .withTemplate(new EntityOperatorTemplateBuilder()
+                    .withNewUserOperatorRoleBinding()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-1", "value-1"))
+                            .withAnnotations(Map.of("anno-1", "value-1"))
+                        .endMetadata()
+                    .endUserOperatorRoleBinding()
+                    .build())
             .build();
 
     private final Kafka resource =
@@ -308,6 +318,8 @@ public class EntityUserOperatorTest {
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(uoWatchedNamespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(0));
+        assertThat(binding.getMetadata().getLabels().get("label-1"), is("value-1"));
+        assertThat(binding.getMetadata().getAnnotations().get("anno-1"), is("value-1"));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));
@@ -320,6 +332,8 @@ public class EntityUserOperatorTest {
         assertThat(binding.getSubjects().get(0).getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getNamespace(), is(namespace));
         assertThat(binding.getMetadata().getOwnerReferences().size(), is(1));
+        assertThat(binding.getMetadata().getLabels().get("label-1"), is("value-1"));
+        assertThat(binding.getMetadata().getAnnotations().get("anno-1"), is("value-1"));
 
         assertThat(binding.getRoleRef().getKind(), is("Role"));
         assertThat(binding.getRoleRef().getName(), is("foo-entity-operator"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RbacUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/RbacUtilsTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Subject;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class RbacUtilsTest {
+    private final static String NAME = "my-name";
+    private final static String NAMESPACE = "my-namespace";
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-cluster")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-name")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+    private final static ResourceTemplate TEMPLATE = new ResourceTemplateBuilder()
+            .withNewMetadata()
+                .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+            .endMetadata()
+            .build();
+
+    @ParallelTest
+    public void testRole()  {
+        PolicyRule rule = new PolicyRuleBuilder()
+                .withApiGroups("kafka.strimzi.io")
+                .withResources("kafkausers", "kafkausers/status")
+                .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
+                .build();
+
+        Role role = RbacUtils.createRole(NAME, NAMESPACE, List.of(rule), LABELS, OWNER_REFERENCE, null);
+
+        assertThat(role.getMetadata().getName(), is(NAME));
+        assertThat(role.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(role.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(role.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(role.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(role.getRules(), is(List.of(rule)));
+    }
+
+    @ParallelTest
+    public void testRoleWithTemplate()  {
+        PolicyRule rule = new PolicyRuleBuilder()
+                .withApiGroups("kafka.strimzi.io")
+                .withResources("kafkausers", "kafkausers/status")
+                .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
+                .build();
+
+        Role role = RbacUtils.createRole(NAME, NAMESPACE, List.of(rule), LABELS, OWNER_REFERENCE, TEMPLATE);
+
+        assertThat(role.getMetadata().getName(), is(NAME));
+        assertThat(role.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(role.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(role.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(role.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(role.getRules(), is(List.of(rule)));
+    }
+
+    @ParallelTest
+    public void testRoleBinding()  {
+        Subject subject = new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName("my-sa")
+                .withNamespace(NAMESPACE)
+                .build();
+
+        RoleRef roleRef = new RoleRefBuilder()
+                .withName("my-role")
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("Role")
+                .build();
+
+        RoleBinding roleBinding = RbacUtils.createRoleBinding(NAME, NAMESPACE, roleRef, List.of(subject), LABELS, OWNER_REFERENCE, null);
+
+        assertThat(roleBinding.getMetadata().getName(), is(NAME));
+        assertThat(roleBinding.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(roleBinding.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(roleBinding.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(roleBinding.getRoleRef(), is(roleRef));
+        assertThat(roleBinding.getSubjects(), is(List.of(subject)));
+    }
+
+    @ParallelTest
+    public void testRoleBindingWithTemplate()  {
+        Subject subject = new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName("my-sa")
+                .withNamespace(NAMESPACE)
+                .build();
+
+        RoleRef roleRef = new RoleRefBuilder()
+                .withName("my-role")
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("Role")
+                .build();
+
+        RoleBinding roleBinding = RbacUtils.createRoleBinding(NAME, NAMESPACE, roleRef, List.of(subject), LABELS, OWNER_REFERENCE, TEMPLATE);
+
+        assertThat(roleBinding.getMetadata().getName(), is(NAME));
+        assertThat(roleBinding.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(roleBinding.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(roleBinding.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(roleBinding.getRoleRef(), is(roleRef));
+        assertThat(roleBinding.getSubjects(), is(List.of(subject)));
+    }
+
+    @ParallelTest
+    public void testClusterRoleBinding()  {
+        Subject subject = new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName("my-sa")
+                .withNamespace(NAMESPACE)
+                .build();
+
+        RoleRef roleRef = new RoleRefBuilder()
+                .withName("my-role")
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("Role")
+                .build();
+
+        ClusterRoleBinding roleBinding = RbacUtils.createClusterRoleBinding(NAME, roleRef, List.of(subject), LABELS, null);
+
+        assertThat(roleBinding.getMetadata().getName(), is(NAME));
+        assertThat(roleBinding.getMetadata().getNamespace(), is(nullValue()));
+        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(roleBinding.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(roleBinding.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(roleBinding.getRoleRef(), is(roleRef));
+        assertThat(roleBinding.getSubjects(), is(List.of(subject)));
+    }
+
+    @ParallelTest
+    public void testClusterRoleBindingWithTemplate()  {
+        Subject subject = new SubjectBuilder()
+                .withKind("ServiceAccount")
+                .withName("my-sa")
+                .withNamespace(NAMESPACE)
+                .build();
+
+        RoleRef roleRef = new RoleRefBuilder()
+                .withName("my-role")
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("Role")
+                .build();
+
+        ClusterRoleBinding roleBinding = RbacUtils.createClusterRoleBinding(NAME, roleRef, List.of(subject), LABELS, TEMPLATE);
+
+        assertThat(roleBinding.getMetadata().getName(), is(NAME));
+        assertThat(roleBinding.getMetadata().getNamespace(), is(nullValue()));
+        assertThat(roleBinding.getMetadata().getOwnerReferences(), is(List.of()));
+        assertThat(roleBinding.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(roleBinding.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(roleBinding.getRoleRef(), is(roleRef));
+        assertThat(roleBinding.getSubjects(), is(List.of(subject)));
+    }
+}

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1271,22 +1271,24 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 
 [options="header"]
 |====
-|Property                          |Description
-|deployment                 1.2+<.<a|Template for Entity Operator `Deployment`.
+|Property                         |Description
+|deployment                1.2+<.<a|Template for Entity Operator `Deployment`.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|pod                        1.2+<.<a|Template for Entity Operator `Pods`.
+|pod                       1.2+<.<a|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
-|topicOperatorContainer     1.2+<.<a|Template for the Entity Topic Operator container.
+|topicOperatorContainer    1.2+<.<a|Template for the Entity Topic Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|userOperatorContainer      1.2+<.<a|Template for the Entity User Operator container.
+|userOperatorContainer     1.2+<.<a|Template for the Entity User Operator container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|tlsSidecarContainer        1.2+<.<a|Template for the Entity Operator TLS sidecar container.
+|tlsSidecarContainer       1.2+<.<a|Template for the Entity Operator TLS sidecar container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-|serviceAccount             1.2+<.<a|Template for the Entity Operator service account.
+|serviceAccount            1.2+<.<a|Template for the Entity Operator service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|entityOperatorRole         1.2+<.<a|Template for the Entity Operator Role.
+|entityOperatorRole        1.2+<.<a|Template for the Entity Operator Role.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|entityOperatorRoleBinding  1.2+<.<a|Template for the Entity Operator RoleBinding.
+|topicOperatorRoleBinding  1.2+<.<a|Template for the Entity Topic Operator RoleBinding.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|userOperatorRoleBinding   1.2+<.<a|Template for the Entity Topic Operator RoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |====
 
@@ -2987,6 +2989,8 @@ Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`]
 |xref:type-PodDisruptionBudgetTemplate-{context}[`PodDisruptionBudgetTemplate`]
 |bridgeContainer      1.2+<.<a|Template for the Kafka Bridge container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|clusterRoleBinding   1.2+<.<a|Template for the Kafka Bridge ClusterRoleBinding.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |serviceAccount       1.2+<.<a|Template for the Kafka Bridge service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |initContainer        1.2+<.<a|Template for the Kafka Bridge init container.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -3759,7 +3759,7 @@ spec:
                                   description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                               description: Metadata applied to the resource.
                           description: Template for the Entity Operator Role.
-                        entityOperatorRoleBinding:
+                        topicOperatorRoleBinding:
                           type: object
                           properties:
                             metadata:
@@ -3774,7 +3774,23 @@ spec:
                                   type: object
                                   description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                               description: Metadata applied to the resource.
-                          description: Template for the Entity Operator RoleBinding.
+                          description: Template for the Entity Topic Operator RoleBinding.
+                        userOperatorRoleBinding:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                                annotations:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                  description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              description: Metadata applied to the resource.
+                          description: Template for the Entity Topic Operator RoleBinding.
                       description: Template for Entity Operator resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
                   description: Configuration of the Entity Operator.
                 clusterCa:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1001,6 +1001,22 @@ spec:
                                   type: string
                           description: Security context for the container.
                       description: Template for the Kafka Bridge container.
+                    clusterRoleBinding:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          description: Metadata applied to the resource.
+                      description: Template for the Kafka Bridge ClusterRoleBinding.
                     serviceAccount:
                       type: object
                       properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -3758,7 +3758,7 @@ spec:
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
                         description: Template for the Entity Operator Role.
-                      entityOperatorRoleBinding:
+                      topicOperatorRoleBinding:
                         type: object
                         properties:
                           metadata:
@@ -3773,7 +3773,23 @@ spec:
                                 type: object
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
-                        description: Template for the Entity Operator RoleBinding.
+                        description: Template for the Entity Topic Operator RoleBinding.
+                      userOperatorRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Topic Operator RoleBinding.
                     description: Template for Entity Operator resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
                 description: Configuration of the Entity Operator.
               clusterCa:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1000,6 +1000,22 @@ spec:
                                 type: string
                         description: Security context for the container.
                     description: Template for the Kafka Bridge container.
+                  clusterRoleBinding:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Bridge ClusterRoleBinding.
                   serviceAccount:
                     type: object
                     properties:


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues the refactoring of the `AbstractModel` class and its subclasses. This PR moved the methods and fields used to create RBAC resources (Roles, RoleBindings, and ClusterRoleBindings) to a separate `RbacUtils` class.

It also addresses some issues left-over by previous PRs:
* Adds the template to the Bridge ClusterRoleBinding to mirror what we have for Kafka, Connect, and MM2
* Fixes the RoleBinding template for TO and UO
    * As we have two separate role bindings, it uses two separate templates
    * It also sets the template in the right class so that they actually find their way into the Kubernetes resource

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally