### PR TITLE
Move creation of workload resources from the `AbstractModel` class

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/template/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/CruiseControlTemplate.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class CruiseControlTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private InternalServiceTemplate apiService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
@@ -43,11 +43,11 @@ public class CruiseControlTemplate implements Serializable, UnknownPropertyPrese
 
     @Description("Template for Cruise Control `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/EntityOperatorTemplate.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @EqualsAndHashCode
 public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate entityOperatorRole;
     private ResourceTemplate topicOperatorRoleBinding;
@@ -41,11 +41,11 @@ public class EntityOperatorTemplate implements Serializable, UnknownPropertyPres
 
     @Description("Template for Entity Operator `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/JmxTransTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/JmxTransTemplate.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class JmxTransTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
-    private ResourceTemplate deployment;
+    private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ContainerTemplate container;
     private ResourceTemplate serviceAccount;
@@ -38,11 +38,11 @@ public class JmxTransTemplate implements Serializable, UnknownPropertyPreserving
 
     @Description("Template for JmxTrans `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public ResourceTemplate getDeployment() {
+    public DeploymentTemplate getDeployment() {
         return deployment;
     }
 
-    public void setDeployment(ResourceTemplate deployment) {
+    public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -205,7 +205,7 @@ public class EntityTopicOperator extends AbstractModel {
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        return List.of(createTempDirVolumeMount(TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
+        return List.of(VolumeUtils.createTempDirVolumeMount(TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
                 VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
                 VolumeUtils.createVolumeMount(EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -236,7 +236,7 @@ public class EntityUserOperator extends AbstractModel {
     }
 
     private List<VolumeMount> getVolumeMounts() {
-        return List.of(createTempDirVolumeMount(USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
+        return List.of(VolumeUtils.createTempDirVolumeMount(USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
                 VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
                 VolumeUtils.createVolumeMount(EntityOperator.EUO_CERTS_VOLUME_NAME, EntityOperator.EUO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -113,7 +113,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         }        
         cluster.setConfiguration(new KafkaMirrorMaker2Configuration(reconciliation, connectCluster.getConfig().entrySet()));
         KafkaMirrorMaker2Cluster mm2 = fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, cluster);
-        mm2.templatePodLabels = Util.mergeLabelsOrAnnotations(mm2.templatePodLabels, DEFAULT_POD_LABELS);
+
         return mm2;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/TemplateUtils.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
+import io.strimzi.api.kafka.model.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.template.HasMetadataTemplate;
 
 import java.util.Map;
@@ -44,5 +46,17 @@ public class TemplateUtils {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Extracts the deployment strategy configuration from the Deployment template
+     *
+     * @param template      Deployment template which maybe contains custom deployment strategy configuration
+     * @param defaultValue  The default value which should be used if the deployment strategy is not set
+     *
+     * @return  Custom deployment strategy or default value if not defined
+     */
+    public static DeploymentStrategy deploymentStrategy(DeploymentTemplate template, DeploymentStrategy defaultValue)  {
+        return template != null && template.getDeploymentStrategy() != null ? template.getDeploymentStrategy() : defaultValue;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStrategy;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStrategyBuilder;
+import io.fabric8.kubernetes.api.model.apps.RollingUpdateDeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
+import io.strimzi.api.kafka.model.template.DeploymentTemplate;
+import io.strimzi.api.kafka.model.template.PodManagementPolicy;
+import io.strimzi.api.kafka.model.template.PodTemplate;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.template.StatefulSetTemplate;
+import io.strimzi.operator.cluster.operator.resource.PodRevision;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Shared methods for creating Workload resources (Deployments, StatefulSets, StrimziPodSets)
+ */
+public class WorkloadUtils {
+    /**
+     * Create a Kubernetes Deployment with the Pod template passed as a parameter
+     *
+     * @param name              Name of the Deployment
+     * @param namespace         Namespace of the Deployment
+     * @param labels            Labels of the Deployment
+     * @param ownerReference    OwnerReference of the Deployment
+     * @param template          Deployment template with user's custom configuration
+     * @param replicas          Number of replicas
+     * @param updateStrategy    Deployment update strategy (Recreate or Rolling Update)
+     * @param podTemplateSpec   The PodTemplateSpec which defines how the pods created by this Deployment look like
+     *
+     * @return  Created Deployment
+     */
+    public static Deployment createDeployment(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            DeploymentTemplate template,
+            int replicas,
+            DeploymentStrategy updateStrategy,
+            PodTemplateSpec podTemplateSpec
+    ) {
+        return new DeploymentBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(TemplateUtils.annotations(template))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withStrategy(updateStrategy)
+                    .withReplicas(replicas)
+                    .withNewSelector()
+                        .withMatchLabels(labels.strimziSelectorLabels().toMap())
+                    .endSelector()
+                    .withTemplate(podTemplateSpec)
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Create a Kubernetes StatefulSet with the Pod template passed as a parameter
+     *
+     * @param name                      Name of the StatefulSet
+     * @param namespace                 Namespace of the StatefulSet
+     * @param labels                    Labels of the StatefulSet
+     * @param ownerReference            OwnerReference of the StatefulSet
+     * @param template                  StatefulSet template with user's custom configuration
+     * @param replicas                  Number of replicas
+     * @param headlessServiceName       Name of the headless service used by this StatefulSet
+     * @param annotations               Additional annotations which should be set on the StatefulSet. This might
+     *                                  contain annotations for tracking storage configuration, Kafka versions and similar.
+     * @param volumeClaimsTemplates     PersistentVolumeClaim templates to be used in the StatefulSet
+     * @param podTemplate               The PodTemplateSpec which defines how the pods created by this StatefulSet look like
+
+     * @return  Created StatefulSet
+     */
+    public static StatefulSet createStatefulSet(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            StatefulSetTemplate template,
+            int replicas,
+            String headlessServiceName,
+            Map<String, String> annotations,
+            List<PersistentVolumeClaim> volumeClaimsTemplates,
+            PodTemplateSpec podTemplate
+    ) {
+        return new StatefulSetBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(annotations, TemplateUtils.annotations(template)))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withPodManagementPolicy(template != null && template.getPodManagementPolicy() != null ? template.getPodManagementPolicy().toValue() : PodManagementPolicy.PARALLEL.toValue())
+                    .withNewUpdateStrategy()
+                        .withType("OnDelete")
+                    .endUpdateStrategy()
+                    .withNewSelector()
+                        .withMatchLabels(labels.strimziSelectorLabels().toMap())
+                    .endSelector()
+                    .withServiceName(headlessServiceName)
+                    .withReplicas(replicas)
+                    .withTemplate(podTemplate)
+                    .withVolumeClaimTemplates(volumeClaimsTemplates)
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Create a Strimzi PodSet with Pod definitions
+     *
+     * @param name           Name of the PodSet
+     * @param namespace      Namespace of the PodSet
+     * @param labels         Labels of the PodSet
+     * @param ownerReference OwnerReference of the PodSet
+     * @param template       PodSet template with user's custom configuration
+     * @param replicas       Number of replicas
+     * @param annotations    Additional annotations which should be set on the PodSet. This might contain annotations
+     *                       for tracking storage configuration, Kafka versions and similar.
+     * @param podCreator     Function for generating the Pods which should be included in this PodSet based on their
+     *                       index number.
+     * @return Created PodSet
+     */
+    public static StrimziPodSet createPodSet(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            ResourceTemplate template,
+            int replicas,
+            Map<String, String> annotations,
+            Function<Integer, Pod> podCreator
+    )  {
+        List<Map<String, Object>> pods = new ArrayList<>(replicas);
+
+        for (int i = 0; i < replicas; i++)  {
+            Pod pod = podCreator.apply(i);
+            pods.add(PodSetUtils.podToMap(pod));
+        }
+
+        return new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(annotations, TemplateUtils.annotations(template)))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
+                    .addAllToPods(pods)
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates a stateful Pod for use with StrimziPodSets. Stateful in this context means that it has a stable name and
+     * typically uses storage.
+     *
+     * @param reconciliation          Reconciliation marker
+     * @param name                    Name of the Pod
+     * @param namespace               Namespace of the Pod
+     * @param labels                  Labels of the Pod
+     * @param strimziPodSetName       Name of the StrimziPodSet which is used to generate the controller labels
+     * @param serviceAccountName      Name of the Service Account used by this Pod
+     * @param template                Pod template with custom configurations
+     * @param defaultPodLabels        The default pod labels
+     * @param podAnnotations          Additional annotations used for the pod. Used to track things such as storage
+     *                                configuration, Kafka versions, configuration or certificate hash stubs etc.
+     * @param headlessServiceName     Name of the headless service used by this Pod
+     * @param affinity                Pod's affinity
+     * @param initContainers          List of init container
+     * @param containers              List of main containers
+     * @param volumes                 List of volumes
+     * @param defaultImagePullSecrets Default image pull secrets
+     * @param podSecurityContext      Pod security context
+     * @return Created Pod for use with StrimziPodSet
+     */
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    public static Pod createStatefulPod(
+            Reconciliation reconciliation,
+            String name,
+            String namespace,
+            Labels labels,
+            String strimziPodSetName,
+            String serviceAccountName,
+            PodTemplate template,
+            Map<String, String> defaultPodLabels,
+            Map<String, String> podAnnotations,
+            String headlessServiceName,
+            Affinity affinity,
+            List<Container> initContainers,
+            List<Container> containers,
+            List<Volume> volumes,
+            List<LocalObjectReference> defaultImagePullSecrets,
+            PodSecurityContext podSecurityContext
+    ) {
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withStrimziPodName(name).withStatefulSetPod(name).withStrimziPodSetController(strimziPodSetName).withAdditionalLabels(Util.mergeLabelsOrAnnotations(defaultPodLabels, TemplateUtils.labels(template))).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(podAnnotations, TemplateUtils.annotations(template)))
+                .endMetadata()
+                .withNewSpec()
+                    .withRestartPolicy("Always")
+                    .withHostname(name)
+                    .withSubdomain(headlessServiceName)
+                    .withServiceAccountName(serviceAccountName)
+                    .withEnableServiceLinks(template != null ? template.getEnableServiceLinks() : null)
+                    .withAffinity(affinity)
+                    .withInitContainers(initContainers)
+                    .withContainers(containers)
+                    .withVolumes(volumes)
+                    .withTolerations(template != null && template.getTolerations() != null ? removeEmptyValuesFromTolerations(template.getTolerations()) : null)
+                    .withTerminationGracePeriodSeconds(template != null ? (long) template.getTerminationGracePeriodSeconds() : 30L)
+                    .withImagePullSecrets(imagePullSecrets(template, defaultImagePullSecrets))
+                    .withSecurityContext(podSecurityContext)
+                    .withPriorityClassName(template != null ? template.getPriorityClassName() : null)
+                    .withSchedulerName(template != null && template.getSchedulerName() != null ? template.getSchedulerName() : "default-scheduler")
+                    .withHostAliases(template != null ? template.getHostAliases() : null)
+                    .withTopologySpreadConstraints(template != null ? template.getTopologySpreadConstraints() : null)
+                .endSpec()
+                .build();
+
+        // Set the pod revision annotation
+        pod.getMetadata().getAnnotations().put(PodRevision.STRIMZI_REVISION_ANNOTATION, PodRevision.getRevision(reconciliation, pod));
+
+        return pod;
+    }
+
+    /**
+     * Creates a Pod template for use with StatefulSet or deployment.
+     *
+     * @param workloadName              Name of the workload resource which will own this Pod (Deployment or StatefulSet)
+     * @param labels                    Labels of the Pod
+     * @param template                  Pod template with custom configurations
+     * @param defaultPodLabels          The default pod labels
+     * @param podAnnotations            Additional annotations used for the pod. Used to track things such as storage
+     *                                  configuration, Kafka versions, configuration or certificate hash stubs etc.
+     * @param affinity                  Pod's affinity
+     * @param initContainers            List of init container
+     * @param containers                List of main containers
+     * @param volumes                   List of volumes
+     * @param defaultImagePullSecrets   Default image pull secrets
+     * @param podSecurityContext        Pod security context
+     *
+     * @return  Created Pod template for use with StatefulSet or Deployment
+     */
+    public static PodTemplateSpec createPodTemplateSpec(
+            String workloadName,
+            Labels labels,
+            PodTemplate template,
+            Map<String, String> defaultPodLabels,
+            Map<String, String> podAnnotations,
+            Affinity affinity,
+            List<Container> initContainers,
+            List<Container> containers,
+            List<Volume> volumes,
+            List<LocalObjectReference> defaultImagePullSecrets,
+            PodSecurityContext podSecurityContext
+    )   {
+        return new PodTemplateSpecBuilder()
+                .withNewMetadata()
+                    .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(defaultPodLabels, TemplateUtils.labels(template))).toMap())
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(podAnnotations, TemplateUtils.annotations(template)))
+                .endMetadata()
+                .withNewSpec()
+                    .withServiceAccountName(workloadName)
+                    .withEnableServiceLinks(template != null ? template.getEnableServiceLinks() : null)
+                    .withAffinity(affinity)
+                    .withInitContainers(initContainers)
+                    .withContainers(containers)
+                    .withVolumes(volumes)
+                    .withTolerations(template != null && template.getTolerations() != null ? removeEmptyValuesFromTolerations(template.getTolerations()) : null)
+                    .withTerminationGracePeriodSeconds(template != null ? (long) template.getTerminationGracePeriodSeconds() : 30L)
+                    .withImagePullSecrets(imagePullSecrets(template, defaultImagePullSecrets))
+                    .withSecurityContext(podSecurityContext)
+                    .withPriorityClassName(template != null ? template.getPriorityClassName() : null)
+                    .withSchedulerName(template != null && template.getSchedulerName() != null ? template.getSchedulerName() : "default-scheduler")
+                    .withHostAliases(template != null ? template.getHostAliases() : null)
+                    .withTopologySpreadConstraints(template != null ? template.getTopologySpreadConstraints() : null)
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates a Pod which can be used as a standalone pod to for example execute some task.
+     *
+     * @param name                      Name of the Pod
+     * @param namespace                 Namespace of the Pod
+     * @param labels                    Labels of the Pod
+     * @param ownerReference            OwnerReference of the Pod
+     * @param template                  Pod template with custom configurations
+     * @param defaultPodLabels          The default pod labels
+     * @param podAnnotations            Additional annotations used for the pod. Used to track things such as storage
+     *                                  configuration, Kafka versions, configuration or certificate hash stubs etc.
+     * @param affinity                  Pod's affinity
+     * @param initContainers            List of init container
+     * @param containers                List of main containers
+     * @param volumes                   List of volumes
+     * @param defaultImagePullSecrets   Default image pull secrets
+     * @param podSecurityContext        Pod security context
+     *
+     * @return  Created Pod which can be used on its own
+     */
+    public static Pod createPod(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            PodTemplate template,
+            Map<String, String> defaultPodLabels,
+            Map<String, String> podAnnotations,
+            Affinity affinity,
+            List<Container> initContainers,
+            List<Container> containers,
+            List<Volume> volumes,
+            List<LocalObjectReference> defaultImagePullSecrets,
+            PodSecurityContext podSecurityContext
+    )   {
+        return new PodBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(defaultPodLabels, TemplateUtils.labels(template))).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(podAnnotations, TemplateUtils.annotations(template)))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withRestartPolicy("Never")
+                    .withServiceAccountName(name)
+                    .withEnableServiceLinks(template != null ? template.getEnableServiceLinks() : null)
+                    .withAffinity(affinity)
+                    .withInitContainers(initContainers)
+                    .withContainers(containers)
+                    .withVolumes(volumes)
+                    .withTolerations(template != null && template.getTolerations() != null ? removeEmptyValuesFromTolerations(template.getTolerations()) : null)
+                    .withTerminationGracePeriodSeconds(template != null ? (long) template.getTerminationGracePeriodSeconds() : 30L)
+                    .withImagePullSecrets(imagePullSecrets(template, defaultImagePullSecrets))
+                    .withSecurityContext(podSecurityContext)
+                    .withPriorityClassName(template != null ? template.getPriorityClassName() : null)
+                    .withSchedulerName(template != null && template.getSchedulerName() != null ? template.getSchedulerName() : "default-scheduler")
+                    .withHostAliases(template != null ? template.getHostAliases() : null)
+                    .withTopologySpreadConstraints(template != null ? template.getTopologySpreadConstraints() : null)
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates the Deployment strategy for a Deployment
+     *
+     * @param strategy  The type of deployment strategy which should be created
+     *
+     * @return  Created deployment strategy
+     */
+    public static DeploymentStrategy deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy strategy) {
+        return switch (strategy) {
+            case ROLLING_UPDATE -> rollingUpdateStrategy();
+            case RECREATE -> recreateStrategy();
+        };
+    }
+
+    /**
+     * Creates the 'Recreate' deployment strategy
+     *
+     * @return  Recreate deployment strategy
+     */
+    private static DeploymentStrategy recreateStrategy()   {
+        return new DeploymentStrategyBuilder()
+                .withType("Recreate")
+                .build();
+    }
+
+    /**
+     * Creates the Rolling update deployment strategy
+     *
+     * @return  Rolling update deployment strategy
+     */
+    private static DeploymentStrategy rollingUpdateStrategy()    {
+        return new DeploymentStrategyBuilder()
+                .withType("RollingUpdate")
+                .withRollingUpdate(new RollingUpdateDeploymentBuilder()
+                        .withMaxSurge(new IntOrString(1))
+                        .withMaxUnavailable(new IntOrString(0))
+                        .build())
+                .build();
+    }
+
+    /**
+     * If the toleration value is an empty string, set it to null. That solves an issue when built STS contains a filed
+     * with an empty property value. K8s is removing properties like this, and thus we cannot fetch an equal STS which was
+     * created with (some) empty value.
+     *
+     * @param tolerations   Tolerations list to check whether toleration value is an empty string and eventually replace it by null
+     *
+     * @return              List of tolerations with fixed empty strings
+     */
+    public static List<Toleration> removeEmptyValuesFromTolerations(List<Toleration> tolerations) {
+        if (tolerations != null) {
+            tolerations.stream().filter(toleration -> toleration.getValue() != null && toleration.getValue().isEmpty()).forEach(emptyValTol -> emptyValTol.setValue(null));
+            return tolerations;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the image pull secrets configuration from the Pod template
+     *
+     * @param template      Pod template which maybe contains custom image pull secrets configuration
+     * @param defaultValue  The default value which should be used if the image pull secrets are not set
+     *
+     * @return  Custom list of image pull secrets or default value if not defined
+     */
+    /* test */ static List<LocalObjectReference> imagePullSecrets(PodTemplate template, List<LocalObjectReference> defaultValue)  {
+        return template != null && template.getImagePullSecrets() != null ? template.getImagePullSecrets() : defaultValue;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
@@ -75,10 +74,6 @@ public class StatefulSetOperator extends AbstractScalableNamespacedResourceOpera
         }
     }
 
-    private static ObjectMeta templateMetadata(StatefulSet resource) {
-        return resource.getSpec().getTemplate().getMetadata();
-    }
-
     /**
      * The name of the given pod given by {@code podId} in the given StatefulSet.
      * @param desired The StatefulSet
@@ -86,7 +81,7 @@ public class StatefulSetOperator extends AbstractScalableNamespacedResourceOpera
      * @return The name of the pod.
      */
     public String getPodName(StatefulSet desired, int podId) {
-        return templateMetadata(desired).getName() + "-" + podId;
+        return desired.getMetadata().getName() + "-" + podId;
     }
 
     private void setGeneration(StatefulSet desired, int nextGeneration) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -404,7 +404,7 @@ public class CruiseControlTest {
         assertThat(volume, is(notNullValue()));
         assertThat(volume.getSecret().getSecretName(), is(CruiseControlResources.apiSecretName(cluster)));
 
-        volume = volumes.stream().filter(vol -> AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
+        volume = volumes.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volume, is(notNullValue()));
         assertThat(volume.getEmptyDir().getMedium(), is("Memory"));
         assertThat(volume.getEmptyDir().getSizeLimit(), is(new Quantity("100Mi")));
@@ -429,9 +429,9 @@ public class CruiseControlTest {
         assertThat(volumeMount, is(notNullValue()));
         assertThat(volumeMount.getMountPath(), is(CruiseControl.API_AUTH_CONFIG_VOLUME_MOUNT));
 
-        volumeMount = volumesMounts.stream().filter(vol -> AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
+        volumeMount = volumesMounts.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
-        assertThat(volumeMount.getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(volumeMount.getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -140,7 +140,7 @@ public class EntityOperatorTest {
         assertThat(AbstractModel.containerEnvVars(tlsSidecarContainer).get(EntityOperator.ENV_VAR_ZOOKEEPER_CONNECT), is(KafkaResources.zookeeperServiceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT));
         assertThat(AbstractModel.containerEnvVars(tlsSidecarContainer).get(ModelUtils.TLS_SIDECAR_LOG_LEVEL), is(TlsSidecarLogLevel.NOTICE.toValue()));
         assertThat(EntityOperatorTest.volumeMounts(tlsSidecarContainer.getVolumeMounts()), is(map(
-                        EntityOperator.TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
+                        EntityOperator.TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                         EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
                         EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT)));
         assertThat(tlsSidecarContainer.getReadinessProbe().getInitialDelaySeconds(), is(tlsHealthDelay));
@@ -214,8 +214,8 @@ public class EntityOperatorTest {
     @ParallelTest
     public void withAffinityAndTolerations() throws IOException {
         ResourceTester<Kafka, EntityOperator> helper = new ResourceTester<>(Kafka.class, VERSIONS, (kAssembly, versions) -> EntityOperator.fromCrd(new Reconciliation("test", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()), kAssembly, versions, true), this.getClass().getSimpleName() + ".withAffinityAndTolerations");
-        helper.assertDesiredResource("-DeploymentAffinity.yaml", zc -> zc.generateDeployment(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
-        helper.assertDesiredResource("-DeploymentTolerations.yaml", zc -> zc.generateDeployment(true, null, null).getSpec().getTemplate().getSpec().getTolerations());
+        helper.assertDesiredModel("-DeploymentAffinity.yaml", zc -> zc.generateDeployment(true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+        helper.assertDesiredModel("-DeploymentTolerations.yaml", zc -> zc.generateDeployment(true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -265,7 +265,7 @@ public class EntityTopicOperatorTest {
         assertThat(container.getPorts().get(0).getName(), is(EntityTopicOperator.HEALTHCHECK_PORT_NAME));
         assertThat(container.getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(map(
-                EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
+                EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
                 EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -247,7 +247,7 @@ public class EntityUserOperatorTest {
         assertThat(container.getPorts().get(0).getName(), is(EntityUserOperator.HEALTHCHECK_PORT_NAME));
         assertThat(container.getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(map(
-                EntityUserOperator.USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
+                EntityUserOperator.USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-user-operator-metrics-and-logging", "/opt/user-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
                 EntityOperator.EUO_CERTS_VOLUME_NAME, EntityOperator.EUO_CERTS_VOLUME_MOUNT)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JmxTransTest.java
@@ -209,7 +209,7 @@ public class JmxTransTest {
         List<Volume> volumes = dep.getSpec().getTemplate().getSpec().getVolumes();
         assertThat(volumes.size(), is(2));
 
-        Volume volume = volumes.stream().filter(vol -> AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
+        Volume volume = volumes.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volume, is(notNullValue()));
         assertThat(volume.getEmptyDir().getMedium(), is("Memory"));
         assertThat(volume.getEmptyDir().getSizeLimit(), is(new Quantity("5Mi")));
@@ -222,9 +222,9 @@ public class JmxTransTest {
         List<VolumeMount> volumesMounts = dep.getSpec().getTemplate().getSpec().getContainers().get(0).getVolumeMounts();
         assertThat(volumesMounts.size(), is(2));
 
-        VolumeMount volumeMount = volumesMounts.stream().filter(vol -> AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
+        VolumeMount volumeMount = volumesMounts.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
-        assertThat(volumeMount.getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(volumeMount.getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
 
         volumeMount = volumesMounts.stream().filter(vol -> JmxTrans.JMXTRANS_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -218,7 +218,7 @@ public class KafkaBridgeClusterTest {
         assertThat(AbstractModel.containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_TLS), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         TestUtils.checkOwnerReference(dep, resource);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -128,7 +128,7 @@ public class KafkaClusterPodSetTest {
             assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
             assertThat(pod.getSpec().getVolumes().stream()
                     .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-                    .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+                    .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
             assertThat(pod.getSpec().getContainers().size(), is(1));
             assertThat(pod.getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds(), is(5));
@@ -138,8 +138,8 @@ public class KafkaClusterPodSetTest {
             assertThat(AbstractModel.containerEnvVars(pod.getSpec().getContainers().get(0)).get(AbstractModel.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("data-0"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/var/lib/kafka/data-0"));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME_MOUNT));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getName(), is(KafkaCluster.BROKER_CERTS_VOLUME));
@@ -154,7 +154,7 @@ public class KafkaClusterPodSetTest {
             assertThat(pod.getSpec().getVolumes().size(), is(7));
             assertThat(pod.getSpec().getVolumes().get(0).getName(), is("data-0"));
             assertThat(pod.getSpec().getVolumes().get(0).getPersistentVolumeClaim(), is(notNullValue()));
-            assertThat(pod.getSpec().getVolumes().get(1).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+            assertThat(pod.getSpec().getVolumes().get(1).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getVolumes().get(1).getEmptyDir(), is(notNullValue()));
             assertThat(pod.getSpec().getVolumes().get(2).getName(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME));
             assertThat(pod.getSpec().getVolumes().get(2).getSecret().getSecretName(), is("my-cluster-cluster-ca-cert"));
@@ -420,8 +420,8 @@ public class KafkaClusterPodSetTest {
             assertThat(AbstractModel.containerEnvVars(pod.getSpec().getContainers().get(0)).get(AbstractModel.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is("true"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is("data-0"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is("/var/lib/kafka/data-0"));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME_MOUNT));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(3).getName(), is(KafkaCluster.BROKER_CERTS_VOLUME));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterStatefulSetTest.java
@@ -140,8 +140,8 @@ public class KafkaClusterStatefulSetTest {
         assertThat(containers.get(0).getReadinessProbe().getTimeoutSeconds(), is(5));
         assertThat(containers.get(0).getReadinessProbe().getInitialDelaySeconds(), is(15));
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(KafkaCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)));
-        assertThat(containers.get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(containers.get(0).getVolumeMounts().get(1).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(containers.get(0).getVolumeMounts().get(1).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(containers.get(0).getVolumeMounts().get(1).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(containers.get(0).getVolumeMounts().get(3).getName(), is(KafkaCluster.BROKER_CERTS_VOLUME));
         assertThat(containers.get(0).getVolumeMounts().get(3).getMountPath(), is(KafkaCluster.BROKER_CERTS_VOLUME_MOUNT));
         assertThat(containers.get(0).getVolumeMounts().get(2).getName(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME));
@@ -156,7 +156,7 @@ public class KafkaClusterStatefulSetTest {
         assertThat(containers.get(0).getPorts().get(1).getProtocol(), is("TCP"));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         if (kafka.getSpec().getKafka().getRack() != null) {
             Rack rack = kafka.getSpec().getKafka().getRack();
@@ -202,7 +202,7 @@ public class KafkaClusterStatefulSetTest {
 
         // Check Volumes
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().size(), is(6));
-        assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(0).getEmptyDir(), is(notNullValue()));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is(KafkaCluster.CLUSTER_CA_CERTS_VOLUME));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().get(1).getSecret().getSecretName(), is("foo-cluster-ca-cert"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3827,30 +3827,30 @@ public class KafkaClusterTest {
     @ParallelTest
     public void withAffinityWithoutRack() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, versions), this.getClass().getSimpleName() + ".withAffinityWithoutRack");
-        resourceTester.assertDesiredResource(".yaml", KafkaCluster::getMergedAffinity);
+        resourceTester.assertDesiredModel(".yaml", KafkaCluster::getMergedAffinity);
     }
 
     @ParallelTest
     public void withRackWithoutAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, versions), this.getClass().getSimpleName() + ".withRackWithoutAffinity");
-        resourceTester.assertDesiredResource(".yaml", KafkaCluster::getMergedAffinity);
+        resourceTester.assertDesiredModel(".yaml", KafkaCluster::getMergedAffinity);
     }
 
     @ParallelTest
     public void withRackAndAffinityWithMoreTerms() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, versions), this.getClass().getSimpleName() + ".withRackAndAffinityWithMoreTerms");
-        resourceTester.assertDesiredResource(".yaml", KafkaCluster::getMergedAffinity);
+        resourceTester.assertDesiredModel(".yaml", KafkaCluster::getMergedAffinity);
     }
 
     @ParallelTest
     public void withRackAndAffinity() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, versions), this.getClass().getSimpleName() + ".withRackAndAffinity");
-        resourceTester.assertDesiredResource(".yaml", KafkaCluster::getMergedAffinity);
+        resourceTester.assertDesiredModel(".yaml", KafkaCluster::getMergedAffinity);
     }
 
     @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, versions), this.getClass().getSimpleName() + ".withTolerations");
-        resourceTester.assertDesiredResource(".yaml", AbstractModel::getTolerations);
+        resourceTester.assertDesiredResource(".yaml", cr -> cr.getSpec().getKafka().getTemplate().getPod().getTolerations());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -184,7 +184,7 @@ public class KafkaConnectBuildTest {
 
         assertThat(build.baseImage, is("my-source-image:latest"));
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(cluster)));
         assertThat(pod.getMetadata().getNamespace(), is(namespace));
 
@@ -239,7 +239,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getSpec().getVolumes().size(), is(1));
         assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(defaultArgs));
         assertThat(pod.getSpec().getVolumes().get(0).getName(), is("dockerfile"));
@@ -435,7 +435,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getMetadata().getLabels().entrySet().containsAll(buildPodLabels.entrySet()), is(true));
         assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(buildPodAnnos.entrySet()), is(true));
         assertThat(pod.getSpec().getPriorityClassName(), is("top-priority"));
@@ -483,7 +483,7 @@ public class KafkaConnectBuildTest {
 
         KafkaConnectBuild build = KafkaConnectBuild.fromCrd(new Reconciliation("test", kc.getKind(), kc.getMetadata().getNamespace(), kc.getMetadata().getName()), kc, VERSIONS);
 
-        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, null);
+        Pod pod = build.generateBuilderPod(true, ImagePullPolicy.IFNOTPRESENT, null, "cf065b80ede090aa");
         assertThat(pod.getSpec().getContainers().get(0).getArgs(), is(expectedArgs));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -291,14 +291,14 @@ public class KafkaConnectClusterTest {
     public void withAffinity() throws IOException {
         ResourceTester<KafkaConnect, KafkaConnectCluster> resourceTester = new ResourceTester<>(KafkaConnect.class, VERSIONS, (connect, lookup) -> KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, connect, lookup), this.getClass().getSimpleName() + ".withAffinity");
         resourceTester
-            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+            .assertDesiredModel("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<KafkaConnect, KafkaConnectCluster> resourceTester = new ResourceTester<>(KafkaConnect.class, VERSIONS, (connect, lookup) -> KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, connect, lookup), this.getClass().getSimpleName() + ".withTolerations");
         resourceTester
-            .assertDesiredResource("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getTolerations());
+            .assertDesiredModel("-Deployment.yaml", kcc -> kcc.generateDeployment(new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
     @ParallelTest
@@ -436,15 +436,15 @@ public class KafkaConnectClusterTest {
         Deployment dep = kc.generateDeployment(emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(3));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
 
         List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
 
         assertThat(containers.get(0).getVolumeMounts().size(), is(4));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(containers.get(0).getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(containers.get(0).getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(containers.get(0).getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -510,15 +510,15 @@ public class KafkaConnectClusterTest {
         Deployment dep = kc.generateDeployment(emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(3));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
 
         List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
 
         assertThat(containers.get(0).getVolumeMounts().size(), is(4));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(containers.get(0).getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(containers.get(0).getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(containers.get(0).getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -584,15 +584,15 @@ public class KafkaConnectClusterTest {
         Deployment dep = kc.generateDeployment(emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(3));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
 
         List<Container> containers = dep.getSpec().getTemplate().getSpec().getContainers();
 
         assertThat(containers.get(0).getVolumeMounts().size(), is(4));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(containers.get(0).getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(containers.get(0).getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(containers.get(0).getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -1777,7 +1777,7 @@ public class KafkaConnectClusterTest {
         assertThat(AbstractModel.containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_TLS), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         TestUtils.checkOwnerReference(dep, resource);
         checkRack(dep, resource);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -187,7 +187,7 @@ public class KafkaExporterTest {
         List<Volume> volumes = dep.getSpec().getTemplate().getSpec().getVolumes();
         assertThat(volumes.size(), is(3));
 
-        Volume volume = volumes.stream().filter(vol -> AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
+        Volume volume = volumes.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volume, is(notNullValue()));
         assertThat(volume.getEmptyDir().getMedium(), is("Memory"));
         assertThat(volume.getEmptyDir().getSizeLimit(), is(new Quantity("100Mi")));
@@ -204,9 +204,9 @@ public class KafkaExporterTest {
         List<VolumeMount> volumesMounts = dep.getSpec().getTemplate().getSpec().getContainers().get(0).getVolumeMounts();
         assertThat(volumesMounts.size(), is(3));
 
-        VolumeMount volumeMount = volumesMounts.stream().filter(vol -> AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
+        VolumeMount volumeMount = volumesMounts.stream().filter(vol -> VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));
-        assertThat(volumeMount.getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(volumeMount.getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
 
         volumeMount = volumesMounts.stream().filter(vol -> KafkaExporter.CLUSTER_CA_CERTS_VOLUME_NAME.equals(vol.getName())).findFirst().orElseThrow();
         assertThat(volumeMount, is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -304,7 +304,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(AbstractModel.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TLS), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         TestUtils.checkOwnerReference(dep, resource);
     }
@@ -313,7 +313,7 @@ public class KafkaMirrorMaker2ClusterTest {
     public void withAffinity() throws IOException {
         ResourceTester<KafkaMirrorMaker2, KafkaMirrorMaker2Cluster> resourceTester = new ResourceTester<>(KafkaMirrorMaker2.class, VERSIONS, (kafkaMirrorMaker2, versions) -> KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, versions), this.getClass().getSimpleName() + ".withAffinity");
         resourceTester
-            .assertDesiredResource("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(
+            .assertDesiredModel("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(
                     new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
@@ -321,7 +321,7 @@ public class KafkaMirrorMaker2ClusterTest {
     public void withTolerations() throws IOException {
         ResourceTester<KafkaMirrorMaker2, KafkaMirrorMaker2Cluster> resourceTester = new ResourceTester<>(KafkaMirrorMaker2.class, VERSIONS, (kafkaMirrorMaker2, versions) -> KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, versions), this.getClass().getSimpleName() + ".withTolerations");
         resourceTester
-            .assertDesiredResource("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(
+            .assertDesiredModel("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(
                     new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
@@ -509,7 +509,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("target-my-secret"));
@@ -517,8 +517,8 @@ public class KafkaMirrorMaker2ClusterTest {
         Container cont = getContainer(dep);
 
         assertThat(cont.getVolumeMounts().size(), is(6));
-        assertThat(cont.getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(cont.getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(cont.getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(cont.getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(cont.getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -570,7 +570,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(5));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("target-my-secret"));
@@ -579,8 +579,8 @@ public class KafkaMirrorMaker2ClusterTest {
         Container cont = getContainer(dep);
 
         assertThat(cont.getVolumeMounts().size(), is(8));
-        assertThat(cont.getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(cont.getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(cont.getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(cont.getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(cont.getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -662,7 +662,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("target-my-secret"));
@@ -670,8 +670,8 @@ public class KafkaMirrorMaker2ClusterTest {
         Container cont = getContainer(dep);
 
         assertThat(cont.getVolumeMounts().size(), is(6));
-        assertThat(cont.getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(cont.getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(cont.getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(cont.getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(cont.getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -723,7 +723,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(5));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("target-my-secret"));
@@ -732,8 +732,8 @@ public class KafkaMirrorMaker2ClusterTest {
         Container cont = getContainer(dep);
 
         assertThat(cont.getVolumeMounts().size(), is(8));
-        assertThat(cont.getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(cont.getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(cont.getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(cont.getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(cont.getVolumeMounts().get(2).getName(), is("my-secret"));
@@ -816,7 +816,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().toString(), dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("target-my-secret"));
@@ -824,8 +824,8 @@ public class KafkaMirrorMaker2ClusterTest {
         Container cont = getContainer(dep);
 
         assertThat(cont.getVolumeMounts().size(), is(6));
-        assertThat(cont.getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(cont.getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(cont.getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(cont.getVolumeMounts().get(1).getName(), is("kafka-metrics-and-logging"));
         assertThat(cont.getVolumeMounts().get(1).getMountPath(), is("/opt/kafka/custom-config/"));
         assertThat(cont.getVolumeMounts().get(2).getName(), is("my-secret"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -275,7 +275,7 @@ public class KafkaMirrorMakerClusterTest {
         assertThat(dep.getSpec().getStrategy().getRollingUpdate().getMaxUnavailable().getIntVal(), is(0));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream()
             .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+            .findFirst().get().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
         TestUtils.checkOwnerReference(dep, resource);
     }
@@ -414,7 +414,7 @@ public class KafkaMirrorMakerClusterTest {
         Deployment dep = mmc.generateDeployment(emptyMap(), true, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
-        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret-p"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("my-secret-c"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -16,6 +16,8 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageOverrideBuilder;
 import io.strimzi.api.kafka.model.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
+import io.strimzi.api.kafka.model.template.StatefulSetTemplate;
+import io.strimzi.api.kafka.model.template.StatefulSetTemplateBuilder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -161,8 +163,14 @@ public class PersistentVolumeClaimUtilsTest {
                         .build())
                 .build();
 
+        StatefulSetTemplate stsTemplate = new StatefulSetTemplateBuilder()
+                .withNewMetadata()
+                    .withLabels(Map.of("sts-labela-1", "value-from-sts-1"))
+                .endMetadata()
+                .build();
+
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, TEMPLATE, Map.of("sts-labela-1", "value-from-sts-1"));
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, TEMPLATE, stsTemplate);
 
         assertThat(pvcs.size(), is(1));
 
@@ -188,8 +196,14 @@ public class PersistentVolumeClaimUtilsTest {
                         .build())
                 .build();
 
+        StatefulSetTemplate stsTemplate = new StatefulSetTemplateBuilder()
+                .withNewMetadata()
+                    .withLabels(Map.of("sts-labela-1", "value-from-sts-1"))
+                .endMetadata()
+                .build();
+
         List<PersistentVolumeClaim> pvcs = PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, Map.of("sts-labela-1", "value-from-sts-1"));
+                .createPersistentVolumeClaims(NAME, NAMESPACE, 1, jbod, false, LABELS, OWNER_REFERENCE, null, stsTemplate);
 
         assertThat(pvcs.size(), is(1));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ResourceTester.java
@@ -31,6 +31,7 @@ class ResourceTester<R extends HasMetadata, M extends AbstractModel> {
     private final String prefix;
     private final BiFunction<R, KafkaVersion.Lookup, M> fromK8sResource;
     private M model;
+    private R cr;
     private String resourceName;
 
     ResourceTester(Class<R> cls, KafkaVersion.Lookup lookup, BiFunction<R, KafkaVersion.Lookup, M> fromK8sResource, String prefix) {
@@ -64,11 +65,22 @@ class ResourceTester<R extends HasMetadata, M extends AbstractModel> {
         }
     }
 
-    protected void assertDesiredResource(String suffix, Function<M, ?> fn) throws IOException {
+    protected void assertDesiredModel(String suffix, Function<M, ?> fn) throws IOException {
         assertThat("The resource " + resourceName + " does not exist", model, is(notNullValue()));
         String content = readResource(prefix + suffix);
         if (content != null) {
             String ssStr = toYamlString(fn.apply(model));
+            assertThat(ssStr.trim(), is(content.trim()));
+        } else {
+            fail("The resource " + prefix + suffix + " does not exist");
+        }
+    }
+
+    protected void assertDesiredResource(String suffix, Function<R, ?> fn) throws IOException {
+        assertThat("The resource " + resourceName + " does not exist", model, is(notNullValue()));
+        String content = readResource(prefix + suffix);
+        if (content != null) {
+            String ssStr = toYamlString(fn.apply(cr));
             assertThat(ssStr.trim(), is(content.trim()));
         } else {
             fail("The resource " + prefix + suffix + " does not exist");
@@ -108,9 +120,9 @@ class ResourceTester<R extends HasMetadata, M extends AbstractModel> {
         if (resource == null) {
             model = null;
         } else {
-            R cm = fromYaml(resource, cls);
+            cr = fromYaml(resource, cls);
             // Construct the desired resources from the CM
-            model = fromK8sResource.apply(cm, lookup);
+            model = fromK8sResource.apply(cr, lookup);
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TemplateUtilsTest.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
+import io.strimzi.api.kafka.model.template.DeploymentTemplate;
+import io.strimzi.api.kafka.model.template.DeploymentTemplateBuilder;
 import io.strimzi.api.kafka.model.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -54,5 +57,12 @@ public class TemplateUtilsTest {
                 .build();
 
         assertThat(TemplateUtils.labels(template), is(Map.of("label-1", "value-1", "label-2", "value-2")));
+    }
+
+    @ParallelTest
+    public void testDeploymentStrategy() {
+        assertThat(TemplateUtils.deploymentStrategy(null, DeploymentStrategy.RECREATE), is(DeploymentStrategy.RECREATE));
+        assertThat(TemplateUtils.deploymentStrategy(new DeploymentTemplate(), DeploymentStrategy.ROLLING_UPDATE), is(DeploymentStrategy.ROLLING_UPDATE));
+        assertThat(TemplateUtils.deploymentStrategy(new DeploymentTemplateBuilder().withDeploymentStrategy(DeploymentStrategy.RECREATE).build(), DeploymentStrategy.ROLLING_UPDATE), is(DeploymentStrategy.RECREATE));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -1,0 +1,1000 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.AffinityBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.HostAliasBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TolerationBuilder;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraintBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStrategy;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
+import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.api.kafka.model.template.DeploymentTemplateBuilder;
+import io.strimzi.api.kafka.model.template.PodManagementPolicy;
+import io.strimzi.api.kafka.model.template.PodTemplate;
+import io.strimzi.api.kafka.model.template.PodTemplateBuilder;
+import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
+import io.strimzi.api.kafka.model.template.StatefulSetTemplate;
+import io.strimzi.api.kafka.model.template.StatefulSetTemplateBuilder;
+import io.strimzi.operator.cluster.operator.resource.PodRevision;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
+public class WorkloadUtilsTest {
+    private final static String NAME = "my-workload";
+    private final static String NAMESPACE = "my-namespace";
+    private final static String HEADLESS_SERVICE_NAME = "my-workload-headless";
+    private final static int REPLICAS = 5;
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-workload")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+    private static final PodTemplateSpec DUMMY_POD_TEMPLATE_SPEC = new PodTemplateSpecBuilder()
+            .withNewMetadata()
+                .withLabels(Map.of("dummy", "label"))
+                .withAnnotations(Map.of("dummy", "anno"))
+            .endMetadata()
+            .withNewSpec()
+                .withContainers(new Container())
+            .endSpec()
+            .build();
+    private static final Storage DEFAULT_STORAGE = new PersistentClaimStorageBuilder().withSize("100Gi").build();
+    private static final Affinity DEFAULT_AFFINITY = new AffinityBuilder()
+            .withNewNodeAffinity()
+                .withNewRequiredDuringSchedulingIgnoredDuringExecution()
+                    .withNodeSelectorTerms(new NodeSelectorTermBuilder()
+                        .addNewMatchExpression()
+                            .withKey("key1")
+                            .withOperator("In")
+                            .withValues("value1", "value2")
+                        .endMatchExpression()
+                        .build())
+                .endRequiredDuringSchedulingIgnoredDuringExecution()
+            .endNodeAffinity()
+            .build();
+    private static final Toleration DEFAULT_TOLERATION = new TolerationBuilder()
+            .withEffect("NoExecute")
+            .withKey("key1")
+            .withOperator("Equal")
+            .withValue("value1")
+            .build();
+    private static final TopologySpreadConstraint DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT = new TopologySpreadConstraintBuilder()
+            .withTopologyKey("kubernetes.io/zone")
+            .withMaxSkew(1)
+            .withWhenUnsatisfiable("DoNotSchedule")
+            .withLabelSelector(new LabelSelectorBuilder().withMatchLabels(singletonMap("label", "value")).build())
+            .build();
+    private static final PodSecurityContext DEFAULT_POD_SECURITY_CONTEXT = new PodSecurityContextBuilder()
+            .withFsGroup(123L)
+            .withRunAsGroup(456L)
+            .withRunAsUser(789L)
+            .build();
+    private static final HostAlias DEFAULT_HOST_ALIAS = new HostAliasBuilder()
+            .withIp("127.0.0.1")
+            .withHostnames("home")
+            .build();
+
+    //////////////////////////////////////////////////
+    // Deployment tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testCreateDeploymentWithNullTemplateAndRecreateStrategy()  {
+        Deployment dep = WorkloadUtils.createDeployment(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                null,
+                REPLICAS,
+                WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy.RECREATE),
+                DUMMY_POD_TEMPLATE_SPEC
+        );
+
+        assertThat(dep.getMetadata().getName(), is(NAME));
+        assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(dep.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(dep.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(dep.getSpec().getStrategy().getType(), is("Recreate"));
+        assertThat(dep.getSpec().getReplicas(), is(REPLICAS));
+        assertThat(dep.getSpec().getTemplate(), is(DUMMY_POD_TEMPLATE_SPEC));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @Test
+    public void testCreateDeploymentWithTemplateAndRollingUpdateStrategy()  {
+        Deployment dep = WorkloadUtils.createDeployment(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                new DeploymentTemplateBuilder()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                            .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                        .endMetadata()
+                        .build(),
+                REPLICAS,
+                WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE),
+                DUMMY_POD_TEMPLATE_SPEC
+        );
+
+        assertThat(dep.getMetadata().getName(), is(NAME));
+        assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(dep.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(dep.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(dep.getSpec().getStrategy().getType(), is("RollingUpdate"));
+        assertThat(dep.getSpec().getReplicas(), is(REPLICAS));
+        assertThat(dep.getSpec().getTemplate(), is(DUMMY_POD_TEMPLATE_SPEC));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(dep.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    //////////////////////////////////////////////////
+    // StatefulSet tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testCreateStatefulSetWithNullTemplate()  {
+        StatefulSet sts = WorkloadUtils.createStatefulSet(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                null,
+                REPLICAS,
+                HEADLESS_SERVICE_NAME,
+                Map.of("extra", "annotations"),
+                VolumeUtils.createPersistentVolumeClaimTemplates(DEFAULT_STORAGE, false),
+                DUMMY_POD_TEMPLATE_SPEC
+        );
+
+        assertThat(sts.getMetadata().getName(), is(NAME));
+        assertThat(sts.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sts.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sts.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(sts.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(sts.getSpec().getPodManagementPolicy(), is("Parallel"));
+        assertThat(sts.getSpec().getServiceName(), is(HEADLESS_SERVICE_NAME));
+        assertThat(sts.getSpec().getReplicas(), is(REPLICAS));
+        assertThat(sts.getSpec().getTemplate(), is(DUMMY_POD_TEMPLATE_SPEC));
+        assertThat(sts.getSpec().getUpdateStrategy().getType(), is("OnDelete"));
+        assertThat(sts.getSpec().getVolumeClaimTemplates(), is(VolumeUtils.createPersistentVolumeClaimTemplates(DEFAULT_STORAGE, false)));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @Test
+    public void testCreateStatefulSetWithEmptyTemplate()  {
+        StatefulSet sts = WorkloadUtils.createStatefulSet(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                new StatefulSetTemplate(),
+                REPLICAS,
+                HEADLESS_SERVICE_NAME,
+                Map.of("extra", "annotations"),
+                VolumeUtils.createPersistentVolumeClaimTemplates(DEFAULT_STORAGE, false),
+                DUMMY_POD_TEMPLATE_SPEC
+        );
+
+        assertThat(sts.getMetadata().getName(), is(NAME));
+        assertThat(sts.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sts.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sts.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(sts.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(sts.getSpec().getPodManagementPolicy(), is("Parallel"));
+        assertThat(sts.getSpec().getServiceName(), is(HEADLESS_SERVICE_NAME));
+        assertThat(sts.getSpec().getReplicas(), is(REPLICAS));
+        assertThat(sts.getSpec().getTemplate(), is(DUMMY_POD_TEMPLATE_SPEC));
+        assertThat(sts.getSpec().getUpdateStrategy().getType(), is("OnDelete"));
+        assertThat(sts.getSpec().getVolumeClaimTemplates(), is(VolumeUtils.createPersistentVolumeClaimTemplates(DEFAULT_STORAGE, false)));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    @Test
+    public void testCreateStatefulSetWithTemplate()  {
+        StatefulSet sts = WorkloadUtils.createStatefulSet(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                new StatefulSetTemplateBuilder()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                            .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                        .endMetadata()
+                        .withPodManagementPolicy(PodManagementPolicy.ORDERED_READY)
+                        .build(),
+                REPLICAS,
+                HEADLESS_SERVICE_NAME,
+                Map.of("extra", "annotations"),
+                VolumeUtils.createPersistentVolumeClaimTemplates(DEFAULT_STORAGE, false),
+                DUMMY_POD_TEMPLATE_SPEC
+        );
+
+        assertThat(sts.getMetadata().getName(), is(NAME));
+        assertThat(sts.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sts.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sts.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(sts.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(sts.getSpec().getPodManagementPolicy(), is("OrderedReady"));
+        assertThat(sts.getSpec().getServiceName(), is(HEADLESS_SERVICE_NAME));
+        assertThat(sts.getSpec().getReplicas(), is(REPLICAS));
+        assertThat(sts.getSpec().getTemplate(), is(DUMMY_POD_TEMPLATE_SPEC));
+        assertThat(sts.getSpec().getUpdateStrategy().getType(), is("OnDelete"));
+        assertThat(sts.getSpec().getVolumeClaimTemplates(), is(VolumeUtils.createPersistentVolumeClaimTemplates(DEFAULT_STORAGE, false)));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(sts.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+    }
+
+    //////////////////////////////////////////////////
+    // StrimziPodSet tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testCreateStrimziPodSetWithNullTemplate()  {
+        List<Integer> podIds = new ArrayList<>();
+
+        StrimziPodSet sps = WorkloadUtils.createPodSet(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                null,
+                REPLICAS,
+                Map.of("extra", "annotations"),
+                i -> {
+                    podIds.add(i);
+                    return new PodBuilder()
+                            .withNewMetadata()
+                                .withName(NAME + "-" + i)
+                            .endMetadata()
+                            .build();
+                }
+        );
+
+        assertThat(sps.getMetadata().getName(), is(NAME));
+        assertThat(sps.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sps.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(sps.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+
+        // Test generating pods from the PodCreator method
+        assertThat(podIds.size(), is(5));
+        assertThat(podIds, is(List.of(0, 1, 2, 3, 4)));
+        assertThat(sps.getSpec().getPods().size(), is(5));
+        assertThat(sps.getSpec().getPods().stream().map(pod -> PodSetUtils.mapToPod(pod).getMetadata().getName()).toList(), is(List.of("my-workload-0", "my-workload-1", "my-workload-2", "my-workload-3", "my-workload-4")));
+    }
+
+    @Test
+    public void testCreateStrimziPodSetWithTemplate()  {
+        List<Integer> podIds = new ArrayList<>();
+
+        StrimziPodSet sps = WorkloadUtils.createPodSet(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                new ResourceTemplateBuilder()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                            .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                        .endMetadata()
+                        .build(),
+                REPLICAS,
+                Map.of("extra", "annotations"),
+                i -> {
+                    podIds.add(i);
+                    return new PodBuilder()
+                            .withNewMetadata()
+                                .withName(NAME + "-" + i)
+                            .endMetadata()
+                            .build();
+                }
+        );
+
+        assertThat(sps.getMetadata().getName(), is(NAME));
+        assertThat(sps.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sps.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sps.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(sps.getSpec().getSelector().getMatchLabels().size(), is(3));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+
+        // Test generating pods from the PodCreator method
+        assertThat(podIds.size(), is(5));
+        assertThat(podIds, is(List.of(0, 1, 2, 3, 4)));
+        assertThat(sps.getSpec().getPods().size(), is(5));
+        assertThat(sps.getSpec().getPods().stream().map(pod -> PodSetUtils.mapToPod(pod).getMetadata().getName()).toList(), is(List.of("my-workload-0", "my-workload-1", "my-workload-2", "my-workload-3", "my-workload-4")));
+    }
+
+    //////////////////////////////////////////////////
+    // Stateful Pod tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testCreateStatefulPodWithNullValues()  {
+        Pod pod = WorkloadUtils.createStatefulPod(
+                Reconciliation.DUMMY_RECONCILIATION,
+                NAME + "-0",    // => Pod name
+                NAMESPACE,
+                LABELS,
+                NAME,   // => Workload name
+                NAME + "-sa",   // => Service Account name
+                null,
+                null,
+                null,
+                HEADLESS_SERVICE_NAME,
+                null,
+                null,
+                List.of(new ContainerBuilder().withName("container").build()),
+                null,
+                null,
+                null
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME + "-0"));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS
+                .withStrimziPodSetController(NAME)
+                .withStrimziPodName(NAME + "-0")
+                .withAdditionalLabels(Map.of("statefulset.kubernetes.io/pod-name", "my-workload-0"))
+                .toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of(PodRevision.STRIMZI_REVISION_ANNOTATION, "6a6a679b")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Always"));
+        assertThat(pod.getSpec().getHostname(), is(NAME + "-0"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME + "-sa"));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(nullValue()));
+        assertThat(pod.getSpec().getInitContainers(), is(nullValue()));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(nullValue()));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(nullValue()));
+        assertThat(pod.getSpec().getSecurityContext(), is(nullValue()));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreateStatefulPodWithNullValuesAndNullTemplate()  {
+        Pod pod = WorkloadUtils.createStatefulPod(
+                Reconciliation.DUMMY_RECONCILIATION,
+                NAME + "-0",    // => Pod name
+                NAMESPACE,
+                LABELS,
+                NAME,   // => Workload name
+                NAME + "-sa",   // => Service Account name
+                null,
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                HEADLESS_SERVICE_NAME,
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME + "-0"));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS
+                .withStrimziPodSetController(NAME)
+                .withStrimziPodName(NAME + "-0")
+                .withAdditionalLabels(Map.of("statefulset.kubernetes.io/pod-name", "my-workload-0", "default-label", "default-value"))
+                .toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", PodRevision.STRIMZI_REVISION_ANNOTATION, "da09ff49")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Always"));
+        assertThat(pod.getSpec().getHostname(), is(NAME + "-0"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME + "-sa"));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreateStatefulPodWithEmptyTemplate()  {
+        Pod pod = WorkloadUtils.createStatefulPod(
+                Reconciliation.DUMMY_RECONCILIATION,
+                NAME + "-0",    // => Pod name
+                NAMESPACE,
+                LABELS,
+                NAME,   // => Workload name
+                NAME + "-sa",   // => Service Account name
+                new PodTemplate(),
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                HEADLESS_SERVICE_NAME,
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME + "-0"));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS
+                .withStrimziPodSetController(NAME)
+                .withStrimziPodName(NAME + "-0")
+                .withAdditionalLabels(Map.of("statefulset.kubernetes.io/pod-name", "my-workload-0", "default-label", "default-value"))
+                .toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", PodRevision.STRIMZI_REVISION_ANNOTATION, "da09ff49")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Always"));
+        assertThat(pod.getSpec().getHostname(), is(NAME + "-0"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME + "-sa"));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreateStatefulPodWithTemplate()  {
+        Pod pod = WorkloadUtils.createStatefulPod(
+                Reconciliation.DUMMY_RECONCILIATION,
+                NAME + "-0",    // => Pod name
+                NAMESPACE,
+                LABELS,
+                NAME,   // => Workload name
+                NAME + "-sa",   // => Service Account name
+                new PodTemplateBuilder()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                            .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                        .endMetadata()
+                        .withEnableServiceLinks(false)
+                        .withAffinity(new Affinity()) // => should be ignored
+                        .withImagePullSecrets(List.of(new LocalObjectReference("some-other-pull-secret")))
+                        .withPriorityClassName("my-priority-class")
+                        .withHostAliases(DEFAULT_HOST_ALIAS)
+                        .withTolerations(DEFAULT_TOLERATION)
+                        .withTerminationGracePeriodSeconds(15)
+                        .withSecurityContext(new PodSecurityContextBuilder().withRunAsUser(0L).build()) // => should be ignored
+                        .withTopologySpreadConstraints(DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT)
+                        .withSchedulerName("my-scheduler")
+                        .build(),
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                HEADLESS_SERVICE_NAME,
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME + "-0"));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS
+                .withStrimziPodSetController(NAME)
+                .withStrimziPodName(NAME + "-0")
+                .withAdditionalLabels(Map.of("statefulset.kubernetes.io/pod-name", "my-workload-0", "default-label", "default-value", "label-3", "value-3", "label-4", "value-4"))
+                .toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2", PodRevision.STRIMZI_REVISION_ANNOTATION, "4c2e5618")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Always"));
+        assertThat(pod.getSpec().getHostname(), is(NAME + "-0"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME + "-sa"));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(false));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(List.of(DEFAULT_TOLERATION)));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(15L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-other-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is("my-priority-class"));
+        assertThat(pod.getSpec().getSchedulerName(), is("my-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(List.of(DEFAULT_HOST_ALIAS)));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(List.of(DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT)));
+    }
+
+    //////////////////////////////////////////////////
+    // PodTemplateSpec tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testCreatePodTemplateSpecWithNullValues()  {
+        PodTemplateSpec pod = WorkloadUtils.createPodTemplateSpec(
+                NAME,
+                LABELS,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(new ContainerBuilder().withName("container").build()),
+                null,
+                null,
+                null
+        );
+
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of()));
+
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(nullValue()));
+        assertThat(pod.getSpec().getInitContainers(), is(nullValue()));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(nullValue()));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(nullValue()));
+        assertThat(pod.getSpec().getSecurityContext(), is(nullValue()));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreatePodTemplateSpecWithNullTemplate()  {
+        PodTemplateSpec pod = WorkloadUtils.createPodTemplateSpec(
+                NAME,
+                LABELS,
+                null,
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("default-label", "default-value")).toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreatePodTemplateSpecWithEmptyTemplate()  {
+        PodTemplateSpec pod = WorkloadUtils.createPodTemplateSpec(
+                NAME,
+                LABELS,
+                new PodTemplate(),
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("default-label", "default-value")).toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreatePodTemplateSpecWithTemplate()  {
+        PodTemplateSpec pod = WorkloadUtils.createPodTemplateSpec(
+                NAME,
+                LABELS,
+                new PodTemplateBuilder()
+                        .withNewMetadata()
+                            .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                            .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                        .endMetadata()
+                        .withEnableServiceLinks(false)
+                        .withAffinity(new Affinity()) // => should be ignored
+                        .withImagePullSecrets(List.of(new LocalObjectReference("some-other-pull-secret")))
+                        .withPriorityClassName("my-priority-class")
+                        .withHostAliases(DEFAULT_HOST_ALIAS)
+                        .withTolerations(DEFAULT_TOLERATION)
+                        .withTerminationGracePeriodSeconds(15)
+                        .withSecurityContext(new PodSecurityContextBuilder().withRunAsUser(0L).build()) // => should be ignored
+                        .withTopologySpreadConstraints(DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT)
+                        .withSchedulerName("my-scheduler")
+                        .build(),
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("default-label", "default-value", "label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(false));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(List.of(DEFAULT_TOLERATION)));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(15L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-other-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is("my-priority-class"));
+        assertThat(pod.getSpec().getSchedulerName(), is("my-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(List.of(DEFAULT_HOST_ALIAS)));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(List.of(DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT)));
+    }
+
+    //////////////////////////////////////////////////
+    // Pod tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testCreatePodWithNullValues()  {
+        Pod pod = WorkloadUtils.createPod(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(new ContainerBuilder().withName("container").build()),
+                null,
+                null,
+                null
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of()));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Never"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(nullValue()));
+        assertThat(pod.getSpec().getInitContainers(), is(nullValue()));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(nullValue()));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(nullValue()));
+        assertThat(pod.getSpec().getSecurityContext(), is(nullValue()));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreatePodWithNullValuesAndNullTemplate()  {
+        Pod pod = WorkloadUtils.createPod(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                null,
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("default-label", "default-value")).toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Never"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreatePodWithEmptyTemplate()  {
+        Pod pod = WorkloadUtils.createPod(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                new PodTemplate(),
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("default-label", "default-value")).toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Never"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(nullValue()));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(nullValue()));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is(nullValue()));
+        assertThat(pod.getSpec().getSchedulerName(), is("default-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(nullValue()));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(nullValue()));
+    }
+
+    @Test
+    public void testCreatePodWithTemplate()  {
+        Pod pod = WorkloadUtils.createPod(
+                NAME,
+                NAMESPACE,
+                LABELS,
+                OWNER_REFERENCE,
+                new PodTemplateBuilder()
+                        .withNewMetadata()
+                        .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                        .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                        .endMetadata()
+                        .withEnableServiceLinks(false)
+                        .withAffinity(new Affinity()) // => should be ignored
+                        .withImagePullSecrets(List.of(new LocalObjectReference("some-other-pull-secret")))
+                        .withPriorityClassName("my-priority-class")
+                        .withHostAliases(DEFAULT_HOST_ALIAS)
+                        .withTolerations(DEFAULT_TOLERATION)
+                        .withTerminationGracePeriodSeconds(15)
+                        .withSecurityContext(new PodSecurityContextBuilder().withRunAsUser(0L).build()) // => should be ignored
+                        .withTopologySpreadConstraints(DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT)
+                        .withSchedulerName("my-scheduler")
+                        .build(),
+                Map.of("default-label", "default-value"),
+                Map.of("extra", "annotations"),
+                DEFAULT_AFFINITY,
+                List.of(new ContainerBuilder().withName("init-container").build()),
+                List.of(new ContainerBuilder().withName("container").build()),
+                VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false),
+                List.of(new LocalObjectReference("some-pull-secret")),
+                DEFAULT_POD_SECURITY_CONTEXT
+        );
+
+        assertThat(pod.getMetadata().getName(), is(NAME));
+        assertThat(pod.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(pod.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("default-label", "default-value", "label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(pod.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(pod.getSpec().getRestartPolicy(), is("Never"));
+        assertThat(pod.getSpec().getServiceAccountName(), is(NAME));
+        assertThat(pod.getSpec().getEnableServiceLinks(), is(false));
+        assertThat(pod.getSpec().getAffinity(), is(DEFAULT_AFFINITY));
+        assertThat(pod.getSpec().getInitContainers().size(), is(1));
+        assertThat(pod.getSpec().getInitContainers().get(0).getName(), is("init-container"));
+        assertThat(pod.getSpec().getContainers().size(), is(1));
+        assertThat(pod.getSpec().getContainers().get(0).getName(), is("container"));
+        assertThat(pod.getSpec().getVolumes(), is(VolumeUtils.createPodSetVolumes(NAME + "-0", DEFAULT_STORAGE, false)));
+        assertThat(pod.getSpec().getTolerations(), is(List.of(DEFAULT_TOLERATION)));
+        assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(15L));
+        assertThat(pod.getSpec().getImagePullSecrets(), is(List.of(new LocalObjectReference("some-other-pull-secret"))));
+        assertThat(pod.getSpec().getSecurityContext(), is(DEFAULT_POD_SECURITY_CONTEXT));
+        assertThat(pod.getSpec().getPriorityClassName(), is("my-priority-class"));
+        assertThat(pod.getSpec().getSchedulerName(), is("my-scheduler"));
+        assertThat(pod.getSpec().getHostAliases(), is(List.of(DEFAULT_HOST_ALIAS)));
+        assertThat(pod.getSpec().getTopologySpreadConstraints(), is(List.of(DEFAULT_TOPOLOGY_SPREAD_CONSTRAINT)));
+    }
+
+    //////////////////////////////////////////////////
+    // Helper methods tests
+    //////////////////////////////////////////////////
+
+    @Test
+    public void testRemoveEmptyValuesFromTolerations() {
+        Toleration t1 = new TolerationBuilder()
+                .withValue("")
+                .withEffect("NoExecute")
+                .build();
+
+        Toleration t2 = new TolerationBuilder()
+                .withValue(null)
+                .withEffect("NoExecute")
+                .build();
+
+        assertThat(WorkloadUtils.removeEmptyValuesFromTolerations(List.of(t1)), is(WorkloadUtils.removeEmptyValuesFromTolerations(List.of(t2))));
+    }
+
+    @Test
+    public void testImagePullSecrets()  {
+        List<LocalObjectReference> defaults = List.of(new LocalObjectReferenceBuilder().withName("default").build());
+        List<LocalObjectReference> custom = List.of(new LocalObjectReferenceBuilder().withName("custom").build());
+
+        assertThat(WorkloadUtils.imagePullSecrets(null, defaults), is(defaults));
+        assertThat(WorkloadUtils.imagePullSecrets(new PodTemplate(), defaults), is(defaults));
+        assertThat(WorkloadUtils.imagePullSecrets(new PodTemplateBuilder().withImagePullSecrets(custom).build(), defaults), is(custom));
+    }
+
+    @Test
+    public void testDeploymentStrategyRecreate()    {
+        DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy.RECREATE);
+
+        assertThat(strategy.getType(), is("Recreate"));
+        assertThat(strategy.getRollingUpdate(), is(nullValue()));
+    }
+
+    @Test
+    public void testDeploymentStrategyRollingUpdate()    {
+        DeploymentStrategy strategy = WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE);
+
+        assertThat(strategy.getType(), is("RollingUpdate"));
+        assertThat(strategy.getRollingUpdate().getMaxSurge(), is(new IntOrString(1)));
+        assertThat(strategy.getRollingUpdate().getMaxUnavailable(), is(new IntOrString(0)));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -111,7 +111,7 @@ public class ZookeeperClusterPodSetTest {
             assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
             assertThat(pod.getSpec().getVolumes().stream()
                     .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-                    .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+                    .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
 
             assertThat(pod.getSpec().getContainers().size(), is(1));
             assertThat(pod.getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds(), is(5));
@@ -119,8 +119,8 @@ public class ZookeeperClusterPodSetTest {
             assertThat(pod.getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds(), is(5));
             assertThat(pod.getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds(), is(15));
             assertThat(AbstractModel.containerEnvVars(pod.getSpec().getContainers().get(0)).get(ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/lib/zookeeper"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("zookeeper-metrics-and-logging"));
@@ -335,8 +335,8 @@ public class ZookeeperClusterPodSetTest {
             assertThat(pod.getSpec().getContainers().get(0).getReadinessProbe().getSuccessThreshold(), is(readinessProbe.getSuccessThreshold()));
             assertThat(pod.getSpec().getContainers().get(0).getReadinessProbe().getPeriodSeconds(), is(readinessProbe.getPeriodSeconds()));
             assertThat(AbstractModel.containerEnvVars(pod.getSpec().getContainers().get(0)).get(ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is("true"));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/lib/zookeeper"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("zookeeper-metrics-and-logging"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterStatefulSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterStatefulSetTest.java
@@ -132,17 +132,17 @@ public class ZookeeperClusterStatefulSetTest {
                 .addStringPairs(AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
         assertThat(actual, is(expectedConfig));
         assertThat(AbstractModel.containerEnvVars(containers.get(0)).get(ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is(Boolean.toString(AbstractModel.DEFAULT_JVM_GC_LOGGING_ENABLED)));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
-        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
+        assertThat(containers.get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
         assertThat(containers.get(0).getVolumeMounts().get(3).getName(), is(ZookeeperCluster.ZOOKEEPER_NODE_CERTIFICATES_VOLUME_NAME));
         assertThat(containers.get(0).getVolumeMounts().get(3).getMountPath(), is(ZookeeperCluster.ZOOKEEPER_NODE_CERTIFICATES_VOLUME_MOUNT));
         assertThat(containers.get(0).getVolumeMounts().get(4).getName(), is(ZookeeperCluster.ZOOKEEPER_CLUSTER_CA_VOLUME_NAME));
         assertThat(containers.get(0).getVolumeMounts().get(4).getMountPath(), is(ZookeeperCluster.ZOOKEEPER_CLUSTER_CA_VOLUME_MOUNT));
         assertThat(sts.getSpec().getTemplate().getSpec().getVolumes().stream()
                 .filter(volume -> volume.getName().equalsIgnoreCase("strimzi-tmp"))
-                .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(AbstractModel.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
+                .findFirst().orElseThrow().getEmptyDir().getSizeLimit(), is(new Quantity(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE)));
     }
 
     //////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -399,13 +399,13 @@ public class ZookeeperClusterTest {
     @ParallelTest
     public void withAffinity() throws IOException {
         ResourceTester<Kafka, ZookeeperCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly, versions) -> ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, versions), this.getClass().getSimpleName() + ".withAffinity");
-        resourceTester.assertDesiredResource(".yaml", AbstractModel::getMergedAffinity);
+        resourceTester.assertDesiredResource(".yaml", cr -> cr.getSpec().getZookeeper().getTemplate().getPod().getAffinity());
     }
 
     @ParallelTest
     public void withTolerations() throws IOException {
         ResourceTester<Kafka, ZookeeperCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly, versions) -> ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, versions), this.getClass().getSimpleName() + ".withTolerations");
-        resourceTester.assertDesiredResource(".yaml", AbstractModel::getTolerations);
+        resourceTester.assertDesiredResource(".yaml", cr -> cr.getSpec().getZookeeper().getTemplate().getPod().getTolerations());
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiPredicate;
@@ -1467,9 +1468,16 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
             Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
+
+            if (dep.getMetadata().getAnnotations() != null) {
+                dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true");
+            } else {
+                dep.getMetadata().setAnnotations(Map.of(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true"));
+            }
+
             dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub());
-            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true");
             dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
+
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TolerationsIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/TolerationsIT.java
@@ -11,7 +11,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.model.WorkloadUtils;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetDiff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -58,7 +58,7 @@ public class TolerationsIT {
         tolerationList.add(t1);
 
         // CO does this over the generated STS
-        tolerationList = ModelUtils.removeEmptyValuesFromTolerations(tolerationList);
+        tolerationList = WorkloadUtils.removeEmptyValuesFromTolerations(tolerationList);
 
         StatefulSet ss = new StatefulSetBuilder()
                 .withNewMetadata()

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1273,7 +1273,7 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |====
 |Property                         |Description
 |deployment                1.2+<.<a|Template for Entity Operator `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |pod                       1.2+<.<a|Template for Entity Operator `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |topicOperatorContainer    1.2+<.<a|Template for the Entity Topic Operator container.
@@ -1290,6 +1290,28 @@ Used in: xref:type-EntityOperatorSpec-{context}[`EntityOperatorSpec`]
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |userOperatorRoleBinding   1.2+<.<a|Template for the Entity Topic Operator RoleBinding.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|====
+
+[id='type-DeploymentTemplate-{context}']
+### `DeploymentTemplate` schema reference
+
+Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xref:type-EntityOperatorTemplate-{context}[`EntityOperatorTemplate`], xref:type-JmxTransTemplate-{context}[`JmxTransTemplate`], xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
+
+xref:type-DeploymentTemplate-schema-{context}[Full list of `DeploymentTemplate` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.template.DeploymentTemplate.adoc[leveloffset=+1]
+
+[id='type-DeploymentTemplate-schema-{context}']
+==== `DeploymentTemplate` schema properties
+
+
+[options="header"]
+|====
+|Property                   |Description
+|metadata            1.2+<.<a|Metadata applied to the resource.
+|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
+|deploymentStrategy  1.2+<.<a|Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+|string (one of [RollingUpdate, Recreate])
 |====
 
 [id='type-CertificateAuthority-{context}']
@@ -1366,7 +1388,7 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 |====
 |Property                       |Description
 |deployment              1.2+<.<a|Template for Cruise Control `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |pod                     1.2+<.<a|Template for Cruise Control `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService              1.2+<.<a|Template for Cruise Control API `Service`.
@@ -1498,7 +1520,7 @@ Used in: xref:type-JmxTransSpec-{context}[`JmxTransSpec`]
 |====
 |Property               |Description
 |deployment      1.2+<.<a|Template for JmxTrans `Deployment`.
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |pod             1.2+<.<a|Template for JmxTrans `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |container       1.2+<.<a|Template for JmxTrans container.
@@ -1557,28 +1579,6 @@ Used in: xref:type-KafkaExporterSpec-{context}[`KafkaExporterSpec`]
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |serviceAccount  1.2+<.<a|Template for the Kafka Exporter service account.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|====
-
-[id='type-DeploymentTemplate-{context}']
-### `DeploymentTemplate` schema reference
-
-Used in: xref:type-KafkaBridgeTemplate-{context}[`KafkaBridgeTemplate`], xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`], xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`], xref:type-KafkaMirrorMakerTemplate-{context}[`KafkaMirrorMakerTemplate`]
-
-xref:type-DeploymentTemplate-schema-{context}[Full list of `DeploymentTemplate` schema properties]
-
-include::../api/io.strimzi.api.kafka.model.template.DeploymentTemplate.adoc[leveloffset=+1]
-
-[id='type-DeploymentTemplate-schema-{context}']
-==== `DeploymentTemplate` schema properties
-
-
-[options="header"]
-|====
-|Property                   |Description
-|metadata            1.2+<.<a|Metadata applied to the resource.
-|xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
-|deploymentStrategy  1.2+<.<a|Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
-|string (one of [RollingUpdate, Recreate])
 |====
 
 [id='type-KafkaStatus-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -3049,6 +3049,12 @@ spec:
                                   type: object
                                   description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                               description: Metadata applied to the resource.
+                            deploymentStrategy:
+                              type: string
+                              enum:
+                                - RollingUpdate
+                                - Recreate
+                              description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                           description: Template for Entity Operator `Deployment`.
                         pod:
                           type: object
@@ -4061,6 +4067,12 @@ spec:
                                   type: object
                                   description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                               description: Metadata applied to the resource.
+                            deploymentStrategy:
+                              type: string
+                              enum:
+                                - RollingUpdate
+                                - Recreate
+                              description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                           description: Template for Cruise Control `Deployment`.
                         pod:
                           type: object
@@ -4903,6 +4915,12 @@ spec:
                                   type: object
                                   description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                               description: Metadata applied to the resource.
+                            deploymentStrategy:
+                              type: string
+                              enum:
+                                - RollingUpdate
+                                - Recreate
+                              description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                           description: Template for JmxTrans `Deployment`.
                         pod:
                           type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -3048,6 +3048,12 @@ spec:
                                 type: object
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
+                          deploymentStrategy:
+                            type: string
+                            enum:
+                            - RollingUpdate
+                            - Recreate
+                            description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                         description: Template for Entity Operator `Deployment`.
                       pod:
                         type: object
@@ -4060,6 +4066,12 @@ spec:
                                 type: object
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
+                          deploymentStrategy:
+                            type: string
+                            enum:
+                            - RollingUpdate
+                            - Recreate
+                            description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                         description: Template for Cruise Control `Deployment`.
                       pod:
                         type: object
@@ -4902,6 +4914,12 @@ spec:
                                 type: object
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
+                          deploymentStrategy:
+                            type: string
+                            enum:
+                            - RollingUpdate
+                            - Recreate
+                            description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                         description: Template for JmxTrans `Deployment`.
                       pod:
                         type: object


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors the creation of workload resources from the `AbstractModel` class to a separate `WorkloadUtils` class. This includes StrimziPodSets, StatefulSets, Deployments, and standalone Pods. This is done in one step as they use in many cases the same fields and moving only part of them does not allow to identify and remove the unneeded things from `AbstractModel`.

The methods look relatively big with a lot of options. There might be things we can further improve in the future. But right now I think it is most important that to clean the `AbstractModel` class and entangle which field or method belongs to what. that should help us with any possible future imrpovements.

_Note: This is a drat PR which currently does not contain any new unit tests._

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally