### PR TITLE
Continue refactoring `AbstractModel` classes: Secret handling, Service Account name, etc.

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
@@ -62,8 +61,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyMap;
 
 /**
  * AbstractModel an abstract base model for all components of the {@code Kafka} custom resource
@@ -220,8 +217,6 @@ public abstract class AbstractModel {
     protected List<IpFamily> templateHeadlessServiceIpFamilies;
     protected Map<String, String> templateServiceAccountLabels;
     protected Map<String, String> templateServiceAccountAnnotations;
-    protected Map<String, String> templateJmxSecretLabels;
-    protected Map<String, String> templateJmxSecretAnnotations;
 
     protected List<Condition> warningConditions = new ArrayList<>(0);
 
@@ -663,13 +658,6 @@ public abstract class AbstractModel {
     }
 
     /**
-     * @return the name of the service account used by the deployed cluster for Kubernetes API operations.
-     */
-    protected String getServiceAccountName() {
-        return null;
-    }
-
-    /**
      * @return the cluster name.
      */
     public String getCluster() {
@@ -746,14 +734,6 @@ public abstract class AbstractModel {
                 .endMetadata()
                 .withData(data)
                 .build();
-    }
-
-    protected Secret createSecret(String name, Map<String, String> data, Map<String, String> customAnnotations) {
-        return ModelUtils.createSecret(name, namespace, labels, ownerReference, data, customAnnotations, emptyMap());
-    }
-
-    protected Secret createJmxSecret(String name, Map<String, String> data) {
-        return ModelUtils.createSecret(name, namespace, labels, ownerReference, data, templateJmxSecretAnnotations, templateJmxSecretLabels);
     }
 
     protected Service createService(String type, List<ServicePort> ports, Map<String, String> annotations) {
@@ -984,7 +964,7 @@ public abstract class AbstractModel {
     public ServiceAccount generateServiceAccount() {
         return new ServiceAccountBuilder()
                 .withNewMetadata()
-                    .withName(getServiceAccountName())
+                    .withName(componentName)
                     .withNamespace(namespace)
                     .withOwnerReferences(ownerReference)
                     .withLabels(labels.withAdditionalLabels(templateServiceAccountLabels).toMap())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -451,11 +451,6 @@ public class CruiseControl extends AbstractModel {
         return "cruiseControlDefaultLoggingProperties";
     }
 
-    @Override
-    protected String getServiceAccountName() {
-        return CruiseControlResources.serviceAccountName(cluster);
-    }
-
     /**
      * Creates Cruise Control API auth usernames, passwords, and credentials file
      *
@@ -523,8 +518,15 @@ public class CruiseControl extends AbstractModel {
         data.put(keyCertName + ".p12", cert.keyStoreAsBase64String());
         data.put(keyCertName + ".password", cert.storePasswordAsBase64String());
 
-        return createSecret(CruiseControlResources.secretName(cluster), data,
-                Collections.singletonMap(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())));
+        return ModelUtils.createSecret(
+                CruiseControlResources.secretName(cluster),
+                namespace,
+                labels,
+                ownerReference,
+                data,
+                Map.of(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())),
+                Map.of()
+        );
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -312,11 +312,6 @@ public class EntityOperator extends AbstractModel {
     }
 
     @Override
-    protected String getServiceAccountName() {
-        return KafkaResources.entityOperatorDeploymentName(cluster);
-    }
-
-    @Override
     public ServiceAccount generateServiceAccount() {
         return super.generateServiceAccount();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -375,11 +375,6 @@ public class JmxTrans extends AbstractModel {
         return null;
     }
 
-    @Override
-    protected String getServiceAccountName() {
-        return JmxTransResources.serviceAccountName(cluster);
-    }
-
     protected static io.fabric8.kubernetes.api.model.Probe jmxTransReadinessProbe(io.strimzi.api.kafka.model.Probe  kafkaJmxMetricsReadinessProbe, String clusterName) {
         String internalBootstrapServiceName = KafkaResources.brokersServiceName(clusterName);
         String metricsPortValue = String.valueOf(KafkaCluster.JMX_PORT);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -535,11 +535,6 @@ public class KafkaBridgeCluster extends AbstractModel {
         return PodDisruptionBudgetUtils.createPodDisruptionBudgetV1Beta1(componentName, namespace, labels, ownerReference, templatePodDisruptionBudget);
     }
 
-    @Override
-    protected String getServiceAccountName() {
-        return KafkaBridgeResources.serviceAccountName(cluster);
-    }
-
     /**
      * Set Kafka AdminClient's configuration
      * @param kafkaBridgeAdminClient configuration
@@ -601,7 +596,7 @@ public class KafkaBridgeCluster extends AbstractModel {
         if (rack != null) {
             Subject subject = new SubjectBuilder()
                     .withKind("ServiceAccount")
-                    .withName(getServiceAccountName())
+                    .withName(componentName)
                     .withNamespace(namespace)
                     .build();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -209,16 +209,6 @@ public class KafkaConnectBuild extends AbstractModel {
     }
 
     /**
-     * Generates the name of the Service Account used by Kafka Connect Build
-     *
-     * @return  Name of the Kafka Connect Build service account for this cluster
-     */
-    @Override
-    public String getServiceAccountName() {
-        return KafkaConnectResources.buildServiceAccountName(cluster);
-    }
-
-    /**
      * Generates a ConfigMap with the Dockerfile used for the build
      *
      * @param dockerfile    Instance of the KafkaConnectDockerfile class with the prepared Dockerfile

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -285,11 +285,6 @@ public class KafkaExporter extends AbstractModel {
         return null;
     }
 
-    @Override
-    protected String getServiceAccountName() {
-        return KafkaExporterResources.serviceAccountName(cluster);
-    }
-
     /**
      * Generate the Secret containing the Kafka Exporter certificate signed by the cluster CA certificate used for TLS based
      * internal communication with Kafka and Zookeeper.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -158,11 +158,6 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         return "kafkaMirrorMaker2DefaultLoggingProperties";
     }
 
-    @Override
-    public String getServiceAccountName() {
-        return KafkaMirrorMaker2Resources.serviceAccountName(cluster);
-    }
-
     public String getInitContainerClusterRoleBindingName() {
         return KafkaMirrorMaker2Resources.initContainerClusterRoleBindingName(cluster, namespace);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -514,11 +514,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     }
 
     @Override
-    protected String getServiceAccountName() {
-        return KafkaMirrorMakerResources.serviceAccountName(cluster);
-    }
-
-    @Override
     protected boolean shouldPatchLoggerAppender() {
         return true;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -867,7 +867,7 @@ public class KafkaBridgeClusterTest {
         assertThat(crb.getMetadata().getName(), is(KafkaBridgeResources.initContainerClusterRoleBindingName(cluster, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
-        assertThat(crb.getSubjects().get(0).getName(), is(bridgeCluster.getServiceAccountName()));
+        assertThat(crb.getSubjects().get(0).getName(), is(bridgeCluster.componentName));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3263,7 +3263,7 @@ public class KafkaClusterTest {
         assertThat(crb.getMetadata().getName(), is(KafkaResources.initContainerClusterRoleBindingName(CLUSTER, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
-        assertThat(crb.getSubjects().get(0).getName(), is(kc.getServiceAccountName()));
+        assertThat(crb.getSubjects().get(0).getName(), is(kc.componentName));
     }
 
     @ParallelTest
@@ -3287,7 +3287,7 @@ public class KafkaClusterTest {
         assertThat(crb.getMetadata().getName(), is(KafkaResources.initContainerClusterRoleBindingName(CLUSTER, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
-        assertThat(crb.getSubjects().get(0).getName(), is(kc.getServiceAccountName()));
+        assertThat(crb.getSubjects().get(0).getName(), is(kc.componentName));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1732,7 +1732,7 @@ public class KafkaConnectClusterTest {
         assertThat(crb.getMetadata().getName(), is(KafkaConnectResources.initContainerClusterRoleBindingName(clusterName, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
-        assertThat(crb.getSubjects().get(0).getName(), is(cluster.getServiceAccountName()));
+        assertThat(crb.getSubjects().get(0).getName(), is(cluster.componentName));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1994,7 +1994,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(crb.getMetadata().getName(), is(KafkaMirrorMaker2Resources.initContainerClusterRoleBindingName(clusterName, testNamespace)));
         assertThat(crb.getMetadata().getNamespace(), is(nullValue()));
         assertThat(crb.getSubjects().get(0).getNamespace(), is(testNamespace));
-        assertThat(crb.getSubjects().get(0).getName(), is(cluster.getServiceAccountName()));
+        assertThat(crb.getSubjects().get(0).getName(), is(cluster.componentName));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues the refactoring of `AbstractModel` and its subclasses. It removes the `getServiceAccountName` method as the service accounts are anyway always named the same as the component. It also refactors the Secret creation and the related template fields for JMX secrets.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally