### PR TITLE
Fix Maven Sonatype plugin version and configuration and push the `test` module

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -5,7 +5,7 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-annotations,crd-generator,api -P ossrh deploy
+GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-annotations,crd-generator,test,api -P ossrh deploy
 
 rm -rf signing.gpg
 gpg --delete-keys

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
         <maven.jar.version>3.1.0</maven.jar.version>
-        <sonatype.nexus.staging.version>1.6.3</sonatype.nexus.staging.version>
+        <sonatype.nexus.staging.version>1.6.13</sonatype.nexus.staging.version>
         <maven.spotbugs.version>4.5.3.0</maven.spotbugs.version>
         <maven.jacoco.version>0.8.8</maven.jacoco.version>
         <maven.exec.version>3.1.0</maven.exec.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The staging of the artifacts to Sonatype Maven repositories seemed to have some issued during the 0.33.0-rc1 release:
* The old version of the plugin we used was failing (likely related to our Java 17 move since this is the first release with Java 17). This was solved with update tot he latest `1.6.13`.
* The `test` module is a test dependency of the `api` module. For some reason, it sometimes seems to be required for staging, sometimes not. No idea why. But as it is a dependency, it might make sense to push it as well. so this PR adds it to the list of modules we push.