### PR TITLE
Removed generation of similar multiple conditions in the `KafkaRebalance` status for a single issue

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1149,7 +1149,8 @@ public class KafkaRebalanceAssemblyOperator
         String clusterName = kafkaRebalance.getMetadata().getLabels() == null ? null : kafkaRebalance.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         String clusterNamespace = kafkaRebalance.getMetadata().getNamespace();
         if (clusterName == null) {
-            LOGGER.warnCr(reconciliation, "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.");
+            String errorString = "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.";
+            LOGGER.warnCr(reconciliation, errorString);
             KafkaRebalanceStatus status = new KafkaRebalanceStatus();
             return updateStatus(reconciliation, kafkaRebalance, status,
                     new InvalidResourceException(CruiseControlIssues.clusterLabelMissing.getMessage())).mapEmpty();
@@ -1397,7 +1398,7 @@ public class KafkaRebalanceAssemblyOperator
         /**
          * The Kafka cluster label is missing .
          */
-        clusterLabelMissing("Resource lacks label"),
+        clusterLabelMissing("Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance."),
 
         /**
          * Cruise Control was not declared in the Kafka Resource

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1149,13 +1149,10 @@ public class KafkaRebalanceAssemblyOperator
         String clusterName = kafkaRebalance.getMetadata().getLabels() == null ? null : kafkaRebalance.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         String clusterNamespace = kafkaRebalance.getMetadata().getNamespace();
         if (clusterName == null) {
-
-            String errorString = "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.";
-            LOGGER.warnCr(reconciliation, errorString);
+            LOGGER.warnCr(reconciliation, "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.");
             KafkaRebalanceStatus status = new KafkaRebalanceStatus();
-            status.addCondition(StatusUtils.buildWarningCondition(CruiseControlIssues.clusterLabelMissing.getReason(), errorString));
             return updateStatus(reconciliation, kafkaRebalance, status,
-                    new InvalidResourceException(errorString)).mapEmpty();
+                    new InvalidResourceException(CruiseControlIssues.clusterLabelMissing.getMessage())).mapEmpty();
         }
 
         // Get associated Kafka cluster state
@@ -1171,21 +1168,18 @@ public class KafkaRebalanceAssemblyOperator
                     } else if (kafka.getStatus() == null
                             || kafka.getStatus().getConditions() == null
                             || kafka.getStatus().getConditions().stream().noneMatch(condition -> condition.getType().equals("Ready") && condition.getStatus().equals("True"))) {
-                        String errorString = "Kafka cluster is not Ready";
-                        LOGGER.warnCr(reconciliation, errorString);
+                        LOGGER.warnCr(reconciliation, "Kafka cluster is not Ready");
                         KafkaRebalanceStatus status = new KafkaRebalanceStatus();
                         return updateStatus(reconciliation, kafkaRebalance, status,
-                                new RuntimeException(CruiseControlIssues.kafkaClusterNotReady.getReason())).mapEmpty();
+                                new RuntimeException(CruiseControlIssues.kafkaClusterNotReady.getMessage())).mapEmpty();
                     } else if (!Util.matchesSelector(kafkaSelector, kafka)) {
                         LOGGER.debugCr(reconciliation, "{} {} in namespace {} belongs to a Kafka cluster {} which does not match label selector {} and will be ignored", kind(), kafkaRebalance.getMetadata().getName(), clusterNamespace, clusterName, kafkaSelector.get().getMatchLabels());
                         return Future.succeededFuture();
                     } else if (kafka.getSpec().getCruiseControl() == null) {
-                        String errorString = "Kafka resource lacks 'cruiseControl' declaration " + ": No deployed Cruise Control for doing a rebalance.";
-                        LOGGER.warnCr(reconciliation, errorString);
+                        LOGGER.warnCr(reconciliation, "Kafka resource lacks 'cruiseControl' declaration" + ": No deployed Cruise Control for doing a rebalance.");
                         KafkaRebalanceStatus status = new KafkaRebalanceStatus();
-                        status.addCondition(StatusUtils.buildWarningCondition(CruiseControlIssues.cruiseControlDisabled.getReason(), errorString));
                         return updateStatus(reconciliation, kafkaRebalance, status,
-                                new InvalidResourceException(errorString)).mapEmpty();
+                                new InvalidResourceException(CruiseControlIssues.cruiseControlDisabled.getMessage())).mapEmpty();
                     }
 
                     if (kafka.getSpec().getKafka().getStorage() instanceof JbodStorage) {
@@ -1403,31 +1397,31 @@ public class KafkaRebalanceAssemblyOperator
         /**
          * The Kafka cluster label is missing .
          */
-        clusterLabelMissing("Cluster Label missing"),
+        clusterLabelMissing("Resource lacks label"),
 
         /**
          * Cruise Control was not declared in the Kafka Resource
          */
-        cruiseControlDisabled("Cruise Control disabled"),
+        cruiseControlDisabled("Kafka resource lacks 'cruiseControl' declaration"),
 
         /**
          * Kafka Cluster is not ready
          */
         kafkaClusterNotReady("Kafka cluster is not Ready");
 
-        public String getReason() {
-            return reason;
+        public String getMessage() {
+            return message;
         }
 
-        private final String reason;
+        private final String message;
 
-        CruiseControlIssues(String reason) {
-            this.reason = reason;
+        CruiseControlIssues(String message) {
+            this.message = message;
         }
 
         public static boolean checkForMatch(List<Condition> conditions) {
             for (CruiseControlIssues issue : CruiseControlIssues.values()) {
-                if (conditions.stream().anyMatch(condition -> issue.getReason().equals(condition.getReason()))) {
+                if (conditions.stream().anyMatch(condition -> issue.getMessage().equals(condition.getMessage()))) {
                     return true;
                 }
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1530,7 +1530,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 // the resource moved from New to NotReady due to the error
                 assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,
                         KafkaRebalanceState.NotReady, InvalidResourceException.class,
-                        "Resource lacks label");
+                        "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.");
                 checkpoint.flag();
             })));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1422,7 +1422,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     // the resource moved from New to NotReady due to the error
                     assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,
                             KafkaRebalanceState.NotReady, InvalidResourceException.class,
-                            "Kafka resource lacks 'cruiseControl' declaration : No deployed Cruise Control for doing a rebalance.");
+                            "Kafka resource lacks 'cruiseControl' declaration");
                     checkpoint.flag();
                 })));
     }
@@ -1462,7 +1462,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 // the resource moved from New to NotReady due to the error
                 assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,
                         KafkaRebalanceState.NotReady, InvalidResourceException.class,
-                        "Kafka resource lacks 'cruiseControl' declaration : No deployed Cruise Control for doing a rebalance.");
+                        "Kafka resource lacks 'cruiseControl' declaration");
             })))
                 .compose(v -> {
                     try {
@@ -1530,7 +1530,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 // the resource moved from New to NotReady due to the error
                 assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,
                         KafkaRebalanceState.NotReady, InvalidResourceException.class,
-                        "Resource lacks label '" + Labels.STRIMZI_CLUSTER_LABEL + "': No cluster related to a possible rebalance.");
+                        "Resource lacks label");
                 checkpoint.flag();
             })));
     }


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

### Type of change

Currently when the `KafkaRebalance` status went into any sort of issue like `CC is disabled` or `Resource lacks label` then at that time multiple similar conditions were being generated for a single issue. For eg.
```
Status:
  Conditions:
    Last Transition Time:  2023-01-18T10:42:33.409944100Z
    Message:               Kafka resource lacks 'cruiseControl' declaration
    Reason:                CC is disabled
    Status:                True
    Type:                  Warning
    Last Transition Time:  2023-01-18T10:42:33.409944100Z
    Message:               Kafka resource lacks 'cruiseControl' declaration
    Reason:                InvalidResourceException
    Status:                True
    Type:                  NotReady
  Observed Generation:     1
Events:                    <none>
 ```
This PR fixes the generation of multiple conditions and generates only condition per issue and make sure that the next reconciliation picks up the changes and moves the resource to `Ready` state if the issue is fixed

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

