### PR TITLE
Add bridge pipeline

### DIFF
--- a/.azure/bridge-pipeline.yaml
+++ b/.azure/bridge-pipeline.yaml
@@ -1,0 +1,22 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then images will be built as part of the pipeline
+    default: "latest"
+
+jobs:
+  - template: 'templates/jobs/system-tests/bridge_jobs.yaml'
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
+
+

--- a/.azure/templates/jobs/system-tests/bridge_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/bridge_jobs.yaml
@@ -1,0 +1,9 @@
+jobs:
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'bridge'
+      display_name: 'bridge-bundle'
+      profile: 'bridge'
+      cluster_operator_install_type: 'bundle'
+      timeout: 240
+      releaseVersion: '${{ parameters.releaseVersion }}'


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Enhancement / new feature

### Description

This PR adds a new pipeline to our Azure (i.e., bridge pipeline). When Paolo is doing a release of Bridge, and he wants to double-check it, he would need to run the whole regression instead of only the Bridge profile. So this should resolve such an issue.

### Checklist

- [ ] Make sure all tests pass