### PR TITLE
Fix testUOListeningOnlyUsersInSameCluster test case

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1336,7 +1336,7 @@ class KafkaST extends AbstractST {
         String uOLogs = kubeClient(namespaceName).logsInSpecificNamespace(namespaceName, entityOperatorPodName, "user-operator");
         assertThat(uOLogs, containsString("KafkaUser " + userName + " in namespace " + namespaceName + " was ADDED"));
 
-        LOGGER.info("Verifying that user {} in cluster {} is not created", userName, secondClusterName);
+        LOGGER.info("Verifying that KafkaUser {} in cluster {} is not created", userName, secondClusterName);
         entityOperatorPodName = kubeClient(namespaceName).listPodNamesInSpecificNamespace(namespaceName, Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(secondClusterName)).get(0);
         uOLogs = kubeClient(namespaceName).logsInSpecificNamespace(namespaceName, entityOperatorPodName, "user-operator");
         assertThat(uOLogs, not(containsString("KafkaUser " + userName + " in namespace " + namespaceName + " was ADDED")));

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1334,12 +1334,12 @@ class KafkaST extends AbstractST {
         LOGGER.info("Verifying that KafkaUser {} in cluster {} is created", userName, firstClusterName);
         String entityOperatorPodName = kubeClient(namespaceName).listPodNamesInSpecificNamespace(namespaceName, Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(firstClusterName)).get(0);
         String uOLogs = kubeClient(namespaceName).logsInSpecificNamespace(namespaceName, entityOperatorPodName, "user-operator");
-        assertThat(uOLogs, containsString("KafkaUser " + namespaceName + "/" + userName + " was ADDED"));
+        assertThat(uOLogs, containsString("KafkaUser " + userName + " in namespace " + namespaceName + " was ADDED"));
 
-        LOGGER.info("Verifying that KafkaUser {} in cluster {} is not created", userName, secondClusterName);
+        LOGGER.info("Verifying that user {} in cluster {} is not created", userName, secondClusterName);
         entityOperatorPodName = kubeClient(namespaceName).listPodNamesInSpecificNamespace(namespaceName, Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(secondClusterName)).get(0);
         uOLogs = kubeClient(namespaceName).logsInSpecificNamespace(namespaceName, entityOperatorPodName, "user-operator");
-        assertThat(uOLogs, not(containsString("KafkaUser " + namespaceName + "/" + userName + " was ADDED")));
+        assertThat(uOLogs, not(containsString("KafkaUser " + userName + " in namespace " + namespaceName + " was ADDED")));
 
         LOGGER.info("Verifying that KafkaUser belongs to {} cluster", firstClusterName);
         String kafkaUserResource = cmdKubeClient(namespaceName).getResourceAsYaml("kafkauser", userName);


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Bugfix

### Description

This PR solves the log issue:

```
assertThat(uOLogs, containsString("User " + userName + " in namespace " + namespaceName + " was ADDED"));
```
and now we are trying to match with the following:
```
assertThat(uOLogs, containsString("KafkaUser " + namespaceName + "/" + userName + " was ADDED"));
```
and the log from the UO is:
 ```
UserController:123 - KafkaUser my-user-943844112-1364831104 in namespace namespace-0 was ADDED 
```
But that doesn't seem to work.

### Checklist

- [ ] Make sure all tests pass