### PR TITLE
Stable Pod identities for Kafka Connect and Mirror Maker 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.34.0
 
 * Add support for Kafka 3.4.0 and remove support for Kafka 3.2.x
-* Stable Pod identities for Kafka Connect and Mirror Maker 2 (Feature Gate `StableConnectIdentities`)
+* Stable Pod identities for Kafka Connect and MirrorMaker 2 (Feature Gate `StableConnectIdentities`)
 * Use JDK HTTP client in the Kubernetes client instead of the OkHttp client
 * Add truststore configuration for HTTPS connections to OPA server
 * Add image digest support in Helm chart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.0
 
 * Add support for Kafka 3.4.0 and remove support for Kafka 3.2.x
+* Stable Pod identities for Kafka Connect and Mirror Maker 2 (Feature Gate `StableConnectIdentities`)
 * Use JDK HTTP client in the Kubernetes client instead of the OkHttp client
 * Add truststore configuration for HTTPS connections to OPA server
 * Add image digest support in Helm chart

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -24,16 +24,19 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"deployment", "pod", "apiService", "connectContainer", "initContainer", "podDisruptionBudget",
-    "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig", "buildServiceAccount", "jmxSecret"})
+@JsonPropertyOrder({"deployment", "podSet", "pod", "apiService", "headlessService", "connectContainer", "initContainer",
+    "podDisruptionBudget", "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig",
+    "buildServiceAccount", "jmxSecret"})
 @EqualsAndHashCode
 public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
     private DeploymentTemplate deployment;
+    private ResourceTemplate podSet;
     private PodTemplate pod;
     private PodTemplate buildPod;
     private InternalServiceTemplate apiService;
+    private InternalServiceTemplate headlessService;
     private PodDisruptionBudgetTemplate podDisruptionBudget;
     private ContainerTemplate connectContainer;
     private ContainerTemplate initContainer;
@@ -53,6 +56,16 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable,
 
     public void setDeployment(DeploymentTemplate deployment) {
         this.deployment = deployment;
+    }
+
+    @Description("Template for Kafka Connect `StrimziPodSet` resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getPodSet() {
+        return podSet;
+    }
+
+    public void setPodSet(ResourceTemplate podSetTemplate) {
+        this.podSet = podSetTemplate;
     }
 
     @Description("Template for Kafka Connect `Pods`.")
@@ -84,6 +97,16 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable,
 
     public void setApiService(InternalServiceTemplate apiService) {
         this.apiService = apiService;
+    }
+
+    @Description("Template for Kafka Connect headless `Service`.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public InternalServiceTemplate getHeadlessService() {
+        return headlessService;
+    }
+
+    public void setHeadlessService(InternalServiceTemplate headlessService) {
+        this.headlessService = headlessService;
     }
 
     @Description("Template for Kafka Connect `PodDisruptionBudget`.")

