### PR TITLE
Fix and improve report script

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -8,14 +8,12 @@ fi
 { # this ensures the entire script is downloaded #
 NAMESPACE=""
 CLUSTER=""
-BRIDGE=""
-CONNECT=""
-MM2=""
 KUBECTL_INSTALLED=false
 OC_INSTALLED=false
 KUBE_CLIENT="kubectl"
-OUT_DIR=""
 SECRETS_OPT="hidden"
+COMP_NAME=""
+OUT_DIR=""
 
 # sed non-printable text delimiter
 SD=$(echo -en "\001") && readonly SD
@@ -23,8 +21,7 @@ SD=$(echo -en "\001") && readonly SD
 SE="s${SD}^\(\s*.*\password\s*:\s*\).*${SD}\1\[hidden\]${SD}; s${SD}^\(\s*.*\.key\s*:\s*\).*${SD}\1\[hidden\]${SD}" && readonly SE
 
 error() {
-  echo "$@" 1>&2
-  exit 1
+  echo -n "$@" 1>&2 && exit 1
 }
 
 if [[ -x "$(command -v kubectl)" ]]; then
@@ -44,22 +41,19 @@ fi
 $KUBE_CLIENT version -o yaml --request-timeout=5s 1>/dev/null
 
 readonly USAGE="
-Usage: report.sh [required] [optional]
+Usage: report.sh [options]
 
 Required:
-  --namespace=<string>
-  --cluster=<string>
+  --namespace=<string>          Kubernetes namespace.
+  --cluster=<string>            Kafka cluster name.
 
 Optional:
-  --bridge=<string>
-  --connect=<string>
-  --mm2=<string>
-  --out-dir=<string>
-  --secrets=(off|hidden|all)]
-
-Default level of secret verbosity is 'hidden' (only secret key will be reported).
+  --bridge=<string>             Bridge component name to get pods and logs.
+  --connect=<string>            Connect component name to get pods and logs.
+  --mm2=<string>                MM2 component name to get pods and logs.
+  --secrets=(off|hidden|all)    Secret verbosity. Default is hidden, only the secret key will be reported.
+  --out-dir=<string>            Script output directory.
 "
-
 OPTSPEC=":-:"
 while getopts "$OPTSPEC" optchar; do
   case "${optchar}" in
@@ -68,24 +62,18 @@ while getopts "$OPTSPEC" optchar; do
         namespace=*)
           NAMESPACE=${OPTARG#*=} && readonly NAMESPACE
           ;;
-        out-dir=*)
-          OUT_DIR=${OPTARG#*=}
-          OUT_DIR=${OUT_DIR//\~/$HOME} && readonly OUT_DIR
-          ;;
         cluster=*)
           CLUSTER=${OPTARG#*=} && readonly CLUSTER
           ;;
-        bridge=*)
-          BRIDGE=${OPTARG#*=} && readonly BRIDGE
-          ;;
-        connect=*)
-          CONNECT=${OPTARG#*=} && readonly CONNECT
-          ;;
-        mm2=*)
-          MM2=${OPTARG#*=} && readonly MM2
-          ;;
         secrets=*)
           SECRETS_OPT=${OPTARG#*=} && readonly SECRETS_OPT
+          ;;
+        bridge=*|connect=*|mm2=*)
+          COMP_NAME=${OPTARG#*=} && readonly COMP_NAME
+          ;;
+        out-dir=*)
+          OUT_DIR=${OPTARG#*=}
+          OUT_DIR=${OUT_DIR//\~/$HOME} && readonly OUT_DIR
           ;;
         *)
           error "$USAGE"
@@ -176,9 +164,7 @@ get_namespaced_yamls() {
   mkdir -p "$OUT_DIR"/reports/"$type"
   local resources
   resources=$($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$CLUSTER" -o name -n "$NAMESPACE" 2>/dev/null ||true)
-  resources="$resources $($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$BRIDGE" -o name -n "$BRIDGE" 2>/dev/null ||true)"
-  resources="$resources $($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$CONNECT" -o name -n "$NAMESPACE" 2>/dev/null ||true)"
-  resources="$resources $($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$MM2" -o name -n "$NAMESPACE" 2>/dev/null ||true)"
+  resources="$resources $($KUBE_CLIENT get "$type" -l strimzi.io/cluster="$COMP_NAME" -o name -n "$NAMESPACE" 2>/dev/null ||true)"
   echo "$type"
   if [[ -n $resources ]]; then
     for res in $resources; do
@@ -215,6 +201,29 @@ get_nonnamespaced_yamls() {
 for RES in "${CLUSTER_RESOURCES[@]}"; do
   get_nonnamespaced_yamls "$RES"
 done
+
+get_pod_logs() {
+  local pod="$1"
+  local con="${2-}"
+  if [[ -n $pod ]]; then
+    local names && names=$($KUBE_CLIENT -n "$NAMESPACE" get po "$pod" -o jsonpath='{.spec.containers[*].name}' --ignore-not-found)
+    local count && count=$(echo "$names" | wc -w)
+    local logs
+    mkdir -p "$OUT_DIR"/reports/podlogs "$OUT_DIR"/reports/configs
+    if [[ "$count" -eq 1 ]]; then
+      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" ||true)"
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log; fi
+      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -p 2>/dev/null ||true)"
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log.0; fi
+    fi
+    if [[ "$count" -gt 1 && -n "$con" && "$names" == *"$con"* ]]; then
+      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -c "$con" ||true)"
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod"-"$con".log; fi
+      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -p -c "$con" 2>/dev/null ||true)"
+      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod"-"$con".log.0; fi
+    fi
+  fi
+}
 
 echo "clusteroperator"
 CO_DEPLOY=$($KUBE_CLIENT get deploy strimzi-cluster-operator -o name -n "$NAMESPACE" --ignore-not-found) && readonly CO_DEPLOY
