### PR TITLE
Add ZooKeeper certificate annotation per ZK pod in SPS

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -171,11 +171,6 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsJmx {
     public static final String ANNO_STRIMZI_BROKER_CONFIGURATION_HASH = Annotations.STRIMZI_DOMAIN + "broker-configuration-hash";
 
     /**
-     * Annotation for keeping Kafka servers' certificate thumbprints.
-     */
-    public static final String ANNO_STRIMZI_SERVER_CERT_HASH = Annotations.STRIMZI_DOMAIN + "server-cert-hash";
-
-    /**
      * Annotation for keeping certificate thumprints
      */
     public static final String ANNO_STRIMZI_CUSTOM_LISTENER_CERT_THUMBPRINTS = Annotations.STRIMZI_DOMAIN + "custom-listener-cert-thumbprints";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1081,9 +1081,7 @@ public class KafkaReconciler {
                             podSetDiff.resource(),
                             pod,
                             fsResizingRestartRequest,
-                            !Annotations.hasAnnotationWithValue(
-                                    pod, ANNO_STRIMZI_SERVER_CERT_HASH,
-                                    kafkaServerCertificateHash.get(ReconcilerUtils.getPodIndexFromPodName(pod.getMetadata().getName()))),
+                            ReconcilerUtils.trackedServerCertChanged(pod, kafkaServerCertificateHash),
                             clusterCa,
                             clientsCa
                     ), listenerReconciliationResults.advertisedHostnames,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -324,6 +324,6 @@ public class ReconcilerUtils {
     public static boolean trackedServerCertChanged(Pod pod, Map<Integer, String> certHashCache) {
         var currentCertHash = Annotations.stringAnnotation(pod, ANNO_STRIMZI_SERVER_CERT_HASH, null);
         var desiredCertHash = certHashCache.get(ReconcilerUtils.getPodIndexFromPodName(pod.getMetadata().getName()));
-        return certHashCache != null && desiredCertHash != null && !currentCertHash.equals(desiredCertHash);
+        return currentCertHash != null && desiredCertHash != null && !currentCertHash.equals(desiredCertHash);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -297,4 +297,15 @@ public class ReconcilerUtils {
                     }
                 });
     }
+
+    /**
+     * Utility method to extract pod index number from pod name
+     *
+     * @param podName   Name of the pod
+     *
+     * @return          Index of the pod
+     */
+    public static int getPodIndexFromPodName(String podName)  {
+        return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -33,7 +33,10 @@ import io.vertx.core.Future;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_SERVER_CERT_HASH;
 
 /**
  * Utilities used during reconciliation of different operands - mainly Kafka and ZooKeeper
@@ -307,5 +310,20 @@ public class ReconcilerUtils {
      */
     public static int getPodIndexFromPodName(String podName)  {
         return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
+    }
+
+    /**
+     * Check weather the pod is tracking an outdated server certificate.
+     *
+     * Returns false if the pod isn't tracking a server certificate (i.e. isn't annotated with ANNO_STRIMZI_SERVER_CERT_HASH)
+     *
+     * @param pod Pod resource that's possibly tracking a server certificate.
+     * @param certHashCache An up-to-date server cache which maps pod index to the certificate hash
+     * @return True if pod tracks a server certificate, the certificate hash is cached, and the tracked hash differs from the cached one
+     */
+    public static boolean trackedServerCertChanged(Pod pod, Map<Integer, String> certHashCache) {
+        var currentCertHash = Annotations.stringAnnotation(pod, ANNO_STRIMZI_SERVER_CERT_HASH, null);
+        var desiredCertHash = certHashCache.get(ReconcilerUtils.getPodIndexFromPodName(pod.getMetadata().getName()));
+        return certHashCache != null && desiredCertHash != null && !currentCertHash.equals(desiredCertHash);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -775,9 +775,7 @@ public class ZooKeeperReconciler {
                     podSetDiff.resource(),
                     pod,
                     fsResizingRestartRequest,
-                    !Annotations.hasAnnotationWithValue(
-                            pod, ANNO_STRIMZI_SERVER_CERT_HASH,
-                            zkCertificateHash.get(ReconcilerUtils.getPodIndexFromPodName(pod.getMetadata().getName()))),
+                    ReconcilerUtils.trackedServerCertChanged(pod, zkCertificateHash),
                     clusterCa).getAllReasonNotes());
         } else {
             return maybeRollZooKeeper(pod -> ReconcilerUtils.reasonsToRestartPod(reconciliation, statefulSetDiff.resource(), pod, fsResizingRestartRequest, existingCertsChanged, clusterCa).getAllReasonNotes());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -590,10 +590,10 @@ public class ZooKeeperReconciler {
      * @return Map with Pod annotations
      */
     public Map<String, String> zkPodSetPodAnnotations(int podNum) {
-        Map<String, String> podAnnotations = new LinkedHashMap<>(2);
+        Map<String, String> podAnnotations = new LinkedHashMap<>((int) Math.ceil(podNum / 0.75));
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clusterCa)));
         podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, loggingHash);
