### PR TITLE
Added patterns to expose KRaft related metrics via JMX exporter

### DIFF
--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -197,6 +197,22 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
+    # KRaft overall related metrics
+    # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
+    - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
+      name: kafka_server_raftmetrics_$1
+      type: COUNTER
+    - pattern: "kafka.server<type=raft-metrics><>(.+):"
+      name: kafka_server_raftmetrics_$1
+      type: GAUGE
+    # KRaft "low level" channels related metrics
+    # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
+    - pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
+      name: kafka_server_raftchannelmetrics_$1
+      type: COUNTER
+    - pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
+      name: kafka_server_raftchannelmetrics_$1
+      type: GAUGE
   zookeeper-metrics-config.yml: |
     # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
     lowercaseOutputName: true

--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -197,22 +197,6 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
-    # KRaft overall related metrics
-    # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
-    - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
-      name: kafka_server_raftmetrics_$1
-      type: COUNTER
-    - pattern: "kafka.server<type=raft-metrics><>(.+):"
-      name: kafka_server_raftmetrics_$1
-      type: GAUGE
-    # KRaft "low level" channels related metrics
-    # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
-    - pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
-      name: kafka_server_raftchannelmetrics_$1
-      type: COUNTER
-    - pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
-      name: kafka_server_raftchannelmetrics_$1
-      type: GAUGE
   zookeeper-metrics-config.yml: |
     # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
     lowercaseOutputName: true

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -197,22 +197,23 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
+    # KRaft mode: uncomment the following lines to export KRaft related metrics 
     # KRaft overall related metrics
     # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
-    - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
-      name: kafka_server_raftmetrics_$1
-      type: COUNTER
-    - pattern: "kafka.server<type=raft-metrics><>(.+):"
-      name: kafka_server_raftmetrics_$1
-      type: GAUGE
+    #- pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
+    #  name: kafka_server_raftmetrics_$1
+    #  type: COUNTER
+    #- pattern: "kafka.server<type=raft-metrics><>(.+):"
+    #  name: kafka_server_raftmetrics_$1
+    #  type: GAUGE
     # KRaft "low level" channels related metrics
     # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
-    - pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
-      name: kafka_server_raftchannelmetrics_$1
-      type: COUNTER
-    - pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
-      name: kafka_server_raftchannelmetrics_$1
-      type: GAUGE
+    #- pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
+    #  name: kafka_server_raftchannelmetrics_$1
+    #  type: COUNTER
+    #- pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
+    #  name: kafka_server_raftchannelmetrics_$1
+    #  type: GAUGE
   zookeeper-metrics-config.yml: |
     # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
     lowercaseOutputName: true

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -197,7 +197,7 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
-    # KRaft mode: uncomment the following lines to export KRaft related metrics 
+    # KRaft mode: uncomment the following lines to export KRaft related metrics
     # KRaft overall related metrics
     # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
     #- pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -197,6 +197,22 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
+    # KRaft overall related metrics
+    # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
+    - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
+      name: kafka_server_raftmetrics_$1
+      type: COUNTER
+    - pattern: "kafka.server<type=raft-metrics><>(.+):"
+      name: kafka_server_raftmetrics_$1
+      type: GAUGE
+    # KRaft "low level" channels related metrics
+    # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
+    - pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
+      name: kafka_server_raftchannelmetrics_$1
+      type: COUNTER
+    - pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
+      name: kafka_server_raftchannelmetrics_$1
+      type: GAUGE
   zookeeper-metrics-config.yml: |
     # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
     lowercaseOutputName: true


### PR DESCRIPTION
This PR adds JMX exporter pattern to the Kafka metrics example in order to expose KRaft related metrics via Prometheus.
It conveys all the available metrics (as described here https://kafka.apache.org/documentation/#kraft_monitoring) which will be useful to make a KRaft dedicated dashboard or updating the Kafka one. It will come with a different PR because needs more investigation. Anyway with this PR, the user can start to take advantage of the KRaft metrics, to run their Prometheus queries or build their own Grafana dashboards.