@@ -253,30 +262,18 @@ if [[ -n $DC_DEPLOY ]]; then
 fi
 
 echo "customresources"
-mkdir -p "$OUT_DIR"/reports/crs
-CRS=$($KUBE_CLIENT get crd -o name | cut -d "/" -f 2) && readonly CRS
-for CR in $CRS; do
-  if [[ $CR == *".strimzi.io" ]]; then
-    RES=$($KUBE_CLIENT get "$CR" -o name -n "$NAMESPACE" | cut -d "/" -f 2)
-    if [[ -n $RES ]]; then
-      echo "    $CR"
-      for j in $RES; do
-        RES=$(echo "$j" | cut -f 1 -d " ")
-        $KUBE_CLIENT get "$CR" "$RES" -n "$NAMESPACE" -o yaml > "$OUT_DIR"/reports/crs/"$CR"-"$RES".yaml
-        echo "        $RES"
-      done
-    fi
-  fi
-done
-
-echo "customresourcedefinitions"
-mkdir -p "$OUT_DIR"/reports/crds
-CRDS=$($KUBE_CLIENT get crd -o name) && readonly CRDS
+mkdir -p "$OUT_DIR"/reports/crds "$OUT_DIR"/reports/crs
+CRDS=$($KUBE_CLIENT get crd -l app=strimzi -o name | cut -d "/" -f 2) && readonly CRDS
 for CRD in $CRDS; do
-  CRD=$(echo "$CRD" | cut -d "/" -f 2)
-  if [[ "$CRD" == *".strimzi.io" ]]; then
+  RES=$($KUBE_CLIENT get "$CRD" -o name -n "$NAMESPACE" | cut -d "/" -f 2)
+  if [[ -n $RES ]]; then
     echo "    $CRD"
     $KUBE_CLIENT get crd "$CRD" -o yaml > "$OUT_DIR"/reports/crds/"$CRD".yaml
+    for j in $RES; do
+      RES=$(echo "$j" | cut -f 1 -d " ")
+      $KUBE_CLIENT get "$CRD" "$RES" -n "$NAMESPACE" -o yaml > "$OUT_DIR"/reports/crs/"$CRD"-"$RES".yaml
+      echo "        $RES"
+    done
   fi
 done
 
@@ -287,35 +284,9 @@ if [[ -n $EVENTS ]]; then
   echo "$EVENTS" > "$OUT_DIR"/reports/events/events.txt
 fi
 
-get_pod_logs() {
-  local pod="$1"
-  local con="${2-}"
-  if [[ -n $pod ]]; then
-    local names && names=$($KUBE_CLIENT -n "$NAMESPACE" get po "$pod" -o jsonpath='{.spec.containers[*].name}' --ignore-not-found)
-    local count && count=$(echo "$names" | wc -w)
-    local logs
-    if [[ "$count" -eq 1 ]]; then
-      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log; fi
-      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -p 2>/dev/null ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log.0; fi
-    fi
-    if [[ "$count" -gt 1 && -n "$con" && "$names" == *"$con"* ]]; then
-      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -c "$con" ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod"-"$con".log; fi
-      logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" -p -c "$con" 2>/dev/null ||true)"
-      if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod"-"$con".log.0; fi
-    fi
-  fi
-}
-
 echo "podlogs"
-mkdir -p "$OUT_DIR"/reports/podlogs
-mkdir -p "$OUT_DIR"/reports/configs
 PODS=$($KUBE_CLIENT get po -l strimzi.io/cluster="$CLUSTER" -o name -n "$NAMESPACE" | cut -d "/" -f 2)
-PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$BRIDGE" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
-PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$CONNECT" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
-PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$MM2" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
+PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$COMP_NAME" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
 readonly PODS
 for POD in $PODS; do
   echo "    $POD"

