### PR TITLE
feat(helm): support for image digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for Kafka 3.4.0 and remove support for Kafka 3.2.x
 * Use JDK HTTP client in the Kubernetes client instead of the OkHttp client
 * Add truststore configuration for HTTPS connections to OPA server
+* Add image digest support in Helm chart
 
 ## 0.33.0
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -104,6 +104,7 @@ the documentation for more details.
 | `image.repository`                   | Override default Cluster Operator image repository  | `nil`                                      |
 | `image.name`                         | Cluster Operator image name               | `cluster-operator`                                   |
 | `image.tag`                          | Override default Cluster Operator image tag       | `nil`                                        |
+| `image.digest`                       | Override Cluster Operator image tag with digest     | `nil`                                      |
 | `image.imagePullPolicy`              | Image pull policy for all pods deployed by Cluster Operator       | `IfNotPresent`               |
 | `image.imagePullSecrets`             | Docker registry pull secret               | `nil`                                                |
 | `fullReconciliationIntervalMs`       | Full reconciliation interval in milliseconds | 120000                                            |
@@ -120,46 +121,74 @@ the documentation for more details.
 | `jmxtrans.image.repository`          | Override default JmxTrans image repository                 | `nil`                               |
 | `jmxtrans.image.name`                | JmxTrans image name                       | `jmxtrans`                                           |
 | `jmxtrans.image.tag`                 | Override default JmxTrans image tag prefix                 | `nil`                               |
+| `jmxtrans.image.digest`              | Override JmxTrans image tag with digest                    | `nil`                               |
 | `kafka.image.registry`               | Override default Kafka image registry                      | `nil`                               |
 | `kafka.image.repository`             | Override default Kafka image repository                    | `nil`                               |
 | `kafka.image.name`                   | Kafka image name                          | `kafka`                                              |
 | `kafka.image.tagPrefix`              | Override default Kafka image tag prefix                    | `nil`                               |
+| `kafka.image.tag`                    | Override default Kafka image tag and ignore suffix         | `nil`                               |
+| `kafka.image.digest`                 | Override Kafka image tag with digest                       | `nil`                               |
 | `kafkaConnect.image.registry`        | Override default Kafka Connect image registry              | `nil`                               |
 | `kafkaConnect.image.repository`      | Override default Kafka Connect image repository            | `nil`                               |
 | `kafkaConnect.image.name`            | Kafka Connect image name                  | `kafka`                                              |
 | `kafkaConnect.image.tagPrefix`       | Override default Kafka Connect image tag prefix            | `nil`                               |
+| `kafkaConnect.image.tag`             | Override default Kafka Connect image tag and ignore suffix | `nil`                               |
+| `kafkaConnect.image.digest`          | Override Kafka Connect image tag with digest               | `nil`                               |
 | `kafkaMirrorMaker.image.registry`    | Override default Kafka Mirror Maker image registry         | `nil`                               |
 | `kafkaMirrorMaker.image.repository`  | Override default Kafka Mirror Maker image repository       | `nil`                               |
 | `kafkaMirrorMaker.image.name`        | Kafka Mirror Maker image name             | `kafka`                                              |
 | `kafkaMirrorMaker.image.tagPrefix`   | Override default Kafka Mirror Maker image tag prefix       | `nil`                               |
+| `kafkaMirrorMaker.image.tag`         | Override default Kafka Mirror Maker image tag and ignore suffix | `nil`                          |
+| `kafkaMirrorMaker.image.digest`      | Override Kafka Mirror Maker image tag with digest          | `nil`                               |
 | `cruiseControl.image.registry`       | Override default Cruise Control image registry             | `nil`                               |
 | `cruiseControl.image.repository`     | Override default Cruise Control image repository           | `nil`                               |
 | `cruiseControl.image.name`           | Cruise Control image name                 | `kafka`                                              |
-| `cruiseControl.image.tag`            | Override default Cruise Control image tag prefix           | `nil`                               |
+| `cruiseControl.image.tagPrefix`      | Override default Cruise Control image tag prefix           | `nil`                               |
+| `cruiseControl.image.tag`            | Override default Cruise Control image tag and ignore suffix | `nil`                              |
+| `cruiseControl.image.digest`         | Override Cruise Control image tag with digest              | `nil`                               |
 | `topicOperator.image.registry`       | Override default Topic Operator image registry             | `nil`                               |
 | `topicOperator.image.repository`     | Override default  Topic Operator image repository          | `nil`                               |
 | `topicOperator.image.name`           | Topic Operator image name                 | `operator`                                           |
 | `topicOperator.image.tag`            | Override default Topic Operator image tag                  | `nil`                               |
+| `topicOperator.image.digest`         | Override Topic Operator image tag with digest              | `nil`                               |
 | `userOperator.image.registry`        | Override default User Operator image registry              | `nil`                               |
 | `userOperator.image.repository`      | Override default User Operator image repository            | `nil`                               |
 | `userOperator.image.name`            | User Operator image name                  | `operator`                                           |
 | `userOperator.image.tag`             | Override default User Operator image tag                   | `nil`                               |
+| `userOperator.image.digest`          | Override User Operator image tag with digest               | `nil`                               |
 | `kafkaInit.image.registry`           | Override default Init Kafka image registry                 | `nil`                               |
 | `kafkaInit.image.repository`         | Override default Init Kafka image repository               | `nil`                               |
 | `kafkaInit.image.name`               | Init Kafka image name                     | `operator`                                           |
 | `kafkaInit.image.tag`                | Override default Init Kafka image tag                      | `nil`                               |
-| `tlsSidecarTopicOperator.image.registry` | Override default TLS Sidecar for Topic Operator image registry | `nil`                       |
-| `tlsSidecarTopicOperator.image.repository` | Override default TLS Sidecar for Topic Operator image repository | `nil`                   |
-| `tlsSidecarTopicOperator.image.name` | TLS Sidecar for Topic Operator image name | `kafka`                                              |
-| `tlsSidecarTopicOperator.image.tag`  | Override default TLS Sidecar for Topic Operator image tag prefix | `nil`                         |
+| `kafkaInit.image.digest`             | Override Init Kafka image tag with digest                  | `nil`                               |
+| `tlsSidecarEntityOperator.image.registry` | Override default TLS Sidecar Entity Operator image registry | `nil`                         |
+| `tlsSidecarEntityOperator.image.repository` | Override default TLS Sidecar Entity Operator image repository | `nil`                     |
+| `tlsSidecarEntityOperator.image.name` | TLS Sidecar Entity Operator image name | `kafka`                                                |
+| `tlsSidecarEntityOperator.image.tagPrefix` | Override default TLS Sidecar Entity Operator image tag prefix | `nil`                      |
+| `tlsSidecarEntityOperator.image.tag`       | Override default TLS Sidecar Entity Operator image tag and ignore suffix | `nil`           |
+| `tlsSidecarEntityOperator.image.digest` | Override TLS Sidecar Entity Operator image tag with digest | `nil`                            |
 | `kafkaBridge.image.registry`         | Override default Kafka Bridge image registry               | `quay.io`                           |
 | `kafkaBridge.image.repository`       | Override default Kafka Bridge image repository             | `strimzi`                           |
 | `kafkaBridge.image.name`             | Kafka Bridge image name                   | `kafka-bridge`                                       |
 | `kafkaBridge.image.tag`              | Override default Kafka Bridge image tag                    | `0.24.0`                            |
+| `kafkaBridge.image.digest`           | Override Kafka Bridge image tag with digest                | `nil`                               |
+| `kafkaExporter.image.registry`       | Override default Kafka Exporter image registry             | `nil`                               |
+| `kafkaExporter.image.repository`     | Override default Kafka Exporter image repository           | `nil`                               |
+| `kafkaExporter.image.name`           | Kafka Exporter image name                 | `kafka`                                              |
+| `kafkaExporter.image.tagPrefix`      | Override default Kafka Exporter image tag prefix           | `nil`                               |
+| `kafkaExporter.image.tag`            | Override default Kafka Exporter image tag and ignore suffix | `nil`                              |
+| `kafkaExporter.image.digest`         | Override Kafka Exporter image tag with digest              | `nil`                               |
+| `kafkaMirrorMaker2.image.registry`   | Override default Kafka Mirror Maker 2 image registry       | `nil`                               |
+| `kafkaMirrorMaker2.image.repository` | Override default Kafka Mirror Maker 2 image repository     | `nil`                               |
+| `kafkaMirrorMaker2.image.name`       | Kafka Mirror Maker 2 image name           | `kafka`                                              |
+| `kafkaMirrorMaker2.image.tagPrefix`  | Override default Kafka Mirror Maker 2 image tag prefix     | `nil`                               |
+| `kafkaMirrorMaker2.image.tag`        | Override default Kafka Mirror Maker 2 image tag and ignore suffix | `nil`                        |
+| `kafkaMirrorMaker2.image.digest`     | Override Kafka Mirror Maker 2 image tag with digest        | `nil`                               |
 | `kanikoExecutor.image.registry`      | Override default Kaniko Executor image registry            | `nil`                               |
 | `kanikoExecutor.image.repository`    | Override default Kaniko Executor image repository          | `nil`                               |
 | `kanikoExecutor.image.name`          | Kaniko Executor image name                | `kaniko-executor`                                    |
 | `kanikoExecutor.image.tag`           | Override default Kaniko Executor image tag                 | `nil`                               |
+| `kanikoExecutor.image.digest`        | Override Kaniko Executor image tag with digest             | `nil`                               |
 | `resources.limits.memory`            | Memory constraint for limits              | `256Mi`                                              |
 | `resources.limits.cpu`               | CPU constraint for limits                 | `1000m`                                              |
 | `resources.requests.memory`          | Memory constraint for requests            | `256Mi`                                              |
@@ -184,6 +213,7 @@ the documentation for more details.
 | `mavenBuilder.image.repository`      | Maven Builder image repository            | `nil`                                                |
 | `mavenBuilder.image.name`            | Override default Maven Builder image name                  | `maven-builder`                     |
 | `mavenBuilder.image.tag`             | Override default Maven Builder image tag                   | `nil`                               |
+| `mavenBuilder.image.digest`          | Override Maven Builder image tag with digest               | `nil`                               |
 | `logConfiguration`                   | Override default `log4j.properties` content                | `nil`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -49,7 +49,7 @@ spec:
             name: {{ .Values.logConfigMap }}
       containers:
         - name: strimzi-cluster-operator
-          image: {{ default .Values.defaultImageRegistry .Values.image.registry }}/{{ default .Values.defaultImageRepository .Values.image.repository}}/{{ .Values.image.name }}:{{ default .Values.defaultImageTag .Values.image.tag }}
+          image: {{ template "strimzi.image" (set . "key" "") }}
           ports:
             - containerPort: 8080
               name: http
@@ -84,19 +84,19 @@ spec:
               value: {{ .Values.operationTimeoutMs | quote }}
             {{- template "strimzi.kafka.image.map" . }}
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: {{ default .Values.defaultImageRegistry  .Values.topicOperator.image.registry }}/{{ default .Values.defaultImageRepository .Values.topicOperator.image.repository }}/{{ .Values.topicOperator.image.name }}:{{ default  .Values.defaultImageTag .Values.topicOperator.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "topicOperator") }}
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: {{ default .Values.defaultImageRegistry  .Values.userOperator.image.registry }}/{{ default .Values.defaultImageRepository .Values.userOperator.image.repository }}/{{ .Values.userOperator.image.name }}:{{ default .Values.defaultImageTag .Values.userOperator.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "userOperator") }}
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: {{ default .Values.defaultImageRegistry  .Values.kafkaInit.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaInit.image.repository }}/{{ .Values.kafkaInit.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaInit.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "kafkaInit") }}
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-              value: {{ default .Values.defaultImageRegistry  .Values.kafkaBridge.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaBridge.image.repository }}/{{ .Values.kafkaBridge.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaBridge.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "kafkaBridge") }}
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
-              value: {{ default .Values.defaultImageRegistry  .Values.jmxTrans.image.registry }}/{{ default .Values.defaultImageRepository .Values.jmxTrans.image.repository }}/{{ .Values.jmxTrans.image.name }}:{{ default .Values.defaultImageTag .Values.jmxTrans.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "jmxTrans") }}
             - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-              value: {{ default .Values.defaultImageRegistry  .Values.kanikoExecutor.image.registry }}/{{ default .Values.defaultImageRepository .Values.kanikoExecutor.image.repository }}/{{ .Values.kanikoExecutor.image.name }}:{{ default .Values.defaultImageTag .Values.kanikoExecutor.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "kanikoExecutor") }}
             - name: STRIMZI_DEFAULT_MAVEN_BUILDER
-              value: {{ default .Values.defaultImageRegistry  .Values.mavenBuilder.image.registry }}/{{ default .Values.defaultImageRepository .Values.mavenBuilder.image.repository }}/{{ .Values.mavenBuilder.image.name }}:{{ default .Values.defaultImageTag .Values.mavenBuilder.image.tag }}
+              value: {{ template "strimzi.image" (set . "key" "mavenBuilder") }}
             - name: STRIMZI_OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_helpers.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_helpers.tpl
