### PR TITLE
Refactor Service and Config Map generation in AbstractModel and its subclasses

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ConfigMapUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ConfigMapUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.Map;
+
+/**
+ * Shared methods for working with Config Maps
+ */
+public class ConfigMapUtils {
+    /**
+     * Creates a Config Map
+     *
+     * @param name              Name of the Config Map
+     * @param namespace         Namespace of the Config Map
+     * @param labels            Labels of the Config Map
+     * @param ownerReference    OwnerReference of the Config Map
+     * @param data              Data which will be stored int he Config Map
+     *
+     * @return  New Config Map
+     */
+    public static ConfigMap createConfigMap(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            Map<String, String> data
+    ) {
+        return new ConfigMapBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withLabels(labels.toMap())
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withData(data)
+                .build();
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -312,7 +312,7 @@ public class JmxTrans extends AbstractModel {
         Map<String, String> data = new HashMap<>(1);
         data.put(JMXTRANS_CONFIGMAP_KEY, generateJMXConfig());
 
-        return createConfigMap(JmxTransResources.configMapName(cluster), data);
+        return ConfigMapUtils.createConfigMap(JmxTransResources.configMapName(cluster), namespace, labels, ownerReference, data);
     }
 
     private List<Volume> getVolumes() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -216,8 +216,11 @@ public class KafkaConnectBuild extends AbstractModel {
      * @return  ConfigMap with the Dockerfile
      */
     public ConfigMap generateDockerfileConfigMap(KafkaConnectDockerfile dockerfile)   {
-        return createConfigMap(
+        return ConfigMapUtils.createConfigMap(
                 KafkaConnectResources.dockerFileConfigMapName(cluster),
+                namespace,
+                labels,
+                ownerReference,
                 Collections.singletonMap("Dockerfile", dockerfile.getDockerfile())
         );
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -140,7 +140,6 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
     protected KafkaMirrorMakerCluster(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, KafkaMirrorMakerResources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE);
 
-        this.serviceName = KafkaMirrorMakerResources.serviceName(cluster);
         this.ancillaryConfigMapName = KafkaMirrorMakerResources.metricsAndLogConfigMapName(cluster);
         this.readinessPath = "/";
         this.readinessProbeOptions = READINESS_PROBE_OPTIONS;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -29,7 +29,6 @@ import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.storage.Storage;
-import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -225,42 +224,6 @@ public class ModelUtils {
                     .withType("Opaque")
                     .withData(data)
                     .build();
-        }
-    }
-
-    /**
-     * Parses the values from the InternalServiceTemplate in CRD model into the component model
-     *
-     * @param model AbstractModel class where the values from the PodTemplate should be set
-     * @param service InternalServiceTemplate with the values form the CRD
-     */
-    public static void parseInternalServiceTemplate(AbstractModel model, InternalServiceTemplate service)   {
-        if (service != null)  {
-            if (service.getMetadata() != null) {
-                model.templateServiceLabels = service.getMetadata().getLabels();
-                model.templateServiceAnnotations = service.getMetadata().getAnnotations();
-            }
-
-            model.templateServiceIpFamilyPolicy = service.getIpFamilyPolicy();
-            model.templateServiceIpFamilies = service.getIpFamilies();
-        }
-    }
-
-    /**
-     * Parses the values from the InternalServiceTemplate of a headless service in CRD model into the component model
-     *
-     * @param model AbstractModel class where the values from the PodTemplate should be set
-     * @param service InternalServiceTemplate with the values form the CRD
-     */
-    public static void parseInternalHeadlessServiceTemplate(AbstractModel model, InternalServiceTemplate service)   {
-        if (service != null)  {
-            if (service.getMetadata() != null) {
-                model.templateHeadlessServiceLabels = service.getMetadata().getLabels();
-                model.templateHeadlessServiceAnnotations = service.getMetadata().getAnnotations();
-            }
-
-            model.templateHeadlessServiceIpFamilyPolicy = service.getIpFamilyPolicy();
-            model.templateHeadlessServiceIpFamilies = service.getIpFamilies();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.strimzi.api.kafka.model.template.HasMetadataTemplate;
+import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Shared methods for working with Services
+ */
+public class ServiceUtils {
+    /**
+     * Creates a ClusterIP Service
+     *
+     * @param name           Name of the Service
+     * @param namespace      Namespace of the Service
+     * @param labels         Labels of the Service
+     * @param ownerReference OwnerReference of the Service
+     * @param template       Service template with user's custom configuration
+     * @param ports          List of service ports
+     *
+     * @return  New ClusterIP Service
+     */
+    public static Service createClusterIpService(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            InternalServiceTemplate template,
+            List<ServicePort> ports
+    )   {
+        return createService(
+                name,
+                namespace,
+                labels,
+                ownerReference,
+                template,
+                ports,
+                labels.strimziSelectorLabels(),
+                "ClusterIP",
+                null,
+                null,
+                ipFamilyPolicy(template),
+                ipFamilies(template)
+        );
+    }
+
+    /**
+     * Creates a discoverable ClusterIP Service. discoverable service has some additional labels and annotations to
+     * simplify discovery.
+     *
+     * @param name                  Name of the Service
+     * @param namespace             Namespace of the Service
+     * @param labels                Labels of the Service
+     * @param ownerReference        OwnerReference of the Service
+     * @param template              Service template with user's custom configuration
+     * @param ports                 List of service ports
+     * @param discoveryLabels       Additional discovery labels
+     * @param discoveryAnnotations  Additional discovery annotations
+     *
+     * @return  New discoverable ClusterIP Service
+     */
+    public static Service createDiscoverableClusterIpService(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            InternalServiceTemplate template,
+            List<ServicePort> ports,
+            Map<String, String> discoveryLabels,
+            Map<String, String> discoveryAnnotations
+    )   {
+        return createService(
+                name,
+                namespace,
+                labels.withStrimziDiscovery(),
+                ownerReference,
+                template,
+                ports,
+                labels.strimziSelectorLabels(),
+                "ClusterIP",
+                discoveryLabels,
+                discoveryAnnotations,
+                ipFamilyPolicy(template),
+                ipFamilies(template)
+        );
+    }
+
+    /**
+     * Creates a service
+     *
+     * @param name                  Name of the Service
+     * @param namespace             Namespace of the Service
+     * @param labels                Labels of the Service
+     * @param ownerReference        OwnerReference of the Service
+     * @param template              Template with user's custom metadata for this service
+     * @param ports                 List of service ports
+     * @param selector              Selector for selecting the Pods to route the traffic to
+     * @param type                  Type of the service
+     * @param additionalLabels      Additional labels
+     * @param additionalAnnotations Additional annotations
+     * @param ipFamilyPolicy        IP Family Policy configuration
+     * @param ipFamilies            List of IP familiers
+     *
+     * @return  New discoverable ClusterIP Service
+     */
+    public static Service createService(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            HasMetadataTemplate template,
+            List<ServicePort> ports,
+            Labels selector,
+            String type,
+            Map<String, String> additionalLabels,
+            Map<String, String> additionalAnnotations,
+            IpFamilyPolicy ipFamilyPolicy,
+            List<IpFamily> ipFamilies
+    )   {
+        return new ServiceBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(Util.mergeLabelsOrAnnotations(additionalLabels, TemplateUtils.labels(template))).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(Util.mergeLabelsOrAnnotations(additionalAnnotations, TemplateUtils.annotations(template)))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withType(type)
+                    .withSelector(selector.toMap())
+                    .withPorts(ports)
+                    .withIpFamilyPolicy(ipFamilyPolicyToString(ipFamilyPolicy))
+                    .withIpFamilies(ipFamiliesToListOfStrings(ipFamilies))
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates a headless service
+     *
+     * @param name              Name of the Service
+     * @param namespace         Namespace of the Service
+     * @param labels            Labels of the Service
+     * @param ownerReference    OwnerReference of the Service
+     * @param template          Service template with user's custom configuration
+     * @param ports             List of service ports
+     *
+     * @return  New headless service
+     */
+    public static Service createHeadlessService(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            InternalServiceTemplate template,
+            List<ServicePort> ports
+    )   {
+        return new ServiceBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withNamespace(namespace)
+                    .withAnnotations(TemplateUtils.annotations(template))
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("ClusterIP")
+                    .withClusterIP("None")
+                    .withSelector(labels.strimziSelectorLabels().toMap())
+                    .withPorts(ports)
+                    .withPublishNotReadyAddresses(true)
+                    .withIpFamilyPolicy(ipFamilyPolicyToString(ipFamilyPolicy(template)))
+                    .withIpFamilies(ipFamiliesToListOfStrings(ipFamilies(template)))
+                .endSpec()
+                .build();
+    }
+
+    private static String ipFamilyPolicyToString(IpFamilyPolicy ipFamilyPolicy)  {
+        return ipFamilyPolicy != null ? ipFamilyPolicy.toValue() : null;
+    }
+
+    private static List<String> ipFamiliesToListOfStrings(List<IpFamily> ipFamilies)  {
+        return ipFamilies != null ? ipFamilies.stream().map(IpFamily::toValue).collect(Collectors.toList()) : null;
+    }
+
+    private static IpFamilyPolicy ipFamilyPolicy(InternalServiceTemplate template)  {
+        return template != null ? template.getIpFamilyPolicy() : null;
+    }
+
+    private static List<IpFamily> ipFamilies(InternalServiceTemplate template)  {
+        return template != null ? template.getIpFamilies() : null;
+    }
+
+    /**
+     * Creates Service port
+     *
+     * @param name          Name of the port
+     * @param port          The port on the service which can be accessed by clients
+     * @param targetPort    The port on the container / Pod where the connections will be routed
+     * @param protocol      Protocol used by this port
+     *
+     * @return  Created port
+     */
+    public static ServicePort createServicePort(String name, int port, int targetPort, String protocol)   {
+        return createServicePort(name, port, targetPort, null, protocol);
+    }
+
+    /**
+     * Creates Service port with a specific node port
+     *
+     * @param name          Name of the port
+     * @param port          The port on the service which can be accessed by clients
+     * @param targetPort    The port on the container / Pod where the connections will be routed
+     * @param nodePort      The desired node port number
+     * @param protocol      Protocol used by this port
+     *
+     * @return  Created port
+     */
+    public static ServicePort createServicePort(String name, int port, int targetPort, Integer nodePort, String protocol)   {
+        return new ServicePortBuilder()
+                .withName(name)
+                .withProtocol(protocol)
+                .withPort(port)
+                .withNewTargetPort(targetPort)
+                .withNodePort(nodePort)
+                .build();
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -91,7 +91,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
         kafkaBridgeServiceAccount(reconciliation, namespace, bridge)
             .compose(i -> bridgeInitClusterRoleBinding(reconciliation, initCrbName, initCrb))
             .compose(i -> deploymentOperations.scaleDown(reconciliation, namespace, bridge.getComponentName(), bridge.getReplicas()))
-            .compose(scale -> serviceOperations.reconcile(reconciliation, namespace, bridge.getServiceName(), bridge.generateService()))
+            .compose(scale -> serviceOperations.reconcile(reconciliation, namespace, KafkaBridgeResources.serviceName(bridge.getCluster()), bridge.generateService()))
             .compose(i -> Util.metricsAndLogging(reconciliation, configMapOperations, namespace, bridge.getLogging(), null))
             .compose(metricsAndLogging -> configMapOperations.reconcile(reconciliation, namespace, bridge.getAncillaryConfigMapName(), bridge.generateMetricsAndLogConfigMap(metricsAndLogging)))
             .compose(i -> pfa.hasPodDisruptionBudgetV1() ? podDisruptionBudgetOperator.reconcile(reconciliation, namespace, bridge.getComponentName(), bridge.generatePodDisruptionBudget()) : Future.succeededFuture())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1163,7 +1163,7 @@ public class KafkaReconciler {
      * @return  Future which completes when the endpoints are ready
      */
     protected Future<Void> serviceEndpointsReady() {
-        return serviceOperator.endpointReadiness(reconciliation, reconciliation.namespace(), kafka.getServiceName(), 1_000, operationTimeoutMs);
+        return serviceOperator.endpointReadiness(reconciliation, reconciliation.namespace(), KafkaResources.bootstrapServiceName(reconciliation.name()), 1_000, operationTimeoutMs);
     }
 
     /**
@@ -1172,7 +1172,7 @@ public class KafkaReconciler {
      * @return  Future which completes when the endpoints are ready
      */
     protected Future<Void> headlessServiceEndpointsReady() {
-        return serviceOperator.endpointReadiness(reconciliation, reconciliation.namespace(), kafka.getHeadlessServiceName(), 1_000, operationTimeoutMs);
+        return serviceOperator.endpointReadiness(reconciliation, reconciliation.namespace(), KafkaResources.brokersServiceName(reconciliation.name()), 1_000, operationTimeoutMs);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ConfigMapUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ConfigMapUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class ConfigMapUtilsTest {
+    private final static String NAME = "my-cm";
+    private final static String NAMESPACE = "my-namespace";
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-name")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+
+    @ParallelTest
+    public void testConfigMapCreation() {
+        ConfigMap cm = ConfigMapUtils.createConfigMap(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, Map.of("key1", "value1", "key2", "value2"));
+
+        assertThat(cm.getMetadata().getName(), is(NAME));
+        assertThat(cm.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(cm.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(cm.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(cm.getMetadata().getAnnotations(), is(Map.of()));
+
+        assertThat(cm.getData(), is(Map.of("key1", "value1", "key2", "value2")));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -79,7 +79,6 @@ import static io.strimzi.operator.cluster.model.CruiseControl.API_USER_NAME;
 import static io.strimzi.operator.cluster.model.CruiseControl.ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION;
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.ANOMALY_DETECTION_CONFIG_KEY;
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters.DEFAULT_GOALS_CONFIG_KEY;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -525,14 +524,14 @@ public class CruiseControlTest {
         Service svc = cc.generateService();
 
         assertThat(svc.getSpec().getType(), is("ClusterIP"));
-        assertThat(svc.getMetadata().getLabels(), is(expectedLabels(cc.getServiceName())));
+        assertThat(svc.getMetadata().getLabels(), is(expectedLabels(CruiseControlResources.serviceName(cluster))));
         assertThat(svc.getSpec().getSelector(), is(expectedSelectorLabels()));
         assertThat(svc.getSpec().getPorts().size(), is(1));
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(CruiseControl.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getPort(), is(CruiseControl.REST_API_PORT));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
         TestUtils.checkOwnerReference(svc, kafka);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -65,7 +65,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.strimzi.operator.cluster.model.KafkaBridgeCluster.ENV_VAR_KAFKA_INIT_INIT_FOLDER_KEY;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -182,7 +181,7 @@ public class KafkaBridgeClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaBridgeCluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
         assertThat(svc.getMetadata().getAnnotations(), is(kbc.getDiscoveryAnnotation(KafkaBridgeCluster.DEFAULT_REST_API_PORT)));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -123,7 +123,7 @@ public class KafkaClusterPodSetTest {
             assertThat(pod.getMetadata().getAnnotations().get("test-anno"), is(pod.getMetadata().getName()));
 
             assertThat(pod.getSpec().getHostname(), is(pod.getMetadata().getName()));
-            assertThat(pod.getSpec().getSubdomain(), is(kc.getHeadlessServiceName()));
+            assertThat(pod.getSpec().getSubdomain(), is(KafkaResources.brokersServiceName(CLUSTER)));
             assertThat(pod.getSpec().getRestartPolicy(), is("Always"));
             assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
             assertThat(pod.getSpec().getVolumes().stream()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -184,7 +184,7 @@ public class KafkaClusterTest {
         assertThat(headless.getSpec().getPorts().get(3).getPort(), is(9093));
         assertThat(headless.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(headless.getSpec().getIpFamilies(), is(nullValue()));
 
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
     }
@@ -358,7 +358,7 @@ public class KafkaClusterTest {
         assertThat(headful.getSpec().getPorts().get(2).getPort(), is(9093));
         assertThat(headful.getSpec().getPorts().get(2).getProtocol(), is("TCP"));
         assertThat(headful.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(headful.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(headful.getSpec().getIpFamilies(), is(nullValue()));
 
         assertThat(headful.getMetadata().getAnnotations(), is(Util.mergeLabelsOrAnnotations(KC.getInternalDiscoveryAnnotation())));
 
@@ -1486,7 +1486,12 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getName(), is(KafkaResources.externalBootstrapServiceName(CLUSTER)));
         assertThat(ext.getSpec().getType(), is("ClusterIP"));
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels().toMap()));
-        assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+        assertThat(ext.getSpec().getPorts().size(), is(1));
+        assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+        assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
@@ -1495,7 +1500,12 @@ public class KafkaClusterTest {
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
-            assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+            assertThat(srv.getSpec().getPorts().size(), is(1));
+            assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+            assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+            assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             TestUtils.checkOwnerReference(srv, KAFKA);
         }
 
@@ -1654,7 +1664,12 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getFinalizers(), is(emptyList()));
         assertThat(ext.getSpec().getType(), is("LoadBalancer"));
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels().toMap()));
-        assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+        assertThat(ext.getSpec().getPorts().size(), is(1));
+        assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+        assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(ext.getSpec().getLoadBalancerIP(), is(nullValue()));
         assertThat(ext.getSpec().getExternalTrafficPolicy(), is("Cluster"));
         assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
@@ -1667,7 +1682,12 @@ public class KafkaClusterTest {
             assertThat(srv.getMetadata().getFinalizers(), is(emptyList()));
             assertThat(srv.getSpec().getType(), is("LoadBalancer"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
-            assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+            assertThat(srv.getSpec().getPorts().size(), is(1));
+            assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+            assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+            assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             assertThat(srv.getSpec().getLoadBalancerIP(), is(nullValue()));
             assertThat(srv.getSpec().getExternalTrafficPolicy(), is("Cluster"));
             assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(emptyList()));
@@ -2018,7 +2038,12 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getName(), is(KafkaResources.externalBootstrapServiceName(CLUSTER)));
         assertThat(ext.getSpec().getType(), is("NodePort"));
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels().toMap()));
-        assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+        assertThat(ext.getSpec().getPorts().size(), is(1));
+        assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+        assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
@@ -2027,7 +2052,12 @@ public class KafkaClusterTest {
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("NodePort"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
-            assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+            assertThat(srv.getSpec().getPorts().size(), is(1));
+            assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+            assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+            assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             TestUtils.checkOwnerReference(srv, KAFKA);
         }
     }
@@ -2093,7 +2123,13 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getName(), is(KafkaResources.externalBootstrapServiceName(CLUSTER)));
         assertThat(ext.getSpec().getType(), is("NodePort"));
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels().toMap()));
-        assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, 32001, "TCP"))));
+        assertThat(ext.getSpec().getPorts().size(), is(1));
+        assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(32001));
+        assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
+
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
@@ -2103,9 +2139,18 @@ public class KafkaClusterTest {
             assertThat(srv.getSpec().getType(), is("NodePort"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
             if (i == 0) { // pod with index 0 will have overriden port
-                assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, 32101, "TCP"))));
+                assertThat(srv.getSpec().getPorts().size(), is(1));
+                assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+                assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+                assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(srv.getSpec().getPorts().get(0).getNodePort(), is(32101));
+                assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             } else {
-                assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+                assertThat(srv.getSpec().getPorts().size(), is(1));
+                assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+                assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+                assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+                assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             }
             TestUtils.checkOwnerReference(srv, KAFKA);
         }
@@ -2140,7 +2185,12 @@ public class KafkaClusterTest {
                 .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, 32189, "TCP"))));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().size(), is(1));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32189));
