### PR TITLE
Removes un-necessary test cases from systemtests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1593,24 +1593,6 @@ class KafkaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    void testKafkaOffsetsReplicationFactorHigherThanReplicas(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-
-        resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(clusterName, 3, 1)
-            .editSpec()
-                .editKafka()
-                   .addToConfig("offsets.topic.replication.factor", 4)
-                   .addToConfig("transaction.state.log.min.isr", 4)
-                   .addToConfig("transaction.state.log.replication.factor", 4)
-               .endKafka()
-            .endSpec().build());
-
-        KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(clusterName, namespaceName,
-            "Kafka configuration option .* should be set to " + 3 + " or less because 'spec.kafka.replicas' is " + 3);
-    }
-
-    @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(CRUISE_CONTROL)
     void testReadOnlyRootFileSystem(ExtensionContext extensionContext) {


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Refactoring

### Description

This PR removes test cases which we assume are not needed:
1. `testKafkaOffsetsReplicationFactorHigherThanReplicas` - FMPOV, this is specifically a test case for integration level, not a system, and thus we are removing it.
2. `testDrainCleanerWithComponentsDuringNodeDraining` - this test case has been implemented. Still, we are not using it because of the PDB complexity (i.e., if we want to use it, then we will need to implement it for each platform in a different implementation). Moreover, there is also a need for a 9-node cluster.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass