### PR TITLE
[systemtest] Remove extra `openshisft-client-api` dependency from ST's pom.xml

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -104,7 +104,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -237,10 +236,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-model-operatorhub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client-api</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Removal

### Description

This simple PR removes one "extra dependency" of `openshisft-client-api` which I accidentally added to `pom.xml`.

### Checklist

- [ ] Make sure all tests pass