+        assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(kc.generateExternalServices(0).get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
 
         assertThat(ListenersUtils.bootstrapNodePort(kc.getListeners().get(0)), is(32189));
@@ -3014,7 +3064,12 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getName(), is(KafkaResources.externalBootstrapServiceName(CLUSTER)));
         assertThat(ext.getSpec().getType(), is("ClusterIP"));
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels().toMap()));
-        assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+        assertThat(ext.getSpec().getPorts().size(), is(1));
+        assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+        assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
@@ -3023,7 +3078,12 @@ public class KafkaClusterTest {
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
-            assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+            assertThat(srv.getSpec().getPorts().size(), is(1));
+            assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+            assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+            assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             TestUtils.checkOwnerReference(srv, KAFKA);
         }
 
@@ -3198,7 +3258,12 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getName(), is(KafkaResources.externalBootstrapServiceName(CLUSTER)));
         assertThat(ext.getSpec().getType(), is("ClusterIP"));
         assertThat(ext.getSpec().getSelector(), is(kc.getSelectorLabels().toMap()));
-        assertThat(ext.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+        assertThat(ext.getSpec().getPorts().size(), is(1));
+        assertThat(ext.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+        assertThat(ext.getSpec().getPorts().get(0).getPort(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+        assertThat(ext.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+        assertThat(ext.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
@@ -3207,7 +3272,12 @@ public class KafkaClusterTest {
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
-            assertThat(srv.getSpec().getPorts(), is(Collections.singletonList(kc.createServicePort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094, 9094, "TCP"))));
+            assertThat(srv.getSpec().getPorts().size(), is(1));
+            assertThat(srv.getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
+            assertThat(srv.getSpec().getPorts().get(0).getPort(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
+            assertThat(srv.getSpec().getPorts().get(0).getNodePort(), is(nullValue()));
+            assertThat(srv.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
             TestUtils.checkOwnerReference(srv, KAFKA);
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -83,7 +83,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -234,7 +233,7 @@ public class KafkaConnectClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getMetadata().getAnnotations().size(), is(0));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
         TestUtils.checkOwnerReference(svc, resource);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -78,7 +78,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -243,7 +242,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getName(), is(KafkaMirrorMaker2Cluster.REST_API_PORT_NAME));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
 
         TestUtils.checkOwnerReference(svc, resource);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
+import io.strimzi.api.kafka.model.template.InternalServiceTemplateBuilder;
+import io.strimzi.api.kafka.model.template.IpFamily;
+import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class ServiceUtilsTest {
+    private final static String NAME = "my-service";
+    private final static String NAMESPACE = "my-namespace";
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-name")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+    private static final String PORT_NAME = "my-port";
+    private static final ServicePort PORT = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, "HTTP");
+    private static final InternalServiceTemplate TEMPLATE = new InternalServiceTemplateBuilder()
+            .withNewMetadata()
+                .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+            .endMetadata()
+            .withIpFamilyPolicy(IpFamilyPolicy.PREFER_DUAL_STACK)
+            .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
+            .build();
+
+    @ParallelTest
+    public void testCreateServicePort() {
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, "HTTP");
+
+        assertThat(port.getName(), is(PORT_NAME));
+        assertThat(port.getPort(), is(1234));
+        assertThat(port.getTargetPort().getIntVal(), is(5678));
+        assertThat(port.getNodePort(), is(nullValue()));
+        assertThat(port.getProtocol(), is("HTTP"));
+    }
+
+    @ParallelTest
+    public void testCreateServiceWithNodePort() {
+        ServicePort port = ServiceUtils.createServicePort(PORT_NAME, 1234, 5678, 30000, "HTTP");
+
+        assertThat(port.getName(), is(PORT_NAME));
+        assertThat(port.getPort(), is(1234));
+        assertThat(port.getTargetPort().getIntVal(), is(5678));
+        assertThat(port.getNodePort(), is(30000));
+        assertThat(port.getProtocol(), is("HTTP"));
+    }
+
+    @ParallelTest
+    public void testCreateHeadlessServiceWithNullTemplate() {
+        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getClusterIP(), is("None"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getPublishNotReadyAddresses(), is(true));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testCreateHeadlessServiceWithEmptyTemplate() {
+        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, new InternalServiceTemplate(), List.of(PORT));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getClusterIP(), is("None"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getPublishNotReadyAddresses(), is(true));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testCreateHeadlessServiceWithTemplate() {
+        Service svc = ServiceUtils.createHeadlessService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getClusterIP(), is("None"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getPublishNotReadyAddresses(), is(true));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv4", "IPv6")));
+    }
+
+    @ParallelTest
+    public void testCreateClusterIpServiceWithNullTemplate() {
+        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of()));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testCreateClusterIpServiceWithEmptyTemplate() {
+        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, new InternalServiceTemplate(), List.of(PORT));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of()));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testCreateClusterIpServiceWithTemplate() {
+        Service svc = ServiceUtils.createClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv4", "IPv6")));
+    }
+
+    @ParallelTest
+    public void testCreateDiscoverableServiceWithNullTemplate() {
+        Service svc = ServiceUtils.createDiscoverableClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT), Map.of("discovery-label", "label-value"), Map.of("strimzi.io/discovery-anno", "anno-value"));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.withStrimziDiscovery().withAdditionalLabels(Map.of("discovery-label", "label-value")).toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of("strimzi.io/discovery-anno", "anno-value")));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testCreateDiscoverableServiceWithTemplate() {
+        Service svc = ServiceUtils.createDiscoverableClusterIpService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT), Map.of("discovery-label", "label-value"), Map.of("strimzi.io/discovery-anno", "anno-value"));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.withStrimziDiscovery().withAdditionalLabels(Map.of("discovery-label", "label-value", "label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of("strimzi.io/discovery-anno", "anno-value", "anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(svc.getSpec().getType(), is("ClusterIP"));
+        assertThat(svc.getSpec().getSelector().size(), is(3));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_NAME_LABEL), is("my-name"));
+        assertThat(svc.getSpec().getSelector().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv4", "IPv6")));
+    }
+
+    @ParallelTest
+    public void testCreateServiceWithNullTemplate() {
+        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label", "label-value")).toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno", "anno-value")));
+
+        assertThat(svc.getSpec().getType(), is("NodePort"));
+        assertThat(svc.getSpec().getSelector().size(), is(1));
+        assertThat(svc.getSpec().getSelector().get("selector-label"), is("selector-value"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("RequireDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv6")));
+    }
+
+    @ParallelTest
+    public void testCreateServiceWithTemplate() {
+        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6));
+
+        assertThat(svc.getMetadata().getName(), is(NAME));
+        assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(svc.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(svc.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label", "label-value", "label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of("anno", "anno-value", "anno-1", "value-1", "anno-2", "value-2")));
+
+        assertThat(svc.getSpec().getType(), is("NodePort"));
+        assertThat(svc.getSpec().getSelector().size(), is(1));
+        assertThat(svc.getSpec().getSelector().get("selector-label"), is("selector-value"));
+        assertThat(svc.getSpec().getPorts().size(), is(1));
+        assertThat(svc.getSpec().getPorts().get(0), is(PORT));
+        assertThat(svc.getSpec().getIpFamilyPolicy(), is("RequireDualStack"));
+        assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv6")));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -106,7 +106,7 @@ public class ZookeeperClusterPodSetTest {
             assertThat(pod.getMetadata().getAnnotations().get(PodRevision.STRIMZI_REVISION_ANNOTATION), is(notNullValue()));
 
             assertThat(pod.getSpec().getHostname(), is(pod.getMetadata().getName()));
-            assertThat(pod.getSpec().getSubdomain(), is(zc.getHeadlessServiceName()));
+            assertThat(pod.getSpec().getSubdomain(), is(KafkaResources.zookeeperHeadlessServiceName(CLUSTER)));
             assertThat(pod.getSpec().getRestartPolicy(), is("Always"));
             assertThat(pod.getSpec().getTerminationGracePeriodSeconds(), is(30L));
             assertThat(pod.getSpec().getVolumes().stream()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -67,7 +67,6 @@ import static io.strimzi.operator.cluster.model.AbstractModel.JMX_PORT;
 import static io.strimzi.operator.cluster.model.AbstractModel.JMX_PORT_NAME;
 import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -142,7 +141,7 @@ public class ZookeeperClusterTest {
         assertThat(headless.getSpec().getPorts().get(2).getPort(), is(ZookeeperCluster.LEADER_ELECTION_PORT));
         assertThat(headless.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(headless.getSpec().getIpFamilies(), is(nullValue()));
     }
 
     private Secret generateCertificatesSecret() {
@@ -189,8 +188,8 @@ public class ZookeeperClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getPort(), is(ZookeeperCluster.CLIENT_TLS_PORT));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(svc.getSpec().getIpFamilies(), is(emptyList()));
-        assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
+        assertThat(svc.getSpec().getIpFamilies(), is(nullValue()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of()));
 
         TestUtils.checkOwnerReference(svc, KAFKA);
     }
@@ -214,7 +213,7 @@ public class ZookeeperClusterTest {
         assertThat(svc.getSpec().getPorts().get(0).getPort(), is(ZookeeperCluster.CLIENT_TLS_PORT));
         assertThat(svc.getSpec().getPorts().get(0).getProtocol(), is("TCP"));
 
-        assertThat(svc.getMetadata().getAnnotations(), is(nullValue()));
+        assertThat(svc.getMetadata().getAnnotations(), is(Map.of()));
 
         TestUtils.checkOwnerReference(svc, KAFKA);
     }
@@ -254,7 +253,7 @@ public class ZookeeperClusterTest {
         assertThat(headless.getSpec().getPorts().get(3).getPort(), is(ZookeeperCluster.JMX_PORT));
         assertThat(headless.getSpec().getPorts().get(3).getProtocol(), is("TCP"));
         assertThat(headless.getSpec().getIpFamilyPolicy(), is(nullValue()));
-        assertThat(headless.getSpec().getIpFamilies(), is(emptyList()));
+        assertThat(headless.getSpec().getIpFamilies(), is(nullValue()));
 
         TestUtils.checkOwnerReference(headless, KAFKA);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -158,7 +158,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 List<Service> capturedServices = serviceCaptor.getAllValues();
                 assertThat(capturedServices, hasSize(1));
                 Service service = capturedServices.get(0);
-                assertThat(service.getMetadata().getName(), is(bridge.getServiceName()));
+                assertThat(service.getMetadata().getName(), is(KafkaBridgeResources.serviceName(kbName)));
                 assertThat(service, is(bridge.generateService()));
 
                 // Verify Deployment
@@ -345,7 +345,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                 List<Service> capturedServices = serviceCaptor.getAllValues();
                 assertThat(capturedServices, hasSize(1));
                 Service service = capturedServices.get(0);
-                assertThat(service.getMetadata().getName(), is(compareTo.getServiceName()));
+                assertThat(service.getMetadata().getName(), is(KafkaBridgeResources.serviceName(kbName)));
                 assertThat(service, is(compareTo.generateService()));
 
                 // Verify Deployment


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues the refactoring of `AbstractModel` and its subclasses. It moves the Service and Config Map operations into separate utils classes and removes some of the related fields which were defined in the Abstract model but used only in few places.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally