### PR TITLE
[systemtest] Update version of Strimzi to 0.33.1 in upgrade/downgrade and for OLM

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -221,7 +221,7 @@ public class Environment {
     public static final String OLM_SOURCE_NAME = getOrDefault(OLM_SOURCE_NAME_ENV, OLM_SOURCE_NAME_DEFAULT);
     public static final String OLM_SOURCE_NAMESPACE = getOrDefault(OLM_SOURCE_NAMESPACE_ENV, OpenShift.OLM_SOURCE_NAMESPACE);
     public static final String OLM_APP_BUNDLE_PREFIX = getOrDefault(OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX_DEFAULT);
-    public static final String OLM_OPERATOR_LATEST_RELEASE_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, "0.33.0");
+    public static final String OLM_OPERATOR_LATEST_RELEASE_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, "0.33.1");
     // NetworkPolicy variable
     public static final boolean DEFAULT_TO_DENY_NETWORK_POLICIES = getOrDefault(DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, Boolean::parseBoolean, DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT);
     // ClusterOperator installation type variable

--- a/systemtest/src/test/resources/upgrade/StrimziDowngradeST.yaml
+++ b/systemtest/src/test/resources/upgrade/StrimziDowngradeST.yaml
@@ -26,18 +26,18 @@
 # --- Structure ---
   
 - fromVersion: HEAD
-  toVersion: 0.33.0
+  toVersion: 0.33.1
   fromExamples: HEAD
-  toExamples: strimzi-0.33.0
+  toExamples: strimzi-0.33.1
   urlFrom: HEAD
-  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.0/strimzi-0.33.0.zip
+  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.1/strimzi-0.33.1.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.33.0-kafka-3.3.2
-    kafka: strimzi/kafka:0.33.0-kafka-3.3.2
-    topicOperator: strimzi/operator:0.33.0
-    userOperator: strimzi/operator:0.33.0
+    zookeeper: strimzi/kafka:0.33.1-kafka-3.3.2
+    kafka: strimzi/kafka:0.33.1-kafka-3.3.2
+    topicOperator: strimzi/operator:0.33.1
+    userOperator: strimzi/operator:0.33.1
   deployKafkaVersion: 3.3.2
   client:
     continuousClientsMessages: 500
@@ -49,18 +49,18 @@
   featureGatesBefore: "+UseStrimziPodSets"
   featureGatesAfter: "-UseStrimziPodSets"
 - fromVersion: HEAD
-  toVersion: 0.33.0
+  toVersion: 0.33.1
   fromExamples: HEAD
-  toExamples: strimzi-0.33.0
+  toExamples: strimzi-0.33.1
   urlFrom: HEAD
-  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.0/strimzi-0.33.0.zip
+  urlTo: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.1/strimzi-0.33.1.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.33.0-kafka-3.3.2
-    kafka: strimzi/kafka:0.33.0-kafka-3.3.2
-    topicOperator: strimzi/operator:0.33.0
-    userOperator: strimzi/operator:0.33.0
+    zookeeper: strimzi/kafka:0.33.1-kafka-3.3.2
+    kafka: strimzi/kafka:0.33.1-kafka-3.3.2
+    topicOperator: strimzi/operator:0.33.1
+    userOperator: strimzi/operator:0.33.1
   deployKafkaVersion: 3.3.2
   client:
     continuousClientsMessages: 500

--- a/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
+++ b/systemtest/src/test/resources/upgrade/StrimziUpgradeST.yaml
@@ -24,11 +24,11 @@
 #  featureGatesAfter: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on upgrade of CO
 #  --- Structure ---
 
-- fromVersion: 0.33.0
-  fromExamples: strimzi-0.33.0
+- fromVersion: 0.33.1
+  fromExamples: strimzi-0.33.1
   oldestKafka: 3.2.0
-  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.0/strimzi-0.33.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.33.0/kafka-versions.yaml
+  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.1/strimzi-0.33.1.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.33.1/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.4.0
@@ -44,11 +44,11 @@
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: ""
   featureGatesAfter: ""
-- fromVersion: 0.33.0
-  fromExamples: strimzi-0.33.0
+- fromVersion: 0.33.1
+  fromExamples: strimzi-0.33.1
   oldestKafka: 3.2.0
-  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.0/strimzi-0.33.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.33.0/kafka-versions.yaml
+  urlFrom: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.33.1/strimzi-0.33.1.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.33.1/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.4.0


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Enhancement

### Description

This small PR updates version of Strimzi to `0.33.1` in upgrade/downgrade YAMLs and also for default OLM operator version.

### Checklist

- [ ] Make sure all tests pass