### PR TITLE
Wrap missing `ImageStream` error into `InvalidConfigurationException`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -20,6 +20,7 @@ import io.strimzi.operator.cluster.model.KafkaConnectBuildUtils;
 import io.strimzi.operator.cluster.model.KafkaConnectDockerfile;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.InvalidConfigurationException;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
@@ -336,8 +337,7 @@ public class ConnectBuildOperator {
             return imageStreamOperations.getAsync(namespace, imageName)
                 .compose(is -> {
                     if (is == null) {
-                        return Future.failedFuture(
-                            String.format("The build can't start because there is no image stream with name %s", imageName));
+                        return Future.failedFuture(new InvalidConfigurationException(String.format("The build can't start because there is no image stream with name %s", imageName)));
                     } else {
                         return Future.succeededFuture();
                     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the `ImageStream` referenced in Kafka Connect Build is missing, the operator sees that and fails the validation. But in the code, we do not use a proper exception, so the error is easy to miss in the log and uses a weird `NoStackTraceThrowable`:

```
2023-01-22 14:56:05 WARN  AbstractOperator:525 - Reconciliation #69(timer) KafkaConnect(myproject/my-connect): Failed to reconcile
io.vertx.core.impl.NoStackTraceThrowable: The build can't start because there is no image stream with name image-stream-name
```

This PR wraps it into `InvalidConfigurationException` as other errors related to invalid custom resources. This makes it more clear what the issue is and makes it also more visible in the log:

```
2023-01-22 15:10:06 WARN  AbstractOperator:525 - Reconciliation #8(watch) KafkaConnect(myproject/my-connect): Failed to reconcile
io.strimzi.operator.common.InvalidConfigurationException: The build can't start because there is no image stream with name image-stream-name2
	at io.strimzi.operator.cluster.operator.assembly.ConnectBuildOperator.lambda$validateImageStream$27(ConnectBuildOperator.java:340) ~[io.strimzi.cluster-operator-0.34.0-SNAPSHOT.jar:0.34.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.3.6.jar:4.3.6]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.3.6.jar:4.3.6]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.3.6.jar:4.3.6]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.3.6.jar:4.3.6]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.3.6.jar:4.3.6]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.3.6.jar:4.3.6]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[io.netty.netty-common-4.1.86.Final.jar:4.1.86.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[io.netty.netty-common-4.1.86.Final.jar:4.1.86.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty.netty-common-4.1.86.Final.jar:4.1.86.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.86.Final.jar:4.1.86.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.86.Final.jar:4.1.86.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.86.Final.jar:4.1.86.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.86.Final.jar:4.1.86.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally