### PR TITLE
docs(tuning): Moves Kafka tuning content

### DIFF
--- a/documentation/assemblies/managing/assembly-tuning-config.adoc
+++ b/documentation/assemblies/managing/assembly-tuning-config.adoc
@@ -21,9 +21,9 @@ For more information about Apache Kafka configuration properties, see the {kafka
 
 The following tools help with Kafka tuning:
 
-* xref:cruise-control-concepts-str[Cruise Control] generates optimization proposals that you can use to assess and implement a cluster rebalance
-* xref:proc-setting-broker-limits-str[Kafka Static Quota plugin] sets limits on brokers
-* xref:type-Rack-reference[Rack configuration] spreads broker partitions across racks and allows consumers to fetch data from the nearest replica
+* Cruise Control generates optimization proposals that you can use to assess and implement a cluster rebalance
+* Kafka Static Quota plugin sets limits on brokers
+* Rack configuration spreads broker partitions across racks and allows consumers to fetch data from the nearest replica
 
 //Tips to optimize the performance of brokers, and producer and consumer clients
 include::../../modules/managing/con-managed-broker-config-properties.adoc[leveloffset=+1]

--- a/documentation/configuring/configuring.adoc
+++ b/documentation/configuring/configuring.adoc
@@ -16,8 +16,6 @@ include::assemblies/configuring/assembly-external-config.adoc[leveloffset=+1]
 //security context for all pods
 include::assemblies/configuring/assembly-security-providers.adoc[leveloffset=+1]
 
-
-
 include::assemblies/operators/assembly-operators.adoc[leveloffset=+1]
 
 include::assemblies/cruise-control/assembly-cruise-control-concepts.adoc[leveloffset=+1]
@@ -25,8 +23,6 @@ include::assemblies/cruise-control/assembly-cruise-control-concepts.adoc[levelof
 include::assemblies/security/assembly-security.adoc[leveloffset=+1]
 
 include::assemblies/managing/assembly-management-tasks.adoc[leveloffset=+1]
-
-include::assemblies/managing/assembly-tuning-config.adoc[leveloffset=+1]
 
 [id='api_reference-{context}']
 :parent-context: {context}

--- a/documentation/deploying/deploying.adoc
+++ b/documentation/deploying/deploying.adoc
@@ -34,5 +34,7 @@ include::assemblies/upgrading/assembly-upgrade.adoc[leveloffset=+1]
 include::assemblies/upgrading/assembly-downgrade.adoc[leveloffset=+1]
 //How to monitor restart events
 include::assemblies/deploying/assembly-deploy-restart-events.adoc[leveloffset=+1]
+//tuning configuration
+include::assemblies/managing/assembly-tuning-config.adoc[leveloffset=+1]
 //Uninstall the product
 include::assemblies/deploying/assembly-uninstalling.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-config-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-high-volume-messages.adoc
@@ -74,7 +74,7 @@ New messages are not added to the buffer until these messages are acknowledged a
 You can try the following configuration changes to keep the underlying source message queue of outstanding messages at a manageable size:
 
 * Increasing the default value in milliseconds of the `offset.flush.timeout.ms`
-* Ensuring that there are enough xref:con-common-configuration-resources-reference[CPU and memory resources]
+* Ensuring that there are enough CPU and memory resources
 * Increasing the number of tasks that run in parallel by doing the following:
 ** Increasing the number of tasks that run in parallel using the `tasksMax` property
 ** Increasing the number of worker nodes that run tasks using the `replicas` property

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -27,7 +27,7 @@ This method applies especially to confidential data, such as usernames, password
 
 .Handling high volumes of messages
 You can tune the configuration to handle high volumes of messages.
-For more information, see xref:con-high-volume-config-properties-{context}[].
+For more information, see link:{BookURLConfiguring}#con-high-volume-config-properties-{context}[Handling high volumes of messages^].
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -57,7 +57,7 @@ However, try to specify only the topics and consumer groups you need to avoid ca
 
 .Handling high volumes of messages
 You can tune the configuration to handle high volumes of messages.
-For more information, see xref:con-high-volume-config-properties-{context}[].
+For more information, see link:{BookURLConfiguring}#con-high-volume-config-properties-{context}[Handling high volumes of messages^].
 
 .Prerequisites
 

--- a/documentation/modules/managing/con-managed-broker-config-properties.adoc
+++ b/documentation/modules/managing/con-managed-broker-config-properties.adoc
@@ -22,4 +22,4 @@ Broker IDs start from 0 (zero) and correspond to the number of broker replicas.
 Log directories are mounted to `/var/lib/kafka/data/kafka-log__IDX__` based on the `spec.kafka.storage` configuration in the `Kafka` custom resource.
 _IDX_ is the Kafka broker pod index.
 
-For a list of exclusions, see the xref:type-KafkaClusterSpec-reference[`KafkaClusterSpec` schema reference].
+For a list of exclusions, see the link:{BookURLConfiguring}#type-KafkaClusterSpec-reference[`KafkaClusterSpec` schema reference].


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

**Documentation**
Content from the Configuring guide is being moved to the Deploying guide.
The Configuring guide is being positioned as a pure schema reference guide.
Instructions to deploy, configure and administer Strimzi will sit together in the Deploying guide.

This PR moves content related to Kafka tuning
Some link updates required.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

