### PR TITLE
docs(listeners): Updates procedures for creating nodeport and loadbalancer listeners

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-client-access.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-client-access.adoc
@@ -19,5 +19,8 @@ include::../../modules/deploying/proc-deploy-setup-external-clients.adoc[levelof
 //access through external listeners
 include::../../modules/security/proc-accessing-kafka-using-nodeports.adoc[leveloffset=+1]
 include::../../modules/security/proc-accessing-kafka-using-loadbalancers.adoc[leveloffset=+1]
+//Kubernetes only
+ifdef::Section[]
 include::../../modules/security/proc-accessing-kafka-using-ingress.adoc[leveloffset=+1]
+endif::Section[]
 include::../../modules/security/proc-accessing-kafka-using-routes.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -199,7 +199,7 @@ xref:scaling-clusters-{context}[scale clusters].
 <8> Listeners configure how clients connect to the Kafka cluster via bootstrap addresses. Listeners are xref:type-GenericKafkaListener-reference[configured as _internal_ or _external_ listeners for connection from inside or outside the Kubernetes cluster].
 <9> Name to identify the listener. Must be unique within the Kafka cluster.
 <10> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
-<11> Listener type specified as `internal` or `cluster-ip` (to expose Kafka using per-broker `ClusterIP` services), or for external listeners, as `route`, `loadbalancer`, `nodeport` or `ingress`.
+<11> Listener type specified as `internal` or `cluster-ip` (to expose Kafka using per-broker `ClusterIP` services), or for external listeners, as `route` (OpenShift only), `loadbalancer`, `nodeport` or `ingress` (Kubernetes only).
 <12> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners.
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism xref:type-GenericKafkaListener-reference[specified as mTLS, SCRAM-SHA-512, or token-based OAuth 2.0].

--- a/documentation/modules/deploying/con-accessing-kafka-bridge-from-outside.adoc
+++ b/documentation/modules/deploying/con-accessing-kafka-bridge-from-outside.adoc
@@ -13,9 +13,9 @@ If you want to make the Kafka Bridge accessible to applications running outside 
 
 * `LoadBalancer` or `NodePort` type services
 
-* `Ingress` resources
+* `Ingress` resources (Kubernetes only)
 
-* OpenShift routes
+* OpenShift routes (OpenShift only)
 
 If you decide to create Services, use the labels from the `selector` of the `_<kafka_bridge_name>_-bridge-service` service to configure the pods to which the service will route the traffic:
 

--- a/documentation/modules/deploying/con-exposing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-exposing-kafka-connect-api.adoc
@@ -41,9 +41,9 @@ If you want to make the Kafka Connect API accessible to applications running out
 
 * `LoadBalancer` or `NodePort` type services
 
-* `Ingress` resources
+* `Ingress` resources (Kubernetes only)
 
-* OpenShift routes
+* OpenShift routes (OpenShift only)
 
 NOTE: The connection is insecure, so allow external access advisedly.
 

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -90,7 +90,7 @@ spec:
 <1> Configuration options for enabling external listeners are described in the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[Generic Kafka listener schema reference^].
 <2> Name to identify the listener. Must be unique within the Kafka cluster.
 <3> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
-<4> External listener type specified as `route`, `loadbalancer`, `nodeport` or `ingress`. An internal listener is specified as `internal` or `cluster-ip`.
+<4> External listener type specified as `route` (OpenShift only), `loadbalancer`, `nodeport` or `ingress` (Kubernetes only). An internal listener is specified as `internal` or `cluster-ip`.
 <5> Required. TLS encryption on the listener. For `route` and `ingress` type listeners it must be set to `true`. For mTLS authentication, also use the `authentication` property. 
 <6> Client authentication mechanism on the listener. For server and client authentication using mTLS, you specify `tls: true` and `authentication.type: tls`. 
 <7> (Optional) Depending on the requirements of the listener type, you can specify additional link:{BookURLConfiguring}#type-GenericKafkaListenerConfiguration-reference[listener configuration^].

--- a/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
@@ -96,7 +96,7 @@ In this example, we assume the name of the secret is `credential-keycloak`.
 
 . Log in to the Admin Console with the username `admin` and the password you obtained.
 +
-Use `https://__HOSTNAME__` to access the Kubernetes ingress.
+Use `https://__HOSTNAME__` to access the Kubernetes `Ingress`.
 +
 You can now upload the example realm to Keycloak using the Admin Console.
 
@@ -175,7 +175,7 @@ STOREPASS=storepass
 echo "Q" | openssl s_client -showcerts -connect $SSO_HOST_PORT 2>/dev/null | awk ' /BEGIN CERTIFICATE/,/END CERTIFICATE/ { print $0 } ' > /tmp/sso.pem
 ----
 +
-The certificate is required as Kubernetes ingress is used to make a secure (HTTPS) connection.
+The certificate is required as Kubernetes `Ingress` is used to make a secure (HTTPS) connection.
 +
 Usually there is not one single certificate, but a certificate chain. You only have to provide the top-most issuer CA, which is listed last in the `/tmp/sso.pem` file.
 You can extract it manually or using the following commands:

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -23,7 +23,7 @@ External listeners::
 +
 * `nodeport` to use ports on Kubernetes nodes
 * `loadbalancer` to use loadbalancer services
-* `ingress` to use Kubernetes Ingress and the {NginxIngressController} (Kubernetes only)
+* `ingress` to use Kubernetes `Ingress` and the {NginxIngressController} (Kubernetes only)
 * `route` to use OpenShift `Route` and the default HAProxy router (OpenShift only)
 
 IMPORTANT: Do not use `ingress` on OpenShift, use the `route` type instead. The Ingress NGINX Controller is only intended for use on Kubernetes. The `route` type is only supported on OpenShift.

--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -13,7 +13,7 @@ For clients inside the Kubernetes cluster, you can create `plain` (without encry
 The `internal` listener type use a headless service and the DNS names given to the broker pods. 
 As an alternative to the headless service, you can also create a `cluster-ip` type of internal listener to expose Kafka using per-broker `ClusterIP` services.
 For clients outside the Kubernetes cluster, you create _external_ listeners and specify a connection mechanism,
-which can be `nodeport`, `loadbalancer`, `ingress`, or `route` (on OpenShift).
+which can be `nodeport`, `loadbalancer`, `ingress` (Kubernetes only), or `route` (OpenShift only).
 
 For more information on the configuration options for connecting an external client, see xref:deploy-client-access-{context}[].
 

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -13,7 +13,7 @@ When applied, the configuration creates a dedicated ingress and service for an e
 Clients connect to the bootstrap ingress, which routes them through the bootstrap service to connect to a broker. 
 Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific ingresses and services.
 
-To connect to a broker, you specify a hostname for the ingress bootstrap address, as well as the TLS certificate used for authentication.
+To connect to a broker, you specify a hostname for the ingress bootstrap address, as well as the certificate used for TLS encryption.
 For access using an ingress, the port used in the Kafka client is typically 443.
 
 The procedure shows basic `ingress` listener configuration.

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -13,10 +13,19 @@ When applied, the configuration creates a dedicated ingress and service for an e
 Clients connect to the bootstrap ingress, which routes them through the bootstrap service to connect to a broker. 
 Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific ingresses and services.
 
-To connect to a broker, you specify a hostname for the ingress bootstrap address, as well as the TLS certificate.
-Authentication is optional.
+IMPORTANT: The Ingress NGINX Controller for Kubernetes is not supported on OpenShift. 
+For Strimzi on OpenShift, use route listeners instead.
 
+To connect to a broker, you specify a hostname for the ingress bootstrap address, as well as the TLS certificate used for authentication.
 For access using an ingress, the port used in the Kafka client is typically 443.
+
+The procedure shows basic `ingress` listener configuration.
+TLS encryption (`tls`) must be enabled.
+You can also specify a client authentication mechanism (`authentication`).
+Add additional configuration using `configuration` properties.
+For example, you can use the `class` configuration property with `ingress` listeners to specify the ingress controller used.   
+
+For more information on listener configuration, see the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference^].
 
 .TLS passthrough
 
@@ -37,6 +46,7 @@ For more information about enabling TLS passthrough, see the {NginxIngressContro
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
+The name of the listener is `external`.
 
 .Procedure
 
@@ -150,7 +160,7 @@ kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | ba
 
 .. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
 +
-If you enabled any authentication, you will also need to configure it in your client.
+If you enabled a client authentication mechanism, you will also need to configure it in your client.
 
 NOTE: If you are using your own listener certificates, check whether you need to add the CA certificate to the client's truststore configuration. 
 If it is a public (external) CA, you usually won't need to add it.

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -13,9 +13,6 @@ When applied, the configuration creates a dedicated ingress and service for an e
 Clients connect to the bootstrap ingress, which routes them through the bootstrap service to connect to a broker. 
 Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific ingresses and services.
 
-IMPORTANT: The Ingress NGINX Controller for Kubernetes is not supported on OpenShift. 
-For Strimzi on OpenShift, use route listeners instead.
-
 To connect to a broker, you specify a hostname for the ingress bootstrap address, as well as the TLS certificate used for authentication.
 For access using an ingress, the port used in the Kafka client is typically 443.
 

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 Use loadbalancers to access a Strimzi Kafka cluster from an external client outside the Kubernetes cluster.
 
-To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the TLS certificate used for authentication.
+To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the certificate used for TLS encryption.
 
 The procedure shows basic `loadbalancer` listener configuration.
 You can use listener properties to enable TLS encryption (`tls`) and specify a client authentication mechanism (`authentication`).

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -5,15 +5,28 @@
 [id='proc-accessing-kafka-using-loadbalancers-{context}']
 = Accessing Kafka using loadbalancers
 
-This procedure describes how to access a Strimzi Kafka cluster from an external client using loadbalancers.
+[role="_abstract"]
+Use loadbalancers to access a Strimzi Kafka cluster from an external client outside the Kubernetes cluster.
 
-To connect to a broker, you need the address of the _bootstrap loadbalancer_,
-as well as the certificate used for TLS encryption.
+To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the TLS certificate used for authentication.
+
+The procedure shows basic `loadbalancer` listener configuration.
+You can use listener properties to enable TLS encryption (`tls`) and specify a client authentication mechanism (`authentication`).
+Add additional configuration using `configuration` properties.
+For example, you can use the following configuration properties with `loadbalancer` listeners:
+
+`loadBalancerSourceRanges`:: Restricts traffic to a specified list of CIDR (Classless Inter-Domain Routing) ranges.  
+`externalTrafficPolicy`:: Specifies whether the service routes external traffic to node-local or cluster-wide endpoints.
+`loadBalancerIP`:: Requests a specific IP address when creating a loadbalancer.
+
+For more information on listener configuration, see the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference^].
 
 .Prerequisites
 
-* A Kubernetes cluster
 * A running Cluster Operator
+
+In this procedure, the Kafka cluster name is `my-cluster`.
+The name of the listener is `external2`.
 
 .Procedure
 
@@ -25,14 +38,21 @@ For example:
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
 spec:
   kafka:
     # ...
     listeners:
-      - name: external
-        port: 9094
+      - name: external2
+        port: 9095
         type: loadbalancer
         tls: true
+        authentication:
+          type: tls
         # ...
     # ...
   zookeeper:
@@ -44,26 +64,92 @@ spec:
 [source,shell,subs=+quotes]
 kubectl apply -f _<kafka_configuration_file>_
 +
-`loadbalancer` type services and loadbalancers are created for each Kafka broker, as well as an external _bootstrap service_.
-The bootstrap service routes external traffic to all Kafka brokers.
-DNS names and IP addresses used for connection are propagated to the `status` of each service.
+A cluster CA certificate to verify the identity of the kafka brokers is also created in the secret `my-cluster-cluster-ca-cert`.
 +
-The cluster CA certificate to verify the identity of the kafka brokers is also created in the secret `_<cluster_name>_-cluster-ca-cert`.
+`loadbalancer` type services and loadbalancers are created for each Kafka broker, as well as an external bootstrap service.
++
+.Loadbalancer services and loadbalancers created for the bootstraps and brokers
+[source,shell]
+----
+NAME                                  TYPE              CLUSTER-IP     PORT(S)
+my-cluster-kafka-external2-0          LoadBalancer     172.30.204.234  9095:30011/TCP
+my-cluster-kafka-external2-1          LoadBalancer     172.30.164.89   9095:32544/TCP 
+my-cluster-kafka-external2-2          LoadBalancer     172.30.73.151   9095:32504/TCP
+my-cluster-kafka-external2-bootstrap  LoadBalancer     172.30.30.228   9095:30371/TCP
 
-. Retrieve the address of the bootstrap service you can use to access the Kafka cluster from the status of the `Kafka` resource.
+NAME                                  EXTERNAL-IP (loadbalancer)
+my-cluster-kafka-external2-0          a8a519e464b924000b6c0f0a05e19f0d-1132975133.us-west-2.elb.amazonaws.com
+my-cluster-kafka-external2-1          ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com 
+my-cluster-kafka-external2-2          a9173e8ccb1914778aeb17eca98713c0-777597560.us-west-2.elb.amazonaws.com
+my-cluster-kafka-external2-bootstrap  ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com
+----
 +
-[source,shell,subs=+quotes]
-kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
+The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
 +
-For example:
+.Example status for the bootstrap address
+[source,yaml]
+----
+status:
+  clusterId: Y_RJQDGKRXmNF7fEcWldJQ
+  conditions:
+    - lastTransitionTime: '2023-01-31T14:59:37.113630Z'
+      status: 'True'
+      type: Ready
+  listeners:
+    # ...
+    - addresses:
+        - host: >-
+            a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com
+          port: 9095
+      bootstrapServers: >-
+        a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095
+      certificates:
+        - |
+          -----BEGIN CERTIFICATE-----
+          
+          -----END CERTIFICATE-----
+      name: external1
+      type: external1
+  observedGeneration: 2
+ # ...
+----
 +
-[source,shell,subs=+quotes]
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
+The DNS addresses used for client connection are propagated to the `status` of each loadbalancer service.
++
+.Example status for the bootstrap loadbalancer
+[source,yaml]
+----
+status:
+  loadBalancer:
+    ingress:
+      - hostname: >-
+          a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com
+ # ...
+----
 
-. If TLS encryption is enabled, extract the public certificate of the broker certification authority.
+. Retrieve the bootstrap address you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external2")].bootstrapServers}{"\n"}'
+
+a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095
+----
+
+. Extract the cluster CA certificate.
 +
-Use the extracted certificate in your Kafka client to configure the TLS connection.
-If you enabled any authentication, you will also need to configure it in your client.
+[source,shell]
+----
+kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+
+. Configure your client to connect to the brokers.
+
+.. Specify the bootstrap host and port in your Kafka client as the bootstrap address to connect to the Kafka cluster. For example, `a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095`.
+
+.. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
++
+If you enabled a client authentication mechanism, you will also need to configure it in your client.
+
+NOTE: If you are using your own listener certificates, check whether you need to add the CA certificate to the client's truststore configuration. 
+If it is a public (external) CA, you usually won't need to add it.

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -26,7 +26,7 @@ For more information on listener configuration, see the link:{BookURLConfiguring
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `external2`.
+The name of the listener is `external`.
 
 .Procedure
 
@@ -47,7 +47,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external2
+      - name: external
         port: 9095
         type: loadbalancer
         tls: true
@@ -71,17 +71,17 @@ A cluster CA certificate to verify the identity of the kafka brokers is also cre
 .Loadbalancer services and loadbalancers created for the bootstraps and brokers
 [source,shell]
 ----
-NAME                                  TYPE              CLUSTER-IP     PORT(S)
-my-cluster-kafka-external2-0          LoadBalancer     172.30.204.234  9095:30011/TCP
-my-cluster-kafka-external2-1          LoadBalancer     172.30.164.89   9095:32544/TCP 
-my-cluster-kafka-external2-2          LoadBalancer     172.30.73.151   9095:32504/TCP
-my-cluster-kafka-external2-bootstrap  LoadBalancer     172.30.30.228   9095:30371/TCP
+NAME                                  TYPE            CLUSTER-IP      PORT(S)
+my-cluster-kafka-external-0          LoadBalancer     172.30.204.234  9095:30011/TCP
+my-cluster-kafka-external-1          LoadBalancer     172.30.164.89   9095:32544/TCP 
+my-cluster-kafka-external-2          LoadBalancer     172.30.73.151   9095:32504/TCP
+my-cluster-kafka-external-bootstrap  LoadBalancer     172.30.30.228   9095:30371/TCP
 
-NAME                                  EXTERNAL-IP (loadbalancer)
-my-cluster-kafka-external2-0          a8a519e464b924000b6c0f0a05e19f0d-1132975133.us-west-2.elb.amazonaws.com
-my-cluster-kafka-external2-1          ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com 
-my-cluster-kafka-external2-2          a9173e8ccb1914778aeb17eca98713c0-777597560.us-west-2.elb.amazonaws.com
-my-cluster-kafka-external2-bootstrap  ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com
+NAME                                 EXTERNAL-IP (loadbalancer)
+my-cluster-kafka-external-0          a8a519e464b924000b6c0f0a05e19f0d-1132975133.us-west-2.elb.amazonaws.com
+my-cluster-kafka-external-1          ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com 
+my-cluster-kafka-external-2          a9173e8ccb1914778aeb17eca98713c0-777597560.us-west-2.elb.amazonaws.com
+my-cluster-kafka-external-bootstrap  a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com
 ----
 +
 The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
@@ -108,8 +108,8 @@ status:
           -----BEGIN CERTIFICATE-----
           
           -----END CERTIFICATE-----
-      name: external1
-      type: external1
+      name: external
+      type: external
   observedGeneration: 2
  # ...
 ----
@@ -131,7 +131,7 @@ status:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external2")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
 
 a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095
 ----

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 Use node ports to access a Strimzi Kafka cluster from an external client outside the Kubernetes cluster.
 
-To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the TLS certificate used for authentication.
+To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the certificate used for TLS encryption.
 
 The procedure shows basic `nodeport` listener configuration.
 You can use listener properties to enable TLS encryption (`tls`) and specify a client authentication mechanism (`authentication`).

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -26,7 +26,7 @@ For more information on listener configuration, see the link:{BookURLConfiguring
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `external1`.
+The name of the listener is `external`.
 
 .Procedure
 
@@ -47,7 +47,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external1
+      - name: external
         port: 9094
         type: nodeport
         tls: true
@@ -72,10 +72,10 @@ A cluster CA certificate to verify the identity of the kafka brokers is created 
 [source,shell]
 ----
 NAME                                 TYPE      CLUSTER-IP      PORT(S)               
-my-cluster-kafka-external1-0         NodePort  172.30.55.13    9094:31789/TCP
-my-cluster-kafka-external1-1         NodePort  172.30.250.248  9094:30028/TCP
-my-cluster-kafka-external1-2         NodePort  172.30.115.81   9094:32650/TCP
-my-cluster-kafka-external1-bootstrap NodePort  172.30.30.23    9094:32650/TCP
+my-cluster-kafka-external-0          NodePort  172.30.55.13    9094:31789/TCP
+my-cluster-kafka-external-1          NodePort  172.30.250.248  9094:30028/TCP
+my-cluster-kafka-external-2          NodePort  172.30.115.81   9094:32650/TCP
+my-cluster-kafka-external-bootstrap  NodePort  172.30.30.23    9094:32650/TCP
 ----
 +
 The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
@@ -100,8 +100,8 @@ status:
           -----BEGIN CERTIFICATE-----
           
           -----END CERTIFICATE-----
-      name: external1
-      type: external1
+      name: external
+      type: external
   observedGeneration: 2
  # ...
 ----
@@ -110,7 +110,7 @@ status:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external1")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
 
 ip-10-0-224-199.us-west-2.compute.internal:32650
 ----

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -5,15 +5,28 @@
 [id='proc-accessing-kafka-using-nodeports-{context}']
 = Accessing Kafka using node ports
 
-This procedure describes how to access a Strimzi Kafka cluster from an external client using node ports.
+[role="_abstract"]
+Use node ports to access a Strimzi Kafka cluster from an external client outside the Kubernetes cluster.
 
-To connect to a broker, you need a hostname and port number for the Kafka _bootstrap address_,
-as well as the certificate used for authentication.
+To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the TLS certificate used for authentication.
+
+The procedure shows basic `nodeport` listener configuration.
+You can use listener properties to enable TLS encryption (`tls`) and specify a client authentication mechanism (`authentication`).
+Add additional configuration using `configuration` properties.
+For example, you can use the following configuration properties with `nodeport` listeners:
+
+`preferredNodePortAddressType`:: Specifies the first address type that's checked as the node address. 
+`externalTrafficPolicy`:: Specifies whether the service routes external traffic to node-local or cluster-wide endpoints.
+`nodePort`:: Overrides the assigned node port numbers for the bootstrap and broker services.
+
+For more information on listener configuration, see the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference^].
 
 .Prerequisites
 
-* A Kubernetes cluster
 * A running Cluster Operator
+
+In this procedure, the Kafka cluster name is `my-cluster`.
+The name of the listener is `external1`.
 
 .Procedure
 
@@ -25,11 +38,16 @@ For example:
 ----
 apiVersion: {KafkaApiVersion}
 kind: Kafka
+metadata:
+  labels:
+    app: my-cluster
+  name: my-cluster
+  namespace: myproject
 spec:
   kafka:
     # ...
     listeners:
-      - name: external
+      - name: external1
         port: 9094
         type: nodeport
         tls: true
@@ -46,26 +64,72 @@ spec:
 [source,shell,subs=+quotes]
 kubectl apply -f _<kafka_configuration_file>_
 +
-`NodePort` type services are created for each Kafka broker, as well as an external _bootstrap service_.
-The bootstrap service routes external traffic to the Kafka brokers.
-Node addresses used for connection are propagated to the `status` of the Kafka custom resource.
+A cluster CA certificate to verify the identity of the kafka brokers is created in the secret `my-cluster-cluster-ca-cert`.
 +
-The cluster CA certificate to verify the identity of the kafka brokers is also created in the secret `_<cluster_name>_-cluster-ca-cert`.
+`NodePort` type services are created for each Kafka broker, as well as an external bootstrap service.
++
+.Node port services created for the bootstrap and brokers
+[source,shell]
+----
+NAME                                 TYPE      CLUSTER-IP      PORT(S)               
+my-cluster-kafka-external1-0         NodePort  172.30.55.13    9094:31789/TCP
+my-cluster-kafka-external1-1         NodePort  172.30.250.248  9094:30028/TCP
+my-cluster-kafka-external1-2         NodePort  172.30.115.81   9094:32650/TCP
+my-cluster-kafka-external1-bootstrap NodePort  172.30.30.23    9094:32650/TCP
+----
++
+The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
++
+.Example status for the bootstrap address
+[source,yaml]
+----
+status:
+  clusterId: Y_RJQDGKRXmNF7fEcWldJQ
+  conditions:
+    - lastTransitionTime: '2023-01-31T14:59:37.113630Z'
+      status: 'True'
+      type: Ready
+  listeners:
+    # ...
+    - addresses:
+        - host: ip-10-0-224-199.us-west-2.compute.internal
+          port: 32650
+      bootstrapServers: 'ip-10-0-224-199.us-west-2.compute.internal:32650'
+      certificates:
+        - |
+          -----BEGIN CERTIFICATE-----
+          
+          -----END CERTIFICATE-----
+      name: external1
+      type: external1
+  observedGeneration: 2
+ # ...
+----
 
 . Retrieve the bootstrap address you can use to access the Kafka cluster from the status of the `Kafka` resource.
 +
 [source,shell,subs=+quotes]
-kubectl get kafka _<kafka_cluster_name>_ -o=jsonpath='{.status.listeners[?(@.name=="_<listener_name>_")].bootstrapServers}{"\n"}'
-+
-For example:
-+
-[source,shell,subs=+quotes]
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
+----
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external1")].bootstrapServers}{"\n"}'
 
-. If TLS encryption is enabled, extract the public certificate of the broker certification authority.
+ip-10-0-224-199.us-west-2.compute.internal:32650
+----
+
+. Extract the cluster CA certificate.
 +
-[source,shell,subs=+quotes]
-kubectl get secret _KAFKA-CLUSTER-NAME_-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+[source,shell]
+----
+kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+
+. Configure your client to connect to the brokers.
+
+.. Specify the bootstrap host and port in your Kafka client as the bootstrap address to connect to the Kafka cluster. For example, `ip-10-0-224-199.us-west-2.compute.internal:32650`.
+
+.. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
 +
-Use the extracted certificate in your Kafka client to configure TLS connection.
-If you enabled any authentication, you will also need to configure it in your client.
+If you enabled a client authentication mechanism, you will also need to configure it in your client.
+
+NOTE: If you are using your own listener certificates, check whether you need to add the CA certificate to the client's truststore configuration. 
+If it is a public (external) CA, you usually won't need to add it.
+

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -13,12 +13,19 @@ When applied, the configuration creates a dedicated route and service for an ext
 Clients connect to the bootstrap route, which routes them through the bootstrap service to connect to a broker. 
 Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific routes and services.
 
-To connect to a broker, you specify a hostname for the route bootstrap address, as well as the certificate used for authentication.
-
+To connect to a broker, you specify a hostname for the route bootstrap address, as well as the TLS certificate used for authentication.
 For access using routes, the port is always 443.
 
 WARNING: An OpenShift route address comprises the name of the Kafka cluster, the name of the listener, and the name of the project it is created in.
 For example, `my-cluster-kafka-listener1-bootstrap-myproject` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
+
+The procedure shows basic listener configuration.
+TLS encryption (`tls`) must be enabled.
+You can also specify a client authentication mechanism (`authentication`).
+Add additional configuration using `configuration` properties.
+For example, you can use the `host` configuration property with `route` listeners to specify the hostnames used by the bootstrap and per-broker services.   
+
+For more information on listener configuration, see the link:{BookURLConfiguring}#type-GenericKafkaListener-reference[`GenericKafkaListener` schema reference^].
 
 .TLS passthrough
 
@@ -36,6 +43,7 @@ To configure listeners to use your own listener certificates, xref:proc-installi
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
+The name of the listener is `listener1`.
 
 .Procedure
 
@@ -60,6 +68,8 @@ spec:
         port: 9094
         type: route
         tls: true # <1>
+        authentication:
+          type: tls
         # ...
     # ...
   zookeeper:
@@ -147,9 +157,7 @@ kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | ba
 
 .. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
 +
-If you enabled any authentication, you will also need to configure it in your client.
+If you enabled a client authentication mechanism, you will also need to configure it in your client.
 
 NOTE: If you are using your own listener certificates, check whether you need to add the CA certificate to the client's truststore configuration. 
 If it is a public (external) CA, you usually won't need to add it.
-
-

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -17,7 +17,7 @@ To connect to a broker, you specify a hostname for the route bootstrap address, 
 For access using routes, the port is always 443.
 
 WARNING: An OpenShift route address comprises the name of the Kafka cluster, the name of the listener, and the name of the project it is created in.
-For example, `my-cluster-kafka-listener1-bootstrap-myproject` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
+For example, `my-cluster-kafka-external-bootstrap-myproject` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
 
 The procedure shows basic listener configuration.
 TLS encryption (`tls`) must be enabled.
@@ -43,7 +43,7 @@ To configure listeners to use your own listener certificates, xref:proc-installi
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `listener1`.
+The name of the listener is `external`.
 
 .Procedure
 
@@ -64,7 +64,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: listener1
+      - name: external
         port: 9094
         type: route
         tls: true # <1>
@@ -96,10 +96,10 @@ The routes are preconfigured with TLS passthrough.
 [source,shell]
 ----
 NAME                                  HOST/PORT                                                   SERVICES                              PORT  TERMINATION
-my-cluster-kafka-listener1-0          my-cluster-kafka-listener1-0-my-project.router.com          my-cluster-kafka-listener1-0          9094  passthrough
-my-cluster-kafka-listener1-1          my-cluster-kafka-listener1-1-my-project.router.com          my-cluster-kafka-listener1-1          9094  passthrough
-my-cluster-kafka-listener1-2          my-cluster-kafka-listener1-2-my-project.router.com          my-cluster-kafka-listener1-2          9094  passthrough
-my-cluster-kafka-listener1-bootstrap  my-cluster-kafka-listener1-bootstrap-my-project.router.com  my-cluster-kafka-listener1-bootstrap  9094  passthrough
+my-cluster-kafka-external-0          my-cluster-kafka-external-0-my-project.router.com          my-cluster-kafka-external-0          9094  passthrough
+my-cluster-kafka-external-1          my-cluster-kafka-external-1-my-project.router.com          my-cluster-kafka-external-1          9094  passthrough
+my-cluster-kafka-external-2          my-cluster-kafka-external-2-my-project.router.com          my-cluster-kafka-external-2          9094  passthrough
+my-cluster-kafka-external-bootstrap  my-cluster-kafka-external-bootstrap-my-project.router.com  my-cluster-kafka-external-bootstrap  9094  passthrough
 ----
 +
 The DNS addresses used for client connection are propagated to the `status` of each route.
@@ -110,7 +110,7 @@ The DNS addresses used for client connection are propagated to the `status` of e
 status:
   ingress:
     - host: >-
-        my-cluster-kafka-listener1-bootstrap-my-project.router.com
+        my-cluster-kafka-external-bootstrap-my-project.router.com
  # ...
 ----
 
@@ -118,7 +118,7 @@ status:
 +
 [source,shell]
 ----
-openssl s_client -connect my-cluster-kafka-listener1-0-my-project.router.com:443 -servername my-cluster-kafka-listener1-0-my-project.router.com -showcerts
+openssl s_client -connect my-cluster-kafka-external-0-my-project.router.com:443 -servername my-cluster-kafka-external-0-my-project.router.com -showcerts
 ----
 +
 The server name is the SNI for passing the connection to the broker. 
@@ -137,9 +137,9 @@ Certificate chain
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="listener1")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
 
-my-cluster-kafka-listener1-bootstrap-my-project.router.com:443
+my-cluster-kafka-external-bootstrap-my-project.router.com:443
 ----
 +
 The address comprises the cluster name, the listener name, the project name and the domain of the router (`router.com` in this example).

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -13,7 +13,7 @@ When applied, the configuration creates a dedicated route and service for an ext
 Clients connect to the bootstrap route, which routes them through the bootstrap service to connect to a broker. 
 Per-broker connections are then established using DNS names, which route traffic from the client to the broker through the broker-specific routes and services.
 
-To connect to a broker, you specify a hostname for the route bootstrap address, as well as the TLS certificate used for authentication.
+To connect to a broker, you specify a hostname for the route bootstrap address, as well as the certificate used for TLS encryption.
 For access using routes, the port is always 443.
 
 WARNING: An OpenShift route address comprises the name of the Kafka cluster, the name of the listener, and the name of the project it is created in.


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**

- Updates the steps and examples for listener procedures: Accessing Kafka using node ports and Accessing Kafka using loadbalancers (following recent changes to the related procedures for ingress and route listeners https://github.com/strimzi/strimzi-kafka-operator/pull/7842)
- Includes references to type-specific listener configuration
- Makes more clear that ingress listeners are for Strimzi on Kubernetes and route listeners are for Strimzi on OpenShift

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

