### PR TITLE
Fix double space in Kafka Rebalance log message

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -400,7 +400,7 @@ public class KafkaRebalanceAssemblyOperator
         if (kafkaRebalance != null && kafkaRebalance.getStatus() != null
                 && "Ready".equals(rebalanceStateConditionType(kafkaRebalance.getStatus()))
                 && rawRebalanceAnnotation(kafkaRebalance) == null) {
-            LOGGER.infoCr(reconciliation, "Rebalancing is completed. You can use the  `refresh` annotation to ask for a new rebalance request");
+            LOGGER.infoCr(reconciliation, "Rebalancing is completed. You can use the `refresh` annotation to ask for a new rebalance request");
         } else {
             LOGGER.infoCr(reconciliation, "Rebalance action is performed and KafkaRebalance resource is currently in [{}] state", currentState);
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a minor bug where a double space is used in one of the Kafka Rebalance log messages which looks a bit weird in the actual log.