### PR TITLE
Mention StrimziPodSets next to StatefulSets and Development in the PDB template docs

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate.adoc
@@ -1,4 +1,4 @@
-Strimzi creates a `PodDisruptionBudget` for every new `StatefulSet` or `Deployment`.
+Strimzi creates a `PodDisruptionBudget` for every new `StrimziPodSet`, `StatefulSet`, or `Deployment`.
 By default, pod disruption budgets only allow a single pod to be unavailable at a given time.
 You can increase the amount of unavailable pods allowed by changing the default value of the `maxUnavailable` property.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In the PDB template documentation, we explain that we create the PDB for every StatefulSet or Deployment. We should mention StrimziPodSet as well since we create PDB also for them.

### Checklist

- [x] Update documentation