@@ -30,3 +30,23 @@ Create chart name and version as used by the chart label.
 {{- define "strimzi.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Creates the image name from the registry, repository, image, tag, and digest
+- Priority is given to digests over tags
+- Registry, repository, and image will be joined with '/' if values are not blank
+- tagSuffix is added to tagPrefix or default tag.  To ignore the suffix, use tag.
+- tagSuffix can be ignored by using tag instead of tagPrefix
+To use, add the following key/value pairs to the scope:
+- "key" [optional]: the key to lookup under .Values for the image map
+- "tagSuffix" [optional]: the suffix to add to tagPrefix or the default tag
+- Example: `template "strimzi.image" (merge . (dict "key" "tlsSidecarEntityOperator" "tagSuffix" "-kafka-3.1.0"))`
+*/}}
+{{- define "strimzi.image" -}}
+{{- $vals := ternary .Values.image (index .Values .key).image (empty .key) -}}
+{{- $ref := join "/" (compact (list (default .Values.defaultImageRegistry $vals.registry) (default .Values.defaultImageRepository $vals.repository) (default .Values.defaultImageName $vals.name))) -}}
+{{- $tag := join "" (compact (list (coalesce $vals.tag $vals.tagPrefix .Values.defaultImageTag) (ternary .tagSuffix "" (empty $vals.tag)))) -}}
+{{- join "" (compact (list $ref (ternary ":" "@" (empty $vals.digest)) (default $tag $vals.digest))) -}}
+{{- $_ := unset . "key" -}}
+{{- $_ := unset . "tagSuffix" -}}
+{{- end -}}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -6,29 +6,29 @@
 {{/* Generate the kafka image map */}}
 {{- define "strimzi.kafka.image.map" }}
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-              value: {{ default .Values.defaultImageRegistry .Values.tlsSidecarEntityOperator.image.registry }}/{{ default .Values.defaultImageRepository .Values.tlsSidecarEntityOperator.image.repository }}/{{ .Values.tlsSidecarEntityOperator.image.name }}:{{ default .Values.defaultImageTag .Values.tlsSidecarEntityOperator.image.tagPrefix }}-kafka-3.4.0
+              value: {{ template "strimzi.image" (merge . (dict "key" "tlsSidecarEntityOperator" "tagSuffix" "-kafka-3.4.0")) }}
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: {{ default .Values.defaultImageRegistry .Values.kafkaExporter.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaExporter.image.repository }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaExporter.image.tagPrefix }}-kafka-3.4.0
+              value: {{ template "strimzi.image" (merge . (dict "key" "kafkaExporter" "tagSuffix" "-kafka-3.4.0")) }}
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: {{ default .Values.defaultImageRegistry .Values.cruiseControl.image.registry }}/{{ default .Values.defaultImageRepository .Values.cruiseControl.image.repository }}/{{ .Values.cruiseControl.image.name }}:{{ default .Values.defaultImageTag .Values.cruiseControl.image.tagPrefix }}-kafka-3.4.0
+              value: {{ template "strimzi.image" (merge . (dict "key" "cruiseControl" "tagSuffix" "-kafka-3.4.0")) }}
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
-                3.3.1={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-3.3.1
-                3.3.2={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-3.3.2
-                3.4.0={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-3.4.0
+                3.3.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.3.1")) }}
+                3.3.2={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.3.2")) }}
+                3.4.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.4.0")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
-                3.3.1={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-3.3.1
-                3.3.2={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-3.3.2
-                3.4.0={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-3.4.0
+                3.3.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.3.1")) }}
+                3.3.2={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.3.2")) }}
+                3.4.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.4.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |                 
-                3.3.1={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-3.3.1
-                3.3.2={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-3.3.2
-                3.4.0={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-3.4.0
+                3.3.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.3.1")) }}
+                3.3.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.3.2")) }}
+                3.4.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.4.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
-                3.3.1={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-3.3.1
-                3.3.2={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-3.3.2
-                3.4.0={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-3.4.0
+                3.3.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.3.1")) }}
+                3.3.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.3.2")) }}
+                3.4.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.4.0")) }}
 {{- end -}}

--- a/packaging/helm-charts/kafka-version-tpl.sh
+++ b/packaging/helm-charts/kafka-version-tpl.sh
@@ -15,25 +15,25 @@ get_default_kafka_version
 get_kafka_does_not_support
 
 # Set the default images
-entity_operator_tls_sidecar_version="{{ default .Values.defaultImageRegistry .Values.tlsSidecarEntityOperator.image.registry }}/{{ default .Values.defaultImageRepository .Values.tlsSidecarEntityOperator.image.repository }}/{{ .Values.tlsSidecarEntityOperator.image.name }}:{{ default .Values.defaultImageTag .Values.tlsSidecarEntityOperator.image.tagPrefix }}-kafka-${default_kafka_version}"
-kafka_exporter_version="{{ default .Values.defaultImageRegistry .Values.kafkaExporter.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaExporter.image.repository }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaExporter.image.tagPrefix }}-kafka-${default_kafka_version}"
+entity_operator_tls_sidecar_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"tlsSidecarEntityOperator\" \"tagSuffix\" \"-kafka-${default_kafka_version}\")) }}"
+kafka_exporter_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"tagSuffix\" \"-kafka-${default_kafka_version}\")) }}"
 
 for version in "${versions[@]}"
 do
-    entity_operator_tls_sidecar_version="{{ default .Values.defaultImageRegistry .Values.tlsSidecarEntityOperator.image.registry }}/{{ default .Values.defaultImageRepository .Values.tlsSidecarEntityOperator.image.repository }}/{{ .Values.tlsSidecarEntityOperator.image.name }}:{{ default .Values.defaultImageTag .Values.tlsSidecarEntityOperator.image.tagPrefix }}-kafka-${version}"
-    kafka_exporter_version="{{ default .Values.defaultImageRegistry .Values.kafkaExporter.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaExporter.image.repository }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaExporter.image.tagPrefix }}-kafka-${version}"
-    cruise_control_version="{{ default .Values.defaultImageRegistry .Values.cruiseControl.image.registry }}/{{ default .Values.defaultImageRepository .Values.cruiseControl.image.repository }}/{{ .Values.cruiseControl.image.name }}:{{ default .Values.defaultImageTag .Values.cruiseControl.image.tagPrefix }}-kafka-${version}"
+    entity_operator_tls_sidecar_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"tlsSidecarEntityOperator\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+    kafka_exporter_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"tagSuffix\" \"-kafka-${version}\")) }}"
+    cruise_control_version="{{ template \"strimzi.image\" (merge . (dict \"key\" \"cruiseControl\" \"tagSuffix\" \"-kafka-${version}\")) }}"
     kafka_versions="${kafka_versions}
-${version}={{ default .Values.defaultImageRegistry .Values.kafka.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafka.image.repository }}/{{ .Values.kafka.image.name }}:{{ default .Values.defaultImageTag .Values.kafka.image.tagPrefix }}-kafka-${version}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafka\" \"tagSuffix\" \"-kafka-${version}\")) }}"
     kafka_connect_versions="${kafka_connect_versions}
-${version}={{ default .Values.defaultImageRegistry .Values.kafkaConnect.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaConnect.image.repository }}/{{ .Values.kafkaConnect.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaConnect.image.tagPrefix }}-kafka-${version}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaConnect\" \"tagSuffix\" \"-kafka-${version}\")) }}"
     kafka_mirror_maker_versions="${kafka_mirror_maker_versions}
-${version}={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker.image.repository }}/{{ .Values.kafkaMirrorMaker.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker.image.tagPrefix }}-kafka-${version}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaMirrorMaker\" \"tagSuffix\" \"-kafka-${version}\")) }}"
     kafka_exporter_versions="${kafka_exporter_versions}
-${version}={{ default .Values.defaultImageRegistry .Values.kafkaExporter.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaExporter.image.repository }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaExporter.image.tagPrefix }}-kafka-${version}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaExporter\" \"tagSuffix\" \"-kafka-${version}\")) }}"
     if [[ ${version_does_not_support[${version}]} != *"kafkaMirrorMaker2"* ]] ; then
       kafka_mirror_maker_2_versions="${kafka_mirror_maker_2_versions}
-${version}={{ default .Values.defaultImageRegistry .Values.kafkaMirrorMaker2.image.registry }}/{{ default .Values.defaultImageRepository .Values.kafkaMirrorMaker2.image.repository }}/{{ .Values.kafkaMirrorMaker2.image.name }}:{{ default .Values.defaultImageTag .Values.kafkaMirrorMaker2.image.tagPrefix }}-kafka-${version}"
+${version}={{ template \"strimzi.image\" (merge . (dict \"key\" \"kafkaMirrorMaker2\" \"tagSuffix\" \"-kafka-${version}\")) }}"
     fi
 done
 


### PR DESCRIPTION
Signed-off-by: Michael McLeroy <michaelmcleroy@cloudfitsoftware.com>

### Type of change

- Enhancement


### Description

- Adds helper template to generate image references with the following features:
  - Support for image digests (SHA)
  - Support for blank repository, registry and/or name
  - Support for overriding tagPrefix + suffix 
> When using SHA or tagPrefix override, multiple versions of Kafka are not supported

Closes #8098 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

