### PR TITLE
Use default `replication.policy.separator` in docs and examples

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
@@ -30,7 +30,7 @@ The following table describes connector properties and the connectors you config
 |✓
 |✓
 
-|replication.policy.separator:: The separator used for topic naming in the target cluster. Default is `.` (dot). It is only used when the `replication.policy.class` is the `DefaultReplicationPolicy`.
+|replication.policy.separator:: The separator used for topic naming in the target cluster. Default is `.` (dot).
 |✓
 |✓
 |✓

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -125,7 +125,7 @@ spec:
         offset-syncs.topic.replication.factor: 1 # <23>
         sync.topic.acls.enabled: "false" # <24>
         refresh.topics.interval.seconds: 60 # <25>
-        replication.policy.separator: "" # <26>
+        replication.policy.separator: "." # <26>
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy" # <27>
     heartbeatConnector: # <28>
       autoRestart:

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -24,7 +24,6 @@ spec:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
-        replication.policy.separator: ""
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
     heartbeatConnector:
       config:
@@ -32,7 +31,6 @@ spec:
     checkpointConnector:
       config:
         checkpoints.topic.replication.factor: 1
-        replication.policy.separator: ""
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
     topicsPattern: ".*"
     groupsPattern: ".*"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Our examples and docs covering the `IdentityReplicationPolicy` currently use `replication.policy.separator` set to empty string `""`. This does not seem to make much sense:
* The `IdentityReplicationPolicy` itself does not care about it
* But it is used to name some internal MM2 topics which end up with weird names with the empty string separator

This PR removes `replication.policy.separator` from the examples and updates the docs to use the default value / not suggest it is completely irrelevant when `IdentityReplicationPolicy` is used.

### Checklist

- [x] Update documentation