### PR TITLE
Refactor network policy creation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -17,11 +17,8 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
@@ -59,12 +56,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE;
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS;
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_GOALS;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createConfigMapVolume;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createSecretVolume;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createVolumeMount;
-import static io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE;
 
 /**
  * Cruise Control model
@@ -545,56 +542,27 @@ public class CruiseControl extends AbstractModel {
      * @return The network policy.
      */
     public NetworkPolicy generateNetworkPolicy(String operatorNamespace, Labels operatorNamespaceLabels) {
-        List<NetworkPolicyIngressRule> rules = new ArrayList<>(1);
+        NetworkPolicyPeer clusterOperatorPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_KIND_LABEL, "cluster-operator"), NetworkPolicyUtils.clusterOperatorNamespaceSelector(namespace, operatorNamespace, operatorNamespaceLabels));
+
+        // List of network policy rules for all ports
+        List<NetworkPolicyIngressRule> rules = new ArrayList<>();
 
         // CO can access the REST API
-        NetworkPolicyIngressRule restApiRule = new NetworkPolicyIngressRuleBuilder()
-                .addNewPort()
-                    .withNewPort(REST_API_PORT)
-                    .withProtocol("TCP")
-                .endPort()
-                .build();
+        rules.add(NetworkPolicyUtils.createIngressRule(REST_API_PORT, List.of(clusterOperatorPeer)));
 
-        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
-                .withNewPodSelector() // cluster operator
-                .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, "cluster-operator")
-                .endPodSelector()
-                .build();
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
-
-        restApiRule.setFrom(Collections.singletonList(clusterOperatorPeer));
-
-        rules.add(restApiRule);
-
+        // Everyone can access metrics
         if (isMetricsEnabled) {
-            NetworkPolicyIngressRule metricsRule = new NetworkPolicyIngressRuleBuilder()
-                    .addNewPort()
-                        .withNewPort(METRICS_PORT)
-                        .withProtocol("TCP")
-                    .endPort()
-                    .withFrom()
-                    .build();
-
-            rules.add(metricsRule);
+            rules.add(NetworkPolicyUtils.createIngressRule(METRICS_PORT, List.of()));
         }
 
-        NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
-                .withNewMetadata()
-                    .withName(CruiseControlResources.networkPolicyName(cluster))
-                    .withNamespace(namespace)
-                    .withLabels(labels.toMap())
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewPodSelector()
-                        .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(cluster))
-                    .endPodSelector()
-                .withIngress(rules)
-                .endSpec()
-                .build();
-
-        LOGGER.traceCr(reconciliation, "Created network policy {}", networkPolicy);
-        return networkPolicy;
+        // Build the final network policy with all rules covering all the ports
+        return NetworkPolicyUtils.createNetworkPolicy(
+                CruiseControlResources.networkPolicyName(cluster),
+                namespace,
+                labels,
+                ownerReference,
+                rules
+        );
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -30,11 +30,8 @@ import io.fabric8.kubernetes.api.model.networking.v1.IngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressTLSBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleRef;
@@ -1675,122 +1672,46 @@ public class KafkaCluster extends AbstractModel {
      */
     public NetworkPolicy generateNetworkPolicy(String operatorNamespace, Labels operatorNamespaceLabels) {
         // Internal peers => Strimzi components which need access
-        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
-                .withNewPodSelector() // Cluster Operator
-                     .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, "cluster-operator")
-                .endPodSelector()
-                    .build();
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
-
-        NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeerBuilder()
-                .withNewPodSelector() // Kafka cluster
-                     .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(cluster))
-                .endPodSelector()
-                .build();
-
-        NetworkPolicyPeer entityOperatorPeer = new NetworkPolicyPeerBuilder()
-                .withNewPodSelector() // Entity Operator
-                     .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(cluster))
-                .endPodSelector()
-                .build();
-
-        NetworkPolicyPeer kafkaExporterPeer = new NetworkPolicyPeerBuilder()
-                .withNewPodSelector() // Kafka Exporter
-                     .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, KafkaExporterResources.deploymentName(cluster))
-                .endPodSelector()
-                .build();
-
-        NetworkPolicyPeer cruiseControlPeer = new NetworkPolicyPeerBuilder()
-                .withNewPodSelector() // Cruise Control
-                     .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(cluster))
-                .endPodSelector()
-                .build();
+        NetworkPolicyPeer clusterOperatorPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_KIND_LABEL, "cluster-operator"), NetworkPolicyUtils.clusterOperatorNamespaceSelector(namespace, operatorNamespace, operatorNamespaceLabels));
+        NetworkPolicyPeer kafkaClusterPeer = NetworkPolicyUtils.createPeer(labels.strimziSelectorLabels().toMap());
+        NetworkPolicyPeer entityOperatorPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(cluster)));
+        NetworkPolicyPeer kafkaExporterPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_NAME_LABEL, KafkaExporterResources.deploymentName(cluster)));
+        NetworkPolicyPeer cruiseControlPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_NAME_LABEL, CruiseControlResources.deploymentName(cluster)));
 
         // List of network policy rules for all ports
