### PR TITLE
Fix the RBAC rights in the standalone User Operator installation files

### DIFF
--- a/packaging/install/user-operator/02-Role-strimzi-user-operator.yaml
+++ b/packaging/install/user-operator/02-Role-strimzi-user-operator.yaml
@@ -25,6 +25,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
   - create
   - patch
   - update


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The redesigned User Operator is watching Secrets and not just KafkaUser resources. But the RBAC files for the standalone installation were not updated and are missing the watch right, so it fails with an RBAC error. This PR should fix it.

This should be cherry-picked for the upcoming 0.33.2 release as it is trivial fix to the installation files.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally