### PR TITLE
Address various warnings in Restart Events tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.V1EventingAPIGroupDSL;
 import io.strimzi.operator.cluster.model.RestartReason;
 import io.strimzi.operator.cluster.model.RestartReasons;
-import io.strimzi.operator.common.Reconciliation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,7 +98,6 @@ class KubernetesRestartEventPublisherTest {
     @Test
     void testOneEventPublishedPerReason() {
         Pod mockPod = Mockito.mock(Pod.class);
-        Reconciliation mockReconciliation = Mockito.mock(Reconciliation.class);
         ObjectMeta mockPodMeta = new ObjectMetaBuilder().withName("pod").withNamespace("ns").build();
         when(mockPod.getMetadata()).thenReturn(mockPodMeta);
 
@@ -129,12 +127,15 @@ class KubernetesRestartEventPublisherTest {
 
     @Test
     void testPopulatesExpectedFields() {
+        @SuppressWarnings("unchecked")
         Resource<Event> mockEventResource = mock(Resource.class);
 
+        @SuppressWarnings("unchecked")
         NonNamespaceOperation<Event, EventList, Resource<Event>> nonNamespaceOp = mock(NonNamespaceOperation.class);
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
         when(nonNamespaceOp.resource(eventCaptor.capture())).thenReturn(mockEventResource);
 
+        @SuppressWarnings("unchecked")
         MixedOperation<Event, EventList, Resource<Event>> mixedOp = mock(MixedOperation.class);
         when(mixedOp.inNamespace(eq(NAMESPACE))).thenReturn(nonNamespaceOp);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -466,7 +466,7 @@ public class KubernetesRestartEventsMockTest {
             Optional<Event> maybeEvent = events.stream().filter(e -> e.getReason().equals(expectedReasonPascal)).findFirst();
 
             if (maybeEvent.isEmpty()) {
-                List<String> foundEvents = listRestartEvents().stream().map(Event::getReason).collect(Collectors.toList());
+                List<String> foundEvents = listRestartEvents().stream().map(Event::getReason).toList();
                 throw new AssertionError("Expected restart event " + expectedReasonPascal + " not found. Found these events: " + foundEvents);
             }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR addresses some of the warnings in the tests related to the Restart Events publisher. Most of them are trivial such as deprecations, unused fields or methods etc.