### PR TITLE
docs(connect api): Using Kafka Connect REST API securely

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-connect-with-plugins.adoc
@@ -38,5 +38,7 @@ include::../../modules/deploying/proc-manual-restart-connector.adoc[leveloffset=
 include::../../modules/deploying/proc-manual-restart-connector-task.adoc[leveloffset=+1]
 //Exposing the Kafka Connect API
 include::../../modules/deploying/con-exposing-kafka-connect-api.adoc[leveloffset=+1]
+//Securing the Kafka Connect API
+include::../../modules/deploying/con-securing-kafka-connect-api.adoc[leveloffset=+1]
 //Switching from the Kafka Connect API to KafkaConnector
 include::../../modules/deploying/con-switching-api-to-kafka-connector.adoc[leveloffset=+1]

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -42,9 +42,9 @@ Only allow trusted login modules and follow the latest advice from Kafka for the
 For example, later versions of Kafka disable several insecure JNDI login modules by default. 
 As a best practice, you should explicitly disallow insecure login modules in your Kafka Connect configuration by using the `org.apache.kafka.disallowed.login.modules` system property.
 
-`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `none` (default) to prevent connector configurations from being overridden by unauthenticated requests. 
+`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `None` (default) to prevent connector configurations from being overridden by unauthenticated requests. 
 +
-.Example configuration for prevent configurations being overridden
+.Example configuration to specify connector override policy
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaConnectApiVersion}

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -12,17 +12,26 @@ Additionally, the user must have authenticated access to the Kubernetes cluster 
 
 It is crucial to restrict access to the Kafka Connect API only to trusted users to prevent unauthorized actions and potential security issues. 
 The Kafka Connect API provides extensive capabilities for altering connector configurations, which makes it all the more important to take security precautions.
+Someone with access to the Kafka Connect API could potentially obtain sensitive information that an administrator may assume is secure.
 
-If you are using the `KafkaConnector` custom resource to manage connectors, Kubernetes RBAC rules limit permission to make changes to Kubernetes cluster administrators by default.
+For example, suppose an organization uses a Kafka Connect cluster and connectors to stream sensitive data from a customer database to a central database. 
+The administrator uses a configuration provider plugin to store store sensitive information related to connecting to the customer database and the central database, such as database connection details and authentication credentials.  
+The configuration provider protects this sensitive information from being exposed to unauthorized users. 
+However, someone who has access to the Kafka Connect API can still obtain access to the customer database without the consent of the administrator.
+They can do this by setting up a fake database and configuring a connector to connect to it. 
+They then modify the connector configuration to point to the customer database, but instead of sending the data to the central database, they send it to the fake database.
+By configuring the connector to connect to the fake database, the login details and credentials for connecting to the customer database are intercepted, even though they are stored securely in the configuration provider.
+
+If you are using the `KafkaConnector` custom resources, then by default the Kubernetes RBAC rules permit only Kubernetes cluster administrators to make changes to connectors.
 You can also xref:adding-users-the-strimzi-admin-role-str[designate non-cluster administrators to manage Strimzi resources].  
 With `KafkaConnector` resources enabled in your Kafka Connect configuration, changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
-If you are not using the `KafkaConnector` resource, the default RBAC rules do not limit access to the Kafka Connect API directly.
-If you want to limit access to the Kafka Connect REST API using Kubernetes RBAC, you need to enable and use the `KafkaConnector` resources. 
+If you are not using the `KafkaConnector` resource, the default RBAC rules do not limit access to the Kafka Connect API.
+If you want to limit direct access to the Kafka Connect REST API using Kubernetes RBAC, you need to enable and use the `KafkaConnector` resources. 
 
 For improved security, we recommend configuring the following properties for the Kafka Connect API:
 
 `org.apache.kafka.disallowed.login.modules`:: (Kafka 3.4 or later) Set the `org.apache.kafka.disallowed.login.modules` Java system property to prevent the use of insecure login modules. 
-For example, specifying `org.apache.kafka.common.security.kerberos.KerberosLoginModule` prevents the use of the Kafka `KerberosLoginModule`.
+For example, specifying `com.sun.security.auth.module.JndiLoginModule` prevents the use of the Kafka `JndiLoginModule`.
 +
 .Example configuration for disallowing login modules
 [source,yaml,subs=attributes+]
@@ -41,8 +50,6 @@ spec:
         value: com.sun.security.auth.module.JndiLoginModule, org.apache.kafka.common.security.kerberos.KerberosLoginModule
 # ...      
 ----
-+
-System properties are passed to the JVM using the standard `-D` option.
 +
 Only allow trusted login modules and follow the latest advice from Kafka for the version you are using.
 As a best practice, you should explicitly disallow insecure login modules in your Kafka Connect configuration by using the `org.apache.kafka.disallowed.login.modules` system property.

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -1,0 +1,63 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-deploy-kafka-connect-with-plugins.adoc
+
+[id='con-securing-kafka-connect-api-{context}']
+= Using the Kafka Connect API securely
+
+[role="_abstract"]
+To grant a user access to the Kafka Connect API, a Kafka cluster admin must provide them with the API URL. 
+This includes the hostname or IP address of the Kafka Connect cluster and the port number on which the API is running (by default, port 8083). 
+Additionally, the user must have authenticated access to the Kubernetes cluster and the Kafka Connect REST API endpoint in order to make a request.
+
+It is crucial to restrict access to the Kafka Connect API only to trusted users to prevent unauthorized actions and potential security issues. 
+The Kafka Connect API provides extensive capabilities for altering connector configurations, which makes it all the more important to take security precautions.
+
+For improved security, we recommend configuring the following properties for the Kafka Connect API:
+
+`org.apache.kafka.disallowed.login.modules`:: Set the `org.apache.kafka.disallowed.login.modules` Java system property to prevent the use of insecure login modules. 
+For example, specifying `org.apache.kafka.common.security.plain.PlainLoginModule` prevents the use of the Kafka `PlainLoginModule`.
++
+.Example configuration for disallowing login modules
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true" 
+spec:
+  # ...
+  jvmOptions:
+    javaSystemProperties:
+      - name: org.apache.kafka.disallowed.login.modules
+        value: org.apache.kafka.common.security.plain.PlainLoginModule
+# ...      
+----
++
+System properties are passed to the JVM using the standard `-D` option.
++
+Only allow trusted login modules and follow the latest advice from Kafka for the version you are using.
+For example, later versions of Kafka disable several insecure JNDI login modules by default. 
+As a best practice, you should explicitly disallow insecure login modules in your Kafka Connect configuration by using the `org.apache.kafka.disallowed.login.modules` system property.
+
+`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `none` (default) to prevent connector configurations from being overridden by unauthenticated requests. 
++
+.Example configuration for prevent configurations being overridden
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true" 
+spec:
+  # ...
+  config:
+    connector.client.config.override.policy: None
+# ...      
+----
++
+NOTE: You can also configure `connector.client.config.override.policy` at the connector level. 

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -13,11 +13,11 @@ Additionally, the user must have authenticated access to the Kubernetes cluster 
 It is crucial to restrict access to the Kafka Connect API only to trusted users to prevent unauthorized actions and potential security issues. 
 The Kafka Connect API provides extensive capabilities for altering connector configurations, which makes it all the more important to take security precautions.
 
-If you are using the `KafkaConnector` custom resource to manage connectors, Strimzi's RBAC rules limit permission to make changes to Kubernetes cluster administrators by default.
+If you are using the `KafkaConnector` custom resource to manage connectors, Kubernetes RBAC rules limit permission to make changes to Kubernetes cluster administrators by default.
 You can also xref:adding-users-the-strimzi-admin-role-str[designate non-cluster administrators to manage Strimzi resources].  
 With `KafkaConnector` resources enabled in your Kafka Connect configuration, changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
 If you are not using the `KafkaConnector` resource, the default RBAC rules do not limit access to the Kafka Connect API directly.
-If you want to limit access to the Kafka Connect REST API using Kubernetes RBAC, you need to set up additional RBAC rules. 
+If you want to limit access to the Kafka Connect REST API using Kubernetes RBAC, you need to enable and use the `KafkaConnector` resources. 
 
 For improved security, we recommend configuring the following properties for the Kafka Connect API:
 
@@ -38,7 +38,7 @@ spec:
   jvmOptions:
     javaSystemProperties:
       - name: org.apache.kafka.disallowed.login.modules
-        value: org.apache.kafka.common.security.kerberos.KerberosLoginModule
+        value: com.sun.security.auth.module.JndiLoginModule, org.apache.kafka.common.security.kerberos.KerberosLoginModule
 # ...      
 ----
 +
@@ -47,7 +47,7 @@ System properties are passed to the JVM using the standard `-D` option.
 Only allow trusted login modules and follow the latest advice from Kafka for the version you are using.
 As a best practice, you should explicitly disallow insecure login modules in your Kafka Connect configuration by using the `org.apache.kafka.disallowed.login.modules` system property.
 
-`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `None` (default) to prevent connector configurations from being overridden by unauthenticated requests. 
+`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `None` (default) to prevent connector configurations from overriding the Kafka Connect configuration and the consumers and producers it uses. 
 +
 .Example configuration to specify connector override policy
 [source,yaml,subs=attributes+]

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -3,7 +3,7 @@
 // assembly-deploy-kafka-connect-with-plugins.adoc
 
 [id='con-securing-kafka-connect-api-{context}']
-= Using the Kafka Connect API securely
+= Limiting access to the Kafka Connect API
 
 [role="_abstract"]
 To grant a user access to the Kafka Connect API, a Kafka cluster admin must provide them with the API URL. 
@@ -13,10 +13,16 @@ Additionally, the user must have authenticated access to the Kubernetes cluster 
 It is crucial to restrict access to the Kafka Connect API only to trusted users to prevent unauthorized actions and potential security issues. 
 The Kafka Connect API provides extensive capabilities for altering connector configurations, which makes it all the more important to take security precautions.
 
+If you are using the `KafkaConnector` custom resource to manage connectors, Strimzi's RBAC rules limit permission to make changes to Kubernetes cluster administrators by default.
+You can also xref:adding-users-the-strimzi-admin-role-str[designate non-cluster administrators to manage Strimzi resources].  
+With `KafkaConnector` resources enabled in your Kafka Connect configuration, changes made directly using the Kafka Connect REST API are reverted by the Cluster Operator.
+If you are not using the `KafkaConnector` resource, the default RBAC rules do not limit access to the Kafka Connect API directly.
+If you want to limit access to the Kafka Connect REST API using Kubernetes RBAC, you need to set up additional RBAC rules. 
+
 For improved security, we recommend configuring the following properties for the Kafka Connect API:
 
-`org.apache.kafka.disallowed.login.modules`:: Set the `org.apache.kafka.disallowed.login.modules` Java system property to prevent the use of insecure login modules. 
-For example, specifying `org.apache.kafka.common.security.plain.PlainLoginModule` prevents the use of the Kafka `PlainLoginModule`.
+`org.apache.kafka.disallowed.login.modules`:: (Kafka 3.4 or later) Set the `org.apache.kafka.disallowed.login.modules` Java system property to prevent the use of insecure login modules. 
+For example, specifying `org.apache.kafka.common.security.kerberos.KerberosLoginModule` prevents the use of the Kafka `KerberosLoginModule`.
 +
 .Example configuration for disallowing login modules
 [source,yaml,subs=attributes+]
@@ -32,7 +38,7 @@ spec:
   jvmOptions:
     javaSystemProperties:
       - name: org.apache.kafka.disallowed.login.modules
-        value: org.apache.kafka.common.security.plain.PlainLoginModule
+        value: org.apache.kafka.common.security.kerberos.KerberosLoginModule
 # ...      
 ----
 +

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -45,7 +45,6 @@ spec:
 System properties are passed to the JVM using the standard `-D` option.
 +
 Only allow trusted login modules and follow the latest advice from Kafka for the version you are using.
-For example, later versions of Kafka disable several insecure JNDI login modules by default. 
 As a best practice, you should explicitly disallow insecure login modules in your Kafka Connect configuration by using the `org.apache.kafka.disallowed.login.modules` system property.
 
 `connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `None` (default) to prevent connector configurations from being overridden by unauthenticated requests. 
