### PR TITLE
Throw warning when `StatefulSets` are being used in Strimzi 0.34

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
+import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.api.kafka.model.status.ListenerAddress;
 import io.strimzi.api.kafka.model.status.ListenerAddressBuilder;
@@ -71,6 +72,7 @@ import io.strimzi.operator.common.operator.resource.RouteOperator;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.vertx.core.CompositeFuture;
@@ -285,7 +287,16 @@ public class KafkaReconciler {
      * @return              Completes when the warnings are added to the status object
      */
     protected Future<Void> modelWarnings(KafkaStatus kafkaStatus) {
-        kafkaStatus.addConditions(kafka.getWarningConditions());
+        List<Condition> conditions = kafka.getWarningConditions();
+
+        if (!featureGates.useStrimziPodSetsEnabled())   {
+            conditions.add(StatusUtils.buildWarningCondition("StatefulSetRemoval",
+                    "Support for StatefulSets will be removed in Strimzi 0.35. You should consider migrating to StrimziPodSets."));
+            LOGGER.warnCr(reconciliation, "Support for StatefulSets will be removed in Strimzi 0.35. You should consider migrating to StrimziPodSets.");
+        }
+
+        kafkaStatus.addConditions(conditions);
+
         return Future.succeededFuture();
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -75,6 +75,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1369,8 +1370,8 @@ class LoggingChangeST extends AbstractST {
         assertFalse(log4jFile.contains(defaultProps));
 
         LOGGER.info("Checking if Kafka:{} contains error about non-existing CM", clusterName);
-        Condition condition = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getConditions().get(0);
-        assertThat(condition.getType(), is(CustomResourceStatus.NotReady.toString()));
+        Condition condition = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getConditions().stream().filter(con -> CustomResourceStatus.NotReady.toString().equals(con.getType())).findFirst().orElse(null);
+        assertThat(condition, is(notNullValue()));
         assertTrue(condition.getMessage().matches("ConfigMap " + nonExistingCmName + " with external logging configuration does not exist .*"));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ClusterOperatorRbacIsolatedST.java
@@ -12,7 +12,6 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.enums.ClusterOperatorRBACType;
-import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
@@ -23,7 +22,6 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Level;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -110,7 +108,7 @@ public class ClusterOperatorRbacIsolatedST extends AbstractST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, clusterOperator.getDeploymentNamespace(), ".*Forbidden!.*");
         Condition kafkaStatusCondition = KafkaResource.kafkaClient().inNamespace(clusterOperator.getDeploymentNamespace()).withName(clusterName).get().getStatus().getConditions().stream().filter(con -> NotReady.toString().equals(con.getType())).findFirst().orElse(null);
-        assertThat(kafkaStatusCondition, CoreMatchers.is(notNullValue()));
+        assertThat(kafkaStatusCondition, is(notNullValue()));
         assertTrue(kafkaStatusCondition.getMessage().contains("Configured service account doesn't have access."));
 
         resourceManager.createResource(extensionContext, false, KafkaConnectTemplates.kafkaConnect(clusterName, clusterOperator.getDeploymentNamespace(), clusterName, 1)
@@ -121,7 +119,7 @@ public class ClusterOperatorRbacIsolatedST extends AbstractST {
 
         KafkaConnectUtils.waitUntilKafkaConnectStatusConditionContainsMessage(clusterName, clusterOperator.getDeploymentNamespace(), ".*Forbidden!.*");
         Condition kafkaConnectStatusCondition = KafkaConnectResource.kafkaConnectClient().inNamespace(clusterOperator.getDeploymentNamespace()).withName(clusterName).get().getStatus().getConditions().stream().filter(con -> NotReady.toString().equals(con.getType())).findFirst().orElse(null);
-        assertThat(kafkaConnectStatusCondition, CoreMatchers.is(notNullValue()));
+        assertThat(kafkaConnectStatusCondition, is(notNullValue()));
         assertTrue(kafkaConnectStatusCondition.getMessage().contains("Configured service account doesn't have access."));
     }
 }


### PR DESCRIPTION
### Type of change

- Task

### Description

StatefulSet support is planned to be removed in Strimzi 0.35. So it might make sense in Strimzi 0.34 to throw warnings about this. This PR adds warnings for any Kafka cluster using StatefulSets in the log and in its status.

Example of the status warning:

```yaml
    conditions:
    - lastTransitionTime: "2023-01-30T02:48:33.176487347Z"
      message: Support for StatefulSets will be removed in Strimzi 0.35. You should
        consider migrating to StrimziPodSets.
      reason: StatefulSetRemoval
      status: "True"
      type: Warning
```

And in the log:

```
2023-01-30 02:48:33 WARN  KafkaReconciler:295 - Reconciliation #1(watch) Kafka(myproject/my-cluster): Support for StatefulSets will be removed in Strimzi 0.35. You should consider migrating to StrimziPodSets.
```

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally