### PR TITLE
docs(drain cleaner): Adds procedures for adding certificates and Helm deployment

### DIFF
--- a/documentation/assemblies/managing/assembly-drain-cleaner.adoc
+++ b/documentation/assemblies/managing/assembly-drain-cleaner.adoc
@@ -3,12 +3,12 @@
 // using/assembly-management-tasks.adoc
 
 [id='assembly-drain-cleaner-{context}']
-= Evicting pods with Strimzi Drain Cleaner
+= Evicting pods with the Strimzi Drain Cleaner
 
 [role="_abstract"]
-Kafka and ZooKeeper pods might be evicted during Kubernetes upgrades, maintenance or pod rescheduling.
+Kafka and ZooKeeper pods might be evicted during Kubernetes upgrades, maintenance, or pod rescheduling.
 If your Kafka broker and ZooKeeper pods were deployed by Strimzi, you can use the Strimzi Drain Cleaner tool to handle the pod evictions.
-Since the Strimzi Drain Cleaner will handle the eviction instead of Kubernetes, you need to set the `podDisruptionBudget` for your Kafka deployment to `0` (zero).
+Since the Strimzi Drain Cleaner handles the eviction instead of Kubernetes, you need to set the `podDisruptionBudget` for your Kafka deployment to `0` (zero).
 Kubernetes will then no longer be allowed to evict the pod automatically.
 
 By deploying the Strimzi Drain Cleaner, you can use the Cluster Operator to move Kafka pods instead of Kubernetes.
@@ -60,7 +60,7 @@ webhooks:
 ----
 
 [id='drain-cleaner-prereqs-{context}']
-== Prerequisites
+== Downloading the Strimzi Drain Cleaner deployment files
 
 To deploy and use the Strimzi Drain Cleaner, you need to download the deployment files.
 