@@ -65,5 +64,3 @@ spec:
     connector.client.config.override.policy: None
 # ...      
 ----
-+
-NOTE: You can also configure `connector.client.config.override.policy` at the connector level. 

--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -6,13 +6,11 @@
 = Limiting access to the Kafka Connect API
 
 [role="_abstract"]
-To grant a user access to the Kafka Connect API, a Kafka cluster admin must provide them with the API URL. 
-This includes the hostname or IP address of the Kafka Connect cluster and the port number on which the API is running (by default, port 8083). 
-Additionally, the user must have authenticated access to the Kubernetes cluster and the Kafka Connect REST API endpoint in order to make a request.
-
 It is crucial to restrict access to the Kafka Connect API only to trusted users to prevent unauthorized actions and potential security issues. 
 The Kafka Connect API provides extensive capabilities for altering connector configurations, which makes it all the more important to take security precautions.
 Someone with access to the Kafka Connect API could potentially obtain sensitive information that an administrator may assume is secure.
+
+The Kafka Connect REST API can be accessed by anyone who has authenticated access to the Kubernetes cluster and knows the endpoint URL, which includes the hostname/IP address and port number.
 
 For example, suppose an organization uses a Kafka Connect cluster and connectors to stream sensitive data from a customer database to a central database. 
 The administrator uses a configuration provider plugin to store store sensitive information related to connecting to the customer database and the central database, such as database connection details and authentication credentials.  


### PR DESCRIPTION
### Type of change

- Documentation

New section in the deploying guide describes how to use the Kafka Connect API more securely.
Includes config instructions for the following:

- Setting the `org.apache.kafka.disallowed.login.modules` property to prevent the use of insecure login modules.
- Setting the`connector.client.config.override.policy` property to "None" to prevent connector configurations from being overridden by unauthenticated requests.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

