### PR TITLE
[systemtest] Add check for `null` values in Job waits

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -497,12 +497,12 @@ public class KubeClient {
 
     public boolean checkSucceededJobStatus(String namespaceName, String jobName, int expectedSucceededPods) {
         JobStatus jobStatus = getJobStatus(namespaceName, jobName);
-        return jobStatus != null && jobStatus.getSucceeded() != null && jobStatus.equals(expectedSucceededPods);
+        return jobStatus != null && jobStatus.getSucceeded() != null && jobStatus.getSucceeded().equals(expectedSucceededPods);
     }
 
     public boolean checkFailedJobStatus(String namespaceName, String jobName, int expectedFailedPods) {
         JobStatus jobStatus = getJobStatus(namespaceName, jobName);
-        return jobStatus != null && jobStatus.getFailed() != null && jobStatus.equals(expectedFailedPods);
+        return jobStatus != null && jobStatus.getFailed() != null && jobStatus.getFailed().equals(expectedFailedPods);
     }
 
     // Pods Statuses:  0 Running / 0 Succeeded / 1 Failed

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -496,11 +496,13 @@ public class KubeClient {
     }
 
     public boolean checkSucceededJobStatus(String namespaceName, String jobName, int expectedSucceededPods) {
-        return getJobStatus(namespaceName, jobName).getSucceeded().equals(expectedSucceededPods);
+        JobStatus jobStatus = getJobStatus(namespaceName, jobName);
+        return jobStatus != null && jobStatus.getSucceeded() != null && jobStatus.equals(expectedSucceededPods);
     }
 
     public boolean checkFailedJobStatus(String namespaceName, String jobName, int expectedFailedPods) {
-        return getJobStatus(namespaceName, jobName).getFailed().equals(expectedFailedPods);
+        JobStatus jobStatus = getJobStatus(namespaceName, jobName);
+        return jobStatus != null && jobStatus.getFailed() != null && jobStatus.equals(expectedFailedPods);
     }
 
     // Pods Statuses:  0 Running / 0 Succeeded / 1 Failed

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -507,7 +507,8 @@ public class KubeClient {
 
     // Pods Statuses:  0 Running / 0 Succeeded / 1 Failed
     public JobStatus getJobStatus(String namespaceName, String jobName) {
-        return client.batch().v1().jobs().inNamespace(namespaceName).withName(jobName).get().getStatus();
+        Job job = client.batch().v1().jobs().inNamespace(namespaceName).withName(jobName).get();
+        return job == null ? null : job.getStatus();
     }
 
     public JobStatus getJobStatus(String jobName) {


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR adds check for `null` values in `checkSucceededJobStatus` and `checkFailedJobStatus` methods, to get rid of these error lines in log:

```
 2023-02-10 05:17:14 [ForkJoinPool-1-worker-1] ERROR [TestUtils:139] While waiting for clients finished exception occurred: Cannot invoke "java.lang.Integer.equals(Object)" because the return value of "io.fabric8.kubernetes.api.model.batch.v1.JobStatus.getSucceeded()" is null
```

### Checklist

- [ ] Make sure all tests pass
