### PR TITLE
Disable most CustomCaST system test cases for KRaft mode

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -69,7 +69,7 @@ public class CustomCaST extends AbstractST {
     private static final String STRIMZI_INTERMEDIATE_CA = "C=CZ, L=Prague, O=Strimzi, CN=StrimziIntermediateCA";
 
     @ParallelNamespaceTest
-    @KRaftNotSupported
+    @KRaftNotSupported("Using ZK secrets and waiting for the ZK pods are impossible in KRaft mode.")
     void testReplacingCustomClusterKeyPairToInvokeRenewalProcess(ExtensionContext extensionContext) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
         final TestStorage testStorage = new TestStorage(extensionContext);
         // 0. Generate root and intermediate certificate authority with cluster CA
@@ -157,7 +157,7 @@ public class CustomCaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @KRaftNotSupported
+    @KRaftNotSupported("Using ZK secrets and waiting for the ZK pods are impossible in KRaft mode.")
     void testReplacingCustomClientsKeyPairToInvokeRenewalProcess(ExtensionContext extensionContext) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
         final TestStorage testStorage = new TestStorage(extensionContext);
         // 0. Generate root and intermediate certificate authority with clients CA
@@ -320,7 +320,7 @@ public class CustomCaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @KRaftNotSupported
+    @KRaftNotSupported("Using ZK secrets and waiting for the ZK pods are impossible in KRaft mode.")
     void testCustomClusterCaAndClientsCaCertificates(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
         final String testSuite = extensionContext.getRequiredTestClass().getSimpleName();
@@ -414,7 +414,7 @@ public class CustomCaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @KRaftNotSupported
+    @KRaftNotSupported("Using ZK secrets and waiting for the ZK pods are impossible in KRaft mode.")
     void testCustomClusterCACertificateRenew(ExtensionContext extensionContext) {
         TestStorage testStorage = new TestStorage(extensionContext);
         final String testSuite = extensionContext.getRequiredTestClass().getSimpleName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -68,6 +69,7 @@ public class CustomCaST extends AbstractST {
     private static final String STRIMZI_INTERMEDIATE_CA = "C=CZ, L=Prague, O=Strimzi, CN=StrimziIntermediateCA";
 
     @ParallelNamespaceTest
+    @KRaftNotSupported
     void testReplacingCustomClusterKeyPairToInvokeRenewalProcess(ExtensionContext extensionContext) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
         final TestStorage testStorage = new TestStorage(extensionContext);
         // 0. Generate root and intermediate certificate authority with cluster CA
@@ -155,6 +157,7 @@ public class CustomCaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @KRaftNotSupported
     void testReplacingCustomClientsKeyPairToInvokeRenewalProcess(ExtensionContext extensionContext) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
         final TestStorage testStorage = new TestStorage(extensionContext);
         // 0. Generate root and intermediate certificate authority with clients CA
@@ -317,6 +320,7 @@ public class CustomCaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @KRaftNotSupported
     void testCustomClusterCaAndClientsCaCertificates(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
         final String testSuite = extensionContext.getRequiredTestClass().getSimpleName();
@@ -410,6 +414,7 @@ public class CustomCaST extends AbstractST {
     }
 
     @ParallelNamespaceTest
+    @KRaftNotSupported
     void testCustomClusterCACertificateRenew(ExtensionContext extensionContext) {
         TestStorage testStorage = new TestStorage(extensionContext);
         final String testSuite = extensionContext.getRequiredTestClass().getSimpleName();


### PR DESCRIPTION
Signed-off-by: see-quick <maros.orsak159@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes the KRaft pipeline, which is currently failing due to test cases that retrieve ZK secrets (which is impossible in KRaft mode). I have disabled such test cases, and in the following PR, I will change the logic of test cases, which will also support KRaft mode.

### Checklist

- [x] Make sure all tests pass