### PR TITLE
Allow Kubernetes API servers to list from cache instead of always asking for the latest state

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.common.operator.resource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Listable;
@@ -160,7 +161,7 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      * @return  List of resources
      */
     protected List<T> list(Listable<L> listable)    {
-        return listable.list().getItems();
+        return listable.list(new ListOptionsBuilder().withResourceVersion("0").build()).getItems();
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.common.operator.resource;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
@@ -272,7 +273,7 @@ public class ResourceSupport {
         return executeBlocking(
             blockingFuture -> {
                 try {
-                    blockingFuture.complete(resource.list().getItems());
+                    blockingFuture.complete(resource.list(new ListOptionsBuilder().withResourceVersion("0").build()).getItems());
                 } catch (Throwable t) {
                     blockingFuture.fail(t);
                 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorTest.java
@@ -555,7 +555,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         when(mockResourceList.getItems()).thenReturn(List.of(resource1, resource2));
 
         FilterWatchListDeletable mockListable = mock(FilterWatchListDeletable.class);
-        when(mockListable.list()).thenReturn((L) mockResourceList);
+        when(mockListable.list(any())).thenReturn((L) mockResourceList);
 
         NonNamespaceOperation mockNameable = mock(NonNamespaceOperation.class);
         when(mockNameable.withLabels(eq(selector))).thenReturn(mockListable);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/K8sImplTest.java
@@ -64,7 +64,7 @@ public class K8sImplTest {
         when(mockClient.resources(any(Class.class), any(Class.class))).thenReturn(mockResources);
         when(mockResources.withLabels(any())).thenReturn(mockResources);
         when(mockResources.inNamespace(any())).thenReturn(mockResources);
-        when(mockResources.list()).thenAnswer(invocation -> {
+        when(mockResources.list(any())).thenAnswer(invocation -> {
             KafkaTopicList ktl = new KafkaTopicList();
             ktl.setItems(mockKafkaTopicsList);
             return ktl;

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.user.operator;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
@@ -161,7 +162,7 @@ public class KafkaUserOperator {
                 .supplyAsync(() -> Crds.kafkaUserOperation(client)
                                 .inNamespace(namespace)
                                 .withLabelSelector(selector)
-                                .list()
+                                .list(new ListOptionsBuilder().withResourceVersion("0").build())
                                 .getItems()
                                 .stream()
                                 .map(resource -> resource.getMetadata().getName())


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

By default, when listing Kubernetes resources with the Fabric 8 Kubernetes client, it does not set the `resourceVersion` option in the query, which means we are requesting the most recent information. That might create a significant load on the API server as discussed in #7794. When setting the `resourceVersion` to `0`, we loosen the requirement for the most recent state which allows answering the query for example from an existing cache. (You can read more about the `resourceVersion` impact on the query in the [Kube docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list))

This PR tries to use `resourceVErsion=0` in our list queries to create less load on the Kubernetes API servers we communicate with. We should observe if we see any issues, but the expectation is that this should work fine.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally