### PR TITLE
Fix KafkaVersionsST flakiness

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -61,6 +61,9 @@ public class KafkaVersionsST extends AbstractST {
         LOGGER.info("Deploying Kafka with version: {}", testKafkaVersion.version());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3)
+            .editMetadata()
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
             .editOrNewSpec()
                 .editOrNewKafka()
                     .withVersion(testKafkaVersion.version())
@@ -143,7 +146,7 @@ public class KafkaVersionsST extends AbstractST {
                 .build();
 
         resourceManager.createResource(extensionContext,
-            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build(),
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName()).build(),
             readUser,
             writeUser,
             tlsReadWriteUser


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes the problem with KafkaVersionsST when the Kubernetes client context may have the wrong namespace set-up (which could not be present) and thus resulting in the following error: 
```java
KubernetesClient Failure executing: POST at: https://192.168.49.2:8443/apis/kafka.strimzi.io/v1beta2/namespaces/custom-authorizer-st/kafkas. Message: namespaces "custom-authorizer-st" not found. Received status: Status(apiVersion=v1, code=404, details=StatusDetails(causes=[], group=null, kind=namespaces, name=custom-authorizer-st, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=namespaces "custom-authorizer-st" not found, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=NotFound, status=Failure, additionalProperties={}).
```

### Checklist

- [ ] Make sure all tests pass