### PR TITLE
[system test] -> correct namespace handling in RollingUpdateST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -303,7 +303,7 @@ class RollingUpdateST extends AbstractST {
         resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForConsumerClientSuccess(testStorage);
 
-        assertThat((int) kubeClient().listPersistentVolumeClaims().stream().filter(
+        assertThat((int) kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getClusterName()).stream().filter(
             pvc -> pvc.getMetadata().getName().contains(testStorage.getKafkaStatefulSetName())).count(), is(scaleTo));
 
         final int zookeeperScaleTo = initialReplicas + 2;


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes the problem inside RollinUpdateST. The problem description can he found here [1].

[1] - https://github.com/strimzi/strimzi-kafka-operator/issues/6597

### Checklist

- [x] Make sure all tests pass