--- a/api/src/main/java/io/strimzi/platform/KubernetesVersion.java
+++ b/api/src/main/java/io/strimzi/platform/KubernetesVersion.java
@@ -22,6 +22,7 @@ public class KubernetesVersion implements Comparable<KubernetesVersion> {
     public static final KubernetesVersion V1_23 = new KubernetesVersion(1, 23);
     public static final KubernetesVersion V1_24 = new KubernetesVersion(1, 24);
     public static final KubernetesVersion V1_25 = new KubernetesVersion(1, 25);
+    public static final KubernetesVersion V1_26 = new KubernetesVersion(1, 26);
 
     public static final KubernetesVersion MINIMAL_SUPPORTED_VERSION = V1_19;
     public static final int MINIMAL_SUPPORTED_MAJOR = MINIMAL_SUPPORTED_VERSION.major;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -150,9 +150,18 @@ public class ClusterOperator extends AbstractVerticle {
         Promise<Void> handler = Promise.promise();
         vertx.executeBlocking(future -> {
             try {
-                if (config.featureGates().useStrimziPodSetsEnabled()) {
-                    strimziPodSetController = new StrimziPodSetController(namespace, config.getCustomResourceSelector(), resourceOperatorSupplier.kafkaOperator,
-                            resourceOperatorSupplier.strimziPodSetOperator, resourceOperatorSupplier.podOperations, resourceOperatorSupplier.metricsProvider, config.getPodSetControllerWorkQueueSize());
+                if (config.featureGates().useStrimziPodSetsEnabled() || config.featureGates().stableConnectIdentitiesEnabled()) {
+                    strimziPodSetController = new StrimziPodSetController(
+                            namespace,
+                            config.getCustomResourceSelector(),
+                            resourceOperatorSupplier.kafkaOperator,
+                            resourceOperatorSupplier.connectOperator,
+                            resourceOperatorSupplier.mirrorMaker2Operator,
+                            resourceOperatorSupplier.strimziPodSetOperator,
+                            resourceOperatorSupplier.podOperations,
+                            resourceOperatorSupplier.metricsProvider,
+                            config.getPodSetControllerWorkQueueSize()
+                    );
                     strimziPodSetController.start();
                 }
                 future.complete();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -18,10 +18,12 @@ public class FeatureGates {
 
     private static final String USE_STRIMZI_POD_SETS = "UseStrimziPodSets";
     private static final String USE_KRAFT = "UseKRaft";
+    private static final String STABLE_CONNECT_IDENTITIES = "StableConnectIdentities";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate useStrimziPodSets = new FeatureGate(USE_STRIMZI_POD_SETS, true);
     private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, false);
+    private final FeatureGate stableConnectIdentities = new FeatureGate(STABLE_CONNECT_IDENTITIES, false);
 
     /**
      * Constructs the feature gates configuration.
@@ -48,6 +50,9 @@ public class FeatureGates {
                         break;
                     case USE_KRAFT:
                         setValueOnlyOnce(useKRaft, value);
+                        break;
+                    case STABLE_CONNECT_IDENTITIES:
+                        setValueOnlyOnce(stableConnectIdentities, value);
                         break;
                     default:
                         throw new InvalidConfigurationException("Unknown feature gate " + featureGate + " found in the configuration");
@@ -99,6 +104,13 @@ public class FeatureGates {
     }
 
     /**
+     * @return  Returns true when the StableConnectIdentities feature gate is enabled
+     */
+    public boolean stableConnectIdentitiesEnabled() {
+        return stableConnectIdentities.isEnabled();
+    }
+
+    /**
      * Returns a list of all Feature gates. Used for testing.
      *
      * @return  List of all Feature Gates
@@ -106,7 +118,8 @@ public class FeatureGates {
     /*test*/ List<FeatureGate> allFeatureGates()  {
         return List.of(
                 useStrimziPodSets,
-                useKRaft
+                useKRaft,
+                stableConnectIdentities
         );
     }
 
@@ -114,7 +127,8 @@ public class FeatureGates {
     public String toString() {
         return "FeatureGates(" +
                 "UseStrimziPodSets=" + useStrimziPodSets.isEnabled() + "," +
-                "UseKRaft=" + useKRaft.isEnabled() +
+                "UseKRaft=" + useKRaft.isEnabled() + "," +
+                "StableConnectIdentities=" + stableConnectIdentities.isEnabled() +
                 ")";
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -352,6 +352,7 @@ public class CruiseControl extends AbstractModel {
                 ownerReference,
                 templateDeployment,
                 replicas,
+                null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -190,6 +190,7 @@ public class EntityOperator extends AbstractModel {
                 ownerReference,
                 templateDeployment,
                 replicas,
+                null,
                 WorkloadUtils.deploymentStrategy(RECREATE), // we intentionally ignore the template here as EO doesn't support RU strategy
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -176,6 +176,7 @@ public class JmxTrans extends AbstractModel {
                 ownerReference,
                 templateDeployment,
                 replicas,
+                null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -351,6 +351,7 @@ public class KafkaBridgeCluster extends AbstractModel {
                 ownerReference,
                 templateDeployment,
                 replicas,
+                null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, DeploymentStrategy.ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1161,6 +1161,7 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsJmx {
                 templatePodSet,
                 replicas,
                 prepareControllerAnnotations(),
+                labels.strimziSelectorLabels(),
                 brokerId -> WorkloadUtils.createStatefulPod(
                         reconciliation,
                         getPodName(brokerId),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -180,6 +180,7 @@ public class KafkaExporter extends AbstractModel {
                 ownerReference,
                 templateDeployment,
                 replicas,
+                null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -112,9 +112,8 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                     .orElseThrow(() -> new InvalidResourceException("connectCluster with alias " + connectClusterAlias + " cannot be found in the list of clusters at spec.clusters"));
         }        
         cluster.setConfiguration(new KafkaMirrorMaker2Configuration(reconciliation, connectCluster.getConfig().entrySet()));
-        KafkaMirrorMaker2Cluster mm2 = fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, cluster);
 
-        return mm2;
+        return fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, cluster);
     }
 
     private static KafkaConnectSpec buildKafkaConnectSpec(KafkaMirrorMaker2Spec spec, KafkaMirrorMaker2ClusterSpec connectCluster) {
@@ -200,8 +199,8 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
 
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     @Override
-    protected List<EnvVar> getEnvVars() {
-        List<EnvVar> varList = super.getEnvVars();
+    protected List<EnvVar> getEnvVars(boolean stableIdentities) {
+        List<EnvVar> varList = super.getEnvVars(stableIdentities);
 
         final StringBuilder clusterAliases = new StringBuilder();
         final StringBuilder clustersTrustedCerts = new StringBuilder();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -290,6 +290,7 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 ownerReference,
                 templateDeployment,
                 replicas,
+                null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodDisruptionBudgetUtils.java
@@ -118,7 +118,7 @@ public class PodDisruptionBudgetUtils {
                     .withOwnerReferences(ownerReference)
                 .endMetadata()
                 .withNewSpec()
-                    .withMinAvailable(new IntOrString(replicas - (template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE)))
+                    .withMinAvailable(new IntOrString(Math.max(0, replicas - (template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE))))
                     .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
                 .endSpec()
                 .build();
@@ -158,7 +158,7 @@ public class PodDisruptionBudgetUtils {
                     .withOwnerReferences(ownerReference)
                 .endMetadata()
                 .withNewSpec()
-                    .withMinAvailable(new IntOrString(replicas - (template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE)))
+                    .withMinAvailable(new IntOrString(Math.max(0, replicas - (template != null ? template.getMaxUnavailable() : DEFAULT_MAX_UNAVAILABLE))))
                     .withSelector(new LabelSelectorBuilder().withMatchLabels(labels.strimziSelectorLabels().toMap()).build())
                 .endSpec()
                 .build();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -412,6 +412,7 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsJ
                 templatePodSet,
                 replicas,
                 Map.of(Annotations.ANNO_STRIMZI_IO_STORAGE, ModelUtils.encodeStorageToJson(storage)),
+                labels.strimziSelectorLabels(),
                 brokerId -> WorkloadUtils.createStatefulPod(
                         reconciliation,
                         getPodName(brokerId),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -77,11 +77,13 @@ public class ConnectBuildOperator {
     /**
      * Asynchronously runs the KafkaConnectBuild (if present) and reconciles the related resources
      *
-     * @param reconciliation    The reconciliation
-     * @param namespace         Namespace of the Connect cluster
-     * @param controllerResource       Name of the Connect cluster
-     * @param connectBuild      KafkaConnectBuild object
-     * @return                  Future for tracking the asynchronous result of the reconciliation steps
+     * @param reconciliation        The reconciliation
+     * @param namespace             Namespace of the Connect cluster
+     * @param controllerResource    The controller resource (Deployment or StrimziPodSet) with annotations describing
+     *                              the current state. Or null if it does not exist yet.
+     * @param connectBuild          KafkaConnectBuild object from the Kafka Connect custom resource
+     *
+     * @return  Future for tracking the asynchronous result of the reconciliation steps
      */
     public Future<BuildInfo> reconcile(Reconciliation reconciliation, String namespace, HasMetadata controllerResource, KafkaConnectBuild connectBuild) {
         if (connectBuild.getBuild() == null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -6,9 +6,9 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.openshift.api.model.Build;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.connect.build.Output;
@@ -27,7 +27,6 @@ import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.BuildConfigOperator;
 import io.strimzi.operator.common.operator.resource.BuildOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
-import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ImageStreamOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.ServiceAccountOperator;
@@ -42,7 +41,6 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ConnectBuildOperator {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ConnectBuildOperator.class.getName());
 
-    private final DeploymentOperator deploymentOperations;
     private final ImageStreamOperator imageStreamOperations;
     private final PodOperator podOperator;
     private final ConfigMapOperator configMapOperations;
@@ -63,7 +61,6 @@ public class ConnectBuildOperator {
      * @param config    Cluster OPerator configuration
      */
     public ConnectBuildOperator(PlatformFeaturesAvailability pfa, ResourceOperatorSupplier supplier, ClusterOperatorConfig config) {
-        this.deploymentOperations = supplier.deploymentOperations;
         this.imageStreamOperations = supplier.imageStreamOperations;
         this.podOperator = supplier.podOperations;
         this.configMapOperations = supplier.configMapOperations;
@@ -82,11 +79,11 @@ public class ConnectBuildOperator {
      *
      * @param reconciliation    The reconciliation
      * @param namespace         Namespace of the Connect cluster
-     * @param connectName       Name of the Connect cluster
+     * @param controllerResource       Name of the Connect cluster
      * @param connectBuild      KafkaConnectBuild object
      * @return                  Future for tracking the asynchronous result of the reconciliation steps
      */
-    public Future<BuildInfo> reconcile(Reconciliation reconciliation, String namespace, String connectName, KafkaConnectBuild connectBuild) {
+    public Future<BuildInfo> reconcile(Reconciliation reconciliation, String namespace, HasMetadata controllerResource, KafkaConnectBuild connectBuild) {
         if (connectBuild.getBuild() == null) {
             // Build is not configured => we should delete resources
             return configMapOperations.reconcile(reconciliation, namespace, KafkaConnectResources.dockerFileConfigMapName(connectBuild.getCluster()), null)
@@ -96,8 +93,7 @@ public class ConnectBuildOperator {
                     .map(i -> null);
         } else {
             // Build exists => let's build
-            return deploymentOperations.getAsync(namespace, connectName)
-                    .compose(deployment -> build(reconciliation, namespace, connectBuild, deployment));
+            return build(reconciliation, namespace, connectBuild, controllerResource);
 
         }
     }
@@ -105,22 +101,22 @@ public class ConnectBuildOperator {
     /**
      * Builds a new container image with connectors on Kubernetes using Kaniko or on OpenShift using BuildConfig
      *
-     * @param reconciliation    The reconciliation
-     * @param namespace         Namespace of the Connect cluster
-     * @param connectBuild      KafkaConnectBuild object
-     * @param deployment    The existing Connect deployment
+     * @param reconciliation        The reconciliation
+     * @param namespace             Namespace of the Connect cluster
+     * @param connectBuild          KafkaConnectBuild object
+     * @param controllerResource    The existing Connect controllerResource
      *
      * @return              Future for tracking the asynchronous result of the Kubernetes image build
      */
-    private Future<BuildInfo> build(Reconciliation reconciliation, String namespace, KafkaConnectBuild connectBuild, Deployment deployment) {
+    private Future<BuildInfo> build(Reconciliation reconciliation, String namespace, KafkaConnectBuild connectBuild, HasMetadata controllerResource) {
         String currentBuildRevision = "";
         String currentImage = "";
         boolean forceRebuild = false;
-        if (deployment != null) {
-            // Extract information from the current deployment. This is used to figure out if new build needs to be run or not.
-            currentBuildRevision = Annotations.stringAnnotation(deployment.getSpec().getTemplate(), Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
-            currentImage = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage();
-            forceRebuild = Annotations.hasAnnotation(deployment, Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD);
+        if (controllerResource != null) {
+            // Extract information from the current controllerResource. This is used to figure out if new build needs to be run or not.
+            currentBuildRevision = Annotations.stringAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
+            currentImage = Annotations.stringAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, null);
+            forceRebuild = Annotations.hasAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD);
         }
 
         KafkaConnectDockerfile dockerfile = connectBuild.generateDockerfile();
@@ -128,6 +124,7 @@ public class ConnectBuildOperator {
         ConfigMap dockerFileConfigMap = connectBuild.generateDockerfileConfigMap(dockerfile);
 
         if (newBuildRevision.equals(currentBuildRevision)
+                && currentImage != null
                 && !forceRebuild) {
             // The revision is the same and rebuild was not forced => nothing to do
             LOGGER.debugCr(reconciliation, "Build configuration did not change. Nothing new to build. Container image {} will be used.", currentImage);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectMigration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectMigration.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.template.DeploymentStrategy;
+import io.strimzi.operator.cluster.model.ImagePullPolicy;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
+import io.vertx.core.Future;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class contains the methods for migrating Kafka Connect and Kafka Mirror Maker 2 clusters between Deployments
+ * and StrimziPodSets and the other way.
+ */
+public class KafkaConnectMigration {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaConnectMigration.class.getName());
+
+    private final Reconciliation reconciliation;
+    private final KafkaConnectCluster connect;
+
+    private final Map<String, String> controllerAnnotations;
+    private final Map<String, String> podAnnotations;
+    private final long operationTimeoutMs;
+    private final boolean isOpenshift;
+    private final ImagePullPolicy imagePullPolicy;
+    private final List<LocalObjectReference> imagePullSecrets;
+    private final String customContainerImage;
+
+    private final DeploymentOperator deploymentOperator;
+    private final StrimziPodSetOperator podSetOperator;
+    private final PodOperator podOperator;
+
+    /**
+     * Constructs the Connect migration tool
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param connect                   Kafka Connect Cluster model
+     * @param controllerAnnotations     Map with controller annotations
+     * @param podAnnotations            Map with Pod annotations
+     * @param operationTimeoutMs        Operations timeout in milliseconds
+     * @param isOpenshift               Flag indicating whether we are on OpenShift or not
+     * @param imagePullPolicy           Image pull policy
+     * @param imagePullSecrets          List of image pull secrets
+     * @param customContainerImage      Container image built by Kafka Connect Build
+     * @param deploymentOperator        Operator for managing Deployments
+     * @param podSetOperator            Operator for managing StrimziPodSets
+     * @param podOperator               Resource Operator for managing Pods
+     */
+    public KafkaConnectMigration(
+            Reconciliation reconciliation,
+            KafkaConnectCluster connect,
+            Map<String, String> controllerAnnotations,
+            Map<String, String> podAnnotations,
+            long operationTimeoutMs,
+            boolean isOpenshift,
+            ImagePullPolicy imagePullPolicy,
+            List<LocalObjectReference> imagePullSecrets,
+            String customContainerImage,
+            DeploymentOperator deploymentOperator,
+            StrimziPodSetOperator podSetOperator,
+            PodOperator podOperator
+    ) {
+        this.reconciliation = reconciliation;
+        this.connect = connect;
+
+        this.controllerAnnotations = controllerAnnotations;
+        this.podAnnotations = podAnnotations;
+        this.operationTimeoutMs = operationTimeoutMs;
+        this.isOpenshift = isOpenshift;
+        this.imagePullPolicy = imagePullPolicy;
+        this.imagePullSecrets = imagePullSecrets;
+        this.customContainerImage = customContainerImage;
+
+        this.deploymentOperator = deploymentOperator;
+        this.podSetOperator = podSetOperator;
+        this.podOperator = podOperator;
+    }
+
+    /**
+     * Migrates Kafka Connect or Kafka Mirror Maker 2 from Deployment to StrimziPodSet
+     *
+     * @param deployment    Current Deployment resource
+     * @param podSet        Current StrimziPodSet resource
+     *
+     * @return  Future which completes when the migration is completed
+     */
+    public Future<Void> migrateFromDeploymentToStrimziPodSets(Deployment deployment, StrimziPodSet podSet)    {
+        if (deployment == null) {
+            // Deployment does not exist anymore => no migration needed
+            return Future.succeededFuture();
+        } else {
+            int depReplicas = deployment.getSpec().getReplicas();
+            int podSetReplicas = podSet != null ? podSet.getSpec().getPods().size() : 0;
+
+            if (DeploymentStrategy.ROLLING_UPDATE.equals(connect.deploymentStrategy())) {
+                return moveOnePodFromDeploymentToStrimziPodSetWithRollingUpdateStrategy(depReplicas - 1, Math.min(podSetReplicas + 1, connect.getReplicas()));
+            } else {
+                return moveOnePodFromDeploymentToStrimziPodSetWithRecreateStrategy(depReplicas - 1, Math.min(podSetReplicas + 1, connect.getReplicas()));
+            }
+        }
+    }
+
+    /**
+     * Executes one migration step which consists from removing one Deployment replicas and adding one PodSet replica.
+     * When it completes the step, it recursively calls itself again to do the next step and so on. This method is
+     * following the Rolling Update Deployment Strategy: it first creates a new pod before removing the old one.
+     *
+     * @param desiredDeploymentReplicas     Number of desired Deployment replicas in this step
+     * @param desiredPodSetReplicas         Number of desired PodSets in this step
+     *
+     * @return  Future which completes when all steps are done
+     */
+    private Future<Void> moveOnePodFromDeploymentToStrimziPodSetWithRollingUpdateStrategy(int desiredDeploymentReplicas, int desiredPodSetReplicas)  {
+        if (desiredDeploymentReplicas < 1)  {
+            // We are done, there will be no more Pods inside the Deployment
+            // We scale the StrimziPodSet to the final number of replicas and delete the Deployment
+            LOGGER.infoCr(reconciliation, "Migration from Deployment to StrimziPodSet is finishing. Deleting the Deployment.");
+            return scaleUpStrimziPodSet(connect.getReplicas())
+                    .compose(i -> deploymentOperator.deleteAsync(reconciliation, reconciliation.namespace(), connect.getComponentName(), true))
+                    .map((Void) null);
+        } else {
+            LOGGER.infoCr(reconciliation, "Moving one Pod from Deployment to StrimziPodSet");
+            return scaleUpStrimziPodSet(desiredPodSetReplicas)
+                    .compose(i -> scaleDownDeployment(desiredDeploymentReplicas))
+                    .compose(i -> moveOnePodFromDeploymentToStrimziPodSetWithRollingUpdateStrategy(desiredDeploymentReplicas - 1, Math.min(desiredPodSetReplicas + 1, connect.getReplicas())));
+        }
+    }
+
+    /**
+     * Executes one migration step which consists from removing one Deployment replicas and adding one PodSet replica.
+     * When it completes the step, it recursively calls itself again to do the next step and so on. This method is
+     * following the Recreate Deployment Strategy: it first deletes the old pod before creating the new one.
+     *
+     * @param desiredDeploymentReplicas     Number of desired Deployment replicas in this step
+     * @param desiredPodSetReplicas         Number of desired PodSets in this step
+     *
+     * @return  Future which completes when all steps are done
+     */
+    private Future<Void> moveOnePodFromDeploymentToStrimziPodSetWithRecreateStrategy(int desiredDeploymentReplicas, int desiredPodSetReplicas)  {
+        if (desiredDeploymentReplicas < 1)  {
+            // We are done, there will be no more Pods inside the Deployment
+            // We scale the StrimziPodSet to the final number of replicas and delete the Deployment
+            LOGGER.infoCr(reconciliation, "Migration from Deployment to StrimziPodSet is finishing. Deleting the Deployment.");
+            return deploymentOperator.deleteAsync(reconciliation, reconciliation.namespace(), connect.getComponentName(), true)
+                    .compose(i -> scaleUpStrimziPodSet(connect.getReplicas()));
+        } else {
+            LOGGER.infoCr(reconciliation, "Moving one Pod from Deployment to StrimziPodSet");
+            return scaleDownDeployment(desiredDeploymentReplicas)
+                    .compose(i -> scaleUpStrimziPodSet(desiredPodSetReplicas))
+                    .compose(i -> moveOnePodFromDeploymentToStrimziPodSetWithRecreateStrategy(desiredDeploymentReplicas - 1, Math.min(desiredPodSetReplicas + 1, connect.getReplicas())));
+        }
+    }
+
+    /**
+     * Scales-down Deployment
+     *
+     * @param replicas  New number of replicas
+     *
+     * @return  Future which completes when the scale-down is done
+     */
+    private Future<Void> scaleDownDeployment(int replicas)    {
+        LOGGER.infoCr(reconciliation, "Scaling down Deployment {}", connect.getComponentName());
+        return deploymentOperator.scaleDown(reconciliation, reconciliation.namespace(), connect.getComponentName(), replicas)
+                .compose(i -> deploymentOperator.waitForObserved(reconciliation, reconciliation.namespace(), connect.getComponentName(), 1_000, operationTimeoutMs))
+                .compose(i -> deploymentOperator.readiness(reconciliation, reconciliation.namespace(), connect.getComponentName(), 1_000, operationTimeoutMs));
+    }
+
+    /**
+     * Scales-up StrimziPodSet and waits for the new Pod to be ready
+     *
+     * @param replicas  New number of replicas
+     *
+     * @return  Future which completes when the scale-up is done
+     */
+    private Future<Void> scaleUpStrimziPodSet(int replicas)    {
+        LOGGER.infoCr(reconciliation, "Scaling up StrimziPodSet {}", connect.getComponentName());
+        return podSetOperator.reconcile(reconciliation, reconciliation.namespace(), connect.getComponentName(), connect.generatePodSet(replicas, controllerAnnotations, podAnnotations, isOpenshift, imagePullPolicy, imagePullSecrets, customContainerImage))
+                .compose(i -> podOperator.readiness(reconciliation, reconciliation.namespace(), connect.getPodName(replicas - 1), 1_000, operationTimeoutMs));
+    }
+
+    /**
+     * Migrates Kafka Connect or Kafka Mirror Maker 2 from StrimziPodSet to Deployment
+     *
+     * @param deployment    Current Deployment resource
+     * @param podSet        Current StrimziPodSet resource
+     *
+     * @return  Future which completes when the migration is completed
+     */
+    public Future<Void> migrateFromStrimziPodSetsToDeployment(Deployment deployment, StrimziPodSet podSet)    {
+        if (podSet == null) {
+            // StrimziPodSet does not exist anymore => no migration needed
+            return Future.succeededFuture();
+        } else {
+            int depReplicas = deployment != null ? deployment.getSpec().getReplicas() : 0;
+            int podSetReplicas = podSet.getSpec().getPods().size();
+
+            if (DeploymentStrategy.ROLLING_UPDATE.equals(connect.deploymentStrategy())) {
+                return deploymentOperator.reconcile(reconciliation, reconciliation.namespace(), connect.getComponentName(), connect.generateDeployment(depReplicas, controllerAnnotations, podAnnotations, isOpenshift, imagePullPolicy, imagePullSecrets, customContainerImage))
+                        .compose(i -> moveOnePodFromStrimziPodSetToDeploymentWithRollingUpdateStrategy(Math.min(depReplicas + 1, connect.getReplicas()), podSetReplicas - 1));
+            } else {
+                return deploymentOperator.reconcile(reconciliation, reconciliation.namespace(), connect.getComponentName(), connect.generateDeployment(depReplicas, controllerAnnotations, podAnnotations, isOpenshift, imagePullPolicy, imagePullSecrets, customContainerImage))
+                        .compose(i -> moveOnePodFromStrimziPodSetToDeploymentWithRecreateStrategy(Math.min(depReplicas + 1, connect.getReplicas()), podSetReplicas - 1));
+            }
+        }
+    }
+
+    /**
+     * Executes one migration step which consists from adding one Deployment replicas and removing one PodSet replica.
+     * When it completes the step, it recursively calls itself again to do the next step and so on. This method is
+     *      * following the Rolling Update Deployment Strategy: it first creates a new pod before removing the old one.
+     *
+     * @param desiredDeploymentReplicas     Number of desired Deployment replicas in this step
+     * @param desiredPodSetReplicas         Number of desired PodSets in this step
+     *
+     * @return  Future which completes when all steps are done
+     */
+    private Future<Void> moveOnePodFromStrimziPodSetToDeploymentWithRollingUpdateStrategy(int desiredDeploymentReplicas, int desiredPodSetReplicas)  {
+        if (desiredPodSetReplicas < 1)  {
+            // We are done, there will be no more Pods inside the StrimziPodSet
+            // We scale the Deployment to the final number of replicas and delete the StrimziPodSet
+            LOGGER.infoCr(reconciliation, "Migration from StrimziPodSet to Deployment is finishing. Deleting the StrimziPodSet.");
+            return scaleUpDeployment(connect.getReplicas())
+                    .compose(i -> podSetOperator.deleteAsync(reconciliation, reconciliation.namespace(), connect.getComponentName(), true))
+                    .map((Void) null);
+        } else {
+            LOGGER.infoCr(reconciliation, "Moving one Pod from StrimziPodSet to Deployment");
+            return scaleUpDeployment(desiredDeploymentReplicas)
+                    .compose(i -> scaleDownStrimziPodSet(desiredPodSetReplicas))
+                    .compose(i -> moveOnePodFromStrimziPodSetToDeploymentWithRollingUpdateStrategy(Math.min(desiredDeploymentReplicas + 1, connect.getReplicas()), desiredPodSetReplicas - 1));
+        }
+    }
+
+    /**
+     * Executes one migration step which consists from adding one Deployment replicas and removing one PodSet replica.
+     * When it completes the step, it recursively calls itself again to do the next step and so on. This method is
+     *      * following the Recreate Deployment Strategy: it first deletes the old pod before creating the new one.
+     *
+     * @param desiredDeploymentReplicas     Number of desired Deployment replicas in this step
+     * @param desiredPodSetReplicas         Number of desired PodSets in this step
+     *
+     * @return  Future which completes when all steps are done
+     */
+    private Future<Void> moveOnePodFromStrimziPodSetToDeploymentWithRecreateStrategy(int desiredDeploymentReplicas, int desiredPodSetReplicas)  {
+        if (desiredPodSetReplicas < 1)  {
+            // We are done, there will be no more Pods inside the StrimziPodSet
+            // We scale the Deployment to the final number of replicas and delete the StrimziPodSet
+            LOGGER.infoCr(reconciliation, "Migration from StrimziPodSet to Deployment is finishing. Deleting the StrimziPodSet.");
+            return podSetOperator.deleteAsync(reconciliation, reconciliation.namespace(), connect.getComponentName(), true)
+                    .compose(i -> scaleUpDeployment(connect.getReplicas()))
+                    .map((Void) null);
+        } else {
+            LOGGER.infoCr(reconciliation, "Moving one Pod from StrimziPodSet to Deployment");
+            return scaleDownStrimziPodSet(desiredPodSetReplicas)
+                    .compose(i -> scaleUpDeployment(desiredDeploymentReplicas))
+                    .compose(i -> moveOnePodFromStrimziPodSetToDeploymentWithRecreateStrategy(Math.min(desiredDeploymentReplicas + 1, connect.getReplicas()), desiredPodSetReplicas - 1));
+        }
+    }
+
+    /**
+     * Scales-up Deployment and waits for the new Pod to be ready
+     *
+     * @param replicas  New number of replicas
+     *
+     * @return  Future which completes when the scale-up is done
+     */
+    private Future<Void> scaleUpDeployment(int replicas)    {
+        LOGGER.infoCr(reconciliation, "Scaling up Deployment {}", connect.getComponentName());
+        return deploymentOperator.scaleUp(reconciliation, reconciliation.namespace(), connect.getComponentName(), replicas)
+                .compose(i -> deploymentOperator.waitForObserved(reconciliation, reconciliation.namespace(), connect.getComponentName(), 1_000, operationTimeoutMs))
+                .compose(i -> deploymentOperator.readiness(reconciliation, reconciliation.namespace(), connect.getComponentName(), 1_000, operationTimeoutMs));
+    }
+
+    /**
+     * Scales-down StrimziPodSet
+     *
+     * @param replicas  New number of replicas
+     *
+     * @return  Future which completes when the scale-down is done
+     */
+    private Future<ReconcileResult<StrimziPodSet>> scaleDownStrimziPodSet(int replicas)    {
+        LOGGER.infoCr(reconciliation, "Scaling down StrimziPodset {}", connect.getComponentName());
+        return podSetOperator.reconcile(reconciliation, reconciliation.namespace(), connect.getComponentName(), connect.generatePodSet(replicas, controllerAnnotations, podAnnotations, isOpenshift, imagePullPolicy, imagePullSecrets, customContainerImage));
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectRoller.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.readiness.Readiness;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.operator.resource.PodRevision;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.vertx.core.Future;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * This class contains the methods for rolling Kafka Connect and Kafka Mirror Maker 2 clusters based on StrimziPodSets.
+ */
+public class KafkaConnectRoller {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaConnectRoller.class.getName());
+
+    private final Reconciliation reconciliation;
+    private final long operationTimeoutMs;
+    private final KafkaConnectCluster connect;
+
+    private final PodOperator podOperator;
+
+    /**
+     * Constructs the Manual Pod Cleaner.
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param connect               Kafka Connect Cluster model
+     * @param operationTimeoutMs    Operations timeout in milliseconds
+     * @param podOperator           Resource Operator for managing Pods
+     */
+    public KafkaConnectRoller(
+            Reconciliation reconciliation,
+            KafkaConnectCluster connect,
+            long operationTimeoutMs,
+            PodOperator podOperator
+    ) {
+        this.reconciliation = reconciliation;
+        this.connect = connect;
+        this.operationTimeoutMs = operationTimeoutMs;
+        this.podOperator = podOperator;
+    }
+
+    /**
+     * Goes through the Kafka Connect pods, considers them for rolling, and checks their readiness. If there are any
+     * pods which do not exist or are not ready, they will be handled first to avoid killing the whole cluster in
+     * subsequent reconciliations.
+     *
+     * @param podSet    The current StrimziPodSet resource which the Pods are compared against when checking if they
+     *                  are up-to-date
+     *
+     * @return  Future which completes when the rolling update is done
+     */
+    public Future<Void> maybeRoll(StrimziPodSet podSet)    {
+        return podOperator.listAsync(reconciliation.namespace(), connect.getSelectorLabels())
+                .compose(pods -> Future.succeededFuture(prepareRollingOrder(pods)))
+                .compose(rollingOrder -> maybeRollPods(podSet, rollingOrder));
+    }
+
+    /* test */ Queue<String> prepareRollingOrder(List<Pod> pods)   {
+        Deque<String> rollingOrder = new ArrayDeque<>();
+
+        for (int i = 0; i < connect.getReplicas(); i++) {
+            String podName = connect.getPodName(i);
+            Pod matchingPod = pods.stream().filter(pod -> podName.equals(pod.getMetadata().getName())).findFirst().orElse(null);
+
+            if (matchingPod == null || !Readiness.isPodReady(matchingPod))    {
+                // Non-existing or unready pods are handled first
+                // This helps to avoid rolling all pods into some situation where they would be all failing
+                rollingOrder.addFirst(podName);
+            } else {
+                // Ready pods are rolled only at the end
+                rollingOrder.addLast(podName);
+            }
+        }
+
+        return rollingOrder;
+    }
+
+    /**
+     * Goes through the pods in given order and considers them for rolling. It checks if the first pof in the queue
+     * needs rolling and checks its readiness. And then calls itself to move to the next pod.
+     *
+     * @param podSet        The current StrimziPodSet resource which the Pods are compared against when checking if they
+     *                      are up-to-date
+     * @param rollingOrder  Queue with the pod names in the order of their rolling
+     *
+     * @return  Future which completes when all pods were rolled / considered for rolling
+     */
+    private Future<Void> maybeRollPods(StrimziPodSet podSet,
+                                       Queue<String> rollingOrder)  {
+        String podName = rollingOrder.poll();
+
+        if (podName != null)    {
+            // The queue is not empty. We consider rolling of this pod and call this method again to handle the next pod
+            return maybeRollPod(podSet, podName)
+                    .compose(i -> maybeRollPods(podSet, rollingOrder));
+        } else {
+            // Queue is empty => we return completely
+            return Future.succeededFuture();
+        }
+    }
+
+    /**
+     * Checks given pod if it needs rolling and rolls it if needed. It checks the pod readiness afterwards and waits
+     * for it if needed. The Pod is rolled when its revision doesn't match the desired revision form the StrimziPodSet.
+     *
+     * @param podSet    The current StrimziPodSet resource which the Pods are compared against when checking if they
+     *                  are up-to-date
+     * @param podName   Name of the pod which should be considered
+     *
+     * @return  Future which completes when the pod is maybe rolled and ready
+     */
+    /* test */ Future<Void> maybeRollPod(StrimziPodSet podSet,
+                                      String podName) {
+        return podOperator.getAsync(reconciliation.namespace(), podName)
+                .compose(pod -> {
+                    if (pod == null)    {
+                        LOGGER.debugCr(reconciliation, "Pod {} does not exist => waiting for its creation", podName);
+                        return Future.succeededFuture();
+                    } else if (PodRevision.hasChanged(pod, podSet)) {
+                        // Pods changed and needs rolling
+                        LOGGER.infoCr(reconciliation, "Rolling pod {} (Pod revision changed)", podName);
+                        return podOperator.deleteAsync(reconciliation, reconciliation.namespace(), podName, false);
+                    } else {
+                        // Pod exists and does not need to be rolled
+                        LOGGER.debugCr(reconciliation, "Pod {} does not need to be rolled", podName);
+                        return Future.succeededFuture();
+                    }
+                })
+                .compose(i -> {
+                    LOGGER.debugCr(reconciliation, "Waiting for pod {} to become ready", podName);
+                    return podOperator.readiness(reconciliation, reconciliation.namespace(), podName, 1_000, operationTimeoutMs);
+                });
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectRoller.java
@@ -88,7 +88,7 @@ public class KafkaConnectRoller {
     }
 
     /**
-     * Goes through the pods in given order and considers them for rolling. It checks if the first pof in the queue
+     * Goes through the pods in given order and considers them for rolling. It checks if the first pod in the queue
      * needs rolling and checks its readiness. And then calls itself to move to the next pod.
      *
      * @param podSet        The current StrimziPodSet resource which the Pods are compared against when checking if they
@@ -113,7 +113,7 @@ public class KafkaConnectRoller {
 
     /**
      * Checks given pod if it needs rolling and rolls it if needed. It checks the pod readiness afterwards and waits
-     * for it if needed. The Pod is rolled when its revision doesn't match the desired revision form the StrimziPodSet.
+     * for it if needed. The Pod is rolled when its revision doesn't match the desired revision from the StrimziPodSet.
      *
      * @param podSet    The current StrimziPodSet resource which the Pods are compared against when checking if they
      *                  are up-to-date

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -5,7 +5,10 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -18,8 +21,12 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.micrometer.core.instrument.Timer;
+import io.strimzi.api.kafka.KafkaConnectList;
 import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.KafkaMirrorMaker2List;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.status.StrimziPodSetStatus;
@@ -55,6 +62,9 @@ public class StrimziPodSetController implements Runnable {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StrimziPodSetController.class);
 
     private static final long DEFAULT_RESYNC_PERIOD = 5 * 60 * 1_000L; // 5 minutes by default
+    private static final LabelSelector POD_LABEL_SELECTOR = new LabelSelectorBuilder()
+            .withMatchExpressions(new LabelSelectorRequirement(Labels.STRIMZI_KIND_LABEL, "Exists", null))
+            .build();
 
     private final Thread controllerThread;
 
@@ -70,9 +80,13 @@ public class StrimziPodSetController implements Runnable {
     private final SharedIndexInformer<Pod> podInformer;
     private final SharedIndexInformer<StrimziPodSet> strimziPodSetInformer;
     private final SharedIndexInformer<Kafka> kafkaInformer;
+    private final SharedIndexInformer<KafkaConnect> kafkaConnectInformer;
+    private final SharedIndexInformer<KafkaMirrorMaker2> kafkaMirrorMaker2Informer;
     private final Lister<Pod> podLister;
     private final Lister<StrimziPodSet> strimziPodSetLister;
     private final Lister<Kafka> kafkaLister;
+    private final Lister<KafkaConnect> kafkaConnectLister;
+    private final Lister<KafkaMirrorMaker2> kafkaMirrorMaker2Lister;
 
     /**
      * Creates the StrimziPodSet controller. The controller should normally exist once per operator for cluster-wide mode
@@ -82,13 +96,25 @@ public class StrimziPodSetController implements Runnable {
      * @param crSelectorLabels              Selector labels for custom resource managed by this operator instance. This is used
      *                                      to check that the pods belong to a Kafka cluster matching these labels.
      * @param kafkaOperator                 Kafka Operator for getting the Kafka custom resources
+     * @param kafkaConnectOperator          KafkaConnect Operator for getting the KafkaConnect custom resources
+     * @param kafkaMirrorMaker2Operator     KafkaMirrorMaker2 Operator for getting the KafkaMirrorMaker2 custom resources
      * @param strimziPodSetOperator         StrimziPodSet Operator used to manage the StrimziPodSet resources - get them, update
      *                                      their status etc.
      * @param podOperator                   Pod operator for managing pods
      * @param metricsProvider               Metrics provider
      * @param podSetControllerWorkQueueSize Indicates the size of the StrimziPodSetController work queue
      */
-    public StrimziPodSetController(String watchedNamespace, Labels crSelectorLabels, CrdOperator<KubernetesClient, Kafka, KafkaList> kafkaOperator, StrimziPodSetOperator strimziPodSetOperator, PodOperator podOperator, MetricsProvider metricsProvider, int podSetControllerWorkQueueSize) {
+    public StrimziPodSetController(
+            String watchedNamespace,
+            Labels crSelectorLabels,
+            CrdOperator<KubernetesClient, Kafka, KafkaList> kafkaOperator,
+            CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> kafkaConnectOperator,
+            CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> kafkaMirrorMaker2Operator,
+            StrimziPodSetOperator strimziPodSetOperator,
+            PodOperator podOperator,
+            MetricsProvider metricsProvider,
+            int podSetControllerWorkQueueSize
+    ) {
         this.podOperator = podOperator;
         this.strimziPodSetOperator = strimziPodSetOperator;
         this.crSelector = (crSelectorLabels == null || crSelectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, crSelectorLabels.toMap()));
@@ -98,16 +124,21 @@ public class StrimziPodSetController implements Runnable {
         // Set up the metrics holder
         this.metrics = new ControllerMetricsHolder("StrimziPodSet", crSelectorLabels != null ? crSelectorLabels : Labels.EMPTY, metricsProvider);
 
-        // Kafka informer and lister is used to get Kafka CRs quickly. This is needed for verification of the CR selector labels
+        // Kafka, KafkaConnect and KafkaMirrorMaker2 informers and listers are used to get the CRs quickly.
+        // This is needed for verification of the CR selector labels.
         this.kafkaInformer = kafkaOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap());
         this.kafkaLister = new Lister<>(kafkaInformer.getIndexer());
+        this.kafkaConnectInformer = kafkaConnectOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap());
+        this.kafkaConnectLister = new Lister<>(kafkaConnectInformer.getIndexer());
+        this.kafkaMirrorMaker2Informer = kafkaMirrorMaker2Operator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap());
+        this.kafkaMirrorMaker2Lister = new Lister<>(kafkaMirrorMaker2Informer.getIndexer());
 
         // StrimziPodSet informer and lister is used to get events about StrimziPodSet and get StrimziPodSet quickly
         this.strimziPodSetInformer = strimziPodSetOperator.informer(watchedNamespace);
         this.strimziPodSetLister = new Lister<>(strimziPodSetInformer.getIndexer());
 
         // Pod informer and lister is used to get events about pods and get pods quickly
-        this.podInformer = podOperator.informer(watchedNamespace, Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka"));
+        this.podInformer = podOperator.informer(watchedNamespace, POD_LABEL_SELECTOR);
         this.podLister = new Lister<>(podInformer.getIndexer());
 
         this.controllerThread = new Thread(this, "StrimziPodSetController");
@@ -118,7 +149,11 @@ public class StrimziPodSetController implements Runnable {
     }
 
     protected boolean isSynced() {
-        return podInformer.hasSynced() && strimziPodSetInformer.hasSynced() && kafkaInformer.hasSynced();
+        return podInformer.hasSynced()
+                && strimziPodSetInformer.hasSynced()
+                && kafkaInformer.hasSynced()
+                && kafkaConnectInformer.hasSynced()
+                && kafkaMirrorMaker2Informer.hasSynced();
     }
 
     protected void startController() {
@@ -170,6 +205,8 @@ public class StrimziPodSetController implements Runnable {
         podInformer.stop();
         strimziPodSetInformer.stop();
         kafkaInformer.stop();
+        kafkaConnectInformer.stop();
+        kafkaMirrorMaker2Informer.stop();
     }
 
     /**
@@ -214,7 +251,7 @@ public class StrimziPodSetController implements Runnable {
             if (matchesCrSelector(parentPodSet)) {
                 enqueue(new SimplifiedReconciliation(parentPodSet.getMetadata().getNamespace(), parentPodSet.getMetadata().getName()));
             } else {
-                LOGGER.debugOp("Pod {} in namespace {} was {} but does not belong to a Kafka cluster managed by this operator", pod.getMetadata().getName(), pod.getMetadata().getNamespace(), action);
+                LOGGER.debugOp("Pod {} in namespace {} was {} but does not belong to a cluster managed by this operator", pod.getMetadata().getName(), pod.getMetadata().getNamespace(), action);
             }
         } else {
             LOGGER.debugOp("Pod {} in namespace {} which was {} does not seem to be controlled by any StrimziPodSet and will be ignored", pod.getMetadata().getName(), pod.getMetadata().getNamespace(), action);
@@ -232,22 +269,36 @@ public class StrimziPodSetController implements Runnable {
      */
     private boolean matchesCrSelector(StrimziPodSet podSet)    {
         if (podSet.getMetadata().getLabels() != null
+                && podSet.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL) != null
                 && podSet.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL) != null) {
-            // We find the matching Kafka cluster and check the CR selector
-            String kafkaClusterName = podSet.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
-            Kafka kafka = kafkaLister.namespace(podSet.getMetadata().getNamespace()).get(kafkaClusterName);
+            // We find the matching custom resource and check the CR selector
+            HasMetadata cr = findCustomResource(podSet);
 
-            if (kafka != null
-                    && Util.matchesSelector(crSelector, kafka)) {
+            if (cr != null
+                    && Util.matchesSelector(crSelector, cr)) {
                 return true;
             } else {
-                LOGGER.debugOp("StrimziPodSet {} in namespace {} does not belong to a Kafka cluster matching the selector", podSet.getMetadata().getName(), podSet.getMetadata().getNamespace());
+                LOGGER.debugOp("StrimziPodSet {} in namespace {} does not belong to a custom resource matching the selector", podSet.getMetadata().getName(), podSet.getMetadata().getNamespace());
                 return false;
             }
         } else {
-            LOGGER.warnOp("Invalid event received: StrimziPodSet was without the required {} label", Labels.STRIMZI_CLUSTER_LABEL);
+            LOGGER.warnOp("Invalid event received: StrimziPodSet was without the required {} and {} labels", Labels.STRIMZI_KIND_LABEL, Labels.STRIMZI_CLUSTER_LABEL);
             return false;
         }
+    }
+
+    private HasMetadata findCustomResource(StrimziPodSet podSet)    {
+        String customResourceName = podSet.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+        HasMetadata cr = null;
+
+        switch (podSet.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL)) {
+            case Kafka.RESOURCE_KIND -> cr = kafkaLister.namespace(podSet.getMetadata().getNamespace()).get(customResourceName);
+            case KafkaConnect.RESOURCE_KIND -> cr = kafkaConnectLister.namespace(podSet.getMetadata().getNamespace()).get(customResourceName);
+            case KafkaMirrorMaker2.RESOURCE_KIND -> cr = kafkaMirrorMaker2Lister.namespace(podSet.getMetadata().getNamespace()).get(customResourceName);
+            default -> LOGGER.warnOp("StrimziPodSet {} belongs to unsupported custom resource kind {}", podSet.getMetadata().getName(), podSet.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL));
+        }
+
+        return cr;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperator.java
@@ -194,7 +194,7 @@ public class StatefulSetOperator extends AbstractScalableNamespacedResourceOpera
      * {@inheritDoc}
      */
     @Override
-    protected Future<ReconcileResult<StatefulSet>> internalPatch(Reconciliation reconciliation, String namespace, String name, StatefulSet current, StatefulSet desired) {
+    protected Future<ReconcileResult<StatefulSet>> internalUpdate(Reconciliation reconciliation, String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(reconciliation, current, desired);
 
         if (shouldIncrementGeneration(reconciliation, diff)) {
@@ -212,7 +212,7 @@ public class StatefulSetOperator extends AbstractScalableNamespacedResourceOpera
             // When volume claim templates change, we need to delete the STS and re-create it
             return internalReplace(reconciliation, namespace, name, current, desired, false);
         } else {
-            return super.internalPatch(reconciliation, namespace, name, current, desired);
+            return super.internalUpdate(reconciliation, namespace, name, current, desired);
         }
 
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
@@ -204,6 +205,7 @@ public class ClusterOperatorTest {
                 return mockPodInformer;
             });
             when(mockNamespacedPods.withLabels(any())).thenReturn(mockNamespacedPods);
+            when(mockNamespacedPods.withLabelSelector(any(LabelSelector.class))).thenReturn(mockNamespacedPods);
             when(mockPods.inNamespace(namespace)).thenReturn(mockNamespacedPods);
         }
 
@@ -229,7 +231,7 @@ public class ClusterOperatorTest {
                 assertThat("Looks like there were more watchers than namespaces",
                         numWatchers.get(), lessThanOrEqualTo(maximumExpectedNumberOfWatchers));
 
-                int expectedNumberOfInformers = strimziPodSets ? 3 * namespaceList.size() : 0;
+                int expectedNumberOfInformers = strimziPodSets ? 5 * namespaceList.size() : 0;
                 assertThat("Looks like there were more informers than namespaces",
                         numInformers.get(), is(expectedNumberOfInformers));
 
@@ -298,6 +300,7 @@ public class ClusterOperatorTest {
         SharedIndexInformer mockPodInformer = mock(SharedIndexInformer.class);
         when(client.pods()).thenReturn(mockPods);
         when(mockFilteredPods.withLabels(any())).thenReturn(mockFilteredPods);
+        when(mockFilteredPods.withLabelSelector(any(LabelSelector.class))).thenReturn(mockFilteredPods);
         when(mockPods.inAnyNamespace()).thenReturn(mockFilteredPods);
         when(mockPodInformer.getIndexer()).thenReturn(mockPodIndexer);
         when(mockFilteredPods.inform()).thenAnswer(i -> {
@@ -326,7 +329,7 @@ public class ClusterOperatorTest {
                 int maximumExpectedNumberOfWatchers = podSetsOnly ? 0 : 7;
                 assertThat("Looks like there were more watchers than custom resources", numWatchers.get(), lessThanOrEqualTo(maximumExpectedNumberOfWatchers));
 
-                int numberOfInformers = strimziPodSets ? 3 : 0;
+                int numberOfInformers = strimziPodSets ? 5 : 0;
                 assertThat("Looks like there were more informers than we should", numInformers.get(), is(numberOfInformers));
 
                 latch.countDown();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -226,7 +226,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
     @ParallelTest
     public void testEnvVars() {
-        assertThat(kmm2.getEnvVars(), is(getExpectedEnvVars()));
+        assertThat(kmm2.getEnvVars(false), is(getExpectedEnvVars()));
     }
 
     @ParallelTest
@@ -275,7 +275,7 @@ public class KafkaMirrorMaker2ClusterTest {
     @ParallelTest
     public void testGenerateDeployment()   {
         Deployment dep = kmm2.generateDeployment(
-                new HashMap<>(), true, null, null);
+                replicas, null, new HashMap<>(), true, null, null, null);
 
         assertThat(dep.getMetadata().getName(), is(KafkaMirrorMaker2Resources.deploymentName(clusterName)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
@@ -313,7 +313,7 @@ public class KafkaMirrorMaker2ClusterTest {
         ResourceTester<KafkaMirrorMaker2, KafkaMirrorMaker2Cluster> resourceTester = new ResourceTester<>(KafkaMirrorMaker2.class, VERSIONS, (kafkaMirrorMaker2, versions) -> KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, versions), this.getClass().getSimpleName() + ".withAffinity");
         resourceTester
             .assertDesiredModel("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(
-                    new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getAffinity());
+                    replicas, null, new HashMap<>(), true, null, null, null).getSpec().getTemplate().getSpec().getAffinity());
     }
 
     @ParallelTest
@@ -321,7 +321,7 @@ public class KafkaMirrorMaker2ClusterTest {
         ResourceTester<KafkaMirrorMaker2, KafkaMirrorMaker2Cluster> resourceTester = new ResourceTester<>(KafkaMirrorMaker2.class, VERSIONS, (kafkaMirrorMaker2, versions) -> KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, versions), this.getClass().getSimpleName() + ".withTolerations");
         resourceTester
             .assertDesiredModel("-Deployment.yaml", kmm2c -> kmm2c.generateDeployment(
-                    new HashMap<>(), true, null, null).getSpec().getTemplate().getSpec().getTolerations());
+                    replicas, null, new HashMap<>(), true, null, null, null).getSpec().getTemplate().getSpec().getTolerations());
     }
 
     @ParallelTest
@@ -339,7 +339,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .endSpec()
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
-        Deployment dep = kmm2.generateDeployment(emptyMap(), true, null, null);
+        Deployment dep = kmm2.generateDeployment(replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("my-secret"));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("my-another-secret"));
@@ -371,7 +371,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         Container cont = getContainer(dep);
 
         assertThat(io.strimzi.operator.cluster.TestUtils.containerEnvVars(cont).get(KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_TRUSTED_CERTS),
@@ -405,7 +405,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(3).getName(), is("user-secret"));
 
@@ -441,7 +441,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         // 3 = 1 volume from logging/metrics + 2 from above cert mounted for connect and for connectors
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
@@ -466,7 +466,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("user1-secret"));
 
@@ -505,7 +505,7 @@ public class KafkaMirrorMaker2ClusterTest {
             .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -566,7 +566,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(5));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -619,7 +619,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("user1-secret"));
 
@@ -658,7 +658,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -719,7 +719,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(5));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -772,7 +772,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(2).getName(), is("user1-secret"));
 
@@ -812,7 +812,7 @@ public class KafkaMirrorMaker2ClusterTest {
             .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
 
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().toString(), dep.getSpec().getTemplate().getSpec().getVolumes().size(), is(4));
         assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
@@ -930,7 +930,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getMetadata().getLabels().entrySet().containsAll(expectedDepLabels.entrySet()), is(true));
         assertThat(dep.getMetadata().getAnnotations().entrySet().containsAll(depAnots.entrySet()), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getPriorityClassName(), is("top-priority"));
@@ -955,12 +955,12 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(svc.getSpec().getIpFamilies(), contains("IPv6", "IPv4"));
 
         // Check PodDisruptionBudget
-        PodDisruptionBudget pdb = kmm2.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = kmm2.generatePodDisruptionBudget(false);
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdb.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
 
         // Check PodDisruptionBudget
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1(false);
         assertThat(pdbV1Beta1.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
         assertThat(pdbV1Beta1.getMetadata().getAnnotations().entrySet().containsAll(pdbAnots.entrySet()), is(true));
 
@@ -996,7 +996,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<EnvVar> envs = getContainer(dep).getEnv();
         List<EnvVar> selected = envs.stream().filter(var -> var.getName().equals("MY_ENV_VAR")).collect(Collectors.toList());
         assertThat(selected.size(), is(1));
@@ -1024,7 +1024,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<EnvVar> envs = getContainer(dep).getEnv();
         List<EnvVar> selected = envs.stream().filter(var -> var.getName().equals("MY_ENV_VAR")).collect(Collectors.toList());
         assertThat(selected.size(), is(1));
@@ -1050,7 +1050,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<Volume> volumes = dep.getSpec().getTemplate().getSpec().getVolumes();
         List<Volume> selected = volumes.stream().filter(vol -> vol.getName().equals(KafkaMirrorMaker2Cluster.EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + "my-volume")).collect(Collectors.toList());
         assertThat(selected.size(), is(1));
@@ -1082,7 +1082,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<Volume> volumes = dep.getSpec().getTemplate().getSpec().getVolumes();
         List<Volume> selected = volumes.stream().filter(vol -> vol.getName().equals(KafkaMirrorMaker2Cluster.EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + "my-volume")).collect(Collectors.toList());
         assertThat(selected.size(), is(1));
@@ -1115,7 +1115,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<Volume> volumes = dep.getSpec().getTemplate().getSpec().getVolumes();
         List<Volume> selected = volumes.stream().filter(vol -> vol.getName().equals(KafkaMirrorMaker2Cluster.EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + "my-volume")).collect(Collectors.toList());
         assertThat(selected.size(), is(0));
@@ -1142,7 +1142,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<Volume> volumes = dep.getSpec().getTemplate().getSpec().getVolumes();
         List<Volume> selected = volumes.stream().filter(vol -> vol.getName().equals(KafkaMirrorMaker2Cluster.EXTERNAL_CONFIGURATION_VOLUME_NAME_PREFIX + "my-volume")).collect(Collectors.toList());
         assertThat(selected.size(), is(0));
@@ -1173,7 +1173,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<EnvVar> envs = getContainer(dep).getEnv();
         List<EnvVar> selected = envs.stream().filter(var -> var.getName().equals("MY_ENV_VAR")).collect(Collectors.toList());
         assertThat(selected.size(), is(0));
@@ -1198,7 +1198,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         // Check Deployment
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         List<EnvVar> envs = getContainer(dep).getEnv();
         List<EnvVar> selected = envs.stream().filter(var -> var.getName().equals("MY_ENV_VAR")).collect(Collectors.toList());
         assertThat(selected.size(), is(0));
@@ -1218,7 +1218,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(123L));
     }
 
@@ -1227,7 +1227,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource).build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
-        Deployment dep = kmm2.generateDeployment(emptyMap(), true, null, null);
+        Deployment dep = kmm2.generateDeployment(replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getTerminationGracePeriodSeconds(), is(30L));
     }
 
@@ -1248,7 +1248,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(2));
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret1), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
@@ -1266,7 +1266,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, this.resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, secrets);
+                replicas, null, emptyMap(), true, null, secrets, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(2));
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret1), is(true));
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
@@ -1289,7 +1289,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, singletonList(secret1));
+                replicas, null, emptyMap(), true, null, singletonList(secret1), null);
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().size(), is(1));
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret1), is(false));
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets().contains(secret2), is(true));
@@ -1301,7 +1301,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(nullValue()));
     }
 
@@ -1319,7 +1319,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(notNullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(123L));
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext().getRunAsGroup(), is(456L));
@@ -1332,7 +1332,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
     }
 
@@ -1342,7 +1342,7 @@ public class KafkaMirrorMaker2ClusterTest {
         kmm2.securityProvider = new RestrictedPodSecurityProvider();
         kmm2.securityProvider.configure(new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION));
 
-        Deployment dep = kmm2.generateDeployment(emptyMap(), true, null, null);
+        Deployment dep = kmm2.generateDeployment(replicas, null, emptyMap(), true, null, null, null);
         assertThat(dep.getSpec().getTemplate().getSpec().getSecurityContext(), is(nullValue()));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getSecurityContext().getAllowPrivilegeEscalation(), is(false));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getSecurityContext().getRunAsNonRoot(), is(true));
@@ -1363,11 +1363,21 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
-        PodDisruptionBudget pdb = kmm2.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = kmm2.generatePodDisruptionBudget(false);
+        assertThat(pdb.getSpec().getMinAvailable(), is(nullValue()));
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
 
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1(false);
+        assertThat(pdbV1Beta1.getSpec().getMinAvailable(), is(nullValue()));
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(new IntOrString(2)));
+
+        pdb = kmm2.generatePodDisruptionBudget(true);
+        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(0)));
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
+
+        pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1(true);
+        assertThat(pdbV1Beta1.getSpec().getMinAvailable(), is(new IntOrString(0)));
+        assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1375,11 +1385,21 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource).build();
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
-        PodDisruptionBudget pdb = kmm2.generatePodDisruptionBudget();
+        PodDisruptionBudget pdb = kmm2.generatePodDisruptionBudget(false);
+        assertThat(pdb.getSpec().getMinAvailable(), is(nullValue()));
         assertThat(pdb.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
 
-        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1();
+        io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1(false);
+        assertThat(pdbV1Beta1.getSpec().getMinAvailable(), is(nullValue()));
         assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(new IntOrString(1)));
+
+        pdb = kmm2.generatePodDisruptionBudget(true);
+        assertThat(pdb.getSpec().getMinAvailable(), is(new IntOrString(1)));
+        assertThat(pdb.getSpec().getMaxUnavailable(), is(nullValue()));
+
+        pdbV1Beta1 = kmm2.generatePodDisruptionBudgetV1Beta1(true);
+        assertThat(pdbV1Beta1.getSpec().getMinAvailable(), is(new IntOrString(1)));
+        assertThat(pdbV1Beta1.getSpec().getMaxUnavailable(), is(nullValue()));
     }
 
     @ParallelTest
@@ -1387,11 +1407,11 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                Collections.EMPTY_MAP, true, ImagePullPolicy.ALWAYS, null);
+                replicas, null, Collections.EMPTY_MAP, true, ImagePullPolicy.ALWAYS, null, null);
         assertThat(getContainer(dep).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
 
         dep = kmm2.generateDeployment(
-                Collections.EMPTY_MAP, true, ImagePullPolicy.IFNOTPRESENT, null);
+                replicas, null, Collections.EMPTY_MAP, true, ImagePullPolicy.IFNOTPRESENT, null, null);
         assertThat(getContainer(dep).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
     }
 