@@ -68,5 +68,15 @@ The Strimzi Drain Cleaner deployment files are available from the link:{ReleaseD
 
 //steps for deploying drain cleaner
 include::../../modules/managing/proc-drain-cleaner-deploying.adoc[leveloffset=+1]
+ifdef::Section[]
+//deploy using Helm
+include::../../modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc[leveloffset=+1]
+endif::Section[]
 //steps for using drain cleaner
 include::../../modules/managing/proc-drain-cleaner-using.adoc[leveloffset=+1]
+ifdef::Section[]
+//generate tls certificates when deploying on Kubernetes
+include::../../modules/managing/proc-drain-cleaner-certs.adoc[leveloffset=+1]
+endif::Section[]
+//watching TLS certs renewals
+include::../../modules/managing/proc-drain-cleaner-certs-renewals.adoc[leveloffset=+1]

--- a/documentation/assemblies/managing/assembly-drain-cleaner.adoc
+++ b/documentation/assemblies/managing/assembly-drain-cleaner.adoc
@@ -8,7 +8,8 @@
 [role="_abstract"]
 Kafka and ZooKeeper pods might be evicted during Kubernetes upgrades, maintenance, or pod rescheduling.
 If your Kafka broker and ZooKeeper pods were deployed by Strimzi, you can use the Strimzi Drain Cleaner tool to handle the pod evictions.
-Since the Strimzi Drain Cleaner handles the eviction instead of Kubernetes, you need to set the `podDisruptionBudget` for your Kafka deployment to `0` (zero).
+The Strimzi Drain Cleaner handles the eviction instead of Kubernetes.
+You must set the `podDisruptionBudget` for your Kafka deployment to `0` (zero).
 Kubernetes will then no longer be allowed to evict the pod automatically.
 
 By deploying the Strimzi Drain Cleaner, you can use the Cluster Operator to move Kafka pods instead of Kubernetes.

--- a/documentation/modules/managing/proc-drain-cleaner-certs-renewals.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-certs-renewals.adoc
@@ -1,0 +1,86 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-drain-cleaner.adoc
+
+[id='proc-drain-cleaner-certs-renewing-{context}']
+= Watching the TLS certificates used by the Strimzi Drain Cleaner
+
+[role="_abstract"]
+By default, the Drain Cleaner deployment watches the secret containing the TLS certificates its uses for authentication.
+The Drain Cleaner watches for changes, such as certificate renewals.
+If it detects a change, it restarts to reload the TLS certificates.
+The Drain Cleaner installation files enable this behavior by default.
+But you can disable the watching of certificates by setting the `STRIMZI_CERTIFICATE_WATCH_ENABLED` environment variable to `false` in the `Deployment` configuration (`060-Deployment.yaml`) of the Drain Cleaner installation files.
+
+With `STRIMZI_CERTIFICATE_WATCH_ENABLED` enabled, you can also use the following environment variables for watching TLS certificates.
+
+.Drain Cleaner environment variables for watching TLS certificates
+[cols="5m,4,2",options="header"]
+|===
+
+| Environment Variable              
+| Description                                                                               
+| Default
+
+| STRIMZI_CERTIFICATE_WATCH_ENABLED      
+| Enables or disables the certificate watch                                                 
+| `false`
+
+| STRIMZI_CERTIFICATE_WATCH_NAMESPACE    
+| The namespace where the Drain Cleaner is deployed and where the certificate secret exists 
+| `strimzi-drain-cleaner`
+
+| STRIMZI_CERTIFICATE_WATCH_POD_NAME     
+| The Drain Cleaner pod name                                                                
+| -                      
+
+| STRIMZI_CERTIFICATE_WATCH_SECRET_NAME  
+| The name of the secret containing TLS certificates                                             
+| `strimzi-drain-cleaner` 
+
+| STRIMZI_CERTIFICATE_WATCH_SECRET_KEYS  
+| The list of fields inside the secret that contain the TLS certificates                   
+| `tls.crt, tls.key`   
+
+|===
+
+.Example environment variable configuration to control watch operations
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+spec:
+  # ...
+    spec:
+      serviceAccountName: strimzi-drain-cleaner
+      containers:
+        - name: strimzi-drain-cleaner
+          # ...
+          env:
+            - name: STRIMZI_DRAIN_KAFKA
+              value: "true"
+            - name: STRIMZI_DRAIN_ZOOKEEPER
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_CERTIFICATE_WATCH_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+              # ...
+----
+
+TIP: Use the {K8sDownwardAPI} mechanism to configure `STRIMZI_CERTIFICATE_WATCH_NAMESPACE` and `STRIMZI_CERTIFICATE_WATCH_POD_NAME`.
+
+
+
+

--- a/documentation/modules/managing/proc-drain-cleaner-certs.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-certs.adoc
@@ -1,0 +1,154 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-drain-cleaner.adoc
+
+[id='proc-drain-cleaner-certs-{context}']
+= Adding or renewing the TLS certificates used by the Strimzi Drain Cleaner
+
+[role="_abstract"]
+The Drain Cleaner uses a webhook to receive eviction notifications from the Kubernetes API.
+The webhook uses a secure TLS connection and authenticates using TLS certificates.
+If you are not using `cert-manager` to deploy the Drain Cleaner, you need to generate the TLS certificates. 
+You must then add them to the files used to deploy the Drain Cleaner.   
+The certificates must also be renewed before they expire. 
+To renew the certificates, you repeat the steps used to generate and add the certificates to the initial deployment of the Drain Cleaner. 
+
+Generate and add certificates to the standard installation files or your Helm configuration when deploying the Drain Cleaner on Kubernetes without `cert-manager`.
+
+NOTE: If you are using `cert-manager` to deploy the Drain Cleaner, you don't need to perform these steps. Certificates are generated automatically when you deploy the Drain Cleaner. `cert-manager` can also renew certificates automatically.  
+
+.Prerequisites
+
+* The link:https://www.openssl.org/[OpenSSL] TLS management tool for generating certificates.
++
+Use `openssl help` for command-line descriptions of the options used.  
+
+.Generating and renewing TLS certificates
+
+. From the command line, create a directory called `tls-certificate`:
++
+[source,shell]
+----
+mkdir tls-certificate
+cd tls-certificate
+----
++
+Now use OpenSSL to create the certificates in the `tls-certificate` directory.
+
+. Generate a CA (Certificate Authority) public certificate and private key:
++
+[source,shell]
+----
+openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Strimzi Drain Cleaner CA"
+----
++
+A `ca.crt` and `ca.key` file are created.
+
+. Generate a private key for the Drain Cleaner:
++
+[source,shell]
+----
+openssl genrsa -out tls.key 2048
+----
++
+A `tls.key` file is created.
+
+. Generate a CSR (Certificate Signing Request) and sign it by adding the CA public certificate (`ca.crt`) you generated:
++
+[source,shell]
+----
+openssl req -new -key tls.key -subj "/CN=strimzi-drain-cleaner.strimzi-drain-cleaner.svc" \
+  | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:strimzi-drain-cleaner.strimzi-drain-cleaner.svc") -out tls.crt
+----
++
+A `tls.crt` file is created.
++
+NOTE: If you change the name of the Strimzi Drain Cleaner service or install it into a different namespace, you must change the SAN (Subject Alternative Name) of the certificate, following the format `<service_name>.<namespace_name>.svc`.
+
+. Encode the CA public certificate into base64.
++
+[source,shell]
+----
+base64 tls-certificate/ca.crt
+----
++
+With the certificates generated, add them to the installation files or to your Helm configuration depending on your deployment method. 
+ 
+.Adding the TLS certificates to the Drain Cleaner installation files
+
+. Copy the base64-encoded CA public certificate as the value for the `caBundle` property of the `070-ValidatingWebhookConfiguration.yaml` installation file:
++
+[source,yaml]
+----
+# ...
+clientConfig:
+  service:
+    namespace: "strimzi-drain-cleaner"
+    name: "strimzi-drain-cleaner"
+    path: /drainer
+    port: 443
+  caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0...
+# ...
+----
+
+. Create a namespace called `strimzi-drain-cleaner` in your Kubernetes cluster:
++
+[source,shell]
+----
+kubectl create ns strimzi-drain-cleaner
+----
+
+. Create a secret named `strimzi-drain-cleaner` with the `tls.crt` and `tls.key` files you generated:
++
+[source,shell]
+----
+kubectl create secret tls strimzi-drain-cleaner \
+  -n strimzi-drain-cleaner  \
+  --cert=tls-certificate/tls.crt \
+  --key=tls-certificate/tls.key
+----
++
+The secret is used in the Drain Cleaner deployment. 
++
+.Example secret for the Drain Cleaner deployment
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  # ...
+  name: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+# ...
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS...
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLR...
+----
++
+You can now use the certificates and updated installation files xref:proc-drain-cleaner-deploying-{context}[to deploy the Drain Cleaner using installation files].
+
+.Adding the TLS certificates to a Helm deployment
+
+. Edit the `values.yaml` configuration file used in the Helm deployment.
+. Set the `certManager.create` parameter to `false`.
+. Set the `secret.create` parameter to `true`.
+. Copy the certificates as `secret` parameters.
++
+.Example secret configuration for the Drain Cleaner deployment
+[source,yaml]
+----
+# ...
+certManager:
+  create: false
+
+secret:
+  create: true
+  tls_crt: "Cg==" # <1>
+  tls_key: "Cg==" # <2>
+  ca_bundle: "Cg==" # <3>
+----
+<1> The public key (`tls.crt`) signed by the CA public certificate.
+<2> The private key (`tls.key`).
+<3> The base-64 encoded CA public certificate (`ca.crt`).
+
+You can now use the certificates and updated configuration file xref:deploying-cluster-operator-helm-chart-{context}[to deploy the Drain Cleaner using Helm].

--- a/documentation/modules/managing/proc-drain-cleaner-certs.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-certs.adoc
@@ -8,14 +8,14 @@
 [role="_abstract"]
 The Drain Cleaner uses a webhook to receive eviction notifications from the Kubernetes API.
 The webhook uses a secure TLS connection and authenticates using TLS certificates.
-If you are not using `cert-manager` to deploy the Drain Cleaner, you need to generate the TLS certificates. 
+If you are not deploying the Drain Cleaner using the `cert-manager` or on Openshift, you must create and renew the TLS certificates.  
 You must then add them to the files used to deploy the Drain Cleaner.   
 The certificates must also be renewed before they expire. 
 To renew the certificates, you repeat the steps used to generate and add the certificates to the initial deployment of the Drain Cleaner. 
 
 Generate and add certificates to the standard installation files or your Helm configuration when deploying the Drain Cleaner on Kubernetes without `cert-manager`.
 
-NOTE: If you are using `cert-manager` to deploy the Drain Cleaner, you don't need to perform these steps. Certificates are generated automatically when you deploy the Drain Cleaner. `cert-manager` can also renew certificates automatically.  
+NOTE: If you are using `cert-manager` to deploy the Drain Cleaner, you don't need to add or renew TLS certificates. The same applies when deploying the Drain Cleaner on OpenShift, as OpenShift injects the certificates. In both cases, TLS certificates are added and renewed automatically.   
 
 .Prerequisites
 

--- a/documentation/modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc
@@ -25,7 +25,7 @@ If you don't want to use the default configuration, you can override the default
 You specify values in the format `--set key=value[,key=value]`.
 The `values.yaml` file supplied with the Helm deployment files describes the available configuration parameters, including those shown in the following table. 
 
-As you can see, you can override the default image settings.
+You can override the default image settings.
 You can also set `secret.create` as `true` and add your own TLS certificates instead of using `cert-manager` to generate the certificates. 
 For information on using OpenSSL to generate certificates, see xref:proc-drain-cleaner-certs-{context}[].
 

--- a/documentation/modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// deploying/assembly_deploy-cluster-operator.adoc
+
+[id='deploying-cluster-operator-helm-chart-{context}']
+= Deploying the Strimzi Drain Cleaner using Helm
+
+[role="_abstract"]
+link:https://helm.sh/[Helm] charts are used to package, configure, and deploy Kubernetes resources.
+Strimzi provides a Helm chart to deploy the Strimzi Drain Cleaner.
+
+The Drain Cleaner is deployed on the Kubernetes cluster with the default chart configuration, which assumes that `cert-manager` issues the TLS certificates required by the Drain Cleaner.
+
+You can install the Drain Cleaner with `cert-manager` support or provide your own TLS certificates.
+
+.Prerequisites
+
+* You have xref:drain-cleaner-prereqs-str[downloaded the Strimzi Drain Cleaner deployment files].
+* The Helm client must be installed on a local machine.
+* Helm must be installed to the Kubernetes cluster.
+
+.Default configuration values
+Default configuration values are passed into the chart using parameters defined in a `values.yaml` file.  
+If you don't want to use the default configuration, you can override the defaults when you install the chart using the `--set` argument.
+You specify values in the format `--set key=value[,key=value]`.
+The `values.yaml` file supplied with the Helm deployment files describes the available configuration parameters, including those shown in the following table. 
+
+As you can see, you can override the default image settings.
+You can also set `secret.create` as `true` and add your own TLS certificates instead of using `cert-manager` to generate the certificates. 
+For information on using OpenSSL to generate certificates, see xref:proc-drain-cleaner-certs-{context}[].
+
+Any certificates you add must be renewed before they expire. 
+You can use the configuration to control how certificates are watched for updates using environment variables.
+For more information on how the environment variables work, see xref:proc-drain-cleaner-certs-renewing-{context}[].
+
+.Chart configuration options
+[cols="5m,4,2m",options="header"]
+|===
+
+| Parameter             
+| Description                                                                               
+| Default
+
+| replicaCount
+| Number of replicas of the Drain Cleaner webhook	
+| 1
+| image.registry	
+| Drain Cleaner image registry	
+| quay.io
+| image.repository	
+| Drain Cleaner image repository	
+| strimzi
+| image.name	
+| Drain Cleaner image name	
+| drain-cleaner
+| image.tag	
+| Drain Cleaner image tag	
+| latest
+| image.imagePullPolicy	
+| Image pull policy for all pods deployed by the Drain Cleaner	
+| nil
+| secret.create
+| Set to `true` and add certificates when not using `cert-manager` 
+| false
+| namespace.name
+| Default namespace for the Drain Cleaner deployment.
+| strimzi-drain-cleaner
+| resources	
+| Configures resources for the Drain Cleaner pod	
+| []
+| nodeSelector	
+| Add a node selector to the Drain Cleaner pod	
+| {} 
+| tolerations	
+| Add tolerations to the Drain Cleaner pod	
+| []
+| topologySpreadConstraints	
+| Add topology spread constraints to the Drain Cleaner pod	
+| {} 
+| affinity	
+| Add affinities to the Drain Cleaner pod	
+| {}
+ 
+
+|===
+
+.Procedure
+
+. Use the Helm command line tool to add the Strimzi Helm chart repository:
++
+[source,shell,subs=attributes+]
+----
+helm repo add strimzi {ChartRepositoryUrl}
+----
+
+. Deploy the Drain Cleaner:
++
+[source,shell]
+----
+helm install drain-cleaner strimzi/strimzi-drain-cleaner
+----
++
+Specify any changes to the default configuration as parameter values.
++
+.Example configuration that changes the number of webhook replicas
+[source,shell]
+----
+helm install --name drain-cleaner --set replicas=2 strimzi/strimzi-drain-cleaner
+----
+
+. Verify that the Cluster Operator has been deployed successfully:
++
+[source,shell]
+----
+helm ls
+----

--- a/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
@@ -102,11 +102,11 @@ kubectl apply -f <kafka_configuration_file>
 +
 --
 ifdef::Section[]
-* If you are using `cert-manager` with Kubernetes, apply the resources in the `/install/certmanager` directory.
+* If you are using `cert-manager` with Kubernetes, apply the resources in the `/install/drain-cleaner/certmanager` directory.
 +
 [source,shell,subs="attributes+"]
 ----
-kubectl apply -f ./install/certmanager
+kubectl apply -f ./install/drain-cleaner/certmanager
 ----
 +
 The TLS certificates for the webhook are generated automatically and injected into the webhook configuration.
@@ -117,18 +117,18 @@ The TLS certificates for the webhook are generated automatically and injected in
 +
 Any certificates you add must be renewed before they expire. 
 +
-.. Apply the resources in the `/install/kubernetes` directory.
+.. Apply the resources in the `/install/drain-cleaner/kubernetes` directory.
 +
 [source,shell,subs="attributes+"]
 ----
-kubectl apply -f ./install/kubernetes
+kubectl apply -f ./install/drain-cleaner/kubernetes
 ----
 endif::Section[]
 --
 +
-* To run the Drain Cleaner on OpenShift, apply the resources in the `/install/openshift` directory.
+* To run the Drain Cleaner on OpenShift, apply the resources in the `/install/drain-cleaner/openshift` directory.
 +
 [source,shell,subs="attributes+"]
 ----
-kubectl apply -f ./install/openshift
+kubectl apply -f ./install/drain-cleaner/openshift
 ----

--- a/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
@@ -3,9 +3,9 @@
 // assembly-drain-cleaner.adoc
 
 [id='proc-drain-cleaner-deploying-{context}']
-= Deploying the Strimzi Drain Cleaner
+= Deploying the Strimzi Drain Cleaner using installation files
 
-[role="_abstract"]
+[role="_abstract"] 
 Deploy the Strimzi Drain Cleaner to the Kubernetes cluster where the Cluster Operator and Kafka cluster are running.
 
 .Prerequisites
@@ -34,10 +34,14 @@ spec:
     # ...
 ----
 
-.Excluding ZooKeeper
+.Excluding Kafka or ZooKeeper
 
-If you don't want to include ZooKeeper, you can remove the `--zookeeper` command option from the Strimzi Drain Cleaner `Deployment` configuration file.
+If you don't want to include Kafka or ZooKeeper pods in Drain Cleaner operations, change the default environment variables in the Drain Cleaner `Deployment` configuration file.
 
+* Set `STRIMZI_DRAIN_KAFKA` to `false` to exclude Kafka pods
+* Set `STRIMZI_DRAIN_ZOOKEEPER` to `false` to exclude ZooKeeper pods
+
+.Example configuration to exclude ZooKeeper pods
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: apps/v1
@@ -50,14 +54,13 @@ spec:
       containers:
         - name: strimzi-drain-cleaner
           # ...
-          command:
-            - "/application"
-            - "-Dquarkus.http.host=0.0.0.0"
-            - "--kafka"
-            - "--zookeeper" <1>
+          env:
+            - name: STRIMZI_DRAIN_KAFKA
+              value: "true"
+            - name: STRIMZI_DRAIN_ZOOKEEPER
+              value: "false"
           # ...
 ----
-<1> Remove this option to exclude ZooKeeper from Strimzi Drain Cleaner operations.
 
 .Procedure
 
@@ -93,43 +96,39 @@ Add the same configuration for ZooKeeper if you want to use Strimzi Drain Cleane
 . Update the `Kafka` resource:
 +
 [source,shell,subs=+quotes]
-kubectl apply -f _<kafka-configuration-file>_
+kubectl apply -f <kafka_configuration_file>
 
 . Deploy the Strimzi Drain Cleaner.
 +
-ifdef::Section[]
 --
-You can use link:https://cert-manager.io/docs/[`cert-manager`^] in the deployment process.
-
-* If you are using `cert-manager` with Kubernetes, apply the resources in the `/install/drain-cleaner/certmanager` directory.
+ifdef::Section[]
+* If you are using `cert-manager` with Kubernetes, apply the resources in the `/install/certmanager` directory.
 +
 [source,shell,subs="attributes+"]
 ----
-kubectl apply -f ./install/drain-cleaner/certmanager
+kubectl apply -f ./install/certmanager
 ----
 +
 The TLS certificates for the webhook are generated automatically and injected into the webhook configuration.
-
-* If you are not using `cert-manager` with Kubernetes, apply the resources in the `/install/drain-cleaner/kubernetes` directory.
++
+* If you are not using `cert-manager` with Kubernetes, do the following:
++
+.. xref:proc-drain-cleaner-certs-{context}[Add TLS certificates to use in the deployment].
++
+Any certificates you add must be renewed before they expire. 
++
+.. Apply the resources in the `/install/kubernetes` directory.
 +
 [source,shell,subs="attributes+"]
 ----
-kubectl apply -f ./install/drain-cleaner/kubernetes
+kubectl apply -f ./install/kubernetes
 ----
-+
-The resources are configured with TLS certificates that have already been generated.
-Use these certificates if you are not changing any configuration for the Strimzi Drain Cleaner, such as namespaces, service names, or pod names.
-Otherwise, you can generate and use your own certificates. 
-+
-NOTE: You can use the build script and files provided in link:https://github.com/strimzi/drain-cleaner/tree/main/install/kubernetes/webhook-certificates[`webhook-certificates`^]
-to generate your own certificates. The script uses the link:https://github.com/cloudflare/cfssl[`CFSSL`^] and link:https://www.openssl.org/[openSSL] tools to generate the certificates.
-After you have generated the certificates, you need to add them to the `040-Secret.yaml` and `070-ValidatingWebhookConfiguration.yaml` files.
---
 endif::Section[]
-
-* To run the Drain Cleaner on OpenShift, apply the resources in the `/install/drain-cleaner/openshift` directory.
+--
++
+* To run the Drain Cleaner on OpenShift, apply the resources in the `/install/openshift` directory.
 +
 [source,shell,subs="attributes+"]
 ----
-kubectl apply -f ./install/drain-cleaner/openshift
+kubectl apply -f ./install/openshift
 ----


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

Updates [Evicting pods with Strimzi Drain Cleaner](https://strimzi.io/docs/operators/in-development/configuring.html#assembly-drain-cleaner-str) to include the following new procedures:

- Watching the TLS certificates used by the Strimzi Drain Cleaner
- Adding or renewing the TLS certificates used by the Strimzi Drain Cleaner
- Deploying the Strimzi Drain Cleaner using Helm

Plus updates to the current Drain Cleaner doc

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

