### PR TITLE
Remove stability counter in PodUtils

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -47,6 +47,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.BiFunction;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -626,5 +627,10 @@ public class StUtils {
     public static void waitUntilSuppliersAreMatching(final Supplier<?> sup, final Supplier<?> anotherSup) {
         TestUtils.waitFor(sup.get() + " is matching with" + anotherSup.get(), Constants.GLOBAL_POLL_INTERVAL,
                 Constants.GLOBAL_STATUS_TIMEOUT, () -> sup.get().equals(anotherSup.get()));
+    }
+
+    public static void waitUntilSupplierIsSatisfied(final BooleanSupplier sup) {
+        TestUtils.waitFor(sup.getAsBoolean() + " is satisfied", Constants.GLOBAL_POLL_INTERVAL,
+                Constants.GLOBAL_STATUS_TIMEOUT, sup);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -47,6 +47,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -621,5 +622,9 @@ public class StUtils {
         }
 
         return cmNames;
+    }
+    public static void waitUntilSuppliersAreMatching(final Supplier<?> sup, final Supplier<?> anotherSup) {
+        TestUtils.waitFor(sup.get() + " is matching with" + anotherSup.get(), Constants.GLOBAL_POLL_INTERVAL,
+                Constants.GLOBAL_STATUS_TIMEOUT, () -> sup.get().equals(anotherSup.get()));
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -62,9 +62,6 @@ public class PodUtils {
     }
 
     public static void waitForPodsReady(String namespaceName, LabelSelector selector, int expectPods, boolean containers, Runnable onTimeout) {
-        final int stableCount = 10;
-        int[] counter = {0};
-
         TestUtils.waitFor("All pods matching " + selector + "to be ready",
             Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.timeoutForPodsOperation(expectPods),
             () -> {
@@ -84,7 +81,6 @@ public class PodUtils {
                 for (Pod pod : pods) {
                     if (!Readiness.isPodReady(pod)) {
                         LOGGER.debug("Not ready (at least 1 pod not ready: {}/{})", namespaceName, pod.getMetadata().getName());
-                        counter[0] = 0;
                         return false;
                     } else {
                         if (containers) {
@@ -97,17 +93,7 @@ public class PodUtils {
                         }
                     }
                 }
-                // When pod is up, it will check that are rolled pods are stable for next 10 polls and then it return true
-                if (++counter[0] > stableCount) {
-                    LOGGER.debug("Pods {} are ready",
-                            pods.stream().map(p -> p.getMetadata().getName()).collect(Collectors.joining(", ")));
-                    return true;
-                } else {
-                    LOGGER.debug("Pods {} are ready, waiting for stabilization ({}/{})",
-                            pods.stream().map(p -> p.getMetadata().getName()).collect(Collectors.joining(", ")),
-                            counter[0], stableCount);
-                    return false;
-                }
+                return true;
             }, onTimeout);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeIsolatedST.java
@@ -32,7 +32,6 @@ import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.json.JsonArray;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.logging.log4j.LogManager;
@@ -371,15 +370,13 @@ class HttpBridgeIsolatedST extends AbstractST {
 
         LOGGER.info("Checking that observed gen. higher (rolling update) and label is changed");
 
-        TestUtils.waitFor("wait for desired state of Kafka Bridge", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> {
-                final KafkaBridge kB = KafkaBridgeResource.kafkaBridgeClient().inNamespace(clusterOperator.getDeploymentNamespace()).withName(bridgeName).get();
+        StUtils.waitUntilSupplierIsSatisfied(() -> {
+            final KafkaBridge kB = KafkaBridgeResource.kafkaBridgeClient().inNamespace(clusterOperator.getDeploymentNamespace()).withName(bridgeName).get();
 
-                return kB.getStatus().getObservedGeneration() == 2L &&
-                        kB.getMetadata().getLabels().toString().contains("another=label") &&
-                        kB.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
-            }
-        );
+            return kB.getStatus().getObservedGeneration() == 2L &&
+                kB.getMetadata().getLabels().toString().contains("another=label") &&
+                kB.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
+        });
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1009,8 +1009,7 @@ class ConnectIsolatedST extends AbstractST {
 
         LOGGER.info("Check if replicas is set to {}, observed generation is higher - for spec and status - naming prefix should be same", scaleTo);
 
-        TestUtils.waitFor("desired scaled KafkaConnect resource", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> kubeClient(namespaceName).listPods(Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.deploymentName(clusterName)).size() == scaleTo &&
+        StUtils.waitUntilSupplierIsSatisfied(() -> kubeClient(namespaceName).listPods(Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.deploymentName(clusterName)).size() == scaleTo &&
                 KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getReplicas() == scaleTo &&
                 KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getReplicas() == scaleTo);
 
@@ -1243,15 +1242,13 @@ class ConnectIsolatedST extends AbstractST {
 
         LOGGER.info("Checking that observed gen. higher (rolling update) and label is changed");
 
-        TestUtils.waitFor("wait for desired state of Kafka Connect", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
-            () -> {
-                final KafkaConnect kC = KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get();
+        StUtils.waitUntilSupplierIsSatisfied(() -> {
+            final KafkaConnect kC = KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get();
 
-                return kC.getStatus().getObservedGeneration() == 2L &&
-                        kC.getMetadata().getLabels().toString().contains("another=label") &&
-                        kC.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
-            }
-        );
+            return kC.getStatus().getObservedGeneration() == 2L &&
+                    kC.getMetadata().getLabels().toString().contains("another=label") &&
+                    kC.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
+        });
     }
 
     @KRaftNotSupported("Scram-sha is not supported by KRaft mode and is used in this test class")

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1008,10 +1008,13 @@ class ConnectIsolatedST extends AbstractST {
         DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, KafkaConnectResources.deploymentName(clusterName), scaleTo);
 
         LOGGER.info("Check if replicas is set to {}, observed generation is higher - for spec and status - naming prefix should be same", scaleTo);
+
+        TestUtils.waitFor("desired scaled KafkaConnect resource", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> kubeClient(namespaceName).listPods(Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.deploymentName(clusterName)).size() == scaleTo &&
+                KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getReplicas() == scaleTo &&
+                KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getReplicas() == scaleTo);
+
         List<Pod> connectPods = kubeClient(namespaceName).listPods(Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.deploymentName(clusterName));
-        assertThat(connectPods.size(), is(4));
-        assertThat(KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getReplicas(), is(4));
-        assertThat(KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getReplicas(), is(4));
         /*
         observed generation should be higher than before scaling -> after change of spec and successful reconciliation,
         the observed generation is increased
@@ -1239,10 +1242,16 @@ class ConnectIsolatedST extends AbstractST {
         DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, connectDepName, 1);
 
         LOGGER.info("Checking that observed gen. higher (rolling update) and label is changed");
-        kafkaConnect = KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get();
-        assertThat(kafkaConnect.getStatus().getObservedGeneration(), is(2L));
-        assertThat(kafkaConnect.getMetadata().getLabels().toString(), containsString("another=label"));
-        assertThat(kafkaConnect.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(DeploymentStrategy.ROLLING_UPDATE));
+
+        TestUtils.waitFor("wait for desired state of Kafka Connect", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> {
+                final KafkaConnect kC = KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get();
+
+                return kC.getStatus().getObservedGeneration() == 2L &&
+                        kC.getMetadata().getLabels().toString().contains("another=label") &&
+                        kC.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
+            }
+        );
     }
 
     @KRaftNotSupported("Scram-sha is not supported by KRaft mode and is used in this test class")

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1584,16 +1584,17 @@ public class ListenersST extends AbstractST {
         KafkaUser aliceUser = KafkaUserTemplates.tlsUser(testStorage).build();
         resourceManager.createResource(extensionContext, aliceUser);
 
-        String externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        String externalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), testStorage.getClusterName() + "-cluster-ca-cert", "ca.crt");
+        StUtils.waitUntilSuppliersAreMatching(
+            // external certs
+            () -> getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+            // external secret certs
+            () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), testStorage.getClusterName() + "-cluster-ca-cert", "ca.crt"));
+        StUtils.waitUntilSuppliersAreMatching(
+            // external secret certs
+            () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), testStorage.getClusterName() + "-cluster-ca-cert", "ca.crt"),
+            // internal certs
+            () -> getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()));
 
-        String internalCerts = getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-
-        LOGGER.info("Check if KafkaStatus certificates from external listeners are the same as secret certificates");
-        assertThat(externalSecretCerts, is(externalCerts));
-        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        //External secret cert is same as internal in this case
-        assertThat(externalSecretCerts, is(internalCerts));
 
         ExternalKafkaClient externalKafkaClient = new ExternalKafkaClient.Builder()
             .withTopicName(testStorage.getTopicName())
@@ -1647,16 +1648,16 @@ public class ListenersST extends AbstractST {
 
         KafkaUtils.waitForKafkaStatusUpdate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
-        externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        externalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer1, "ca.crt");
-
-        internalCerts = getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        String internalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer2, "ca.crt");
-
-        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
-        assertThat(externalSecretCerts, is(externalCerts));
-        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        assertThat(internalSecretCerts, is(internalCerts));
+        StUtils.waitUntilSuppliersAreMatching(
+            // external certs
+            () -> getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+            // external secret certs
+            () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer1, "ca.crt"));
+        StUtils.waitUntilSuppliersAreMatching(
+            // internal certs
+            () -> getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+            // internal secret certs
+            () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer2, "ca.crt"));
 
         externalKafkaClient = externalKafkaClient.toBuilder()
             .withCertificateAuthorityCertificateName(clusterCustomCertServer1)
@@ -1698,16 +1699,17 @@ public class ListenersST extends AbstractST {
 
         kafkaSnapshot = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaSnapshot);
 
-        externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        externalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer1, "ca.crt");
+        StUtils.waitUntilSuppliersAreMatching(
+                // external certs
+                () -> getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+                // external secret certs
+                () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer1, "ca.crt"));
+        StUtils.waitUntilSuppliersAreMatching(
+                // internal certs
+                () -> getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+                // internal secret certs
+                () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer2, "ca.crt"));
 
-        internalCerts = getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        internalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer2, "ca.crt");
-
-        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
-        assertThat(externalSecretCerts, is(externalCerts));
-        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        assertThat(internalSecretCerts, is(internalCerts));
 
         externalKafkaClient.verifyProducedAndConsumedMessages(
             expectedMessageCountForExternalClient,
@@ -1759,16 +1761,16 @@ public class ListenersST extends AbstractST {
 
         KafkaUtils.waitForKafkaStatusUpdate(testStorage.getNamespaceName(), testStorage.getClusterName());
 
-        externalCerts = getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        externalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), testStorage.getClusterName() + "-cluster-ca-cert", "ca.crt");
-
-        internalCerts = getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName());
-        internalSecretCerts = getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer2, "ca.crt");
-
-        LOGGER.info("Check if KafkaStatus certificates are the same as secret certificates");
-        assertThat(externalSecretCerts, is(externalCerts));
-        LOGGER.info("Check if KafkaStatus certificates from internal TLS listener are the same as secret certificates");
-        assertThat(internalSecretCerts, is(internalCerts));
+        StUtils.waitUntilSuppliersAreMatching(
+                // external certs
+                () -> getKafkaStatusCertificates(Constants.EXTERNAL_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+                // external secret certs
+                () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), testStorage.getClusterName() + "-cluster-ca-cert", "ca.crt"));
+        StUtils.waitUntilSuppliersAreMatching(
+                // internal certs
+                () -> getKafkaStatusCertificates(Constants.TLS_LISTENER_DEFAULT_NAME, testStorage.getNamespaceName(), testStorage.getClusterName()),
+                // internal secret certs
+                () -> getKafkaSecretCertificates(testStorage.getNamespaceName(), clusterCustomCertServer2, "ca.crt"));
 
         externalKafkaClient = externalKafkaClient.toBuilder()
             .withCertificateAuthorityCertificateName(null)

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -482,9 +482,11 @@ class MirrorMaker2IsolatedST extends AbstractST {
         LOGGER.info("Check if replicas is set to {}, naming prefix should be same and observed generation higher", scaleTo);
         List<String> mm2Pods = kubeClient(testStorage.getNamespaceName()).listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND);
 
-        assertThat(mm2Pods.size(), is(scaleTo));
-        assertThat(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getSpec().getReplicas(), is(scaleTo));
-        assertThat(KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getReplicas(), is(scaleTo));
+        TestUtils.waitFor("desired scaled KafkaMirrorMaker2 resource", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+                () -> kubeClient(testStorage.getNamespaceName()).listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND).size() == scaleTo &&
+                    KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getSpec().getReplicas() == scaleTo &&
+                    KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getReplicas() == scaleTo);
+
         /*
         observed generation should be higher than before scaling -> after change of spec and successful reconciliation,
         the observed generation is increased
@@ -760,10 +762,15 @@ class MirrorMaker2IsolatedST extends AbstractST {
         DeploymentUtils.waitForDeploymentAndPodsReady(testStorage.getNamespaceName(), mm2DepName, 1);
 
         LOGGER.info("Checking that observed gen. higher (rolling update) and label is changed");
-        kmm2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
-        assertThat(kmm2.getStatus().getObservedGeneration(), is(2L));
-        assertThat(kmm2.getMetadata().getLabels().toString(), containsString("another=label"));
-        assertThat(kmm2.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(DeploymentStrategy.ROLLING_UPDATE));
+        TestUtils.waitFor("wait for desired state of Kafka Mirror Maker 2", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+                () -> {
+                    final KafkaMirrorMaker2 kMM2 = KafkaMirrorMaker2Resource.kafkaMirrorMaker2Client().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
+
+                    return kMM2.getStatus().getObservedGeneration() == 2L &&
+                            kMM2.getMetadata().getLabels().toString().contains("another=label") &&
+                            kMM2.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
+                }
+        );
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerIsolatedST.java
@@ -38,6 +38,7 @@ import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaMirrorMakerUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
@@ -594,16 +595,19 @@ public class MirrorMakerIsolatedST extends AbstractST {
         DeploymentUtils.waitForDeploymentAndPodsReady(testStorage.getNamespaceName(), KafkaMirrorMakerResources.deploymentName(testStorage.getClusterName()), scaleTo);
 
         LOGGER.info("Check if replicas is set to {}, naming prefix should be same and observed generation higher", scaleTo);
-        List<String> mmPods = kubeClient().listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
-        assertThat(mmPods.size(), is(scaleTo));
-        assertThat(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getSpec().getReplicas(), is(scaleTo));
-        assertThat(KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getReplicas(), is(scaleTo));
+
+        TestUtils.waitFor("desired scaled KafkaMirrorMaker resource", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> kubeClient().listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND).size() == scaleTo &&
+                    KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getSpec().getReplicas() == scaleTo &&
+                    KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getReplicas() == scaleTo);
         /*
         observed generation should be higher than before scaling -> after change of spec and successful reconciliation,
         the observed generation is increased
         */
         long actualObsGen = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getObservedGeneration();
         assertTrue(mmObsGen < actualObsGen);
+
+        List<String> mmPods = kubeClient().listPodNames(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND);
 
         for (String pod : mmPods) {
             assertTrue(pod.contains(mmGenName));
@@ -674,10 +678,15 @@ public class MirrorMakerIsolatedST extends AbstractST {
         DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, mmDepName, 1);
 
         LOGGER.info("Checking that observed gen. higher (rolling update) and label is changed");
-        kmm = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get();
-        assertThat(kmm.getStatus().getObservedGeneration(), is(2L));
-        assertThat(kmm.getMetadata().getLabels().toString(), Matchers.containsString("another=label"));
-        assertThat(kmm.getSpec().getTemplate().getDeployment().getDeploymentStrategy(), is(DeploymentStrategy.ROLLING_UPDATE));
+        TestUtils.waitFor("wait for desired state of Kafka Mirror Maker", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+                () -> {
+                    final KafkaMirrorMaker kMM = KafkaMirrorMakerResource.kafkaMirrorMakerClient().inNamespace(namespaceName).withName(clusterName).get();
+
+                    return kMM.getStatus().getObservedGeneration() == 2L &&
+                            kMM.getMetadata().getLabels().toString().contains("another=label") &&
+                            kMM.getSpec().getTemplate().getDeployment().getDeploymentStrategy().equals(DeploymentStrategy.ROLLING_UPDATE);
+                }
+        );
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -84,8 +84,8 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         int messageCount = 600;
         List<EnvVar> testEnvVars = new ArrayList<>();
-        int zooReplicas = 1;
-        int kafkaReplicas = 1;
+        int zooReplicas = 3;
+        int kafkaReplicas = 3;
 
         testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "-UseStrimziPodSets", null));
 


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR removes stability counter inside our PodUtils. I have tested this on minikube and cluster and it seems everything works without any issues. 

### Checklist

- [x] Make sure all tests pass