### PR TITLE
Fix Helm chart installation docs

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -347,7 +347,7 @@ and pull the official images instead of using your freshly built image.
 
 The `strimzi-kafka-operator` Helm Chart can be installed directly from its source.
 
-    `helm install packaging/helm-charts/helm3/strimzi-kafka-operator`
+    `helm install strimzi-operator packaging/helm-charts/helm3/strimzi-kafka-operator`
 
 The chart is also available in the release artifact as a tarball.
 

--- a/documentation/modules/deploying/proc-deploy-cluster-operator-helm-chart.adoc
+++ b/documentation/modules/deploying/proc-deploy-cluster-operator-helm-chart.adoc
@@ -29,7 +29,7 @@ helm repo add strimzi {ChartRepositoryUrl}
 . Deploy the Cluster Operator using the Helm command line tool:
 +
 [source,shell,subs=attributes+]
-helm install {ChartReleaseCoordinate}
+helm install strimzi-operator {ChartReleaseCoordinate}
 
 . Verify that the Cluster Operator has been deployed successfully using the Helm command line tool:
 +

--- a/documentation/modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying-helm-chart.adoc
@@ -105,7 +105,7 @@ Specify any changes to the default configuration as parameter values.
 .Example configuration that changes the number of webhook replicas
 [source,shell]
 ----
-helm install --name drain-cleaner --set replicas=2 strimzi/strimzi-drain-cleaner
+helm install drain-cleaner --set replicaCount=2 strimzi/strimzi-drain-cleaner
 ----
 
 . Verify that the Cluster Operator has been deployed successfully:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -189,5 +189,5 @@ the documentation for more details.
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release --set logLevel=DEBUG,fullReconciliationIntervalMs=240000 strimzi/strimzi-kafka-operator
+$ helm install my-release --set logLevel=DEBUG,fullReconciliationIntervalMs=240000 strimzi/strimzi-kafka-operator
 ```


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes some docs and README.md issues related to Helm Chart installation. The `helm install` command needs to have a name as the first parameter. There is also no parameter `--name`. It also fixes the invalid `replicas` versus `replicaCount` option of the Drain Cleaner Helm Chart.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally