### PR TITLE
Add truststore configuration for HTTPS connections to OPA server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.0
 
 * Use JDK HTTP client in the Kubernetes client instead of the OkHttp client
+* Add truststore configuration for HTTPS connections to OPA server
 
 ## 0.33.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationOpa.java
@@ -23,7 +23,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({"type", "url", "allowOnError", "initialCacheCapacity", "maximumCacheSize", "expireAfterMs", "superUsers"})
+@JsonPropertyOrder({"type", "url", "allowOnError", "initialCacheCapacity", "maximumCacheSize", "expireAfterMs", "tlsTrustedCertificates", "superUsers"})
 @EqualsAndHashCode
 public class KafkaAuthorizationOpa extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
@@ -39,6 +39,7 @@ public class KafkaAuthorizationOpa extends KafkaAuthorization {
     private int maximumCacheSize = 50000;
     private long expireAfterMs = 3600000;
     private boolean enableMetrics = false;
+    private List<CertSecretSource> tlsTrustedCertificates;
 
     @Description("Must be `" + TYPE_OPA + "`")
     @Override
@@ -137,5 +138,15 @@ public class KafkaAuthorizationOpa extends KafkaAuthorization {
 
     public void setEnableMetrics(boolean enableMetrics) {
         this.enableMetrics = enableMetrics;
+    }
+
+    @Description("Trusted certificates for TLS connection to the OPA server.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<CertSecretSource> getTlsTrustedCertificates() {
+        return tlsTrustedCertificates;
+    }
+
+    public void setTlsTrustedCertificates(List<CertSecretSource> tlsTrustedCertificates) {
+        this.tlsTrustedCertificates = tlsTrustedCertificates;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -636,6 +636,7 @@ public class KafkaBrokerConfigurationBuilder {
      * @param authorization The authorization configuration from the Kafka CR
      * @param useKRaft      Use KRaft mode in the configuration
      */
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     private void configureAuthorization(String clusterName, List<String> superUsers, KafkaAuthorization authorization, boolean useKRaft) {
         if (KafkaAuthorizationSimple.TYPE_SIMPLE.equals(authorization.getType())) {
             KafkaAuthorizationSimple simpleAuthz = (KafkaAuthorizationSimple) authorization;
@@ -661,6 +662,12 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println(String.format("%s=%d", "opa.authorizer.cache.initial.capacity", opaAuthz.getInitialCacheCapacity()));
             writer.println(String.format("%s=%d", "opa.authorizer.cache.maximum.size", opaAuthz.getMaximumCacheSize()));
             writer.println(String.format("%s=%d", "opa.authorizer.cache.expire.after.seconds", Duration.ofMillis(opaAuthz.getExpireAfterMs()).getSeconds()));
+
+            if (opaAuthz.getTlsTrustedCertificates() != null && opaAuthz.getTlsTrustedCertificates().size() > 0)    {
+                writer.println("opa.authorizer.truststore.path=/tmp/kafka/authz-opa.truststore.p12");
+                writer.println("opa.authorizer.truststore.password=" + PLACEHOLDER_CERT_STORE_PASSWORD);
+                writer.println("opa.authorizer.truststore.type=PKCS12");
+            }
 
             // User configured super users
             if (opaAuthz.getSuperUsers() != null && opaAuthz.getSuperUsers().size() > 0) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -383,7 +383,7 @@ public class KafkaBrokerConfigurationBuilderTest {
             .build();
 
         assertThat(configuration, isEquivalent("authorizer.class.name=org.openpolicyagent.kafka.OpaAuthorizer\n" +
-            "opa.authorizer.url=http://opa:8181/v1/data/kafka/allow\n" +
+            "opa.authorizer.url=https://opa:8181/v1/data/kafka/allow\n" +
             "opa.authorizer.allow.on.error=true\n" +
             "opa.authorizer.metrics.enabled=false\n" +
             "opa.authorizer.cache.initial.capacity=1000\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1059,9 +1059,9 @@ public class KafkaClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> "STRIMZI_PLAIN_9092_OAUTH_CLIENT_SECRET".equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-secret-key"));
 
         // Volume mounts
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-0"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/second-certificate-1"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-2"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-0"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/second-certificate-1"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-2"));
 
         // Volumes
         List<Volume> volumes = kc.getNonDataVolumes(false, false, null);
@@ -1172,17 +1172,17 @@ public class KafkaClusterTest {
         assertThat(cont.getEnv().stream().filter(var -> "STRIMZI_EXTERNAL_9094_OAUTH_CLIENT_SECRET".equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-secret-key"));
 
         // Volume mounts
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-0"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/second-certificate-1"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-2"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-0"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/second-certificate-1"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-plain-9092-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-plain-9092-certs/first-certificate-2"));
 
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-tls-9093-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-tls-9093-certs/first-certificate-0"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-tls-9093-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-tls-9093-certs/second-certificate-1"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-tls-9093-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-tls-9093-certs/first-certificate-2"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-tls-9093-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-tls-9093-certs/first-certificate-0"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-tls-9093-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-tls-9093-certs/second-certificate-1"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-tls-9093-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-tls-9093-certs/first-certificate-2"));
 
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-external-9094-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-external-9094-certs/first-certificate-0"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-external-9094-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-external-9094-certs/second-certificate-1"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-external-9094-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-external-9094-certs/first-certificate-2"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-external-9094-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-external-9094-certs/first-certificate-0"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-external-9094-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-external-9094-certs/second-certificate-1"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-external-9094-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/oauth-external-9094-certs/first-certificate-2"));
 
         // Volumes
         List<Volume> volumes = kc.getNonDataVolumes(false, false, null);
@@ -1401,8 +1401,8 @@ public class KafkaClusterTest {
 
         // Volume mounts
         Container cont = kc.getContainers(null).get(0);
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "authz-keycloak-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/first-certificate-0"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "authz-keycloak-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.OAUTH_TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/second-certificate-1"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "authz-keycloak-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/first-certificate-0"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "authz-keycloak-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.TRUSTED_CERTS_BASE_VOLUME_MOUNT + "/authz-keycloak-certs/second-certificate-1"));
 
         // Volumes
         List<Volume> volumes = kc.getNonDataVolumes(false, false, null);

--- a/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -70,6 +70,23 @@ for CRT in /opt/kafka/client-ca-certs/*.crt; do
 done
 echo "Preparing truststore for client authentication is complete"
 
+AUTHZ_OPA_DIR="/opt/kafka/certificates/authz-opa-certs"
+AUTHZ_OPA_STORE="/tmp/kafka/authz-opa.truststore.p12"
+rm -f "$AUTHZ_OPA_STORE"
+if [ -d "$AUTHZ_OPA_DIR" ]; then
+  echo "Preparing truststore for Authorization with OPA"
+
+  # Add each certificate to the trust store
+  declare -i INDEX=0
+  for CRT in "$AUTHZ_OPA_DIR"/**/*; do
+    ALIAS="authz-opa-${INDEX}"
+    echo "Adding $CRT to truststore $AUTHZ_OPA_STORE with alias $ALIAS"
+    create_truststore "$AUTHZ_OPA_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+    INDEX+=1
+  done
+  echo "Preparing truststore for Authorization with OPA is complete"
+fi
+
 AUTHZ_KEYCLOAK_DIR="/opt/kafka/certificates/authz-keycloak-certs"
 AUTHZ_KEYCLOAK_STORE="/tmp/kafka/authz-keycloak.truststore.p12"
 rm -f "$AUTHZ_KEYCLOAK_STORE"

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationOpa.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationOpa.adoc
@@ -26,6 +26,9 @@ Defines how often the cached authorization decisions are reloaded from the Open 
 In milliseconds.
 Defaults to `3600000` milliseconds (1 hour).
 
+=== `tlsTrustedCertificates`
+Trusted certificates for TLS connection to the OPA server.
+
 === `superUsers`
 A list of user principals treated as super users, so that they are always allowed without querying the open Policy Agent policy.
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -564,22 +564,24 @@ The `type` property is a discriminator that distinguishes use of the `KafkaAutho
 It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 [options="header"]
 |====
-|Property                     |Description
-|type                  1.2+<.<a|Must be `opa`.
+|Property                      |Description
+|type                   1.2+<.<a|Must be `opa`.
 |string
-|url                   1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
+|url                    1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
 |string
-|allowOnError          1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
+|allowOnError           1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
 |boolean
-|initialCacheCapacity  1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
+|initialCacheCapacity   1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
 |integer
-|maximumCacheSize      1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
+|maximumCacheSize       1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
 |integer
-|expireAfterMs         1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
+|expireAfterMs          1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
 |integer
-|superUsers            1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
+|tlsTrustedCertificates 1.2+<.<a|Trusted certificates for TLS connection to the OPA server.
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
+|superUsers             1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
 |string array
-|enableMetrics         1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
+|enableMetrics          1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -564,24 +564,22 @@ The `type` property is a discriminator that distinguishes use of the `KafkaAutho
 It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 [options="header"]
 |====
-|Property                      |Description
-|type                   1.2+<.<a|Must be `opa`.
+|Property                     |Description
+|type                  1.2+<.<a|Must be `opa`.
 |string
-|url                    1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
+|url                   1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
 |string
-|allowOnError           1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
+|allowOnError          1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
 |boolean
-|initialCacheCapacity   1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
+|initialCacheCapacity  1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
 |integer
-|maximumCacheSize       1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
+|maximumCacheSize      1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
 |integer
-|expireAfterMs          1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
+|expireAfterMs         1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
 |integer
-|tlsTrustedCertificates 1.2+<.<a|Trusted certificates for TLS connection to the OPA server.
-|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
-|superUsers             1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
+|superUsers            1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
 |string array
-|enableMetrics          1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
+|enableMetrics         1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -270,7 +270,7 @@ Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenti
 [id='type-CertSecretSource-{context}']
 ### `CertSecretSource` schema reference
 
-Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
+Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`], xref:type-KafkaAuthorizationOpa-{context}[`KafkaAuthorizationOpa`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
 
 
 [options="header"]
@@ -564,22 +564,24 @@ The `type` property is a discriminator that distinguishes use of the `KafkaAutho
 It must have the value `opa` for the type `KafkaAuthorizationOpa`.
 [options="header"]
 |====
-|Property                     |Description
-|type                  1.2+<.<a|Must be `opa`.
+|Property                       |Description
+|type                    1.2+<.<a|Must be `opa`.
 |string
-|url                   1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
+|url                     1.2+<.<a|The URL used to connect to the Open Policy Agent server. The URL has to include the policy which will be queried by the authorizer. This option is required.
 |string
-|allowOnError          1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
+|allowOnError            1.2+<.<a|Defines whether a Kafka client should be allowed or denied by default when the authorizer fails to query the Open Policy Agent, for example, when it is temporarily unavailable). Defaults to `false` - all actions will be denied.
 |boolean
-|initialCacheCapacity  1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
+|initialCacheCapacity    1.2+<.<a|Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
 |integer
-|maximumCacheSize      1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
+|maximumCacheSize        1.2+<.<a|Maximum capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request. Defaults to `50000`.
 |integer
-|expireAfterMs         1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
+|expireAfterMs           1.2+<.<a|The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
 |integer
-|superUsers            1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
+|tlsTrustedCertificates  1.2+<.<a|Trusted certificates for TLS connection to the OPA server.
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
+|superUsers              1.2+<.<a|List of super users, which is specifically a list of user principals that have unlimited access rights.
 |string array
-|enableMetrics         1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
+|enableMetrics           1.2+<.<a|Defines whether the Open Policy Agent authorizer plugin should provide metrics. Defaults to `false`.
 |boolean
 |====
 


### PR DESCRIPTION
Type of change
Enhancement / new feature
Description
Add truststore configuration for HTTPS connections to OPA server

Checklist
Related issue: https://github.com/strimzi/strimzi-kafka-operator/issues/8001