-        // Default size is number of listeners configured by the user + 4 (Control Plane listener, replication listener, metrics and JMX)
-        List<NetworkPolicyIngressRule> rules = new ArrayList<>(listeners.size() + 4);
+        List<NetworkPolicyIngressRule> rules = new ArrayList<>();
 
         // Control Plane rule covers the control plane listener.
         // Control plane listener is used by Kafka for internal coordination only
-        NetworkPolicyIngressRule controlPlaneRule = new NetworkPolicyIngressRuleBuilder()
-                .addNewPort()
-                .withNewPort(CONTROLPLANE_PORT)
-                .withProtocol("TCP")
-                .endPort()
-                .build();
-
-        controlPlaneRule.setFrom(List.of(kafkaClusterPeer));
-        rules.add(controlPlaneRule);
+        rules.add(NetworkPolicyUtils.createIngressRule(CONTROLPLANE_PORT, List.of(kafkaClusterPeer)));
 
         // Replication rule covers the replication listener.
         // Replication listener is used by Kafka but also by our own tools => Operators, Cruise Control, and Kafka Exporter
-        NetworkPolicyIngressRule replicationRule = new NetworkPolicyIngressRuleBuilder()
-                .addNewPort()
-                .withNewPort(REPLICATION_PORT)
-                .withProtocol("TCP")
-                .endPort()
-                .build();
-
-        replicationRule.setFrom(List.of(clusterOperatorPeer, kafkaClusterPeer, entityOperatorPeer, kafkaExporterPeer, cruiseControlPeer));
-        rules.add(replicationRule);
+        rules.add(NetworkPolicyUtils.createIngressRule(REPLICATION_PORT, List.of(clusterOperatorPeer, kafkaClusterPeer, entityOperatorPeer, kafkaExporterPeer, cruiseControlPeer)));
 
         // User-configured listeners are by default open for all. Users can pass peers in the Kafka CR.
         for (GenericKafkaListener listener : listeners) {
-            NetworkPolicyIngressRule plainRule = new NetworkPolicyIngressRuleBuilder()
-                    .addNewPort()
-                        .withNewPort(listener.getPort())
-                        .withProtocol("TCP")
-                    .endPort()
-                    .withFrom(listener.getNetworkPolicyPeers())
-                    .build();
-
-            rules.add(plainRule);
+            rules.add(NetworkPolicyUtils.createIngressRule(listener.getPort(), listener.getNetworkPolicyPeers()));
         }
 
         // The Metrics port (if enabled) is opened to all by default
         if (isMetricsEnabled) {
-            NetworkPolicyIngressRule metricsRule = new NetworkPolicyIngressRuleBuilder()
-                    .addNewPort()
-                        .withNewPort(METRICS_PORT)
-                        .withProtocol("TCP")
-                    .endPort()
-                    .withFrom()
-                    .build();
-
-            rules.add(metricsRule);
+            rules.add(NetworkPolicyUtils.createIngressRule(METRICS_PORT, List.of()));
         }
 
         // The JMX port (if enabled) is opened to all by default
         if (isJmxEnabled) {
-            NetworkPolicyIngressRule jmxRule = new NetworkPolicyIngressRuleBuilder()
-                    .addNewPort()
-                        .withNewPort(JMX_PORT)
-                        .withProtocol("TCP")
-                    .endPort()
-                    .withFrom()
-                    .build();
-
-            rules.add(jmxRule);
+            rules.add(NetworkPolicyUtils.createIngressRule(JMX_PORT, List.of()));
         }
 
         // Build the final network policy with all rules covering all the ports
-        NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
-                .withNewMetadata()
-                    .withName(KafkaResources.kafkaNetworkPolicyName(cluster))
-                    .withNamespace(namespace)
-                    .withLabels(labels.toMap())
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewPodSelector()
-                        .addToMatchLabels(Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(cluster))
-                    .endPodSelector()
-                    .withIngress(rules)
-                .endSpec()
-                .build();
-
-        LOGGER.traceCr(reconciliation, "Created network policy {}", networkPolicy);
-        return networkPolicy;
+        return NetworkPolicyUtils.createNetworkPolicy(
+                KafkaResources.kafkaNetworkPolicyName(cluster),
+                namespace,
+                labels,
+                ownerReference,
+                rules
+        );
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Service;
@@ -24,22 +25,18 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
-import io.strimzi.api.kafka.model.ClientTls;
 import io.strimzi.api.kafka.model.CertSecretSource;
+import io.strimzi.api.kafka.model.ClientTls;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
@@ -70,13 +67,12 @@ import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 
 import java.nio.charset.StandardCharsets;
-
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.Base64;
 
 import static io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE;
 
@@ -833,74 +829,33 @@ public class KafkaConnectCluster extends AbstractModel {
     public NetworkPolicy generateNetworkPolicy(boolean connectorOperatorEnabled,
                                                String operatorNamespace, Labels operatorNamespaceLabels) {
         if (connectorOperatorEnabled) {
-            List<NetworkPolicyIngressRule> rules = new ArrayList<>(2);
+            NetworkPolicyPeer clusterOperatorPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_KIND_LABEL, "cluster-operator"), NetworkPolicyUtils.clusterOperatorNamespaceSelector(namespace, operatorNamespace, operatorNamespaceLabels));
+            NetworkPolicyPeer connectPeer = NetworkPolicyUtils.createPeer(labels.strimziSelectorLabels().toMap());
 
-            // Give CO access to the REST API
-            NetworkPolicyIngressRule restApiRule = new NetworkPolicyIngressRuleBuilder()
-                    .addNewPort()
-                        .withNewPort(REST_API_PORT)
-                        .withProtocol("TCP")
-                    .endPort()
-                    .build();
+            // List of network policy rules for all ports
+            List<NetworkPolicyIngressRule> rules = new ArrayList<>();
 
-            // OCP 3.11 doesn't support network policies with the `from` section containing a namespace.
-            // Since the CO can run in a different namespace, we have to leave it wide open on OCP 3.11
-            // Therefore these rules are set only when using something else than OCP 3.11 and leaving
-            // the `from` section empty on 3.11
-            List<NetworkPolicyPeer> peers = new ArrayList<>(2);
+            // Give CO and Connect itself access to the REST API
+            rules.add(NetworkPolicyUtils.createIngressRule(REST_API_PORT, List.of(connectPeer, clusterOperatorPeer)));
 
-            // Other connect pods in the same cluster need to talk with each other over the REST API
-            NetworkPolicyPeer connectPeer = new NetworkPolicyPeerBuilder()
-                    .withNewPodSelector()
-                    .addToMatchLabels(getSelectorLabels().toMap())
-                    .endPodSelector()
-                    .build();
-            peers.add(connectPeer);
-
-            // CO needs to talk with the Connect pods to manage connectors
-            NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
-                    .withNewPodSelector()
-                    .addToMatchLabels(Labels.STRIMZI_KIND_LABEL, "cluster-operator")
-                    .endPodSelector()
-                    .build();
-            ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
-
-            peers.add(clusterOperatorPeer);
-
-            restApiRule.setFrom(peers);
-
-            rules.add(restApiRule);
-
-            // If metrics are enabled, we have to open them as well. Otherwise they will be blocked.
+            // The Metrics port (if enabled) is opened to all by default
             if (isMetricsEnabled) {
-                NetworkPolicyIngressRule metricsRule = new NetworkPolicyIngressRuleBuilder()
-                        .addNewPort()
-                            .withNewPort(METRICS_PORT)
-                            .withProtocol("TCP")
-                        .endPort()
-                        .withFrom()
-                        .build();
-
-                rules.add(metricsRule);
+                rules.add(NetworkPolicyUtils.createIngressRule(METRICS_PORT, List.of()));
             }
 
-            NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
-                    .withNewMetadata()
-                        .withName(componentName)
-                        .withNamespace(namespace)
-                        .withLabels(labels.toMap())
-                        .withOwnerReferences(ownerReference)
-                    .endMetadata()
-                    .withNewSpec()
-                        .withNewPodSelector()
-                            .addToMatchLabels(getSelectorLabels().toMap())
-                        .endPodSelector()
-                        .withIngress(rules)
-                    .endSpec()
-                    .build();
+            // The JMX port (if enabled) is opened to all by default
+            if (isJmxEnabled) {
+                rules.add(NetworkPolicyUtils.createIngressRule(JMX_PORT, List.of()));
+            }
 
-            LOGGER.traceCr(reconciliation, "Created network policy {}", networkPolicy);
-            return networkPolicy;
+            // Build the final network policy with all rules covering all the ports
+            return NetworkPolicyUtils.createNetworkPolicy(
+                    componentName,
+                    namespace,
+                    labels,
+                    ownerReference,
+                    rules
+            );
         } else {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
@@ -21,7 +20,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.HasConfigurableMetrics;
 import io.strimzi.api.kafka.model.JvmOptions;
@@ -553,34 +551,6 @@ public class ModelUtils {
                     .endNodeAffinity();
         }
         return builder;
-    }
-
-    /**
-     * Decides whether the Cluster Operator needs namespaceSelector to be configured in the network policies in order
-     * to talk with the operands. This follows the following rules:
-     *     - If it runs in the same namespace as the operand, do not set namespace selector
-     *     - If it runs in a different namespace, but user provided selector labels, use the labels
-     *     - If it runs in a different namespace, and user didn't provided selector labels, open it to COs in all namespaces
-     *
-     * @param peer                      Network policy peer where the namespace selector should be set
-     * @param operandNamespace          Namespace of the operand
-     * @param operatorNamespace         Namespace of the Strimzi CO
-     * @param operatorNamespaceLabels   Namespace labels provided by the user
-     */
-    public static void setClusterOperatorNetworkPolicyNamespaceSelector(NetworkPolicyPeer peer, String operandNamespace, String operatorNamespace, Labels operatorNamespaceLabels)   {
-        if (!operandNamespace.equals(operatorNamespace)) {
-            // If CO and the operand do not run in the same namespace, we need to handle cross namespace access
-
-            if (operatorNamespaceLabels != null && !operatorNamespaceLabels.toMap().isEmpty())    {
-                // If user specified the namespace labels, we can use them to make the network policy as tight as possible
-                LabelSelector nsLabelSelector = new LabelSelector();
-                nsLabelSelector.setMatchLabels(operatorNamespaceLabels.toMap());
-                peer.setNamespaceSelector(nsLabelSelector);
-            } else {
-                // If no namespace labels were specified, we open the network policy to COs in all namespaces
-                peer.setNamespaceSelector(new LabelSelector());
-            }
-        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NetworkPolicyUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NetworkPolicyUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared methods for working with Network Policies
+ */
+public class NetworkPolicyUtils {
+    /**
+     * Creates a Network Policy
+     *
+     * @param name              Name of the Network Policy
+     * @param namespace         Namespace of the Network Policy
+     * @param labels            Labels of the Network Policy
+     * @param ownerReference    OwnerReference of the Network Policy
+     * @param ingressRules      List of Ingress rules
+     *
+     * @return  New Network Policy
+     */
+    public static NetworkPolicy createNetworkPolicy(
+            String name,
+            String namespace,
+            Labels labels,
+            OwnerReference ownerReference,
+            List<NetworkPolicyIngressRule> ingressRules
+    ) {
+        return new NetworkPolicyBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withLabels(labels.toMap())
+                    .withOwnerReferences(ownerReference)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewPodSelector()
+                        .withMatchLabels(labels.strimziSelectorLabels().toMap())
+                    .endPodSelector()
+                    .withIngress(ingressRules)
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Creates Ingress Rule
+     *
+     * @param port      Port for which should this rule apply
+     * @param peers     Peers who can connect to this port
+     *
+     * @return  New Ingress Rule
+     */
+    public static NetworkPolicyIngressRule createIngressRule(int port, List<NetworkPolicyPeer> peers) {
+        return new NetworkPolicyIngressRuleBuilder()
+                .addNewPort()
+                    .withNewPort(port)
+                    .withProtocol("TCP")
+                .endPort()
+                .withFrom(peers)
+                .build();
+    }
+
+    /**
+     * Create Network Policy Peer with namespace selector
+     *
+     * @param podSelector           Labels matching the Peer
+     * @param namespaceSelector     Labels matching the Peer's namespace
+     *
+     * @return  New Network Policy Peer
+     */
+    public static NetworkPolicyPeer createPeer(Map<String, String> podSelector, LabelSelector namespaceSelector) {
+        return new NetworkPolicyPeerBuilder()
+                .withNewPodSelector()
+                    .withMatchLabels(podSelector)
+                .endPodSelector()
+                .withNamespaceSelector(namespaceSelector)
+                .build();
+    }
+
+    /**
+     * Create Network Policy Peer
+     *
+     * @param matchLabels   Labels matching the Peer
+     *
+     * @return  New Network Policy Peer
+     */
+    public static NetworkPolicyPeer createPeer(Map<String, String> matchLabels) {
+        return createPeer(matchLabels, null);
+    }
+
+    /**
+     * Decides whether the Cluster Operator needs namespaceSelector to be configured in the network policies in order
+     * to talk with the operands. This follows the following rules:
+     *     - If it runs in the same namespace as the operand, do not set namespace selector
+     *     - If it runs in a different namespace, but user provided selector labels, use the labels
+     *     - If it runs in a different namespace, and user didn't provide selector labels, open it to COs in all namespaces
+     *
+     * @param operandNamespace          Namespace of the operand
+     * @param operatorNamespace         Namespace of the Strimzi CO
+     * @param operatorNamespaceLabels   Namespace labels provided by the user
+     *
+     * @return  Label selector for selecting the namespace from which the access should be allowed or null if not selector is set.
+     */
+    public static LabelSelector clusterOperatorNamespaceSelector(String operandNamespace, String operatorNamespace, Labels operatorNamespaceLabels)   {
+        if (!operandNamespace.equals(operatorNamespace)) {
+            // If CO and the operand do not run in the same namespace, we need to handle cross namespace access
+
+            if (operatorNamespaceLabels != null && !operatorNamespaceLabels.toMap().isEmpty())    {
+                // If user specified the namespace labels, we can use them to make the network policy as tight as possible
+                return new LabelSelectorBuilder().withMatchLabels(operatorNamespaceLabels.toMap()).build();
+            } else {
+                // If no namespace labels were specified, we open the network policy to COs in all namespaces by returning empty map => selector which match everything
+                return new LabelSelector();
+            }
+        } else {
+            // They are in the dame namespace => we do not want to set any namespace selector and allow communication only within the same namespace
+            return null;
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -10,8 +10,6 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -22,22 +20,19 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRuleBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPort;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.ContainerEnvVar;
 import io.strimzi.api.kafka.model.InlineLogging;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPassword;
-import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.Probe;
 import io.strimzi.api.kafka.model.ProbeBuilder;
+import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.ZookeeperClusterSpec;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.storage.Storage;
@@ -338,112 +333,40 @@ public class ZookeeperCluster extends AbstractModel {
      * @return The network policy.
      */
     public NetworkPolicy generateNetworkPolicy(String operatorNamespace, Labels operatorNamespaceLabels) {
-        List<NetworkPolicyIngressRule> rules = new ArrayList<>(2);
+        // Internal peers => Strimzi components which need access
+        NetworkPolicyPeer clusterOperatorPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_KIND_LABEL, "cluster-operator"), NetworkPolicyUtils.clusterOperatorNamespaceSelector(namespace, operatorNamespace, operatorNamespaceLabels));
+        NetworkPolicyPeer zookeeperClusterPeer = NetworkPolicyUtils.createPeer(labels.strimziSelectorLabels().toMap());
+        NetworkPolicyPeer kafkaClusterPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(cluster)));
+        NetworkPolicyPeer entityOperatorPeer = NetworkPolicyUtils.createPeer(Map.of(Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(cluster)));
 
-        NetworkPolicyPort clientsPort = new NetworkPolicyPort();
-        clientsPort.setPort(new IntOrString(CLIENT_TLS_PORT));
-        clientsPort.setProtocol("TCP");
-
-        NetworkPolicyPort clusteringPort = new NetworkPolicyPort();
-        clusteringPort.setPort(new IntOrString(CLUSTERING_PORT));
-        clusteringPort.setProtocol("TCP");
-
-        NetworkPolicyPort leaderElectionPort = new NetworkPolicyPort();
-        leaderElectionPort.setPort(new IntOrString(LEADER_ELECTION_PORT));
-        leaderElectionPort.setProtocol("TCP");
-
-        NetworkPolicyPeer zookeeperClusterPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector2 = new LabelSelector();
-        Map<String, String> expressions2 = new HashMap<>(1);
-        expressions2.put(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(cluster));
-        labelSelector2.setMatchLabels(expressions2);
-        zookeeperClusterPeer.setPodSelector(labelSelector2);
+        // List of network policy rules for all ports
+        List<NetworkPolicyIngressRule> rules = new ArrayList<>();
 
         // Zookeeper only ports - 2888 & 3888 which need to be accessed by the Zookeeper cluster members only
-        NetworkPolicyIngressRule zookeeperClusteringIngressRule = new NetworkPolicyIngressRuleBuilder()
-                .withPorts(clusteringPort, leaderElectionPort)
-                .withFrom(zookeeperClusterPeer)
-                .build();
-
-        rules.add(zookeeperClusteringIngressRule);
+        rules.add(NetworkPolicyUtils.createIngressRule(CLUSTERING_PORT, List.of(zookeeperClusterPeer)));
+        rules.add(NetworkPolicyUtils.createIngressRule(LEADER_ELECTION_PORT, List.of(zookeeperClusterPeer)));
 
         // Clients port - needs to be access from outside the Zookeeper cluster as well
-        NetworkPolicyIngressRule clientsIngressRule = new NetworkPolicyIngressRuleBuilder()
-                .withPorts(clientsPort)
-                .withFrom()
-                .build();
+        rules.add(NetworkPolicyUtils.createIngressRule(CLIENT_TLS_PORT, List.of(kafkaClusterPeer, zookeeperClusterPeer, entityOperatorPeer, clusterOperatorPeer)));
 
-        NetworkPolicyPeer kafkaClusterPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector = new LabelSelector();
-        Map<String, String> expressions = new HashMap<>(1);
-        expressions.put(Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(cluster));
-        labelSelector.setMatchLabels(expressions);
-        kafkaClusterPeer.setPodSelector(labelSelector);
-
-        NetworkPolicyPeer entityOperatorPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector3 = new LabelSelector();
-        Map<String, String> expressions3 = new HashMap<>(1);
-        expressions3.put(Labels.STRIMZI_NAME_LABEL, KafkaResources.entityOperatorDeploymentName(cluster));
-        labelSelector3.setMatchLabels(expressions3);
-        entityOperatorPeer.setPodSelector(labelSelector3);
-
-        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeer();
-        LabelSelector labelSelector4 = new LabelSelector();
-        Map<String, String> expressions4 = new HashMap<>(1);
-        expressions4.put(Labels.STRIMZI_KIND_LABEL, "cluster-operator");
-        labelSelector4.setMatchLabels(expressions4);
-        clusterOperatorPeer.setPodSelector(labelSelector4);
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(clusterOperatorPeer, namespace, operatorNamespace, operatorNamespaceLabels);
-
-        // This is a hack because we have no guarantee that the CO namespace has some particular labels
-        List<NetworkPolicyPeer> clientsPortPeers = new ArrayList<>(4);
-        clientsPortPeers.add(kafkaClusterPeer);
-        clientsPortPeers.add(zookeeperClusterPeer);
-        clientsPortPeers.add(entityOperatorPeer);
-        clientsPortPeers.add(clusterOperatorPeer);
-        clientsIngressRule.setFrom(clientsPortPeers);
-
-        rules.add(clientsIngressRule);
-
+        // The Metrics port (if enabled) is opened to all by default
         if (isMetricsEnabled) {
-            NetworkPolicyIngressRule metricsRule = new NetworkPolicyIngressRuleBuilder()
-                    .addNewPort()
-                        .withNewPort(METRICS_PORT)
-                        .withProtocol("TCP")
-                    .endPort()
-                    .withFrom()
-                    .build();
-
-            rules.add(metricsRule);
+            rules.add(NetworkPolicyUtils.createIngressRule(METRICS_PORT, List.of()));
         }
 
+        // The JMX port (if enabled) is opened to all by default
         if (isJmxEnabled) {
-            NetworkPolicyPort jmxPort = new NetworkPolicyPort();
-            jmxPort.setPort(new IntOrString(JMX_PORT));
-
-            NetworkPolicyIngressRule jmxRule = new NetworkPolicyIngressRuleBuilder()
-                    .withPorts(jmxPort)
-                    .withFrom()
-                    .build();
-
-            rules.add(jmxRule);
+            rules.add(NetworkPolicyUtils.createIngressRule(JMX_PORT, List.of()));
         }
 
-        NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
-                .withNewMetadata()
-                    .withName(KafkaResources.zookeeperNetworkPolicyName(cluster))
-                    .withNamespace(namespace)
-                    .withLabels(labels.toMap())
-                    .withOwnerReferences(ownerReference)
-                .endMetadata()
-                .withNewSpec()
-                    .withPodSelector(labelSelector2)
-                    .withIngress(rules)
-                .endSpec()
-                .build();
-
-        LOGGER.traceCr(reconciliation, "Created network policy {}", networkPolicy);
-        return networkPolicy;
+        // Build the final network policy with all rules covering all the ports
+        return NetworkPolicyUtils.createNetworkPolicy(
+                KafkaResources.zookeeperNetworkPolicyName(cluster),
+                namespace,
+                labels,
+                ownerReference,
+                rules
+        );
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2351,7 +2351,7 @@ public class KafkaClusterTest {
     public void testControlPlanePortNetworkPolicy() {
         NetworkPolicyPeer kafkaBrokersPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
-                    .withMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(CLUSTER)))
+                    .withMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(CLUSTER)))
                 .endPodSelector()
                 .build();
 
@@ -2372,7 +2372,7 @@ public class KafkaClusterTest {
     public void testReplicationPortNetworkPolicy() {
         NetworkPolicyPeer kafkaBrokersPeer = new NetworkPolicyPeerBuilder()
                 .withNewPodSelector()
-                    .withMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(CLUSTER)))
+                    .withMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaStatefulSetName(CLUSTER)))
                 .endPodSelector()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -14,7 +14,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -25,7 +24,6 @@ import io.strimzi.api.kafka.model.storage.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
