### PR TITLE
Added additional broker metrics related to metadata topic in KRaft mode

### DIFF
--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -214,6 +214,10 @@ data:
     #- pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
     #  name: kafka_server_raftchannelmetrics_$1
     #  type: GAUGE
+    # Broker metrics related to fetching metadata topic records in KRaft mode
+    #- pattern: "kafka.server<type=broker-metadata-metrics><>(.+):"
+    #  name: kafka_server_brokermetadatametrics_$1
+    #  type: GAUGE
   zookeeper-metrics-config.yml: |
     # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
     lowercaseOutputName: true


### PR DESCRIPTION
This PR adds another JMX exporter pattern to get broker metrics related to metadata topic in KRaft mode.
More details here https://kafka.apache.org/documentation/#kraft_broker_monitoring
They are anyway commented out to leave them out for the default example (people can uncomment if they are using Kraft mode in Strimzi).