@@ -1413,7 +1433,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                Collections.EMPTY_MAP, true, null, null);
+                replicas, null, Collections.EMPTY_MAP, true, null, null, null);
         Container cont = getContainer(dep);
         assertThat(cont.getResources().getLimits(), is(limits));
         assertThat(cont.getResources().getRequests(), is(requests));
@@ -1437,7 +1457,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                Collections.EMPTY_MAP, true, null, null);
+                replicas, null, Collections.EMPTY_MAP, true, null, null, null);
         Container cont = getContainer(dep);
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:+UseG1GC"), is(true));
         assertThat(cont.getEnv().stream().filter(env -> "KAFKA_JVM_PERFORMANCE_OPTS".equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("-XX:MaxGCPauseMillis=20"), is(true));
@@ -1474,7 +1494,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .endSpec()
                 .build();
 
-        List<EnvVar> kafkaEnvVars = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS).getEnvVars();
+        List<EnvVar> kafkaEnvVars = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS).getEnvVars(false);
 
         assertThat("Failed to correctly set container environment variable: " + testEnvOneKey,
                 kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
@@ -1512,7 +1532,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .endSpec()
                 .build();
 
-        List<EnvVar> kafkaEnvVars = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS).getEnvVars();
+        List<EnvVar> kafkaEnvVars = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS).getEnvVars(false);
 
         assertThat("Failed to prevent over writing existing container environment variable: " + testEnvOneKey,
                 kafkaEnvVars.stream().filter(env -> testEnvOneKey.equals(env.getName()))
@@ -1559,7 +1579,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
 
         Deployment dep = kmm2.generateDeployment(
-                Collections.EMPTY_MAP, true, null, null);
+                replicas, null, Collections.EMPTY_MAP, true, null, null, null);
         Container cont = getContainer(dep);
         assertThat(cont.getEnv().stream().filter(env -> KafkaMirrorMaker2Cluster.ENV_VAR_STRIMZI_TRACING.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").equals(type), is(true));
         assertThat(cont.getEnv().stream().filter(env -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_CONFIGURATION.equals(env.getName())).map(EnvVar::getValue).findFirst().orElse("").contains("consumer.interceptor.classes=" + consumerInterceptor), is(true));
@@ -1585,7 +1605,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         Container cont = getContainer(dep);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
@@ -1618,7 +1638,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         Container cont = getContainer(dep);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
@@ -1650,7 +1670,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         Container cont = getContainer(dep);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
@@ -1686,7 +1706,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         Container cont = getContainer(dep);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
@@ -1779,7 +1799,7 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
         Deployment dep = kmm2.generateDeployment(
-                emptyMap(), true, null, null);
+                replicas, null, emptyMap(), true, null, null, null);
         Container cont = getContainer(dep);
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
@@ -1957,7 +1977,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .build();
 
         KafkaMirrorMaker2Cluster cluster = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, VERSIONS);
-        Deployment deployment = cluster.generateDeployment(new HashMap<>(), false, null, null);
+        Deployment deployment = cluster.generateDeployment(replicas, null, new HashMap<>(), false, null, null, null);
 
         if (resource.getSpec().getRack() != null) {
             PodSpec podSpec = deployment.getSpec().getTemplate().getSpec();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -132,6 +132,7 @@ public class WorkloadUtilsTest {
                 OWNER_REFERENCE,
                 null,
                 REPLICAS,
+                Map.of("extra", "annotations"),
                 WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy.RECREATE),
                 DUMMY_POD_TEMPLATE_SPEC
         );
@@ -140,7 +141,7 @@ public class WorkloadUtilsTest {
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
         assertThat(dep.getMetadata().getLabels(), is(LABELS.toMap()));
-        assertThat(dep.getMetadata().getAnnotations(), is(nullValue()));
+        assertThat(dep.getMetadata().getAnnotations(), is(Map.of("extra", "annotations")));
 
         assertThat(dep.getSpec().getStrategy().getType(), is("Recreate"));
         assertThat(dep.getSpec().getReplicas(), is(REPLICAS));
@@ -165,6 +166,7 @@ public class WorkloadUtilsTest {
                         .endMetadata()
                         .build(),
                 REPLICAS,
+                Map.of("extra", "annotations"),
                 WorkloadUtils.deploymentStrategy(io.strimzi.api.kafka.model.template.DeploymentStrategy.ROLLING_UPDATE),
                 DUMMY_POD_TEMPLATE_SPEC
         );
@@ -173,7 +175,7 @@ public class WorkloadUtilsTest {
         assertThat(dep.getMetadata().getNamespace(), is(NAMESPACE));
         assertThat(dep.getMetadata().getOwnerReferences(), is(List.of(OWNER_REFERENCE)));
         assertThat(dep.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
-        assertThat(dep.getMetadata().getAnnotations(), is(Map.of("anno-1", "value-1", "anno-2", "value-2")));
+        assertThat(dep.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
 
         assertThat(dep.getSpec().getStrategy().getType(), is("RollingUpdate"));
         assertThat(dep.getSpec().getReplicas(), is(REPLICAS));
@@ -309,6 +311,7 @@ public class WorkloadUtilsTest {
                 null,
                 REPLICAS,
                 Map.of("extra", "annotations"),
+                LABELS.strimziSelectorLabels(),
                 i -> {
                     podIds.add(i);
                     return new PodBuilder()
@@ -354,6 +357,7 @@ public class WorkloadUtilsTest {
                         .build(),
                 REPLICAS,
                 Map.of("extra", "annotations"),
+                Labels.fromMap(Map.of("custom", "selector")),
                 i -> {
                     podIds.add(i);
                     return new PodBuilder()
@@ -370,10 +374,8 @@ public class WorkloadUtilsTest {
         assertThat(sps.getMetadata().getLabels(), is(LABELS.withAdditionalLabels(Map.of("label-3", "value-3", "label-4", "value-4")).toMap()));
         assertThat(sps.getMetadata().getAnnotations(), is(Map.of("extra", "annotations", "anno-1", "value-1", "anno-2", "value-2")));
 
-        assertThat(sps.getSpec().getSelector().getMatchLabels().size(), is(3));
-        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is("my-cluster"));
-        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_NAME_LABEL), is("my-workload"));
-        assertThat(sps.getSpec().getSelector().getMatchLabels().get(Labels.STRIMZI_KIND_LABEL), is("my-kind"));
+        assertThat(sps.getSpec().getSelector().getMatchLabels().size(), is(1));
+        assertThat(sps.getSpec().getSelector().getMatchLabels(), is(Map.of("custom", "selector")));
 
         // Test generating pods from the PodCreator method
         assertThat(podIds.size(), is(5));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -144,7 +144,7 @@ public class JbodStorageMockTest {
                         ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(),
                         ResourceUtils.metricsProvider(), pfa, 60_000L);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, ros.kafkaOperator, ros.strimziPodSetOperator, ros.podOperations, ros.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, ros.kafkaOperator, ros.connectOperator, ros.mirrorMaker2Operator, ros.strimziPodSetOperator, ros.podOperations, ros.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         this.operator = new KafkaAssemblyOperator(JbodStorageMockTest.vertx, pfa, new MockCertManager(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -87,7 +87,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         supplier = supplier(client, pfa);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.connectOperator, supplier.mirrorMaker2Operator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -170,7 +170,7 @@ public class KafkaAssemblyOperatorMockTest {
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         supplier = supplierWithMocks();
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.connectOperator, supplier.mirrorMaker2Operator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -97,6 +97,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
         // Configure the Kubernetes Mock
         mockKube = new MockKube2.MockKube2Builder(client)
                 .withKafkaConnectCrd()
+                .withStrimziPodSetCrd()
                 .withInitialKafkaConnects(connectResource)
                 .withDeploymentController()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -1,0 +1,746 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
+import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.PodSetUtils;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
+import io.strimzi.platform.KubernetesVersion;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaConnectAssemblyOperatorPodSetTest {
+    private final static String NAME = "my-connect";
+    private final static String COMPONENT_NAME = NAME + "-connect";
+    private final static String NAMESPACE = "my-namespace";
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.V1_26;
+    private static final Reconciliation RECONCILIATION = new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME);
+
+    private static final KafkaConnect CONNECT = new KafkaConnectBuilder()
+            .withNewMetadata()
+                .withName(NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(3)
+            .endSpec()
+            .build();
+    private static final KafkaConnectCluster CLUSTER = KafkaConnectCluster.fromCrd(RECONCILIATION, CONNECT, VERSIONS);
+
+    protected static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    public void testCreateCluster(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT).build();
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities")
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify services => one regular and one headless
+                    List<Service> capturedServices = serviceCaptor.getAllValues();
+                    assertThat(capturedServices, hasSize(2));
+
+                    Service service = capturedServices.get(0);
+                    assertThat(service.getMetadata().getName(), is(KafkaConnectResources.serviceName(NAME)));
+                    assertThat(service.getSpec().getType(), is("ClusterIP"));
+                    assertThat(service.getSpec().getClusterIP(), is(not("None")));
+
+                    Service headlessService = capturedServices.get(1);
+                    assertThat(headlessService.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(headlessService.getSpec().getType(), is("ClusterIP"));
+                    assertThat(headlessService.getSpec().getClusterIP(), is("None"));
+
+                    // Verify Deployment => one getAsync call
+                    verify(mockDepOps, times(1)).getAsync(eq(NAMESPACE), eq(COMPONENT_NAME));
+
+                    // Verify PDB => should be set up for custom controller
+                    List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                    assertThat(capturedPdb.size(), is(1));
+                    PodDisruptionBudget pdb = capturedPdb.get(0);
+                    assertThat(pdb.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(pdb.getSpec().getMinAvailable().getIntVal(), is(2));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testScaleCluster(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT).build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(1, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities")
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testScaleClusterToZero(VertxTestContext context)  {
+        KafkaConnect newConnect = new KafkaConnectBuilder(CONNECT)
+                .editSpec()
+                    .withReplicas(0)
+                .endSpec()
+                .build();
+
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(newConnect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(newConnect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities")
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(0));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is(nullValue()));
+                    assertThat(connectStatus.getReplicas(), is(0));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUpdateCluster(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT)
+                .editSpec()
+                    .withConfig(Map.of("group.id", "my-group"))
+                .endSpec()
+                .build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities")
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Check rolling happened
+                    verify(mockPodOps, times(3)).deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false));
+
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBuildChangedCluster(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT)
+                .editSpec()
+                    .withNewBuild()
+                        .withNewDockerOutput()
+                            .withImage("my-image:latest")
+                            .withPushSecret("my-docker-credentials")
+                        .endDockerOutput()
+                        .withPlugins(new PluginBuilder()
+                                .withName("plugin1")
+                                .withArtifacts(new JarArtifactBuilder().withUrl("https://my-domain.tld/my.jar").build())
+                                .build())
+                    .endBuild()
+                .endSpec()
+                .build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        Pod terminatedBuildPod = new PodBuilder()
+                .withNewMetadata()
+                    .withName(KafkaConnectResources.buildPodName(NAME))
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .withNewStatus()
+                    .withContainerStatuses(new ContainerStatusBuilder()
+                        .withName(KafkaConnectResources.buildPodName(NAME))
+                        .withNewState()
+                            .withNewTerminated()
+                                .withExitCode(0)
+                                .withMessage("my-connect-build@sha256:blablabla")
+                            .endTerminated()
+                        .endState()
+                        .build())
+                .endStatus()
+                .build();
+
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.waitFor(any(), eq(NAMESPACE), eq(KafkaConnectResources.buildPodName(NAME)), anyString(), anyLong(), anyLong(), any(BiPredicate.class))).thenReturn(Future.succeededFuture((Void) null));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            if (KafkaConnectResources.buildPodName(NAME).equals(i.getArgument(1)))  {
+                return Future.succeededFuture(terminatedBuildPod);
+            } else {
+                Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+                return Future.succeededFuture(pod);
+            }
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities")
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Check rolling happened
+                    verify(mockPodOps, times(3)).deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false));
+
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("a324347c751944b0"));
+                    assertThat(podSet.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE), is("my-connect-build@sha256:blablabla"));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    for (Pod pod : PodSetUtils.mapsToPods(podSet.getSpec().getPods()))  {
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("a324347c751944b0"));
+                        assertThat(pod.getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
+                    }
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testClusterMigrationToPodSets(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT).build();
+        Deployment deployment = CLUSTER.generateDeployment(3, null, null, false, null, null, null);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(deployment));
+        when(mockDepOps.scaleDown(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyInt())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.deleteAsync(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(null));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities")
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Check migration happened
+                    verify(mockDepOps, times(1)).deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(true));
+                    verify(mockDepOps, times(2)).scaleDown(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyInt());
+
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(4));
+
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(1));
+
+                    podSet = capturesPodSets.get(1);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(2));
+
+                    podSet = capturesPodSets.get(2);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    podSet = capturesPodSets.get(3);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -22,6 +22,7 @@ import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.Plugin;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
+import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -131,6 +132,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -162,6 +164,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -294,6 +299,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -324,6 +330,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -436,6 +445,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -461,9 +471,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -471,6 +481,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -607,6 +620,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -632,9 +646,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.hashStub(oldBuild.getBuild().getOutput().getImage()));
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build-2@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.hashStub(oldBuild.getBuild().getOutput().getImage()));
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build-2@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -642,6 +656,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -779,6 +796,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -804,9 +822,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -814,6 +832,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -959,6 +980,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -984,9 +1006,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -994,6 +1016,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1143,6 +1168,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -1168,9 +1194,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, "oldhashstub");
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -1178,6 +1204,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1313,6 +1342,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -1338,9 +1368,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
+            Deployment dep = connect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:blablabla");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -1348,6 +1378,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1442,6 +1475,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -1467,7 +1501,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
+            Deployment dep = connect.generateDeployment(3, null, emptyMap(), false, null, null, null);
 
             if (dep.getMetadata().getAnnotations() != null) {
                 dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true");
@@ -1475,8 +1509,8 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
                 dep.getMetadata().setAnnotations(Map.of(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true"));
             }
 
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub());
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub());
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:blablabla");
 
             return Future.succeededFuture(dep);
         });
@@ -1485,6 +1519,9 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.Plugin;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
+import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -129,6 +130,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -160,6 +162,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -276,6 +281,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -307,6 +313,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -412,6 +421,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -438,9 +448,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -448,6 +458,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -579,6 +592,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -605,9 +619,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.hashStub(oldBuild.getBuild().getOutput().getImage()));
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build-2@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub() + Util.hashStub(oldBuild.getBuild().getOutput().getImage()));
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build-2@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -615,6 +629,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -732,6 +749,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -739,7 +757,6 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
         PodOperator mockPodOps = supplier.podOperations;
         BuildConfigOperator mockBcOps = supplier.buildConfigOperations;
-        BuildOperator mockBuildOps = supplier.buildOperations;
         SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
@@ -758,9 +775,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
+            Deployment dep = connect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:blablabla");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -768,6 +785,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -856,6 +876,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -882,7 +903,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = connect.generateDeployment(emptyMap(), false, null, null);
+            Deployment dep = connect.generateDeployment(3, null, emptyMap(), false, null, null, null);
 
             if (dep.getMetadata().getAnnotations() != null) {
                 dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true");
@@ -890,8 +911,8 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
                 dep.getMetadata().setAnnotations(Map.of(Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, "true"));
             }
 
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:blablabla");
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, build.generateDockerfile().hashStub() + OUTPUT_IMAGE_HASH_STUB);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:blablabla");
 
             return Future.succeededFuture(dep);
         });
@@ -900,6 +921,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1029,6 +1053,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -1055,9 +1080,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -1065,6 +1090,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1219,6 +1247,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -1245,9 +1274,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -1255,6 +1284,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
@@ -1411,6 +1443,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         CrdOperator mockConnectOps = supplier.connectOperator;
         DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         PodDisruptionBudgetV1Beta1Operator mockPdbOpsV1Beta1 = supplier.podDisruptionBudgetV1Beta1Operator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
@@ -1437,9 +1470,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         ArgumentCaptor<Deployment> depCaptor = ArgumentCaptor.forClass(Deployment.class);
         when(mockDepOps.reconcile(any(), anyString(), anyString(), depCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockDepOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.deploymentName(NAME)))).thenAnswer(inv -> {
-            Deployment dep = oldConnect.generateDeployment(emptyMap(), false, null, null);
-            dep.getSpec().getTemplate().getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
-            dep.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("my-connect-build@sha256:olddigest");
+            Deployment dep = oldConnect.generateDeployment(3, null, emptyMap(), false, null, null, null);
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, oldBuild.generateDockerfile().hashStub());
+            dep.getMetadata().getAnnotations().put(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, "my-connect-build@sha256:olddigest");
             return Future.succeededFuture(dep);
         });
         when(mockDepOps.scaleUp(any(), anyString(), anyString(), anyInt())).thenReturn(Future.succeededFuture(42));