--- a/tools/report.sh
+++ b/tools/report.sh
@@ -219,7 +219,7 @@ get_pod_logs() {
     local names && names=$($KUBE_CLIENT -n "$NAMESPACE" get po "$pod" -o jsonpath='{.spec.containers[*].name}' --ignore-not-found)
     local count && count=$(echo "$names" | wc -w)
     local logs
-    mkdir -p "$OUT_DIR"/reports/podlogs "$OUT_DIR"/reports/configs
+    mkdir -p "$OUT_DIR"/reports/podlogs
     if [[ "$count" -eq 1 ]]; then
       logs="$($KUBE_CLIENT -n "$NAMESPACE" logs "$pod" ||true)"
       if [[ -n $logs ]]; then printf "%s" "$logs" > "$OUT_DIR"/reports/podlogs/"$pod".log; fi
@@ -295,6 +295,7 @@ if [[ -n $EVENTS ]]; then
 fi
 
 echo "podlogs"
+mkdir -p "$OUT_DIR"/reports/configs
 PODS=$($KUBE_CLIENT get po -l strimzi.io/cluster="$CLUSTER" -o name -n "$NAMESPACE" | cut -d "/" -f 2)
 PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$BRIDGE" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"
 PODS="$PODS $($KUBE_CLIENT get po -l strimzi.io/cluster="$CONNECT" -o name -n "$NAMESPACE" | cut -d "/" -f 2)"


### PR DESCRIPTION
- Fix: command not found error with namespaced operator/drain-cleaner
- Fix: missing pods and logs when using --bridge option
- Improvement: add short descriptions to the usage prompt
- Improvement: merge CRDs and CRs download blocks

## Command not found issue

Happens with namespaced CO deployments.

```sh
$ tools/report.sh --namespace=test --cluster=my-cluster --out-dir=~/Downloads
...
clusterrolebindings
    clusterrolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator
    clusterrolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator-kafka-broker-delegation
    clusterrolebinding.rbac.authorization.k8s.io/strimzi-cluster-operator-kafka-client-delegation
clusteroperator
    deployment.apps/strimzi-cluster-operator
    pod/strimzi-cluster-operator-77448fbdd6-v2c5h
tools/report-old.sh: line 229: get_pod_logs: command not found
```

## Bridge issue

Happens always.

```sh
### BEFORE
$ tools/report.sh --namespace=test --cluster=my-cluster --bridge=my-bridge --out-dir=~/Downloads
pods
    pod/my-cluster-entity-operator-6c56d7f4fb-l874k
    pod/my-cluster-kafka-0
    pod/my-cluster-kafka-1
    pod/my-cluster-kafka-2
    pod/my-cluster-zookeeper-0
    pod/my-cluster-zookeeper-1
    pod/my-cluster-zookeeper-2
...
podlogs
    my-cluster-entity-operator-6c56d7f4fb-l874k
    my-cluster-kafka-0
    my-cluster-kafka-1
    my-cluster-kafka-2
    my-cluster-zookeeper-0
    my-cluster-zookeeper-1
    my-cluster-zookeeper-2
...

### AFTER
$ tools/report.sh --namespace=test --cluster=my-cluster --bridge=my-bridge --out-dir=~/Downloads
...
pods
    pod/my-cluster-entity-operator-6c56d7f4fb-l874k
    pod/my-cluster-kafka-0
    pod/my-cluster-kafka-1
    pod/my-cluster-kafka-2
    pod/my-cluster-zookeeper-0
    pod/my-cluster-zookeeper-1
    pod/my-cluster-zookeeper-2
    pod/my-bridge-bridge-5d8f74f9b7-fntzv <<<<<<<
...
podlogs
    my-cluster-entity-operator-6c56d7f4fb-l874k
    my-cluster-kafka-0
    my-cluster-kafka-1
    my-cluster-kafka-2
    my-cluster-zookeeper-0
    my-cluster-zookeeper-1
    my-cluster-zookeeper-2
    my-bridge-bridge-5d8f74f9b7-fntzv <<<<<<<<
...
```

## Improved help

```sh
### BEFORE
$ tools/report.sh
Usage: report.sh [required] [optional]

Required:
  --namespace=<string>
  --cluster=<string>

Optional:
  --bridge=<string>
  --connect=<string>
  --mm2=<string>
  --out-dir=<string>
  --secrets=(off|hidden|all)]

Default level of secret verbosity is 'hidden' (only secret key will be reported).

### AFTER
$ tools/report.sh
Usage: report.sh [options]

Required:
  --namespace=<string>          Kubernetes namespace.
  --cluster=<string>            Kafka cluster name.

Optional:
  --bridge=<string>             Bridge component name to get pods and logs.
  --connect=<string>            Connect component name to get pods and logs.
  --mm2=<string>                MM2 component name to get pods and logs.
  --secrets=(off|hidden|all)    Secret verbosity. Default is hidden, only the secret key will be reported.
  --out-dir=<string>            Script output directory.
```