-import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 import org.junit.jupiter.api.Test;
@@ -36,8 +34,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.Util.parseMap;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -190,31 +186,6 @@ public class ModelUtilsTest {
         assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedSecret), is(true));
         assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleUpSecret), is(true));
         assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleDownSecret), is(true));
-    }
-
-    @ParallelTest
-    public void testCONetworkPolicyPeerNamespaceSelectorSameNS()  {
-        NetworkPolicyPeer peer = new NetworkPolicyPeer();
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-ns", null);
-        assertThat(peer.getNamespaceSelector(), is(nullValue()));
-    }
-
-    @ParallelTest
-    public void testCONetworkPolicyPeerNamespaceSelectorDifferentNSNoLabels()  {
-        NetworkPolicyPeer peer = new NetworkPolicyPeer();
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", null);
-        assertThat(peer.getNamespaceSelector().getMatchLabels(), is(Map.of()));
-
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", Labels.fromMap(emptyMap()));
-        assertThat(peer.getNamespaceSelector().getMatchLabels(), is(Map.of()));
-    }
-
-    @ParallelTest
-    public void testCONetworkPolicyPeerNamespaceSelectorDifferentNSWithLabels()  {
-        NetworkPolicyPeer peer = new NetworkPolicyPeer();
-        Labels nsLabels = Labels.fromMap(singletonMap("labelKey", "labelValue"));
-        ModelUtils.setClusterOperatorNetworkPolicyNamespaceSelector(peer, "my-ns", "my-operator-ns", nsLabels);
-        assertThat(peer.getNamespaceSelector().getMatchLabels(), is(nsLabels.toMap()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NetworkPolicyUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NetworkPolicyUtilsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.annotations.ParallelSuite;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ParallelSuite
+public class NetworkPolicyUtilsTest {
+    private final static String NAME = "my-np";
+    private final static String NAMESPACE = "my-namespace";
+    private static final OwnerReference OWNER_REFERENCE = new OwnerReferenceBuilder()
+            .withApiVersion("v1")
+            .withKind("my-kind")
+            .withName("my-name")
+            .withUid("my-uid")
+            .withBlockOwnerDeletion(false)
+            .withController(false)
+            .build();
+    private static final Labels LABELS = Labels
+            .forStrimziKind("my-kind")
+            .withStrimziName("my-name")
+            .withStrimziCluster("my-cluster")
+            .withStrimziComponentType("my-component-type")
+            .withAdditionalLabels(Map.of("label-1", "value-1", "label-2", "value-2"));
+
+    @Test
+    public void testNetworkPolicy() {
+        List<NetworkPolicyIngressRule> rules = List.of(
+                NetworkPolicyUtils.createIngressRule(1234, List.of(NetworkPolicyUtils.createPeer(Map.of("key", "peer1")))),
+                NetworkPolicyUtils.createIngressRule(5678, List.of(NetworkPolicyUtils.createPeer(Map.of("key", "peer2"))))
+        );
+
+        NetworkPolicy np = NetworkPolicyUtils.createNetworkPolicy(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, rules);
+
+        assertThat(np.getMetadata().getName(), is(NAME));
+        assertThat(np.getMetadata().getNamespace(), is(NAMESPACE));
+        assertThat(np.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
+        assertThat(np.getMetadata().getLabels(), is(LABELS.toMap()));
+        assertThat(np.getSpec().getPodSelector().getMatchLabels(), is(LABELS.strimziSelectorLabels().toMap()));
+        assertThat(np.getSpec().getIngress(), is(rules));
+    }
+
+    @Test
+    public void testCreateRule()   {
+        NetworkPolicyIngressRule rule = NetworkPolicyUtils.createIngressRule(1234, List.of(NetworkPolicyUtils.createPeer(Map.of("key", "peer1"))));
+        assertThat(rule.getPorts().size(), is(1));
+        assertThat(rule.getPorts().get(0).getPort().getIntVal(), is(1234));
+        assertThat(rule.getPorts().get(0).getProtocol(), is("TCP"));
+        assertThat(rule.getFrom().size(), is(1));
+        assertThat(rule.getFrom().get(0), is(NetworkPolicyUtils.createPeer(Map.of("key", "peer1"))));
+    }
+
+    @Test
+    public void testCreatePeerWithPodLabelsAndNullNamespaceSelector()   {
+        NetworkPolicyPeer peer = NetworkPolicyUtils.createPeer(Map.of("labelKey", "labelValue"), null);
+        assertThat(peer.getNamespaceSelector(), is(nullValue()));
+        assertThat(peer.getPodSelector().getMatchLabels(), is(Map.of("labelKey", "labelValue")));
+    }
+
+    @Test
+    public void testCreatePeerWithPodLabelsAndEmptyNamespaceSelector()   {
+        NetworkPolicyPeer peer = NetworkPolicyUtils.createPeer(Map.of("labelKey", "labelValue"), new LabelSelectorBuilder().withMatchLabels(Map.of()).build());
+        assertThat(peer.getNamespaceSelector().getMatchLabels(), is(Map.of()));
+        assertThat(peer.getPodSelector().getMatchLabels(), is(Map.of("labelKey", "labelValue")));
+    }
+
+    @Test
+    public void testCreatePeerWithPodLabelsAndNamespaceSelector()   {
+        NetworkPolicyPeer peer = NetworkPolicyUtils.createPeer(Map.of("labelKey", "labelValue"), new LabelSelectorBuilder().withMatchLabels(Map.of("nsLabelKey", "nsLabelValue")).build());
+        assertThat(peer.getNamespaceSelector().getMatchLabels(), is(Map.of("nsLabelKey", "nsLabelValue")));
+        assertThat(peer.getPodSelector().getMatchLabels(), is(Map.of("labelKey", "labelValue")));
+    }
+
+    @Test
+    public void testCreatePeerWithPodLabels()   {
+        NetworkPolicyPeer peer = NetworkPolicyUtils.createPeer(Map.of("labelKey", "labelValue"));
+        assertThat(peer.getNamespaceSelector(), is(nullValue()));
+        assertThat(peer.getPodSelector().getMatchLabels(), is(Map.of("labelKey", "labelValue")));
+    }
+
+    @Test
+    public void testCreatePeerWithEmptyLabels()   {
+        NetworkPolicyPeer peer = NetworkPolicyUtils.createPeer(Map.of());
+        assertThat(peer.getNamespaceSelector(), is(nullValue()));
+        assertThat(peer.getPodSelector().getMatchLabels(), is(Map.of()));
+    }
+
+    @Test
+    public void testClusterOperatorNamespaceSelector()  {
+        assertThat(NetworkPolicyUtils.clusterOperatorNamespaceSelector("my-ns", "my-ns", null), is(nullValue()));
+        assertThat(NetworkPolicyUtils.clusterOperatorNamespaceSelector("my-ns", "my-operator-ns", null).getMatchLabels(), is(Map.of()));
+        assertThat(NetworkPolicyUtils.clusterOperatorNamespaceSelector("my-ns", "my-operator-ns", Labels.EMPTY).getMatchLabels(), is(Map.of()));
+        assertThat(NetworkPolicyUtils.clusterOperatorNamespaceSelector("my-ns", "my-operator-ns", Labels.fromMap(Map.of("labelKey", "labelValue"))).getMatchLabels(), is(Map.of("labelKey", "labelValue")));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -578,25 +578,34 @@ public class ZookeeperClusterTest {
         NetworkPolicy np = zc.generateNetworkPolicy("operator-namespace", null);
 
         LabelSelector podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(zc.getCluster())));
+        podSelector.setMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(np.getSpec().getPodSelector(), is(podSelector));
 
         List<NetworkPolicyIngressRule> rules = np.getSpec().getIngress();
-        assertThat(rules.size(), is(3));
+        assertThat(rules.size(), is(4));
 
-        // Ports 2888 and 3888
+        // Ports 2888
         NetworkPolicyIngressRule zooRule = rules.get(0);
-        assertThat(zooRule.getPorts().size(), is(2));
+        assertThat(zooRule.getPorts().size(), is(1));
         assertThat(zooRule.getPorts().get(0).getPort(), is(new IntOrString(2888)));
-        assertThat(zooRule.getPorts().get(1).getPort(), is(new IntOrString(3888)));
 
         assertThat(zooRule.getFrom().size(), is(1));
         podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(zc.getCluster())));
+        podSelector.setMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(zooRule.getFrom().get(0), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
+        // Ports 3888
+        NetworkPolicyIngressRule zooRule2 = rules.get(1);
+        assertThat(zooRule2.getPorts().size(), is(1));
+        assertThat(zooRule2.getPorts().get(0).getPort(), is(new IntOrString(3888)));
+
+        assertThat(zooRule2.getFrom().size(), is(1));
+        podSelector = new LabelSelector();
+        podSelector.setMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(CLUSTER)));
+        assertThat(zooRule2.getFrom().get(0), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
+
         // Port 2181
-        NetworkPolicyIngressRule clientsRule = rules.get(1);
+        NetworkPolicyIngressRule clientsRule = rules.get(2);
         assertThat(clientsRule.getPorts().size(), is(1));
         assertThat(clientsRule.getPorts().get(0).getPort(), is(new IntOrString(ZookeeperCluster.CLIENT_TLS_PORT)));
 
@@ -607,7 +616,7 @@ public class ZookeeperClusterTest {
         assertThat(clientsRule.getFrom().get(0), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         podSelector = new LabelSelector();
-        podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(zc.getCluster())));
+        podSelector.setMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(clientsRule.getFrom().get(1), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         podSelector = new LabelSelector();
@@ -619,7 +628,7 @@ public class ZookeeperClusterTest {
         assertThat(clientsRule.getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(new LabelSelector()).build()));
 
         // Port 9404
-        NetworkPolicyIngressRule metricsRule = rules.get(2);
+        NetworkPolicyIngressRule metricsRule = rules.get(3);
         assertThat(metricsRule.getPorts().size(), is(1));
         assertThat(metricsRule.getPorts().get(0).getPort(), is(new IntOrString(9404)));
         assertThat(metricsRule.getFrom().size(), is(0));
@@ -628,13 +637,13 @@ public class ZookeeperClusterTest {
         np = zc.generateNetworkPolicy(NAMESPACE, null);
         podSelector = new LabelSelector();
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
-        assertThat(np.getSpec().getIngress().get(1).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
+        assertThat(np.getSpec().getIngress().get(2).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         // Check Network Policies => The same namespace with namespace labels
         np = zc.generateNetworkPolicy(NAMESPACE, Labels.fromMap(Collections.singletonMap("nsLabelKey", "nsLabelValue")));
         podSelector = new LabelSelector();
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
-        assertThat(np.getSpec().getIngress().get(1).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
+        assertThat(np.getSpec().getIngress().get(2).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).build()));
 
         // Check Network Policies => Other namespace with namespace labels
         np = zc.generateNetworkPolicy("operator-namespace", Labels.fromMap(Collections.singletonMap("nsLabelKey", "nsLabelValue")));
@@ -642,7 +651,7 @@ public class ZookeeperClusterTest {
         podSelector.setMatchLabels(Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator"));
         LabelSelector namespaceSelector = new LabelSelector();
         namespaceSelector.setMatchLabels(Collections.singletonMap("nsLabelKey", "nsLabelValue"));
-        assertThat(np.getSpec().getIngress().get(1).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(namespaceSelector).build()));
+        assertThat(np.getSpec().getIngress().get(2).getFrom().get(3), is(new NetworkPolicyPeerBuilder().withPodSelector(podSelector).withNamespaceSelector(namespaceSelector).build()));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors how the network policies are created in the `AbstractModel` subclasses. It does not affect the `AbstractModel` class itself. But it creates a new class `NetworkPolicyUtils` which has the methods for generating the Network Policies and its components. These are then called from the different model classes using network policies instead of each of them having to generate everything form scratch.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally