### PR TITLE
Fix testCaRenewalBreakInMiddle flakiness

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1120,9 +1120,7 @@ class SecurityST extends AbstractST {
         Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
         Map<String, String> eoPods = DeploymentUtils.depSnapshot(testStorage.getNamespaceName(), testStorage.getEoDeploymentName());
 
-        InputStream secretInputStream = getClass().getClassLoader().getResourceAsStream("security-st-certs/expired-cluster-ca.crt");
-        String clusterCaCert = TestUtils.readResource(secretInputStream);
-        SecretUtils.createSecret(testStorage.getNamespaceName(), clusterCaCertificateSecretName(testStorage.getClusterName()), "ca.crt", clusterCaCert);
+        final String clusterCaCert = kubeClient().getSecret(testStorage.getNamespaceName(), KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName())).getData().get("ca.crt");
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
             k.getSpec()


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes the problem with the flakiness of the testCaRenewalBreakInMiddle test cases. During 5th phase (i.e., trying to consume messages from Kafka broker), the consumer was sometimes unable to receive messages because of the hidden race condition.

1. Setup up Kafka cluster:
```java
.editSpec()
    .withNewClusterCa()
        .withRenewalDays(1)
        .withValidityDays(3)
    .endClusterCa()
.endSpec()
```

2. then, we create an expired certificate for a particular Kafka cluster,
```java
InputStream secretInputStream = getClass().getClassLoader().getResourceAsStream("security-st-certs/expired-cluster-ca.crt");
String clusterCaCert = TestUtils.readResource(secretInputStream);
SecretUtils.createSecret(testStorage.getNamespaceName(), clusterCaCertificateSecretName(testStorage.getClusterName()), "ca.crt", clusterCaCert);
```

3. We set a new CA for that Kafka cluster, and we also set a high CPU to trigger the Kafka pod in the `PENDING` state,
```java
KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
    k.getSpec()
        .getKafka()
        .setResources(new ResourceRequirementsBuilder()
            .addToRequests("cpu", new Quantity("100000m"))
            .build());
    k.getSpec().setClusterCa(new CertificateAuthorityBuilder()
        .withRenewalDays(4)
        .withValidityDays(7)
        .build());
}, testStorage.getNamespaceName());
```
4. then we wait for the PENDING state.
5. Consumer has to receive messages from the broker.

The problem was in the 2nd step, where we set the expired certificate. Suppose such a certificate is configured on the Kafka cluster. In that case, the Operator will be unable to restore the Kafka cluster (i.e., the consumer will be unable to the consumer any messages and the same for a producer in the analogy). Thanks @scholzj  for a help.

### Checklist

- [ ] Make sure all tests pass


