### PR TITLE
Move from OkHttp client to JDK HTTP client (for use in Fabric8 Kubernetes client)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.34.0
 
+* Use JDK HTTP client in the Kubernetes client instead of the OkHttp client
+
 ## 0.33.0
 
 * Add support for Kafka 3.3.2

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube2/MockKube2.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube2/MockKube2.java
@@ -75,13 +75,13 @@ public class MockKube2 {
     private void registerCrd(String apiVersion, String kind, Class<? extends KubernetesResource> crdClass, String crdPath)  {
         KubernetesDeserializer.registerCustomKind(apiVersion, kind, crdClass);
 
-        CustomResourceDefinition kafkaCrd = client
+        CustomResourceDefinition crd = client
                 .apiextensions().v1()
                 .customResourceDefinitions()
                 .load(crdPath)
                 .get();
 
-        client.apiextensions().v1().customResourceDefinitions().resource(kafkaCrd).create();
+        client.apiextensions().v1().customResourceDefinitions().resource(crd).create();
     }
 
     /**

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>openshift-client-api</artifactId>
         </dependency>
         <dependency>

--- a/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/PlatformFeaturesAvailabilityTest.java
@@ -196,7 +196,8 @@ public class PlatformFeaturesAvailabilityTest {
     }
 
     KubernetesClient buildKubernetesClient(String masterUrl)    {
-        return new KubernetesClientBuilder().withConfig(new ConfigBuilder().withMasterUrl(masterUrl).build()).build();
+        // We have to disable HTTP2 => the mock webserver used here does not support HTTP2 without TLS
+        return new KubernetesClientBuilder().withConfig(new ConfigBuilder().withMasterUrl(masterUrl).withHttp2Disable().build()).build();
     }
 
     void startMockApi(Vertx vertx, String version, List<APIGroup> apis) throws InterruptedException, ExecutionException {

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,17 @@
                 <artifactId>kubernetes-client</artifactId>
                 <version>${fabric8.kubernetes-client.version}</version>
                 <scope>runtime</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-httpclient-jdk</artifactId>
+                <version>${fabric8.kubernetes-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>
@@ -1102,6 +1113,7 @@
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:openshift-client</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-clients</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-streams</ignoredUnusedDeclaredDependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -215,8 +215,7 @@ public class KubeClusterResource {
                     .forEach(namespaceName -> {
                         LOGGER.debug("Deleting Namespace: {}", namespaceName);
                         kubeClient().deleteNamespace(namespaceName);
-                        client.getClient().namespaces().withName(namespaceName).waitUntilCondition(
-                            namespace -> client.getClient().namespaces().withName(namespaceName).get() == null, 4, TimeUnit.MINUTES);
+                        client.getClient().namespaces().withName(namespaceName).waitUntilCondition(namespace -> namespace == null, 4, TimeUnit.MINUTES);
                     }));
 
         MAP_WITH_SUITE_NAMESPACES.clear();

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/user-operator/src/test/java/io/strimzi/operator/user/UserControllerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/UserControllerTest.java
@@ -275,7 +275,8 @@ public class UserControllerTest {
                     10_000,
                     () -> {
                         KafkaUser u = Crds.kafkaUserOperation(client).inNamespace(NAMESPACE).withName(NAME).get();
-                        return u.getStatus() != null
+                        return u != null
+                                && u.getStatus() != null
                                 && u.getStatus().getConditions() != null
                                 && u.getStatus().getConditions().stream().filter(c -> "NotReady".equals(c.getType())).findFirst().orElse(null) != null;
                     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR moves away from using the OkHttp client which is used in an old version (3.x) which is not updated anymore and moves to use the JDK HTTP Client. It also fixes some related tests which were failing with the change.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md