### PR TITLE
Reflect that `UseStrimziPodSets` feature gate is enabled by default in the docs

### DIFF
--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -54,7 +54,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 `_cluster-name_-kafka-_listener-name_-_pod-id_`:: Service used to route traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled. The new service name will be used for all other external listeners.
 `_cluster-name_-kafka-_listener-name_-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
 `_cluster-name_-kafka-_listener-name_-_pod-id_`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
-`_cluster-name_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods (if the `UseStrimziPodSets` feature gate is disabled).
+`_cluster-name_-kafka-config`:: ConfigMap containing the Kafka ancillary configuration, which is mounted as a volume by the broker pods when the `UseStrimziPodSets` feature gate is disabled.
 `_cluster-name_-kafka-brokers`:: Secret with Kafka broker keys.
 `_cluster-name_-network-policy-kafka`:: Network policy managing access to the Kafka services.
 `strimzi-_namespace-name_-_cluster-name_-kafka-init`:: Cluster role binding used by the Kafka brokers.

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -19,7 +19,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 `_cluster-name_-zookeeper`:: Name given to the following ZooKeeper resources:
 +
-- StatefulSet or StrimziPodSet (if the `UseStrimziPodSets` feature gate is enabled) for managing the ZooKeeper node pods.
+- StrimziPodSet or StatefulSet (if the `UseStrimziPodSets` feature gate is disabled) for managing the ZooKeeper node pods.
 - Service account used by the ZooKeeper nodes.
 - PodDisruptionBudget configured for the ZooKeeper nodes.
 
@@ -35,7 +35,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 `_cluster-name_-kafka`:: Name given to the following Kafka resources:
 +
-- StatefulSet or StrimziPodSet (if the `UseStrimziPodSets` feature gate is enabled) for managing the Kafka broker pods.
+- StrimziPodSet or StatefulSet (if the `UseStrimziPodSets` feature gate is disabled) for managing the Kafka broker pods.
 - Service account used by the Kafka pods.
 - PodDisruptionBudget configured for the Kafka brokers.
 
@@ -54,7 +54,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 `_cluster-name_-kafka-_listener-name_-_pod-id_`:: Service used to route traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled. The new service name will be used for all other external listeners.
 `_cluster-name_-kafka-_listener-name_-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
 `_cluster-name_-kafka-_listener-name_-_pod-id_`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
-`_cluster-name_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods.
+`_cluster-name_-kafka-config`:: ConfigMap which contains the Kafka ancillary configuration and is mounted as a volume by the Kafka broker pods (if the `UseStrimziPodSets` feature gate is disabled).
 `_cluster-name_-kafka-brokers`:: Secret with Kafka broker keys.
 `_cluster-name_-network-policy-kafka`:: Network policy managing access to the Kafka services.
 `strimzi-_namespace-name_-_cluster-name_-kafka-init`:: Cluster role binding used by the Kafka brokers.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The `UseStrimziPodSets` feature gate is now enabled by default. So when referring to StatefulSets versus StrimziPodSets, we should not state that StrimziPodSets are used when the feature gate is enabled but rather that StatefulSets is used when it is disabled. Otherwise, it might confuse users who did not enable anything and yet they now use StrimziPodSets.

### Checklist

- [x] Update documentation