### PR TITLE
[ST] KafkaConnector autorestart + update echo-sink-connector version

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -72,6 +72,18 @@ public interface Constants {
     long JAEGER_DEPLOYMENT_POLL = Duration.ofMinutes(1).toMillis();
 
     /**
+     * Constants for KafkaConnect EchoSink plugin
+      */
+    String ECHO_SINK_CONNECTOR_NAME = "echo-sink-connector";
+    String ECHO_SINK_CLASS_NAME = "cz.scholz.kafka.connect.echosink.EchoSinkConnector";
+    String ECHO_SINK_TGZ_URL = "https://github.com/scholzj/echo-sink/archive/1.3.1.tar.gz";
+    String ECHO_SINK_TGZ_CHECKSUM = "6b360470e0a9aa92977be4e669a99d324149ed1544db91a527e6af5f25e9b01fd53e18eeae675c5edc7b8237aeeba9265bf999d77bb1e16df3e4263b3a5003b3";
+    String ECHO_SINK_JAR_URL = "https://github.com/scholzj/echo-sink/releases/download/1.3.1/echo-sink-1.3.1.jar";
+    String ECHO_SINK_JAR_CHECKSUM = "1d59ede165c0d547e3217d20fd40d7f67ed820c78fc9b5551a3cea53c5928479dc8f5ddf8806d1775e9080bac6a59d044456402c375ae5393f67b96171df7caf";
+    String ECHO_SINK_FILE_NAME = "echo-sink-test.jar";
+    String ECHO_SINK_JAR_WRONG_CHECKSUM = "f1f167902325062efc8c755647bc1b782b2b067a87a6e507ff7a3f6205803220";
+
+    /**
      * Scraper pod labels
      */
     String SCRAPER_LABEL_KEY = "user-test-app";

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -59,6 +59,14 @@ import java.util.stream.Collectors;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_CLASS_NAME;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_CONNECTOR_NAME;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_FILE_NAME;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_JAR_CHECKSUM;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_JAR_URL;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_JAR_WRONG_CHECKSUM;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_TGZ_CHECKSUM;
+import static io.strimzi.systemtest.Constants.ECHO_SINK_TGZ_URL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
@@ -80,25 +88,12 @@ class ConnectBuilderIsolatedST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(ConnectBuilderIsolatedST.class);
 
-    private static final String ECHO_SINK_CLASS_NAME = "cz.scholz.kafka.connect.echosink.EchoSinkConnector";
     private static final String CAMEL_CONNECTOR_HTTP_SINK_CLASS_NAME = "org.apache.camel.kafkaconnector.http.CamelHttpSinkConnector";
     private static final String CAMEL_CONNECTOR_TIMER_CLASS_NAME = "org.apache.camel.kafkaconnector.timer.CamelTimerSourceConnector";
-
-    private static final String ECHO_SINK_JAR_URL = "https://github.com/scholzj/echo-sink/releases/download/1.1.0/echo-sink-1.1.0.jar";
-    private static final String ECHO_SINK_JAR_CHECKSUM = "b7da48d5ecd1e4199886d169ced1bf702ffbdfd704d69e0da97e78ff63c1bcece2f59c2c6c751f9c20be73472b8cb6a31b6fd4f75558c1cb9d96daa9e9e603d2";
-    private static final String ECHO_SINK_FILE_NAME = "echo-sink-test.jar";
-
-    private static final String ECHO_SINK_JAR_WRONG_CHECKSUM = "f1f167902325062efc8c755647bc1b782b2b067a87a6e507ff7a3f6205803220";
-
-    private static final String ECHO_SINK_TGZ_URL = "https://github.com/scholzj/echo-sink/archive/1.1.0.tar.gz";
-    private static final String ECHO_SINK_TGZ_CHECKSUM = "5318b1f031d4e5eeab6f8b774c76de297237574fc51d1e81b03a10e0b5d5435a46a108b85fdb604c644529f38830ae83239c17b6ec91c90a60ac790119bb2950";
-
     private static final String CAMEL_CONNECTOR_TGZ_URL = "https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.tar.gz";
     private static final String CAMEL_CONNECTOR_TGZ_CHECKSUM = "d0bb8c6a9e50b68eee3e4d70b6b7e5ae361373883ed3156bc11771330095b66195ac1c12480a0669712da4e5f38e64f004ffecabca4bf70d312f3f7ae0ad51b5";
-
     private static final String CAMEL_CONNECTOR_ZIP_URL = "https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-http-kafka-connector/0.7.0/camel-http-kafka-connector-0.7.0-package.zip";
     private static final String CAMEL_CONNECTOR_ZIP_CHECKSUM = "bc15135b8ef7faccd073508da0510c023c0f6fa3ec7e48c98ad880dd112b53bf106ad0a47bcb353eed3ec03bb3d273da7de356f3f7f1766a13a234a6bc28d602";
-
     private static final String CAMEL_CONNECTOR_MAVEN_GROUP_ID = "org.apache.camel.kafkaconnector";
     private static final String CAMEL_CONNECTOR_MAVEN_ARTIFACT_ID = "camel-timer-kafka-connector";
     private static final String CAMEL_CONNECTOR_MAVEN_VERSION = "0.9.0";
@@ -330,7 +325,6 @@ class ConnectBuilderIsolatedST extends AbstractST {
     void testUpdateConnectWithAnotherPlugin(ExtensionContext extensionContext) {
         TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
-        String echoConnector = "echo-sink-connector";
         String camelConnector = "camel-http-connector";
         final String imageName = getImageNameForTestCase();
 
@@ -377,7 +371,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         echoSinkConfig.put("level", "INFO");
 
         LOGGER.info("Creating EchoSink connector");
-        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(echoConnector, testStorage.getClusterName())
+        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(ECHO_SINK_CONNECTOR_NAME, testStorage.getClusterName())
             .editOrNewSpec()
                 .withClassName(ECHO_SINK_CLASS_NAME)
                 .withConfig(echoSinkConfig)

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -59,14 +59,6 @@ import java.util.stream.Collectors;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_CLASS_NAME;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_CONNECTOR_NAME;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_FILE_NAME;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_JAR_CHECKSUM;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_JAR_URL;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_JAR_WRONG_CHECKSUM;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_TGZ_CHECKSUM;
-import static io.strimzi.systemtest.Constants.ECHO_SINK_TGZ_URL;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
@@ -109,12 +101,12 @@ class ConnectBuilderIsolatedST extends AbstractST {
         .withName(PLUGIN_WITH_TAR_AND_JAR_NAME)
         .withArtifacts(
             new JarArtifactBuilder()
-                .withUrl(ECHO_SINK_JAR_URL)
-                .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                .withUrl(Constants.ECHO_SINK_JAR_URL)
+                .withSha512sum(Constants.ECHO_SINK_JAR_CHECKSUM)
                 .build(),
             new TgzArtifactBuilder()
-                .withUrl(ECHO_SINK_TGZ_URL)
-                .withSha512sum(ECHO_SINK_TGZ_CHECKSUM)
+                .withUrl(Constants.ECHO_SINK_TGZ_URL)
+                .withSha512sum(Constants.ECHO_SINK_TGZ_CHECKSUM)
                 .build())
         .build();
 
@@ -131,9 +123,9 @@ class ConnectBuilderIsolatedST extends AbstractST {
         .withName(PLUGIN_WITH_OTHER_TYPE_NAME)
         .withArtifacts(
             new OtherArtifactBuilder()
-                .withUrl(ECHO_SINK_JAR_URL)
-                .withFileName(ECHO_SINK_FILE_NAME)
-                .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                .withUrl(Constants.ECHO_SINK_JAR_URL)
+                .withFileName(Constants.ECHO_SINK_FILE_NAME)
+                .withSha512sum(Constants.ECHO_SINK_JAR_CHECKSUM)
                 .build()
         )
         .build();
@@ -158,8 +150,8 @@ class ConnectBuilderIsolatedST extends AbstractST {
         Plugin pluginWithWrongChecksum = new PluginBuilder()
             .withName("connector-with-wrong-checksum")
             .withArtifacts(new JarArtifactBuilder()
-                .withUrl(ECHO_SINK_JAR_URL)
-                .withSha512sum(ECHO_SINK_JAR_WRONG_CHECKSUM)
+                .withUrl(Constants.ECHO_SINK_JAR_URL)
+                .withSha512sum(Constants.ECHO_SINK_JAR_WRONG_CHECKSUM)
                 .build())
             .build();
 
@@ -198,8 +190,8 @@ class ConnectBuilderIsolatedST extends AbstractST {
             Plugin pluginWithRightChecksum = new PluginBuilder()
                 .withName("connector-with-right-checksum")
                 .withArtifacts(new JarArtifactBuilder()
-                    .withUrl(ECHO_SINK_JAR_URL)
-                    .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                    .withUrl(Constants.ECHO_SINK_JAR_URL)
+                    .withSha512sum(Constants.ECHO_SINK_JAR_CHECKSUM)
                     .build())
                 .build();
 
@@ -214,11 +206,11 @@ class ConnectBuilderIsolatedST extends AbstractST {
         LOGGER.info("Checking if KafkaConnect API contains EchoSink connector");
         String plugins = cmdKubeClient().execInPod(scraperPodName, "curl", "-X", "GET", "http://" + KafkaConnectResources.serviceName(testStorage.getClusterName()) + ":8083/connector-plugins").out();
 
-        assertTrue(plugins.contains(ECHO_SINK_CLASS_NAME));
+        assertTrue(plugins.contains(Constants.ECHO_SINK_CLASS_NAME));
 
         LOGGER.info("Checking if KafkaConnect resource contains EchoSink connector in status");
         kafkaConnect = KafkaConnectResource.kafkaConnectClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
-        assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(ECHO_SINK_CLASS_NAME)));
+        assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(Constants.ECHO_SINK_CLASS_NAME)));
     }
 
     @ParallelTest
@@ -256,13 +248,13 @@ class ConnectBuilderIsolatedST extends AbstractST {
 
         resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(testStorage.getClusterName())
             .editOrNewSpec()
-                .withClassName(ECHO_SINK_CLASS_NAME)
+                .withClassName(Constants.ECHO_SINK_CLASS_NAME)
                 .withConfig(connectorConfig)
             .endSpec()
             .build());
 
         KafkaConnector kafkaConnector = KafkaConnectorResource.kafkaConnectorClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
-        assertThat(kafkaConnector.getSpec().getClassName(), is(ECHO_SINK_CLASS_NAME));
+        assertThat(kafkaConnector.getSpec().getClassName(), is(Constants.ECHO_SINK_CLASS_NAME));
 
         KafkaClients kafkaClients = new KafkaClientsBuilder()
             .withTopicName(testStorage.getTopicName())
@@ -318,7 +310,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         assertThat(kafkaConnect.getStatus().getConditions().get(0).getType(), is(Ready.toString()));
 
         assertTrue(kafkaConnect.getStatus().getConnectorPlugins().size() > 0);
-        assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(ECHO_SINK_CLASS_NAME)));
+        assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(Constants.ECHO_SINK_CLASS_NAME)));
     }
 
     @ParallelTest
@@ -371,9 +363,9 @@ class ConnectBuilderIsolatedST extends AbstractST {
         echoSinkConfig.put("level", "INFO");
 
         LOGGER.info("Creating EchoSink connector");
-        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(ECHO_SINK_CONNECTOR_NAME, testStorage.getClusterName())
+        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(Constants.ECHO_SINK_CONNECTOR_NAME, testStorage.getClusterName())
             .editOrNewSpec()
-                .withClassName(ECHO_SINK_CLASS_NAME)
+                .withClassName(Constants.ECHO_SINK_CLASS_NAME)
                 .withConfig(echoSinkConfig)
             .endSpec()
             .build());
@@ -386,7 +378,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         String plugins = cmdKubeClient().execInPod(scraperPodName, "curl", "-X", "GET", "http://" + KafkaConnectResources.serviceName(testStorage.getClusterName()) + ":8083/connector-plugins").out();
 
         assertFalse(plugins.contains(CAMEL_CONNECTOR_HTTP_SINK_CLASS_NAME));
-        assertTrue(plugins.contains(ECHO_SINK_CLASS_NAME));
+        assertTrue(plugins.contains(Constants.ECHO_SINK_CLASS_NAME));
 
         LOGGER.info("Adding one more connector to the KafkaConnect");
         KafkaConnectResource.replaceKafkaConnectResourceInSpecificNamespace(testStorage.getClusterName(), kafkaConnect -> {
@@ -412,7 +404,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
         LOGGER.info("Checking if both Connectors were created and Connect contains both plugins");
         assertThat(kafkaConnect.getSpec().getBuild().getPlugins().size(), is(2));
 
-        assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(ECHO_SINK_CLASS_NAME)));
+        assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(Constants.ECHO_SINK_CLASS_NAME)));
         assertTrue(kafkaConnect.getStatus().getConnectorPlugins().stream().anyMatch(connectorPlugin -> connectorPlugin.getConnectorClass().contains(CAMEL_CONNECTOR_HTTP_SINK_CLASS_NAME)));
     }
 
