### PR TITLE
[systemtest] Few minor fixups to STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/RequiredMinKubeOrOpenshiftVersionCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/RequiredMinKubeOrOpenshiftVersionCondition.java
@@ -28,7 +28,7 @@ public class RequiredMinKubeOrOpenshiftVersionCondition implements ExecutionCond
         final boolean isOcp = cluster.isOpenShift();
 
         if ((isOcp && Double.parseDouble(cluster.client().clusterKubernetesVersion()) >= ocpBasedKubeVersion) ||
-            Double.parseDouble(cluster.client().clusterKubernetesVersion()) >= kubeVersion) {
+            !isOcp && Double.parseDouble(cluster.client().clusterKubernetesVersion()) >= kubeVersion) {
             return ConditionEvaluationResult.enabled("Test is enabled");
         } else {
             LOGGER.info("@RequiredMinKubeOrOpenshiftVersion with type of cluster: {} and version {}, but the running on cluster with {}: Ignoring {}",

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -73,7 +73,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
     void testManualTriggeringRollingUpdate(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        final String continuousTopicName = "continuous-topic";
+        final String continuousTopicName = "continuous-" + testStorage.getTopicName();
         final String continuousProducerName = "continuous-" + testStorage.getProducerName();
         final String continuousConsumerName = "continuous-" + testStorage.getConsumerName();
 
@@ -334,7 +334,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
     void testAddingAndRemovingJbodVolumes(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 
-        final String continuousTopicName = "continuous-topic";
+        final String continuousTopicName = "continuous-" + testStorage.getTopicName();
         final String continuousProducerName = "continuous-" + testStorage.getProducerName();
         final String continuousConsumerName = "continuous-" + testStorage.getConsumerName();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
@@ -111,7 +111,7 @@ public class OlmUpgradeIsolatedST extends AbstractUpgradeST {
         this.kafkaUpgradeTopic = new YAMLMapper().readValue(new File(dir, upgradeData.getFromExamples() + "/examples/topic/kafka-topic.yaml"), KafkaTopic.class);
         this.kafkaUpgradeTopic.getMetadata().setName(topicUpgradeName);
         this.kafkaUpgradeTopic.getSpec().setReplicas(3);
-        this.kafkaUpgradeTopic.getSpec().setAdditionalProperty("min.insync.replicas", 2);
+        this.kafkaUpgradeTopic.getSpec().getConfig().put("min.insync.replicas", 2);
 
         LOGGER.info("Deploy KafkaTopic: {}", this.kafkaUpgradeTopic.toString());
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Test fixups

### Description

This PR fixes few minor issues in STs:

- `testManualTriggeringRollingUpdate` and `testAddingAndRemovingJbodVolumes` have problem with same topic name - change from `continuous-topic` to `"continuous-" + testStorage.getTopicName();`
- `RequiredMinKubeOrOpenshiftVersionCondition` -> issue with the check when the cluster is not OCP
- `OlmUpgradeIsolatedST` - change of how we are putting the configuration to the KafkaTopic

### Checklist

- [ ] Make sure all tests pass