@@ -1447,6 +1480,9 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         when(mockDepOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockDepOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+
+        // Mock StrimziPodSet ops
+        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         // Mock and capture CM ops
         when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectRollerTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectBuilder;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.StrimziPodSetBuilder;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.PodSetUtils;
+import io.strimzi.operator.cluster.operator.resource.PodRevision;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.vertx.core.Future;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+@SuppressWarnings("unchecked")
+public class KafkaConnectRollerTest {
+    private final static String NAME = "my-connect";
+    private final static String NAMESPACE = "my-namespace";
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+    private static final Reconciliation RECONCILIATION = new Reconciliation("test", "KafkaConnect", NAMESPACE, NAME);
+
+    private static final KafkaConnect CONNECT = new KafkaConnectBuilder()
+            .withNewMetadata()
+                .withName(NAME)
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(3)
+            .endSpec()
+            .build();
+
+    private static final KafkaConnectCluster CLUSTER = KafkaConnectCluster.fromCrd(RECONCILIATION, CONNECT, VERSIONS);
+
+    private static final Pod READY_POD = new PodBuilder()
+            .withNewMetadata()
+                .withName("my-connect-connect-0")
+                .withAnnotations(Map.of(PodRevision.STRIMZI_REVISION_ANNOTATION, "avfc1874"))
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .withNewStatus()
+                .addNewCondition()
+                    .withType("Ready")
+                    .withStatus("True")
+                .endCondition()
+            .endStatus()
+            .build();
+    private static final Pod UNREADY_POD = new PodBuilder(READY_POD)
+            .withNewStatus()
+                .addNewCondition()
+                    .withType("Ready")
+                    .withStatus("False")
+                .endCondition()
+            .endStatus()
+            .build();
+
+    @Test
+    public void testRollingOrderWithAllPodsReady()  {
+        List<Pod> pods = List.of(
+                renamePod(READY_POD, "my-connect-connect-0"),
+                renamePod(READY_POD, "my-connect-connect-1"),
+                renamePod(READY_POD, "my-connect-connect-2")
+        );
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, null);
+        Queue<String> rollingOrder = roller.prepareRollingOrder(pods);
+
+        assertThat(rollingOrder.poll(), is("my-connect-connect-0"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-1"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-2"));
+    }
+
+    @Test
+    public void testRollingOrderWithMissingPod()  {
+        List<Pod> pods = List.of(
+                renamePod(READY_POD, "my-connect-connect-0"),
+                renamePod(READY_POD, "my-connect-connect-2")
+        );
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, null);
+        Queue<String> rollingOrder = roller.prepareRollingOrder(pods);
+
+        assertThat(rollingOrder.poll(), is("my-connect-connect-1"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-0"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-2"));
+    }
+
+    @Test
+    public void testRollingOrderWithUnreadyPod()  {
+        List<Pod> pods = List.of(
+                renamePod(READY_POD, "my-connect-connect-0"),
+                renamePod(UNREADY_POD, "my-connect-connect-1"),
+                renamePod(READY_POD, "my-connect-connect-2")
+        );
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, null);
+        Queue<String> rollingOrder = roller.prepareRollingOrder(pods);
+
+        assertThat(rollingOrder.poll(), is("my-connect-connect-1"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-0"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-2"));
+    }
+
+    @Test
+    public void testRollingOrderWithUnreadyAndMissingPod()  {
+        List<Pod> pods = List.of(
+                renamePod(READY_POD, "my-connect-connect-0"),
+                renamePod(UNREADY_POD, "my-connect-connect-1")
+        );
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, null);
+        Queue<String> rollingOrder = roller.prepareRollingOrder(pods);
+
+        assertThat(rollingOrder.poll(), is("my-connect-connect-2"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-1"));
+        assertThat(rollingOrder.poll(), is("my-connect-connect-0"));
+    }
+
+    @Test
+    public void testMaybeRollPodNoChange(VertxTestContext context)  {
+        StrimziPodSet podSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-connect-connect")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podToMap(READY_POD))
+                .endSpec()
+                .build();
+
+        PodOperator mockPodOps = mock(PodOperator.class);
+        when(mockPodOps.getAsync(eq(NAMESPACE), eq("my-connect-connect-0"))).thenReturn(Future.succeededFuture(READY_POD));
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), eq("my-connect-connect-0"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, mockPodOps);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollPod(podSet, "my-connect-connect-0")
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    verify(mockPodOps, never()).deleteAsync(any(), any(), any(), anyBoolean());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMaybeRollPodMissingPod(VertxTestContext context)  {
+        StrimziPodSet podSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-connect-connect")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podToMap(READY_POD))
+                .endSpec()
+                .build();
+
+        PodOperator mockPodOps = mock(PodOperator.class);
+        when(mockPodOps.getAsync(eq(NAMESPACE), eq("my-connect-connect-0"))).thenReturn(Future.succeededFuture(null));
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), eq("my-connect-connect-0"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, mockPodOps);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollPod(podSet, "my-connect-connect-0")
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    verify(mockPodOps, never()).deleteAsync(any(), any(), any(), anyBoolean());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMaybeRollPodNeedRolling(VertxTestContext context)  {
+        StrimziPodSet podSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-connect-connect")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podToMap(READY_POD))
+                .endSpec()
+                .build();
+
+        PodOperator mockPodOps = mock(PodOperator.class);
+        when(mockPodOps.getAsync(eq(NAMESPACE), eq("my-connect-connect-0"))).thenReturn(Future.succeededFuture(changeRevision(READY_POD, "skso1919")));
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), eq("my-connect-connect-0"), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), eq("my-connect-connect-0"), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, mockPodOps);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollPod(podSet, "my-connect-connect-0")
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    verify(mockPodOps, times(1)).deleteAsync(any(), eq(NAMESPACE), eq("my-connect-connect-0"), eq(false));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMaybeRollPodFailsWhenNotReady(VertxTestContext context)  {
+        StrimziPodSet podSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-connect-connect")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podToMap(READY_POD))
+                .endSpec()
+                .build();
+
+        PodOperator mockPodOps = mock(PodOperator.class);
+        when(mockPodOps.getAsync(eq(NAMESPACE), eq("my-connect-connect-0"))).thenReturn(Future.succeededFuture(null));
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), eq("my-connect-connect-0"), anyLong(), anyLong())).thenReturn(Future.failedFuture(new RuntimeException("Timeout")));
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, mockPodOps);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRollPod(podSet, "my-connect-connect-0")
+                .onComplete(context.failing(v -> context.verify(() -> {
+                    verify(mockPodOps, never()).deleteAsync(any(), any(), any(), anyBoolean());
+
+                    assertThat(v.getMessage(), is("Timeout"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMaybeRollInOrder(VertxTestContext context)  {
+        StrimziPodSet podSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-connect-connect")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podToMap(renamePod(READY_POD, "my-connect-connect-0")),
+                            PodSetUtils.podToMap(renamePod(READY_POD, "my-connect-connect-1")),
+                            PodSetUtils.podToMap(renamePod(READY_POD, "my-connect-connect-2")))
+                .endSpec()
+                .build();
+
+        PodOperator mockPodOps = mock(PodOperator.class);
+
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of(renamePod(READY_POD, "my-connect-connect-0"), renamePod(READY_POD, "my-connect-connect-2"))));
+
+        ArgumentCaptor<String> getAsyncCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockPodOps.getAsync(eq(NAMESPACE), getAsyncCaptor.capture())).thenAnswer(i -> {
+            if ("my-connect-connect-1".equals(i.getArgument(1)))    {
+                return Future.succeededFuture(null);
+            } else {
+                return Future.succeededFuture(renamePod(READY_POD, i.getArgument(1)));
+            }
+        });
+
+        ArgumentCaptor<String> readinessCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), readinessCaptor.capture(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, mockPodOps);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRoll(podSet)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    verify(mockPodOps, never()).deleteAsync(any(), any(), any(), anyBoolean());
+
+                    List<String> getAsync = getAsyncCaptor.getAllValues();
+                    assertThat(getAsync.size(), is(3));
+                    assertThat(getAsync.get(0), is("my-connect-connect-1"));
+                    assertThat(getAsync.get(1), is("my-connect-connect-0"));
+                    assertThat(getAsync.get(2), is("my-connect-connect-2"));
+
+                    List<String> readiness = readinessCaptor.getAllValues();
+                    assertThat(readiness.size(), is(3));
+                    assertThat(readiness.get(0), is("my-connect-connect-1"));
+                    assertThat(readiness.get(1), is("my-connect-connect-0"));
+                    assertThat(readiness.get(2), is("my-connect-connect-2"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMaybeRollNotReady(VertxTestContext context)  {
+        StrimziPodSet podSet = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-connect-connect")
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podToMap(renamePod(READY_POD, "my-connect-connect-0")),
+                            PodSetUtils.podToMap(renamePod(READY_POD, "my-connect-connect-1")),
+                            PodSetUtils.podToMap(renamePod(READY_POD, "my-connect-connect-2")))
+                .endSpec()
+                .build();
+
+        PodOperator mockPodOps = mock(PodOperator.class);
+
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of(renamePod(READY_POD, "my-connect-connect-0"), renamePod(READY_POD, "my-connect-connect-2"))));
+
+        when(mockPodOps.getAsync(eq(NAMESPACE), any())).thenAnswer(i -> Future.succeededFuture(renamePod(READY_POD, i.getArgument(1))));
+
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), any(), anyLong(), anyLong())).thenReturn(Future.failedFuture(new RuntimeException("Timeout")));
+
+        KafkaConnectRoller roller = new KafkaConnectRoller(RECONCILIATION, CLUSTER, 1_000L, mockPodOps);
+
+        Checkpoint async = context.checkpoint();
+        roller.maybeRoll(podSet)
+                .onComplete(context.failing(v -> context.verify(() -> {
+                    assertThat(v.getMessage(), is("Timeout"));
+                    async.flag();
+                })));
+    }
+
+    /**
+     * Utility method for easily renaming pods
+     *
+     * @param pod   Pod
+     * @param name  New name
+     *
+     * @return  Renamed pod
+     */
+    private static Pod renamePod(Pod pod, String name) {
+        return new PodBuilder(pod)
+                .editMetadata()
+                    .withName(name)
+                .endMetadata()
+                .build();
+    }
+
+    /**
+     * Utility method for easily changing pods revision
+     *
+     * @param pod   Pod
+     * @param revision  New revision
+     *
+     * @return  Renamed pod
+     */
+    private static Pod changeRevision(Pod pod, String revision) {
+        return new PodBuilder(pod)
+                .editMetadata()
+                    .withAnnotations(Map.of(PodRevision.STRIMZI_REVISION_ANNOTATION, revision))
+                .endMetadata()
+                .build();
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -1,0 +1,636 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.KafkaMirrorMaker2List;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2Builder;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
+import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.status.KafkaMirrorMaker2Status;
+import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.KafkaMirrorMaker2Cluster;
+import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.PodSetUtils;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.OrderedProperties;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.DeploymentOperator;
+import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
+import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
+import io.strimzi.operator.common.operator.resource.PodOperator;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
+import io.strimzi.platform.KubernetesVersion;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
+    private final static String NAME = "my-mm2";
+    private final static String COMPONENT_NAME = NAME + "-mirrormaker2";
+    private final static String NAMESPACE = "my-namespace";
+    private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
+    private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.V1_26;
+    private static final Reconciliation RECONCILIATION = new Reconciliation("test", "KafkaMirrorMaker2", NAMESPACE, NAME);
+
+    private static final KafkaMirrorMaker2 MM2 = new KafkaMirrorMaker2Builder()
+            .withNewMetadata()
+                .withName(NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(3)
+            .endSpec()
+            .build();
+    private static final KafkaMirrorMaker2Cluster CLUSTER = KafkaMirrorMaker2Cluster.fromCrd(RECONCILIATION, MM2, VERSIONS);
+
+    protected static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    public void testCreateCluster(VertxTestContext context)  {
+        KafkaMirrorMaker2 mm2 = new KafkaMirrorMaker2Builder(MM2).build();
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaMirrorMaker2 CRs
+        CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> mockConnectOps = supplier.mirrorMaker2Operator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(mm2);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(mm2));
+        ArgumentCaptor<KafkaMirrorMaker2> mm2StatusCaptor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
+        when(mockConnectOps.updateStatusAsync(any(), mm2StatusCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Connect API
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+
+        KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities"),
+                x -> mockConnectClient
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify services => one regular and one headless
+                    List<Service> capturedServices = serviceCaptor.getAllValues();
+                    assertThat(capturedServices, hasSize(2));
+
+                    Service service = capturedServices.get(0);
+                    assertThat(service.getMetadata().getName(), is(KafkaMirrorMaker2Resources.serviceName(NAME)));
+                    assertThat(service.getSpec().getType(), is("ClusterIP"));
+                    assertThat(service.getSpec().getClusterIP(), is(not("None")));
+
+                    Service headlessService = capturedServices.get(1);
+                    assertThat(headlessService.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(headlessService.getSpec().getType(), is("ClusterIP"));
+                    assertThat(headlessService.getSpec().getClusterIP(), is("None"));
+
+                    // Verify Deployment => one getAsync call
+                    verify(mockDepOps, times(1)).getAsync(eq(NAMESPACE), eq(COMPONENT_NAME));
+
+                    // Verify PDB => should be set up for custom controller
+                    List<PodDisruptionBudget> capturedPdb = pdbCaptor.getAllValues();
+                    assertThat(capturedPdb.size(), is(1));
+                    PodDisruptionBudget pdb = capturedPdb.get(0);
+                    assertThat(pdb.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(pdb.getSpec().getMinAvailable().getIntVal(), is(2));
+
+                    // Verify CR status
+                    List<KafkaMirrorMaker2> capturedMm2Statuses = mm2StatusCaptor.getAllValues();
+                    assertThat(capturedMm2Statuses, hasSize(1));
+                    KafkaMirrorMaker2Status mm2Status = capturedMm2Statuses.get(0).getStatus();
+
+                    assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
+                    assertThat(mm2Status.getReplicas(), is(3));
+                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testScaleCluster(VertxTestContext context)  {
+        KafkaMirrorMaker2 mm2 = new KafkaMirrorMaker2Builder(MM2).build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(1, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaMirrorMaker2 CRs
+        CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> mockConnectOps = supplier.mirrorMaker2Operator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(mm2);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(mm2));
+        ArgumentCaptor<KafkaMirrorMaker2> mm2StatusCaptor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
+        when(mockConnectOps.updateStatusAsync(any(), mm2StatusCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Connect API
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+
+        KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities"),
+                x -> mockConnectClient
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify CR status
+                    List<KafkaMirrorMaker2> capturedMm2Statuses = mm2StatusCaptor.getAllValues();
+                    assertThat(capturedMm2Statuses, hasSize(1));
+                    KafkaMirrorMaker2Status mm2Status = capturedMm2Statuses.get(0).getStatus();
+
+                    assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
+                    assertThat(mm2Status.getReplicas(), is(3));
+                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testScaleClusterToZero(VertxTestContext context)  {
+        KafkaMirrorMaker2 mm2 = new KafkaMirrorMaker2Builder(MM2)
+                .editSpec()
+                    .withReplicas(0)
+                .endSpec()
+                .build();
+
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaMirrorMaker2 CRs
+        CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> mockConnectOps = supplier.mirrorMaker2Operator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(mm2);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(mm2));
+        ArgumentCaptor<KafkaMirrorMaker2> mm2StatusCaptor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
+        when(mockConnectOps.updateStatusAsync(any(), mm2StatusCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Connect API
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+
+        KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities"),
+                x -> mockConnectClient
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(0));
+
+                    // Verify CR status
+                    List<KafkaMirrorMaker2> capturedMm2Statuses = mm2StatusCaptor.getAllValues();
+                    assertThat(capturedMm2Statuses, hasSize(1));
+                    KafkaMirrorMaker2Status mm2Status = capturedMm2Statuses.get(0).getStatus();
+
+                    assertThat(mm2Status.getUrl(), is(nullValue()));
+                    assertThat(mm2Status.getReplicas(), is(0));
+                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUpdateCluster(VertxTestContext context)  {
+        KafkaMirrorMaker2 mm2 = new KafkaMirrorMaker2Builder(MM2)
+                .editSpec()
+                    .withResources(new ResourceRequirementsBuilder().withRequests(Map.of("Memory", new Quantity("1Gi"))).build())
+                .endSpec()
+                .build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaMirrorMaker2 CRs
+        CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> mockConnectOps = supplier.mirrorMaker2Operator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(mm2);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(mm2));
+        ArgumentCaptor<KafkaMirrorMaker2> mm2StatusCaptor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
+        when(mockConnectOps.updateStatusAsync(any(), mm2StatusCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Connect API
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+
+        KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities"),
+                x -> mockConnectClient
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Check rolling happened
+                    verify(mockPodOps, times(3)).deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false));
+
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify CR status
+                    List<KafkaMirrorMaker2> capturedMm2Statuses = mm2StatusCaptor.getAllValues();
+                    assertThat(capturedMm2Statuses, hasSize(1));
+                    KafkaMirrorMaker2Status mm2Status = capturedMm2Statuses.get(0).getStatus();
+
+                    assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
+                    assertThat(mm2Status.getReplicas(), is(3));
+                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testClusterMigrationToPodSets(VertxTestContext context)  {
+        KafkaMirrorMaker2 mm2 = new KafkaMirrorMaker2Builder(MM2).build();
+        Deployment deployment = CLUSTER.generateDeployment(3, null, null, false, null, null, null);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(deployment));
+        when(mockDepOps.scaleDown(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyInt())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.waitForObserved(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockDepOps.deleteAsync(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(null));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock KafkaMirrorMaker2 CRs
+        CrdOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List> mockConnectOps = supplier.mirrorMaker2Operator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(mm2);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(mm2));
+        ArgumentCaptor<KafkaMirrorMaker2> mm2StatusCaptor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
+        when(mockConnectOps.updateStatusAsync(any(), mm2StatusCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Connect API
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+
+        KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig("+StableConnectIdentities"),
+                x -> mockConnectClient
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Check migration happened
+                    verify(mockDepOps, times(1)).deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(true));
+                    verify(mockDepOps, times(2)).scaleDown(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyInt());
+
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(4));
+                    
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(1));
+
+                    podSet = capturesPodSets.get(1);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(2));
+
+                    podSet = capturesPodSets.get(2);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    podSet = capturesPodSets.get(3);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+
+                    // Verify CR status
+                    List<KafkaMirrorMaker2> capturedMm2Statuses = mm2StatusCaptor.getAllValues();
+                    assertThat(capturedMm2Statuses, hasSize(1));
+                    KafkaMirrorMaker2Status mm2Status = capturedMm2Statuses.get(0).getStatus();
+
+                    assertThat(mm2Status.getUrl(), is("http://my-mm2-mirrormaker2-api.my-namespace.svc:8083"));
+                    assertThat(mm2Status.getReplicas(), is(3));
+                    assertThat(mm2Status.getLabelSelector(), is("strimzi.io/cluster=my-mm2,strimzi.io/name=my-mm2-mirrormaker2,strimzi.io/kind=KafkaMirrorMaker2"));
+                    assertThat(mm2Status.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(mm2Status.getConditions().get(0).getType(), is("Ready"));
+
+                    async.flag();
+                })));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -134,7 +134,7 @@ public class KafkaUpgradeDowngradeMockTest {
         supplier =  new ResourceOperatorSupplier(vertx, client, ResourceUtils.zookeeperLeaderFinder(vertx, client),
                 ResourceUtils.adminClientProvider(), ResourceUtils.zookeeperScalerProvider(), ResourceUtils.metricsProvider(), PFA, 2_000);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.connectOperator, supplier.mirrorMaker2Operator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         ClusterOperatorConfig config = ResourceUtils.dummyClusterOperatorConfig(VERSIONS, ClusterOperatorConfig.DEFAULT_OPERATION_TIMEOUT_MS);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -137,7 +137,7 @@ public class PartialRollingUpdateMockTest {
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
         supplier = supplier(client, pfa);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.connectOperator, supplier.mirrorMaker2Operator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         kco = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(), new PasswordGenerator(10, "a", "a"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -169,7 +169,7 @@ public class KubernetesRestartEventsMockTest {
                 PFA,
                 60_000);
 
-        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
+        podSetController = new StrimziPodSetController(NAMESPACE, Labels.EMPTY, supplier.kafkaOperator, supplier.connectOperator, supplier.mirrorMaker2Operator, supplier.strimziPodSetOperator, supplier.podOperations, supplier.metricsProvider, ClusterOperatorConfig.DEFAULT_POD_SET_CONTROLLER_WORK_QUEUE_SIZE);
         podSetController.start();
 
         // Initial reconciliation to create cluster

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
@@ -119,7 +119,7 @@ cat <<EOF
 bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
 # REST Listeners
 rest.port=8083
-rest.advertised.host.name=$(hostname -I | awk '{ print $1 }')
+rest.advertised.host.name=${ADVERTISED_HOSTNAME}
 rest.advertised.port=8083
 # Plugins
 plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -13,6 +13,17 @@ if [ -e "$KAFKA_HOME/init/rack.id" ]; then
   export STRIMZI_RACK_ID
 fi
 
+# Prepare hostname depending on whether we use StrimziPodSets (Stable Pod Identities) or Deployments
+# For StrimziPodSets we use the Pod DNS name assigned through the headless service
+# For Deployments we use the Pod IP address
+if [ "$STRIMZI_STABLE_IDENTITIES_ENABLED" = "true" ]; then
+  ADVERTISED_HOSTNAME=$(hostname -f | cut -d "." -f1-4)
+  export ADVERTISED_HOSTNAME
+else
+  ADVERTISED_HOSTNAME=$(hostname -I | awk '{ print $1 }')
+  export ADVERTISED_HOSTNAME
+fi
+
 # Generate temporary keystore password
 CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
 export CERTS_STORE_PASSWORD

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1962,9 +1962,13 @@ Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Kaf
 |Property                    |Description
 |deployment           1.2+<.<a|Template for Kafka Connect `Deployment`.
 |xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
+|podSet               1.2+<.<a|Template for Kafka Connect `StrimziPodSet` resource.
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |pod                  1.2+<.<a|Template for Kafka Connect `Pods`.
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |apiService           1.2+<.<a|Template for Kafka Connect API `Service`.
+|xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
+|headlessService      1.2+<.<a|Template for Kafka Connect headless `Service`.
 |xref:type-InternalServiceTemplate-{context}[`InternalServiceTemplate`]
 |connectContainer     1.2+<.<a|Template for the Kafka Connect container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]

--- a/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
+++ b/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
@@ -7,7 +7,12 @@
 
 The following resources are created by the Cluster Operator in the Kubernetes cluster:
 
-_connect-cluster-name_-connect:: Deployment which is in charge to create the Kafka Connect worker node pods.
+_connect-cluster-name_-connect:: Name given to the following Kafka Connect resources:
++
+- Deployment which is in charge to create the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is disabled).
+- StrimziPodSet which is in charge to create the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is enabled).
+- Headless service which is used to provide stable DNS names to the Connect pods (when `StableConnectIdentities` feature gate is enabled).
+- Pod Disruption Budget configured for the Kafka Connect worker nodes.
+_connect-cluster-name_-connect-_idx_:: Pods created by the Kafka Connect StrimziPodSet (when `StableConnectIdentities` feature gate is enabled).
 _connect-cluster-name_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
 _connect-cluster-name_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.
-_connect-cluster-name_-connect:: Pod Disruption Budget configured for the Kafka Connect worker nodes.

--- a/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
+++ b/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
@@ -9,10 +9,10 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 _connect-cluster-name_-connect:: Name given to the following Kafka Connect resources:
 +
-- Deployment which is in charge to create the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is disabled).
-- StrimziPodSet which is in charge to create the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is enabled).
-- Headless service which is used to provide stable DNS names to the Connect pods (when `StableConnectIdentities` feature gate is enabled).
+- Deployment that creates the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is disabled).
+- StrimziPodSet that creates the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is enabled).
+- Headless service that provides stable DNS names to the Connect pods (when `StableConnectIdentities` feature gate is enabled).
 - Pod Disruption Budget configured for the Kafka Connect worker nodes.
-_connect-cluster-name_-connect-_idx_:: Pods created by the Kafka Connect StrimziPodSet (when `StableConnectIdentities` feature gate is enabled).
+_connect-cluster-name_-connect-_idx_:: Pods created by the Kafka Connect StrimziPodSet (when `StableConnectIdentities` feature gate is enabled). 
 _connect-cluster-name_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
 _connect-cluster-name_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -22,6 +22,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseStrimziPodSets` feature gate moved to beta stage in Strimzi 0.30.
   It moves to GA in Strimzi 0.35 when the support for StatefulSets is completely removed.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
+* The `StableConnectIdentities` feature gate is in alpha stage and is disabled by default.
+  It is expected to move to beta phase and be enabled by default from Strimzi 0.36.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -54,6 +56,11 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦ -
 ¦ -
 
+¦`StableConnectIdentities`
+¦0.34
+¦0.36 (planned)
+¦ -
+
 |===
 
 If a feature gate is enabled, you may need to disable it before upgrading or downgrading from a specific Strimzi version.
@@ -74,5 +81,9 @@ The following table shows which feature gates you need to disable when upgrading
 ¦`UseStrimziPodSets`
 ¦-
 ¦0.27 and earlier
+
+¦`StableConnectIdentities`
+¦-
+¦0.33 and earlier
 
 |===

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -96,3 +96,17 @@ To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATU
 
 IMPORTANT: The `UseKRaft` feature gate depends on the `UseStrimziPodSets` feature gate.
 When enabling the `UseKRaft` feature gate, make sure that the `USeStrimziPodSets` feature gate is enabled as well.
+
+[id='ref-operator-stable-connect-identities-feature-gate-{context}']
+== StableConnectIdentities feature gate
+
+The `StableConnectIdentities` feature gate has a default state of _disabled_.
+
+The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage the Kafka Connect and Kafka Mirror Maker 2 instead of the Kubernetes Deployment resources.
+`StrimziPodSets` give the pods stable names and stable addresses which do not change during rolling upgrades.
+This helps to minimize the number of rebalances of connector tasks.
+
+.Enabling the `StableConnectIdentities` feature gate
+To enable the `StableConnectIdentities` feature gate, specify `+StableConnectIdentities` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+IMPORTANT: The `StableConnectIdentities` feature gate must be disabled when downgrading to Strimzi 0.33 and earlier versions.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -102,8 +102,8 @@ When enabling the `UseKRaft` feature gate, make sure that the `USeStrimziPodSets
 
 The `StableConnectIdentities` feature gate has a default state of _disabled_.
 
-The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage the Kafka Connect and Kafka Mirror Maker 2 instead of the Kubernetes Deployment resources.
-`StrimziPodSets` give the pods stable names and stable addresses which do not change during rolling upgrades.
+The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2.0  pods instead of using Kubernetes Deployment resources.
+`StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
 This helps to minimize the number of rebalances of connector tasks.
 
 .Enabling the `StableConnectIdentities` feature gate

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -59,6 +59,12 @@ public class Annotations {
     public static final String STRIMZI_IO_CONNECT_BUILD_REVISION = STRIMZI_DOMAIN + "connect-build-revision";
 
     /**
+     * Annotation used to store the container image created by Kafka Connect build (This is used to track what was the
+     * result of previous build when it does not change)
+     */
+    public static final String STRIMZI_IO_CONNECT_BUILD_IMAGE = STRIMZI_DOMAIN + "connect-build-image";
+
+    /**
      * Annotation used to force rebuild of the container image even if the dockerfile did not changed
      */
     public static final String STRIMZI_IO_CONNECT_FORCE_REBUILD = STRIMZI_DOMAIN + "force-rebuild";

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
@@ -35,10 +35,10 @@ public class BuildConfigOperator extends AbstractNamespacedResourceOperator<Open
     }
 
     @Override
-    protected Future<ReconcileResult<BuildConfig>> internalPatch(Reconciliation reconciliation, String namespace, String name, BuildConfig current, BuildConfig desired) {
+    protected Future<ReconcileResult<BuildConfig>> internalUpdate(Reconciliation reconciliation, String namespace, String name, BuildConfig current, BuildConfig desired) {
         desired.getSpec().setTriggers(current.getSpec().getTriggers());
         // Cascading needs to be set to false to make sure the Builds are not deleted during reconciliation
-        return super.internalPatch(reconciliation, namespace, name, current, desired);
+        return super.internalUpdate(reconciliation, namespace, name, current, desired);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ConfigMapOperator.java
@@ -40,7 +40,7 @@ public class ConfigMapOperator extends AbstractNamespacedResourceOperator<Kubern
     }
 
     @Override
-    protected Future<ReconcileResult<ConfigMap>> internalPatch(Reconciliation reconciliation, String namespace, String name, ConfigMap current, ConfigMap desired) {
+    protected Future<ReconcileResult<ConfigMap>> internalUpdate(Reconciliation reconciliation, String namespace, String name, ConfigMap current, ConfigMap desired) {
         try {
             if (compareObjects(current.getData(), desired.getData())
                     && compareObjects(current.getMetadata().getName(), desired.getMetadata().getName())
@@ -52,7 +52,7 @@ public class ConfigMapOperator extends AbstractNamespacedResourceOperator<Kubern
                 LOGGER.debugCr(reconciliation, "{} {} in namespace {} has not been patched because resources are equal", resourceKind, name, namespace);
                 return Future.succeededFuture(ReconcileResult.noop(current));
             } else {
-                return super.internalPatch(reconciliation, namespace, name, current, desired);
+                return super.internalUpdate(reconciliation, namespace, name, current, desired);
             }
         } catch (Exception e) {
             LOGGER.errorCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentConfigOperator.java
@@ -44,9 +44,9 @@ public class DeploymentConfigOperator extends AbstractScalableNamespacedResource
     }
 
     @Override
-    protected Future<ReconcileResult<DeploymentConfig>> internalPatch(Reconciliation reconciliation, String namespace, String name, DeploymentConfig current, DeploymentConfig desired) {
+    protected Future<ReconcileResult<DeploymentConfig>> internalUpdate(Reconciliation reconciliation, String namespace, String name, DeploymentConfig current, DeploymentConfig desired) {
         desired.getSpec().getTemplate().getSpec().getContainers().get(0).setImage(current.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
-        return super.internalPatch(reconciliation, namespace, name, current, desired);
+        return super.internalUpdate(reconciliation, namespace, name, current, desired);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/DeploymentOperator.java
@@ -90,10 +90,10 @@ public class DeploymentOperator extends AbstractScalableNamespacedResourceOperat
     }
 
     @Override
-    protected Future<ReconcileResult<Deployment>> internalPatch(Reconciliation reconciliation, String namespace, String name, Deployment current, Deployment desired) {
+    protected Future<ReconcileResult<Deployment>> internalUpdate(Reconciliation reconciliation, String namespace, String name, Deployment current, Deployment desired) {
         String k8sRev = Annotations.annotations(current).get(Annotations.ANNO_DEP_KUBE_IO_REVISION);
         Annotations.annotations(desired).put(Annotations.ANNO_DEP_KUBE_IO_REVISION, k8sRev);
-        return super.internalPatch(reconciliation, namespace, name, current, desired);
+        return super.internalUpdate(reconciliation, namespace, name, current, desired);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/IngressOperator.java
@@ -57,10 +57,10 @@ public class IngressOperator extends AbstractNamespacedResourceOperator<Kubernet
      * @return  Future with reconciliation result
      */
     @Override
-    protected Future<ReconcileResult<Ingress>> internalPatch(Reconciliation reconciliation, String namespace, String name, Ingress current, Ingress desired) {
+    protected Future<ReconcileResult<Ingress>> internalUpdate(Reconciliation reconciliation, String namespace, String name, Ingress current, Ingress desired) {
         patchIngressClassName(current, desired);
 
-        return super.internalPatch(reconciliation, namespace, name, current, desired);
+        return super.internalUpdate(reconciliation, namespace, name, current, desired);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -69,13 +69,13 @@ public class PvcOperator extends AbstractNamespacedResourceOperator<KubernetesCl
      * @return  Future with reconciliation result
      */
     @Override
-    protected Future<ReconcileResult<PersistentVolumeClaim>> internalPatch(Reconciliation reconciliation, String namespace, String name, PersistentVolumeClaim current, PersistentVolumeClaim desired) {
+    protected Future<ReconcileResult<PersistentVolumeClaim>> internalUpdate(Reconciliation reconciliation, String namespace, String name, PersistentVolumeClaim current, PersistentVolumeClaim desired) {
         try {
             if (current.getSpec() != null && desired.getSpec() != null)   {
                 revertImmutableChanges(current, desired);
             }
 
-            return super.internalPatch(reconciliation, namespace, name, current, desired);
+            return super.internalUpdate(reconciliation, namespace, name, current, desired);
         } catch (Exception e) {
             LOGGER.errorCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperator.java
@@ -32,7 +32,7 @@ public class ServiceAccountOperator extends AbstractNamespacedResourceOperator<K
     }
 
     @Override
-    protected Future<ReconcileResult<ServiceAccount>> internalPatch(Reconciliation reconciliation, String namespace, String name, ServiceAccount current, ServiceAccount desired) {
+    protected Future<ReconcileResult<ServiceAccount>> internalUpdate(Reconciliation reconciliation, String namespace, String name, ServiceAccount current, ServiceAccount desired) {
         if (desired.getSecrets() == null || desired.getSecrets().isEmpty())    {
             desired.setSecrets(current.getSecrets());
         }
@@ -41,6 +41,6 @@ public class ServiceAccountOperator extends AbstractNamespacedResourceOperator<K
             desired.setImagePullSecrets(current.getImagePullSecrets());
         }
 
-        return super.internalPatch(reconciliation, namespace, name, current, desired);
+        return super.internalUpdate(reconciliation, namespace, name, current, desired);
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -83,7 +83,7 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
      * @return  Future with reconciliation result
      */
     @Override
-    protected Future<ReconcileResult<Service>> internalPatch(Reconciliation reconciliation, String namespace, String name, Service current, Service desired) {
+    protected Future<ReconcileResult<Service>> internalUpdate(Reconciliation reconciliation, String namespace, String name, Service current, Service desired) {
         try {
             if (current.getSpec() != null && desired.getSpec() != null) {
                 if (("NodePort".equals(current.getSpec().getType()) && "NodePort".equals(desired.getSpec().getType()))
@@ -96,7 +96,7 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
                 patchDualStackNetworking(current, desired);
             }
 
-            return super.internalPatch(reconciliation, namespace, name, current, desired);
+            return super.internalUpdate(reconciliation, namespace, name, current, desired);
         } catch (Exception e) {
             LOGGER.errorCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
             return Future.failedFuture(e);

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StrimziPodSetOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StrimziPodSetOperator.java
@@ -54,6 +54,34 @@ public class StrimziPodSetOperator extends CrdOperator<KubernetesClient, Strimzi
     }
 
     /**
+     * StrimziPodSetOperator overrides this method in order to use replace instead of patch.
+     *
+     * @param name          Name of the resource
+     * @param desired       Desired resource
+     *
+     * @return  The patched or replaced resource
+     */
+    @Override
+    protected StrimziPodSet patchOrReplace(String namespace, String name, StrimziPodSet desired)   {
+        return operation().inNamespace(namespace).resource(desired).replace();
+    }
+
+    /**
+     * Waits for StrimziPodSet to get ready
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param namespace         Namespace of the StrimziPodSet
+     * @param name              Name of the StrimziPodSet
+     * @param pollIntervalMs    How often should it poll for readiness
+     * @param timeoutMs         How long should it wait for the resource to get ready
+     *
+     * @return  A future which completes when the resource is ready or times out
+     */
+    public Future<Void> readiness(Reconciliation reconciliation, String namespace, String name, long pollIntervalMs, long timeoutMs) {
+        return waitFor(reconciliation, namespace, name, pollIntervalMs, timeoutMs, this::isReady);
+    }
+
+    /**
      * Check if the PodSet is in the Ready state. The PodSet is ready when all the following conditions are fulfilled:
      *     - All pods are created
      *     - All pods are up-to-date

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -158,7 +158,7 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
                 .build();
 
         ServiceOperator op = new ServiceOperator(vertx, client);
-        op.internalPatch(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, current, desired);
+        op.internalUpdate(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, RESOURCE_NAME, current, desired);
 
         assertThat(desired.getMetadata().getAnnotations().get("field.cattle.io~1publicEndpoints"), equalTo("foo"));
         assertThat(desired.getMetadata().getAnnotations().get("cattle.io/test"), equalTo("bar"));

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -397,6 +397,22 @@ spec:
                             - Recreate
                           description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                       description: Template for Kafka Connect `Deployment`.
+                    podSet:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka Connect `StrimziPodSet` resource.
                     pod:
                       type: object
                       properties:
@@ -883,6 +899,37 @@ spec:
                               - IPv6
                           description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
                       description: Template for Kafka Connect API `Service`.
+                    headlessService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          description: Metadata applied to the resource.
+                        ipFamilyPolicy:
+                          type: string
+                          enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                          description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                        ipFamilies:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - IPv4
+                              - IPv6
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                      description: Template for Kafka Connect headless `Service`.
                     connectContainer:
                       type: object
                       properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -512,6 +512,22 @@ spec:
                             - Recreate
                           description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                       description: Template for Kafka Connect `Deployment`.
+                    podSet:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka Connect `StrimziPodSet` resource.
                     pod:
                       type: object
                       properties:
@@ -998,6 +1014,37 @@ spec:
                               - IPv6
                           description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
                       description: Template for Kafka Connect API `Service`.
+                    headlessService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            annotations:
+                              x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                              description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          description: Metadata applied to the resource.
+                        ipFamilyPolicy:
+                          type: string
+                          enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                          description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                        ipFamilies:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - IPv4
+                              - IPv6
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                      description: Template for Kafka Connect headless `Service`.
                     connectContainer:
                       type: object
                       properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -396,6 +396,22 @@ spec:
                         - Recreate
                         description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                     description: Template for Kafka Connect `Deployment`.
+                  podSet:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for Kafka Connect `StrimziPodSet` resource.
                   pod:
                     type: object
                     properties:
@@ -882,6 +898,37 @@ spec:
                           - IPv6
                         description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
                     description: Template for Kafka Connect API `Service`.
+                  headlessService:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                    description: Template for Kafka Connect headless `Service`.
                   connectContainer:
                     type: object
                     properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -511,6 +511,22 @@ spec:
                         - Recreate
                         description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                     description: Template for Kafka Connect `Deployment`.
+                  podSet:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for Kafka Connect `StrimziPodSet` resource.
                   pod:
                     type: object
                     properties:
@@ -997,6 +1013,37 @@ spec:
                           - IPv6
                         description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
                     description: Template for Kafka Connect API `Service`.
+                  headlessService:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                    description: Template for Kafka Connect headless `Service`.
                   connectContainer:
                     type: object
                     properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the [Strimzi Proposal 045](https://github.com/strimzi/proposals/blob/main/045-Stable-identities-for-Kafka-Connect-worker-nodes.md). It adds support to Kafka Connect and Kafka Mirror Maker 2 to run with StrimziPodSets and use stable pod names similarly to for example our Kafka brokers. This feature is protected through a Feature Gate which is in the alpha stage (i.e. disabled by default).

The only notable change compared to the proposal is that it does not create a dependency between `UseStrimziPodSets` feature gate and the new `StableConnectIdentities` feature gate. The `UseStrimziPodSets` feature gate is planned to be removed in the next Strimzi release, so we would need to change it again. It would also complicate the regression system tests since it would not be possible to test this in the _feature gates regression_ pipeline which has `USeStrimziPodSets` disabled.

The functionality for rolling updates of Kafka Connect / MM2 and for migration between Deployments and StrimziPodSets is done in separate classes so that it can be easily reused between Connect and MM2. It is non-trivial right now to use a single assembly operator to reconcile both Connect and MM2. That might be something to possibly look at in a different PR.

It also makes some necessary changes to the shared components. The StrimziPodSetController now needs to watch the Connect and MM2 Pods and reconcile them. It also updates the resource operators to allow them to influence the mechanism with which the different resources are updated easily - mainly to choose between patching and replacing as sometimes you might need to use a specific mechanism.

_This PR is currently a draft => the implementation is complete, but there are no unit tests for the new features._

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md