@@ -448,15 +440,15 @@ class ConnectBuilderIsolatedST extends AbstractST {
         Map<String, String> connectSnapshot = DeploymentUtils.depSnapshot(testStorage.getNamespaceName(), deploymentName);
         String connectPodName = kubeClient().listPods(testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 
-        LOGGER.info("Checking that plugin has correct file name: {}", ECHO_SINK_FILE_NAME);
-        assertEquals(getPluginFileNameFromConnectPod(connectPodName), ECHO_SINK_FILE_NAME);
+        LOGGER.info("Checking that plugin has correct file name: {}", Constants.ECHO_SINK_FILE_NAME);
+        assertEquals(getPluginFileNameFromConnectPod(connectPodName), Constants.ECHO_SINK_FILE_NAME);
 
         final Plugin pluginWithoutFileName = new PluginBuilder()
             .withName(PLUGIN_WITH_OTHER_TYPE_NAME)
             .withArtifacts(
                 new OtherArtifactBuilder()
-                    .withUrl(ECHO_SINK_JAR_URL)
-                    .withSha512sum(ECHO_SINK_JAR_CHECKSUM)
+                    .withUrl(Constants.ECHO_SINK_JAR_URL)
+                    .withSha512sum(Constants.ECHO_SINK_JAR_CHECKSUM)
                     .build()
             )
             .build();
@@ -471,8 +463,8 @@ class ConnectBuilderIsolatedST extends AbstractST {
         LOGGER.info("Checking that plugin has different name than before");
         connectPodName = kubeClient().listPods(testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         String fileName = getPluginFileNameFromConnectPod(connectPodName);
-        assertNotEquals(fileName, ECHO_SINK_FILE_NAME);
-        assertEquals(fileName, Util.hashStub(ECHO_SINK_JAR_URL));
+        assertNotEquals(fileName, Constants.ECHO_SINK_FILE_NAME);
+        assertEquals(fileName, Util.hashStub(Constants.ECHO_SINK_JAR_URL));
     }
 
     @Tag(SANITY)

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -107,13 +107,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
 @Tag(REGRESSION)
 @Tag(CONNECT)
 @Tag(CONNECT_COMPONENTS)
 @IsolatedSuite
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 class ConnectIsolatedST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(ConnectIsolatedST.class);
@@ -654,7 +654,7 @@ class ConnectIsolatedST extends AbstractST {
         echoSinkConfig.put("fail.task.after.records", "1");
 
         LOGGER.info("Creating EchoSink connector");
-        resourceManager.createResource(extensionContext,KafkaConnectorTemplates.kafkaConnector(echoSinkConnector, testStorage.getClusterName())
+        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(echoSinkConnector, testStorage.getClusterName())
             .editOrNewSpec()
                 .withTasksMax(1)
                 .withClassName(ECHO_SINK_CLASS_NAME)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature


### Description

This PR adds new ST into Connect class testing auto-restart feature for connectors. Test checks for failed state of connector task and verifies auto restart attempt count. Also, there is version update of echo-sink-connector to version 1.3.1.


### Checklist

- [] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