-        podAnnotations.put(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, zkCertificateHash.get(podNum));
+        podAnnotations.put(ANNO_STRIMZI_SERVER_CERT_HASH, zkCertificateHash.get(podNum));
         return podAnnotations;
     }
 
@@ -775,9 +775,9 @@ public class ZooKeeperReconciler {
                     podSetDiff.resource(),
                     pod,
                     fsResizingRestartRequest,
-                    Annotations.hasAnnotationWithValue(
+                    !Annotations.hasAnnotationWithValue(
                             pod, ANNO_STRIMZI_SERVER_CERT_HASH,
-                            zkCertificateHash.get(ANNO_STRIMZI_SERVER_CERT_HASH)),
+                            zkCertificateHash.get(ReconcilerUtils.getPodIndexFromPodName(pod.getMetadata().getName()))),
                     clusterCa).getAllReasonNotes());
         } else {
             return maybeRollZooKeeper(pod -> ReconcilerUtils.reasonsToRestartPod(reconciliation, statefulSetDiff.resource(), pod, fsResizingRestartRequest, existingCertsChanged, clusterCa).getAllReasonNotes());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -443,15 +443,14 @@ public class ZooKeeperReconciler {
                                         // The secret is patched and some changes to the existing certificates actually occurred
                                         existingCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
                                     }
-                                    IntStream.range(0, zk.getReplicas())
-                                            .forEach(podNum -> {
-                                                var podName = KafkaResources.zookeeperPodName(reconciliation.name(), podNum);
-                                                zkCertificateHash.put(
-                                                        podNum,
-                                                        CertUtils.getCertificateThumbprint(patchResult.resource(),
-                                                                Ca.secretEntryNameForPod(podName, Ca.SecretEntry.CRT)
-                                                        ));
-                                            });
+                                    for (int podNum = 0; podNum < zk.getReplicas(); podNum++) {
+                                        var podName = KafkaResources.zookeeperPodName(reconciliation.name(), podNum);
+                                        zkCertificateHash.put(
+                                                podNum,
+                                                CertUtils.getCertificateThumbprint(patchResult.resource(),
+                                                        Ca.secretEntryNameForPod(podName, Ca.SecretEntry.CRT)
+                                                ));
+                                    }
                                 }
 
                                 return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -66,6 +66,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_SERVER_CERT_HASH;
 import static java.util.Collections.singletonList;
 
 /**
@@ -769,7 +770,15 @@ public class ZooKeeperReconciler {
      */
     protected Future<Void> rollingUpdate() {
         if (featureGates.useStrimziPodSetsEnabled())   {
-            return maybeRollZooKeeper(pod -> ReconcilerUtils.reasonsToRestartPod(reconciliation, podSetDiff.resource(), pod, fsResizingRestartRequest, existingCertsChanged, clusterCa).getAllReasonNotes());
+            return maybeRollZooKeeper(pod -> ReconcilerUtils.reasonsToRestartPod(
+                    reconciliation,
+                    podSetDiff.resource(),
+                    pod,
+                    fsResizingRestartRequest,
+                    Annotations.hasAnnotationWithValue(
+                            pod, ANNO_STRIMZI_SERVER_CERT_HASH,
+                            zkCertificateHash.get(ANNO_STRIMZI_SERVER_CERT_HASH)),
+                    clusterCa).getAllReasonNotes());
         } else {
             return maybeRollZooKeeper(pod -> ReconcilerUtils.reasonsToRestartPod(reconciliation, statefulSetDiff.resource(), pod, fsResizingRestartRequest, existingCertsChanged, clusterCa).getAllReasonNotes());
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -33,7 +33,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2Builder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.api.kafka.model.MetricsConfig;
@@ -103,7 +102,6 @@ import java.lang.reflect.Constructor;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -193,39 +191,6 @@ public class ResourceUtils {
                         .withMetricsConfig(metricsConfig)
                     .endZookeeper()
                 .endSpec()
-                .build();
-    }
-
-    /**
-     * Create a mock Secret for brokers certificates that uses the same cert and key for each replica
-     * @param clusterNamespace Namespace of the Kafka cluster
-     * @param clusterName Kafka cluster name
-     * @param replicas Number of broker replicas
-     * @param secretName Name of the secret
-     * @param brokerCert Broker x509 certificate
-     * @param brokerKey Broker private key
-     * @param p12KeyStore P12 keystore for cert & key
-     * @param p12KeyStorePassword P12 keystore password
-     * @return A Secret object
-     */
-    public static Secret createMockBrokersCertsSecret(String clusterNamespace, String clusterName, int replicas, String secretName,
-                                                      String brokerCert, String brokerKey, String p12KeyStore, String p12KeyStorePassword) {
-        Map<String, String> data = new HashMap<>((int) (1 + replicas * 4 / 0.75));
-        for (int i = 0; i < replicas; i++) {
-            data.put(Ca.secretEntryNameForPod(KafkaResources.kafkaPodName(clusterName, i), Ca.SecretEntry.KEY), brokerKey);
-            data.put(Ca.secretEntryNameForPod(KafkaResources.kafkaPodName(clusterName, i), Ca.SecretEntry.CRT), brokerCert);
-            data.put(Ca.secretEntryNameForPod(KafkaResources.kafkaPodName(clusterName, i), Ca.SecretEntry.P12_KEYSTORE), p12KeyStore);
-            data.put(Ca.secretEntryNameForPod(KafkaResources.kafkaPodName(clusterName, i), Ca.SecretEntry.P12_KEYSTORE_PASSWORD), p12KeyStorePassword);
-        }
-        return new SecretBuilder()
-                .withNewMetadata()
-                    .withName(secretName)
-                    .withNamespace(clusterNamespace)
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "0")
-                    .addToAnnotations(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0")
-                    .withLabels(Labels.forStrimziCluster(clusterName).withStrimziKind(Kafka.RESOURCE_KIND).toMap())
-                .endMetadata()
-                .addToData(data)
                 .build();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -673,6 +673,10 @@ public class ResourceUtils {
                 ClusterOperatorConfig.DEFAULT_POD_SECURITY_PROVIDER_CLASS, null);
     }
 
+    public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions, long operationTimeoutMs) {
+        return dummyClusterOperatorConfig(versions, operationTimeoutMs, "");
+    }
+
     public static ClusterOperatorConfig dummyClusterOperatorConfig(KafkaVersion.Lookup versions) {
         return dummyClusterOperatorConfig(versions, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS, "");
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -89,7 +89,7 @@ public class ZookeeperClusterPodSetTest {
     @ParallelTest
     public void testPodSet()   {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
-        StrimziPodSet ps = zc.generatePodSet(3, true, null, null, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, true, null, null, podNumber -> Map.of());
 
         assertThat(ps.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(zc.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));
@@ -278,7 +278,7 @@ public class ZookeeperClusterPodSetTest {
 
         // Test the resources
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        StrimziPodSet ps = zc.generatePodSet(3, true, null, null, Map.of("special", "annotation"));
+        StrimziPodSet ps = zc.generatePodSet(3, true, null, null, podNum -> Map.of("special", "annotation"));
 
         assertThat(ps.getMetadata().getName(), is(KafkaResources.zookeeperStatefulSetName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(spsLabels.entrySet()), is(true));
@@ -372,7 +372,7 @@ public class ZookeeperClusterPodSetTest {
                 .build();
 
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        StrimziPodSet sps = zc.generatePodSet(3, true, null, null, Map.of());
+        StrimziPodSet sps = zc.generatePodSet(3, true, null, null, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
         List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
@@ -393,7 +393,7 @@ public class ZookeeperClusterPodSetTest {
         secrets.add(secret2);
 
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
-        StrimziPodSet ps = zc.generatePodSet(3, true, null, secrets, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, true, null, secrets, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
@@ -423,7 +423,7 @@ public class ZookeeperClusterPodSetTest {
                 .build();
 
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
-        StrimziPodSet ps = zc.generatePodSet(3, true, null, List.of(secret1), Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, true, null, List.of(secret1), podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
@@ -439,7 +439,7 @@ public class ZookeeperClusterPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
 
         // Test ALWAYS policy
-        StrimziPodSet ps = zc.generatePodSet(3, true, ImagePullPolicy.ALWAYS, null, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, true, ImagePullPolicy.ALWAYS, null, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
@@ -448,7 +448,7 @@ public class ZookeeperClusterPodSetTest {
         }
 
         // Test IFNOTPRESENT policy
-        ps = zc.generatePodSet(3, true, ImagePullPolicy.IFNOTPRESENT, null, Map.of());
+        ps = zc.generatePodSet(3, true, ImagePullPolicy.IFNOTPRESENT, null, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
         pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
@@ -470,7 +470,7 @@ public class ZookeeperClusterPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         // Test generated SPS
-        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
@@ -490,7 +490,7 @@ public class ZookeeperClusterPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         // Test generated SPS
-        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(Matchers.nullValue()));
@@ -509,7 +509,7 @@ public class ZookeeperClusterPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         // Test generated SPS
-        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().stream().filter(v -> "data".equals(v.getName())).findFirst().orElseThrow().getEmptyDir(), is(notNullValue()));
@@ -527,7 +527,7 @@ public class ZookeeperClusterPodSetTest {
         zc.securityProvider.configure(new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION));
 
         // Test generated SPS
-        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, Map.of());
+        StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
         List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getSecurityContext().getFsGroup(), is(0L));
@@ -549,7 +549,7 @@ public class ZookeeperClusterPodSetTest {
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
         // Test generated SPS
-        StrimziPodSet sps = zc.generatePodSet(3, false, null, null, Map.of());
+        StrimziPodSet sps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
         assertThat(sps.getMetadata().getLabels().get("foo"), is("bar"));
 
         List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
@@ -560,7 +560,7 @@ public class ZookeeperClusterPodSetTest {
 
     @ParallelTest
     public void testDefaultSecurityContext() {
-        StrimziPodSet sps = ZC.generatePodSet(3, false, null, null, Map.of());
+        StrimziPodSet sps = ZC.generatePodSet(3, false, null, null, podNum -> Map.of());
 
         List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
         for (Pod pod : pods) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -140,7 +140,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
 
         if (useStrimziPodSets) {
             StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
-            when(mockPodSetOps.getAsync(any(), eq(zkCluster.getComponentName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, null)));
+            when(mockPodSetOps.getAsync(any(), eq(zkCluster.getComponentName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null)));
             when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getComponentName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null)));
 
             StatefulSetOperator mockStsOps = supplier.stsOperations;
@@ -260,7 +260,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
         if (useStrimziPodSets) {
             StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
             when(mockPodSetOps.getAsync(any(), eq(zkCluster.getComponentName()))).thenAnswer(i -> {
-                StrimziPodSet zkPodSet = zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+                StrimziPodSet zkPodSet = zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
                 zkPodSet.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true");
                 return Future.succeededFuture(zkPodSet);
             });
@@ -401,7 +401,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
 
         if (useStrimziPodSets) {
             StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
-            when(mockPodSetOps.getAsync(any(), eq(zkCluster.getComponentName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, null)));
+            when(mockPodSetOps.getAsync(any(), eq(zkCluster.getComponentName()))).thenReturn(Future.succeededFuture(zkCluster.generatePodSet(kafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null)));
             when(mockPodSetOps.getAsync(any(), eq(kafkaCluster.getComponentName()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePodSet(kafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null)));
 
             StatefulSetOperator mockStsOps = supplier.stsOperations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -29,7 +29,6 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.CertUtils;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -196,7 +195,7 @@ public class KafkaAssemblyOperatorMockTest {
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
                     var brokersSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get();
-                    assertThat(pod.getMetadata().getAnnotations(), hasEntry(KafkaCluster.ANNO_STRIMZI_SERVER_CERT_HASH,
+                    assertThat(pod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH,
                             CertUtils.getCertificateThumbprint(brokersSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
                     ));
                 });
@@ -204,6 +203,10 @@ public class KafkaAssemblyOperatorMockTest {
                 StrimziPodSet zkSps = supplier.strimziPodSetOperator.client().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).get();
                 zkSps.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
+                    var zooKeeperSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperSecretName(CLUSTER_NAME)).get();
+                    assertThat(pod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH,
+                            CertUtils.getCertificateThumbprint(zooKeeperSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
+                    ));
                 });
                 assertThat(client.configMaps().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));
                 assertThat(client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.clientsCaKeySecretName(CLUSTER_NAME)).get(), is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -176,7 +176,7 @@ public class KafkaAssemblyOperatorPodSetTest {
     @Test
     public void testRegularReconciliation(VertxTestContext context)  {
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
-        StrimziPodSet zkPodSet = zkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+        StrimziPodSet zkPodSet = zkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
         StrimziPodSet kafkaPodSet = kafkaCluster.generatePodSet(KAFKA.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
 
@@ -289,7 +289,7 @@ public class KafkaAssemblyOperatorPodSetTest {
     @Test
     public void testFirstReconciliation(VertxTestContext context)  {
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
-        StrimziPodSet zkPodSet = zkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+        StrimziPodSet zkPodSet = zkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
         StrimziPodSet kafkaPodSet = kafkaCluster.generatePodSet(KAFKA.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
 
@@ -408,7 +408,7 @@ public class KafkaAssemblyOperatorPodSetTest {
     @Test
     public void testFirstReconciliationWithSts(VertxTestContext context)  {
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
-        StrimziPodSet zkPodSet = zkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+        StrimziPodSet zkPodSet = zkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS);
         StrimziPodSet kafkaPodSet = kafkaCluster.generatePodSet(KAFKA.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
 
@@ -527,7 +527,7 @@ public class KafkaAssemblyOperatorPodSetTest {
                 .build();
 
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS);
-        StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+        StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSet(KAFKA.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
 
@@ -647,7 +647,7 @@ public class KafkaAssemblyOperatorPodSetTest {
                 .build();
 
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS);
-        StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+        StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSet(oldKafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
 
@@ -789,7 +789,7 @@ public class KafkaAssemblyOperatorPodSetTest {
                 .build();
 
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS);
-        StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, null);
+        StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSet(oldKafka.getSpec().getKafka().getReplicas(), false, null, null, brokerId -> null);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -184,17 +184,7 @@ public class KafkaAssemblyOperatorPodSetTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
-        when(secretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        kafkaCluster.getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
+
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(kafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(List.of()));
         ArgumentCaptor<String> cmReconciliationCaptor = ArgumentCaptor.forClass(String.class);
@@ -297,17 +287,6 @@ public class KafkaAssemblyOperatorPodSetTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
-        when(secretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        kafkaCluster.getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(kafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(kafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -538,17 +517,6 @@ public class KafkaAssemblyOperatorPodSetTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
-        when(secretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        newKafkaCluster.getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -659,17 +627,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
-        when(secretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        kafkaCluster.getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
+
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
         ArgumentCaptor<String> cmReconciliationCaptor = ArgumentCaptor.forClass(String.class);
@@ -801,17 +759,6 @@ public class KafkaAssemblyOperatorPodSetTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
-        when(secretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        oldKafkaCluster.getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1114,17 +1114,7 @@ public class KafkaAssemblyOperatorTest {
         when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.zookeeperSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );
-        when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.kafkaSecretName(clusterName))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(clusterNamespace,
-                        clusterName,
-                        updatedKafkaCluster.getReplicas(),
-                        KafkaResources.kafkaSecretName(clusterName),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
+
         when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.entityTopicOperatorSecretName(clusterName))).thenReturn(
                 Future.succeededFuture()
         );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -1151,7 +1151,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Mock StrimziPodSets
         AtomicReference<StrimziPodSet> zooPodSetRef = new AtomicReference<>();
-        zooPodSetRef.set(originalZookeeperCluster.generatePodSet(originalZookeeperCluster.getReplicas(), openShift, null, null, Map.of()));
+        zooPodSetRef.set(originalZookeeperCluster.generatePodSet(originalZookeeperCluster.getReplicas(), openShift, null, null, podNum -> Map.of()));
         when(mockPodSetOps.reconcile(any(), eq(clusterNamespace), eq(KafkaResources.zookeeperStatefulSetName(clusterName)), any())).thenAnswer(invocation -> {
             StrimziPodSet sps = invocation.getArgument(3, StrimziPodSet.class);
             zooPodSetRef.set(sps);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
@@ -141,17 +141,6 @@ public class KafkaReconcilerUpgradeDowngradeTest {
 
         // Mock Secret gets
         SecretOperator mockSecretOps = supplier.secretOperations;
-        when(mockSecretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        kafka.getSpec().getKafka().getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
 
         // Run the test
         KafkaReconciler reconciler = new MockKafkaReconciler(
@@ -195,17 +184,6 @@ public class KafkaReconcilerUpgradeDowngradeTest {
 
         // Mock Secret gets
         SecretOperator mockSecretOps = supplier.secretOperations;
-        when(mockSecretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        KAFKA.getSpec().getKafka().getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
 
         // Run the test
         KafkaReconciler reconciler = new MockKafkaReconciler(
@@ -259,17 +237,6 @@ public class KafkaReconcilerUpgradeDowngradeTest {
 
         // Mock Secret gets
         SecretOperator mockSecretOps = supplier.secretOperations;
-        when(mockSecretOps.getAsync(NAMESPACE, KafkaResources.kafkaSecretName(CLUSTER_NAME))).thenReturn(
-                Future.succeededFuture(ResourceUtils.createMockBrokersCertsSecret(NAMESPACE,
-                        CLUSTER_NAME,
-                        kafka.getSpec().getKafka().getReplicas(),
-                        KafkaResources.kafkaSecretName(CLUSTER_NAME),
-                        MockCertManager.serverCert(),
-                        MockCertManager.serverKey(),
-                        MockCertManager.serverKeyStore(),
-                        MockCertManager.certStorePassword()
-                ))
-        );
 
         // Run the test
         KafkaReconciler reconciler = new MockKafkaReconciler(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -15,20 +15,22 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
-import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
+import io.strimzi.operator.cluster.model.CertUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.test.mockkube2.MockKube2;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -64,6 +67,7 @@ public class PartialRollingUpdateMockTest {
     private static Vertx vertx;
     private static WorkerExecutor sharedWorkerExecutor;
     private KafkaAssemblyOperator kco;
+    private Kafka cluster;
 
     // Injected by Fabric8 Mock Kubernetes Server
     @SuppressWarnings("unused")
@@ -86,7 +90,7 @@ public class PartialRollingUpdateMockTest {
 
     @BeforeEach
     public void beforeEach(VertxTestContext context) throws InterruptedException {
-        Kafka cluster = new KafkaBuilder()
+        cluster = new KafkaBuilder()
                 .withMetadata(new ObjectMetaBuilder().withName(CLUSTER_NAME)
                 .withNamespace(NAMESPACE)
                 .build())
@@ -218,6 +222,39 @@ public class PartialRollingUpdateMockTest {
     }
 
     @Test
+    public void testReconcileOfPartiallyRolledKafkaClusterForServerCertificates(VertxTestContext context) {
+        Checkpoint async = context.checkpoint();
+        var brokersSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get();
+
+        IntStream.range(0, cluster.getSpec().getKafka().getReplicas())
+                .forEach(brokerId -> {
+                    var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, brokerId)).get();
+                    var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
+                    var expectedCertHash = CertUtils.getCertificateThumbprint(brokersSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+
+                    assertThat("Pod " + brokerId + " had unexpected revision", podCertHash, is(expectedCertHash));
+                });
+
+        LOGGER.info("Recovery reconciliation");
+        updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 1), Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, "oldhash");
+        updatePodAnnotation(KafkaResources.kafkaPodName(CLUSTER_NAME, 4), Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, "oldhash");
+
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
+            context.verify(() -> assertThat(ar.succeeded(), is(true)));
+
+            IntStream.range(0, cluster.getSpec().getKafka().getReplicas())
+                    .forEach(brokerId -> {
+                        var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, brokerId)).get();
+                        var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
+                        var expectedCertHash = CertUtils.getCertificateThumbprint(brokersSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+
+                        context.verify(() -> assertThat("Pod " + brokerId + " had unexpected revision", podCertHash, is(expectedCertHash)));
+                    });
+            async.flag();
+        });
+    }
+
+    @Test
     public void testReconcileOfPartiallyRolledZookeeperCluster(VertxTestContext context) {
         updatePodAnnotation(KafkaResources.zookeeperPodName(CLUSTER_NAME, 1), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
         updatePodAnnotation(KafkaResources.zookeeperPodName(CLUSTER_NAME, 2), PodRevision.STRIMZI_REVISION_ANNOTATION, "notmatchingrevision");
@@ -247,6 +284,41 @@ public class PartialRollingUpdateMockTest {
 
                 context.verify(() -> assertThat("Pod " + finalI + " had unexpected revision", podRrevision, is(spsRevision)));
             }
+            async.flag();
+        });
+    }
+
+    @Test
+    public void testReconcileOfPartiallyRolledZookeeperClusterForServerCertificates(VertxTestContext context) {
+        Checkpoint async = context.checkpoint();
+        var zkSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperSecretName(CLUSTER_NAME)).get();
+
+        IntStream.range(0, cluster.getSpec().getZookeeper().getReplicas())
+                .forEach(zkIndex -> {
+                    var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, zkIndex)).get();
+                    var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
+                    var expectedCertHash = CertUtils.getCertificateThumbprint(zkSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+
+                    assertThat("Pod " + zkIndex + " had unexpected revision", podCertHash, is(expectedCertHash));
+
+                });
+
+        LOGGER.info("Recovery reconciliation");
+        updatePodAnnotation(KafkaResources.zookeeperPodName(CLUSTER_NAME, 1), Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, "oldhash");
+        updatePodAnnotation(KafkaResources.zookeeperPodName(CLUSTER_NAME, 2), Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, "oldhash");
+
+        kco.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)).onComplete(ar -> {
+            context.verify(() -> assertThat(ar.succeeded(), is(true)));
+
+            IntStream.range(0, cluster.getSpec().getZookeeper().getReplicas())
+                    .forEach(zkIndex -> {
+                        var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, zkIndex)).get();
+                        var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
+                        var expectedCertHash = CertUtils.getCertificateThumbprint(zkSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+
+                        context.verify(() -> assertThat("Pod " + zkIndex + " had unexpected revision", podCertHash, is(expectedCertHash)));
+
+                    });
             async.flag();
         });
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -28,6 +28,11 @@ public class Annotations {
     public static final String STRIMZI_DOMAIN = "strimzi.io/";
 
     /**
+     * Annotation for keeping Kafka and ZooKeeper servers' certificate thumbprints.
+     */
+    public static final String ANNO_STRIMZI_SERVER_CERT_HASH = STRIMZI_DOMAIN + "server-cert-hash";
+
+    /**
      * Strimzi logging annotation
      */
     public static final String STRIMZI_LOGGING_ANNOTATION = STRIMZI_DOMAIN + "logging";
@@ -264,7 +269,7 @@ public class Annotations {
     }
 
     /**
-     * Gets a string value of an annotation from a Por template
+     * Gets a string value of an annotation from a Pod template
      *
      * @param podSpec                   Por template from which the annotation should be extracted
      * @param annotation                Annotation key for which we want the value
@@ -291,6 +296,22 @@ public class Annotations {
         ObjectMeta metadata = resource.getMetadata();
         String str = annotation(annotation, null, metadata, null);
         return str != null;
+    }
+
+    /**
+     * Check if Kubernetes resource has an annotation with given key and value.
+     * @param resource      Kubernetes resource which should be checked for the annotations presence
+     * @param annotation    Annotation key
+     * @param value         Annotation value
+     * @return True if the annotation exists and has the given value. False otherwise.
+     */
+    public static boolean hasAnnotationWithValue(HasMetadata resource, String annotation, String value) {
+        if (resource == null || value == null) {
+            return false;
+        }
+        ObjectMeta metadata = resource.getMetadata();
+        String str = annotation(annotation, null, metadata, null);
+        return str != null && str.equals(value);
     }
 
     private static String annotation(String annotation, String defaultValue, ObjectMeta metadata, String... deprecatedAnnotations) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -298,22 +298,6 @@ public class Annotations {
         return str != null;
     }
 
-    /**
-     * Check if Kubernetes resource has an annotation with given key and value.
-     * @param resource      Kubernetes resource which should be checked for the annotations presence
-     * @param annotation    Annotation key
-     * @param value         Annotation value
-     * @return True if the annotation exists and has the given value. False otherwise.
-     */
-    public static boolean hasAnnotationWithValue(HasMetadata resource, String annotation, String value) {
-        if (resource == null || value == null) {
-            return false;
-        }
-        ObjectMeta metadata = resource.getMetadata();
-        String str = annotation(annotation, null, metadata, null);
-        return str != null && str.equals(value);
-    }
-
     private static String annotation(String annotation, String defaultValue, ObjectMeta metadata, String... deprecatedAnnotations) {
         Map<String, String> annotations = annotations(metadata);
         return annotation(annotation, defaultValue, annotations, deprecatedAnnotations);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

Followup for #7654 

### Description

To fix avoid the same behavior of #3913 when rolling ZooKeeper, this PR adds an annotation per pod that contains the ZooKeeper certificate thumbprint. That way in case of a certificate update, the ZooKeeper Roller would detect if the pods were not rolled consistently since pods would still be annotated by the old certificate thumbprint .

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards