### PR TITLE
Refactor `ServiceAccount` creation, various getters and setters and add `AbstractStatefulModel`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractStatefulModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractStatefulModel.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.operator.common.Reconciliation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AbstractModel an abstract base model for all components of the {@code Kafka} custom resource
+ */
+public abstract class AbstractStatefulModel extends AbstractModel {
+    /**
+     * Storage configuration
+     */
+    protected Storage storage;
+
+    /**
+     * Warning conditions generated from the Custom Resource
+     */
+    protected List<Condition> warningConditions = new ArrayList<>(0);
+
+    /**
+     * Constructor
+     *
+     * @param reconciliation    The reconciliation marker
+     * @param resource          Custom resource with metadata containing the namespace and cluster name
+     * @param componentName     Name of the Strimzi component usually consisting from the cluster name and component type
+     * @param componentType     Type of the component that the extending class is deploying (e.g. Kafka, ZooKeeper etc. )
+     */
+    protected AbstractStatefulModel(Reconciliation reconciliation, HasMetadata resource, String componentName, String componentType) {
+        super(reconciliation, resource, componentName, componentType);
+    }
+
+    /**
+     * @return The storage.
+     */
+    public Storage getStorage() {
+        return storage;
+    }
+
+    /**
+     * Set the Storage
+     *
+     * @param storage Persistent Storage configuration
+     */
+    protected void setStorage(Storage storage) {
+        StorageUtils.validatePersistentStorage(storage);
+        this.storage = storage;
+    }
+
+    /**
+     * Returns a list of warning conditions set by the model. Returns an empty list if no warning conditions were set.
+     *
+     * @return  List of warning conditions.
+     */
+    public List<Condition> getWarningConditions() {
+        return warningConditions;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.SecurityContext;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
@@ -168,14 +167,10 @@ public class EntityOperator extends AbstractModel {
                     result.templateTlsSidecarContainerSecurityContext = template.getTlsSidecarContainer().getSecurityContext();
                 }
 
-                if (template.getServiceAccount() != null && template.getServiceAccount().getMetadata() != null) {
-                    result.templateServiceAccountLabels = template.getServiceAccount().getMetadata().getLabels();
-                    result.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
-                }
-
                 result.templateRole = template.getEntityOperatorRole();
                 result.templateDeployment = template.getDeployment();
                 result.templatePod = template.getPod();
+                result.templateServiceAccount = template.getServiceAccount();
             }
 
             return result;
@@ -309,11 +304,6 @@ public class EntityOperator extends AbstractModel {
         volumeList.add(VolumeUtils.createTempDirVolume(TLS_SIDECAR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, templatePod));
         volumeList.add(VolumeUtils.createSecretVolume(TLS_SIDECAR_CA_CERTS_VOLUME_NAME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
         return volumeList;
-    }
-
-    @Override
-    public ServiceAccount generateServiceAccount() {
-        return super.generateServiceAccount();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -138,14 +138,14 @@ public class EntityUserOperator extends AbstractModel {
             result.reconciliationIntervalMs = userOperatorSpec.getReconciliationIntervalSeconds() * 1_000;
             result.secretPrefix = userOperatorSpec.getSecretPrefix() == null ? EntityUserOperatorSpec.DEFAULT_SECRET_PREFIX : userOperatorSpec.getSecretPrefix();
             result.setLogging(userOperatorSpec.getLogging());
-            result.setGcLoggingEnabled(userOperatorSpec.getJvmOptions() == null ? DEFAULT_JVM_GC_LOGGING_ENABLED : userOperatorSpec.getJvmOptions().isGcLoggingEnabled());
-            result.setJvmOptions(userOperatorSpec.getJvmOptions());
-            result.setResources(userOperatorSpec.getResources());
+            result.gcLoggingEnabled = userOperatorSpec.getJvmOptions() == null ? DEFAULT_JVM_GC_LOGGING_ENABLED : userOperatorSpec.getJvmOptions().isGcLoggingEnabled();
+            result.jvmOptions = userOperatorSpec.getJvmOptions();
+            result.resources = userOperatorSpec.getResources();
             if (userOperatorSpec.getReadinessProbe() != null) {
-                result.setReadinessProbe(userOperatorSpec.getReadinessProbe());
+                result.readinessProbeOptions = userOperatorSpec.getReadinessProbe();
             }
             if (userOperatorSpec.getLivenessProbe() != null) {
-                result.setLivenessProbe(userOperatorSpec.getLivenessProbe());
+                result.livenessProbeOptions = userOperatorSpec.getLivenessProbe();
             }
 
             if (kafkaAssembly.getSpec().getEntityOperator().getTemplate() != null)  {
@@ -190,7 +190,7 @@ public class EntityUserOperator extends AbstractModel {
                 .withPorts(List.of(createContainerPort(HEALTHCHECK_PORT_NAME, HEALTHCHECK_PORT, "TCP")))
                 .withLivenessProbe(ProbeGenerator.httpProbe(livenessProbeOptions, livenessPath + "healthy", HEALTHCHECK_PORT_NAME))
                 .withReadinessProbe(ProbeGenerator.httpProbe(readinessProbeOptions, readinessPath + "ready", HEALTHCHECK_PORT_NAME))
-                .withResources(getResources())
+                .withResources(resources)
                 .withVolumeMounts(getVolumeMounts())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, getImage()))
                 .withSecurityContext(securityProvider.entityUserOperatorContainerSecurityContext(new ContainerSecurityProviderContextImpl(templateContainerSecurityContext)))
@@ -215,7 +215,7 @@ public class EntityUserOperator extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_SECRET_PREFIX, secretPrefix));
         varList.add(buildEnvVar(ENV_VAR_ACLS_ADMIN_API_SUPPORTED, String.valueOf(aclsAdminApiSupported)));
         varList.add(buildEnvVar(ENV_VAR_KRAFT_ENABLED, String.valueOf(kraftEnabled)));
-        ModelUtils.javaOptions(varList, getJvmOptions());
+        ModelUtils.javaOptions(varList, jvmOptions);
 
         // Add shared environment variables used for all containers
         varList.addAll(getRequiredEnvVars());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -142,13 +142,13 @@ public class JmxTrans extends AbstractModel {
             result.kafkaQueries = jmxTransSpec.getKafkaQueries();
             result.outputDefinitions = jmxTransSpec.getOutputDefinitions();
             result.loggingLevel = jmxTransSpec.getLogLevel() == null ? "INFO" : jmxTransSpec.getLogLevel();
-            result.setResources(jmxTransSpec.getResources());
+            result.resources = jmxTransSpec.getResources();
 
             String image = jmxTransSpec.getImage();
             if (image == null) {
                 image = System.getenv().getOrDefault(STRIMZI_DEFAULT_JMXTRANS_IMAGE, "quay.io/strimzi/jmxtrans:latest");
             }
-            result.setImage(image);
+            result.image = image;
 
             if (jmxTransSpec.getTemplate() != null) {
                 JmxTransTemplate template = jmxTransSpec.getTemplate();
@@ -161,13 +161,9 @@ public class JmxTrans extends AbstractModel {
                     result.templateContainerSecurityContext = template.getContainer().getSecurityContext();
                 }
 
-                if (template.getServiceAccount() != null && template.getServiceAccount().getMetadata() != null) {
-                    result.templateServiceAccountLabels = template.getServiceAccount().getMetadata().getLabels();
-                    result.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
-                }
-
                 result.templateDeployment = template.getDeployment();
                 result.templatePod = template.getPod();
+                result.templateServiceAccount = template.getServiceAccount();
             }
 
             return result;
@@ -340,7 +336,7 @@ public class JmxTrans extends AbstractModel {
                 .withImage(getImage())
                 .withEnv(getEnvVars())
                 .withReadinessProbe(jmxTransReadinessProbe(readinessProbeOptions, cluster))
-                .withResources(getResources())
+                .withResources(resources)
                 .withVolumeMounts(getVolumeMounts())
                 .withImagePullPolicy(determineImagePullPolicy(imagePullPolicy, getImage()))
                 .withSecurityContext(securityProvider.jmxTransContainerSecurityContext(new ContainerSecurityProviderContextImpl(templateContainerSecurityContext)))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -145,12 +145,8 @@ public class KafkaConnectBuild extends AbstractModel {
                 }
             }
 
-            if (template.getBuildServiceAccount() != null && template.getBuildServiceAccount().getMetadata() != null) {
-                build.templateServiceAccountLabels = template.getBuildServiceAccount().getMetadata().getLabels();
-                build.templateServiceAccountAnnotations = template.getBuildServiceAccount().getMetadata().getAnnotations();
-            }
-
             build.templatePod = template.getBuildPod();
+            build.templateServiceAccount = template.getBuildServiceAccount();
         }
 
         build.build = spec.getBuild();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -122,14 +122,14 @@ public class KafkaExporter extends AbstractModel {
         if (spec != null) {
             KafkaExporter kafkaExporter = new KafkaExporter(reconciliation, kafkaAssembly);
 
-            kafkaExporter.setResources(spec.getResources());
+            kafkaExporter.resources = spec.getResources();
 
             if (spec.getReadinessProbe() != null) {
-                kafkaExporter.setReadinessProbe(spec.getReadinessProbe());
+                kafkaExporter.readinessProbeOptions = spec.getReadinessProbe();
             }
 
             if (spec.getLivenessProbe() != null) {
-                kafkaExporter.setLivenessProbe(spec.getLivenessProbe());
+                kafkaExporter.livenessProbeOptions = spec.getLivenessProbe();
             }
 
             kafkaExporter.groupRegex = spec.getGroupRegex();
@@ -140,7 +140,7 @@ public class KafkaExporter extends AbstractModel {
                 KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
                 image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE, versions.kafkaImage(kafkaClusterSpec.getImage(), versions.defaultVersion().version()));
             }
-            kafkaExporter.setImage(image);
+            kafkaExporter.image = image;
 
             kafkaExporter.logging = spec.getLogging();
             kafkaExporter.saramaLoggingEnabled = spec.getEnableSaramaLogging();
@@ -157,13 +157,9 @@ public class KafkaExporter extends AbstractModel {
                     }
                 }
 
-                if (template.getServiceAccount() != null && template.getServiceAccount().getMetadata() != null) {
-                    kafkaExporter.templateServiceAccountLabels = template.getServiceAccount().getMetadata().getLabels();
-                    kafkaExporter.templateServiceAccountAnnotations = template.getServiceAccount().getMetadata().getAnnotations();
-                }
-
                 kafkaExporter.templateDeployment = template.getDeployment();
                 kafkaExporter.templatePod = template.getPod();
+                kafkaExporter.templateServiceAccount = template.getServiceAccount();
             }
 
             kafkaExporter.version = versions.supportedVersion(kafkaAssembly.getSpec().getKafka().getVersion()).version();
@@ -226,7 +222,7 @@ public class KafkaExporter extends AbstractModel {
                 .withPorts(getContainerPortList())
                 .withLivenessProbe(ProbeGenerator.httpProbe(livenessProbeOptions, livenessPath, METRICS_PORT_NAME))
                 .withReadinessProbe(ProbeGenerator.httpProbe(readinessProbeOptions, readinessPath, METRICS_PORT_NAME))
-                .withResources(getResources())
+                .withResources(resources)
                 .withVolumeMounts(VolumeUtils.createTempDirVolumeMount(),
                         VolumeUtils.createVolumeMount(KAFKA_EXPORTER_CERTS_VOLUME_NAME, KAFKA_EXPORTER_CERTS_VOLUME_MOUNT),
                         VolumeUtils.createVolumeMount(CLUSTER_CA_CERTS_VOLUME_NAME, CLUSTER_CA_CERTS_VOLUME_MOUNT))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -98,7 +98,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         KafkaMirrorMaker2Cluster cluster = new KafkaMirrorMaker2Cluster(reconciliation, kafkaMirrorMaker2);
         KafkaMirrorMaker2Spec spec = kafkaMirrorMaker2.getSpec();
 
-        cluster.setImage(versions.kafkaMirrorMaker2Version(spec.getImage(), spec.getVersion()));
+        cluster.image = versions.kafkaMirrorMaker2Version(spec.getImage(), spec.getVersion());
 
         List<KafkaMirrorMaker2ClusterSpec> clustersList = ModelUtils.asListOrEmptyList(spec.getClusters());
         cluster.setClusters(clustersList);
@@ -302,7 +302,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_PASSWORDS_CLUSTERS, clustersOauthPasswords.toString()));
         }
 
-        ModelUtils.jvmSystemProperties(varList, getJvmOptions());
+        ModelUtils.jvmSystemProperties(varList, jvmOptions);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -591,7 +591,7 @@ public class ModelUtils {
      */
     public static void parseMetrics(AbstractModel model, HasConfigurableMetrics resourceWithMetrics)   {
         if (resourceWithMetrics.getMetricsConfig() != null)    {
-            model.setMetricsEnabled(true);
+            model.isMetricsEnabled = true;
             model.setMetricsConfigInCm(resourceWithMetrics.getMetricsConfig());
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceAccountUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceAccountUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.operator.common.model.Labels;
+
+/**
+ * Shared methods for working with Service Account
+ */
+public class ServiceAccountUtils {
+    /**
+     * Creates a Service Account
+     *
+     * @param name              Name of the Service Account
+     * @param namespace         Namespace of the Service Account
+     * @param labels            Labels of the Service Account
+     * @param ownerReference    OwnerReference of the Service Account
+     * @param template          Service Account template with user's custom configuration
+     *
+     * @return  New Service Account
+     */
+    public static ServiceAccount createServiceAccount(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            ResourceTemplate template
+    ) {
+        return new ServiceAccountBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withOwnerReferences(ownerReference)
+                    .withLabels(labels.withAdditionalLabels(TemplateUtils.labels(template)).toMap())
+                    .withAnnotations(TemplateUtils.annotations(template))
+                .endMetadata()
+                .build();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -75,9 +75,9 @@ public class AbstractModelTest {
                 .build();
 
         AbstractModel am = new Model(kafka);
-        am.setJvmOptions(opts);
+        am.jvmOptions = opts;
         List<EnvVar> envVars = new ArrayList<>(1);
-        ModelUtils.jvmPerformanceOptions(envVars, am.getJvmOptions());
+        ModelUtils.jvmPerformanceOptions(envVars, am.jvmOptions);
 
         if (!envVars.isEmpty()) {
             return envVars.get(0).getValue();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceAccountUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceAccountUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.strimzi.api.kafka.model.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.template.ResourceTemplateBuilder;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import io.strimzi.test.annotations.ParallelTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class ServiceAccountUtilsTest {
+    private final static String NAME = "my-sa";
+    private final static String NAMESPACE = "my-namespace";
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-name")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+
+    @ParallelTest
+    public void testServiceAccountCreationWithNullTemplate() {
+        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null);
+
+        assertThat(sa.getMetadata().getName(), is(NAME));
+        assertThat(sa.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sa.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(sa.getMetadata().getAnnotations(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testServiceAccountCreationWithEmptyTemplate() {
+        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, new ResourceTemplate());
+
+        assertThat(sa.getMetadata().getName(), is(NAME));
+        assertThat(sa.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sa.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(sa.getMetadata().getAnnotations(), is(nullValue()));
+    }
+
+    @ParallelTest
+    public void testServiceAccountCreationWithTemplate() {
+        ResourceTemplate template = new ResourceTemplateBuilder()
+                .withNewMetadata()
+                    .withLabels(Map.of("label-3", "value-3", "label-4", "value-4"))
+                    .withAnnotations(Map.of("anno-1", "value-1", "anno-2", "value-2"))
+                .endMetadata()
+                .build();
+
+        ServiceAccount sa = ServiceAccountUtils.createServiceAccount(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, template);
+
+        assertThat(sa.getMetadata().getName(), is(NAME));
+        assertThat(sa.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(sa.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(sa.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
+        assertThat(sa.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+    }
+}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues the refactoring of the `AbstractModel` and its subclasses. This PR
* Moves the Service Account creation to a separate utils class
* Removes some getters and setters which did not seem to add much value and were called only internally
* Creates new `AbstractStatefulModel` which stands in between `AbstractModel` and `KafkaCluster` and `ZooKeeperCluster` and wraps some things used only by these two classes such as storage handling or the model warnings.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally