### PR TITLE
docs(operators): Moves content related to using operators

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -134,4 +134,3 @@ listeners:
 ----
 
 If your Kubernetes cluster uses a different service suffix than `.cluster.local`, you can configure the suffix using the `KUBERNETES_SERVICE_DNS_DOMAIN` environment variable in the Cluster Operator configuration.
-See xref:ref-operator-cluster-str[] for more details.

--- a/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
+++ b/documentation/assemblies/configuring/assembly-kafka-entity-operator.adoc
@@ -17,7 +17,6 @@ Through `Kafka` resource configuration, the Cluster Operator can deploy the Enti
 
 The operators are automatically configured to manage the topics and users of the Kafka cluster.
 The Topic Operator and User Operator can only watch a single namespace.
-For more information, see xref:con-operators-namespaces-{context}[].
 
 NOTE: When deployed, the Entity Operator pod contains the operators according to the deployment configuration.
 

--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -62,7 +62,7 @@ For more information on configuring logging for specific Kafka components or ope
 
 .Operator logging
 
-* xref:ref-operator-cluster-logging-configmap-str[Cluster Operator logging]
+* link:{BookURLConfiguring}#ref-operator-cluster-logging-configmap-str[Cluster Operator logging^]
 * xref:property-topic-operator-logging-reference[Topic Operator logging]
 * xref:property-user-operator-logging-reference[User Operator logging]
 

--- a/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-cluster-operator.adoc
@@ -12,7 +12,7 @@ When the Cluster Operator is running, it starts to watch for updates of Kafka re
 
 By default, a single replica of the Cluster Operator is deployed. 
 You can add replicas with leader election so that additional Cluster Operators are on standby in case of disruption. 
-For more information, see link:{BookURLConfiguring}#assembly-using-multiple-cluster-operator-replicas-str[Running multiple Cluster Operator replicas with leader election]. 
+For more information, see xref:assembly-using-multiple-cluster-operator-replicas-str[]. 
 
 //Options for deploying the Cluster Operator
 include::../../modules/deploying/con-deploy-cluster-operator-watch-options.adoc[leveloffset=+1]

--- a/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-cluster-operator.adoc
@@ -6,9 +6,7 @@
 = Using the Cluster Operator
 
 [role="_abstract"]
-The Cluster Operator is used to deploy a Kafka cluster and other Kafka components.
-
-For information on deploying the Cluster Operator, see link:{BookURLDeploying}#cluster-operator-str[Deploying the Cluster Operator^].
+Use the Cluster Operator to deploy a Kafka cluster and other Kafka components.
 
 //rbac resources
 include::../../modules/operators/ref-operator-cluster-rbac-resources.adoc[leveloffset=+1]

--- a/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
@@ -9,7 +9,7 @@
 When you create, modify or delete a topic using the `KafkaTopic` resource,
 the Topic Operator ensures those changes are reflected in the Kafka cluster.
 
-For more information on the `KafkaTopic` resource, see the xref:type-KafkaTopic-reference[`KafkaTopic` schema reference].
+For more information on the `KafkaTopic` resource, see the link:{BookURLConfiguring}#type-KafkaTopic-reference[`KafkaTopic` schema reference^].
 
 .Deploying the Topic Operator
 
@@ -18,8 +18,8 @@ You would use a standalone Topic Operator with a Kafka cluster that is not manag
 
 For deployment instructions, see the following:
 
-* link:{BookURLDeploying}#deploying-the-topic-operator-using-the-cluster-operator-{context}[Deploying the Topic Operator using the Cluster Operator (recommended)^]
-* link:{BookURLDeploying}#deploying-the-topic-operator-standalone-{context}[Deploying the standalone Topic Operator^]
+* xref:deploying-the-topic-operator-using-the-cluster-operator-{context}[Deploying the Topic Operator using the Cluster Operator (recommended)]
+* xref:deploying-the-topic-operator-standalone-{context}[Deploying the standalone Topic Operator]
 
 [IMPORTANT]
 ====

--- a/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-user-operator.adoc
@@ -9,7 +9,7 @@
 When you create, modify or delete a user using the `KafkaUser` resource,
 the User Operator ensures those changes are reflected in the Kafka cluster.
 
-For more information on the `KafkaUser` resource, see the xref:type-KafkaUser-reference[`KafkaUser` schema reference].
+For more information on the `KafkaUser` resource, see the link:{BookURLConfiguring}#type-KafkaUser-reference[`KafkaUser` schema reference^].
 
 .Deploying the User Operator
 
@@ -18,8 +18,8 @@ You would use a standalone User Operator with a Kafka cluster that is not manage
 
 For deployment instructions, see the following:
 
-* link:{BookURLDeploying}#deploying-the-user-operator-using-the-cluster-operator-{context}[Deploying the User Operator using the Cluster Operator (recommended)^]
-* link:{BookURLDeploying}#deploying-the-user-operator-standalone-{context}[Deploying the standalone User Operator^]
+* xref:deploying-the-user-operator-using-the-cluster-operator-{context}[Deploying the User Operator using the Cluster Operator (recommended)]
+* xref:deploying-the-user-operator-standalone-{context}[Deploying the standalone User Operator]
 
 [IMPORTANT]
 ====

--- a/documentation/configuring/configuring.adoc
+++ b/documentation/configuring/configuring.adoc
@@ -16,8 +16,6 @@ include::assemblies/configuring/assembly-external-config.adoc[leveloffset=+1]
 //security context for all pods
 include::assemblies/configuring/assembly-security-providers.adoc[leveloffset=+1]
 
-include::assemblies/operators/assembly-operators.adoc[leveloffset=+1]
-
 include::assemblies/cruise-control/assembly-cruise-control-concepts.adoc[leveloffset=+1]
 
 include::assemblies/security/assembly-security.adoc[leveloffset=+1]

--- a/documentation/deploying/deploying-docinfo.xml
+++ b/documentation/deploying/deploying-docinfo.xml
@@ -2,7 +2,9 @@
 <productnumber>{ProductVersion}</productnumber>
 <subtitle>For Use with Strimzi</subtitle>
 <abstract>
-    <para>Instructions for deploying and upgrading Strimzi</para>
+    <para>This guide provides a comprehensive overview of how to deploy and manage Strimzi. 
+    The guide describes how to install and upgrade Strimzi, configure security features, optimize performance, and monitor operations. 
+ </para>
 </abstract>
 <authorgroup>
 </authorgroup>

--- a/documentation/deploying/deploying.adoc
+++ b/documentation/deploying/deploying.adoc
@@ -4,7 +4,7 @@ include::shared/attributes.adoc[]
 :context: str
 
 [id="deploying-book_{context}"]
-= Deploying and Upgrading Strimzi
+= Deploying and Managing Strimzi
 
 //Introduction to the install process
 include::assemblies/deploying/assembly-deploy-intro.adoc[leveloffset=+1]
@@ -24,6 +24,8 @@ include::modules/deploying/proc-deploy-cluster-operator-helm-chart.adoc[leveloff
 include::assemblies/deploying/assembly-deploy-client-access.adoc[leveloffset=+1]
 //Securing the deployment
 include::assemblies/security/assembly-securing-access.adoc[leveloffset=+1]
+//Using operators
+include::assemblies/operators/assembly-operators.adoc[leveloffset=+1]
 //Introduce metrics and monitoring to your deployment
 include::assemblies/metrics/assembly-metrics.adoc[leveloffset=+1]
 //Introduce tracing to your deployment

--- a/documentation/modules/configuring/con-config-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-high-volume-messages.adoc
@@ -132,7 +132,7 @@ spec:
 ----
 
 NOTE: `FileStreamSourceConnector` and `FileStreamSinkConnector` are provided as example connectors. 
-For information on deploying them as `KafkaConnector` resources, see link:{BookURLDeploying}#proc-deploying-kafkaconnector-str[Deploying example KafkaConnector resources^]. 
+For information on deploying them as `KafkaConnector` resources, see xref:proc-deploying-kafkaconnector-str[]. 
 
 Consumer configuration is added for the sink connector. 
 
@@ -236,5 +236,5 @@ You can use these metrics to gauge whether or not you need to tune your configur
 [role="_additional-resources"]
 .Additional resources
 
-* link:{BookURLDeploying}#assembly-metrics-setup-{context}[Grafana dashboards^]
-* link:{BookURLDeploying}#using-kafka-connect-with-plug-ins-{context}[Adding connectors^]
+* xref:assembly-metrics-setup-{context}[]
+* xref:using-kafka-connect-with-plug-ins-{context}[]

--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -71,7 +71,7 @@ It configures the pods managed by Strimzi with a baseline security profile.
 The baseline profile is compatible with previous versions of Strimzi.
 
 The Baseline Provider is enabled by default if you don't specify a provider.
-Though you can enable it explicitly by setting the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable to `baseline` when xref:ref-operator-cluster-str[configuring the Cluster Operator]. 
+Though you can enable it explicitly by setting the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable to `baseline` when configuring the Cluster Operator. 
 
 .Configuration for the Baseline Provider
 [source,yaml,options="nowrap"]
@@ -91,7 +91,7 @@ Instead of specifying `baseline` as the value, you can specify the `io.strimzi.p
 The Restricted Provider provides a higher level of security than the Baseline Provider.
 It configures the pods managed by Strimzi with a restricted security profile.
 
-You enable the Restricted Provider by setting the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable to `restricted` when xref:ref-operator-cluster-str[configuring the Cluster Operator].
+You enable the Restricted Provider by setting the `STRIMZI_POD_SECURITY_PROVIDER_CLASS` environment variable to `restricted` when configuring the Cluster Operator.
 
 .Configuration for the Restricted Provider
 [source,yaml,options="nowrap"]

--- a/documentation/modules/configuring/con-customizing-image-pull-policy.adoc
+++ b/documentation/modules/configuring/con-customizing-image-pull-policy.adoc
@@ -24,5 +24,5 @@ Changing the policy will result in a rolling update of all your Kafka, Kafka Con
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about Cluster Operator configuration, see xref:using-the-cluster-operator-{context}[].
-* For more information about Image Pull Policies, see {K8sImagePullPolicies}.
+* link:{BookURLConfiguring}#using-the-cluster-operator-{context}[Using the Cluster Operator^].
+* {K8sImagePullPolicies}.

--- a/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
+++ b/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
@@ -23,8 +23,3 @@ In practice, maintenance windows should be set in conjunction with the `Kafka.sp
 NOTE: Strimzi does not schedule maintenance operations exactly according to the given windows. Instead, for each reconciliation, it checks whether a maintenance window is currently "open".
 This means that the start of maintenance operations within a given time window can be delayed by up to the Cluster Operator reconciliation interval.
 Maintenance time windows must therefore be at least this long.
-
-[role="_additional-resources"]
-.Additional resources
-
-* For more information about the Cluster Operator configuration, see xref:ref-operator-cluster-str[].

--- a/documentation/modules/configuring/proc-creating-logging-filters.adoc
+++ b/documentation/modules/configuring/proc-creating-logging-filters.adoc
@@ -168,6 +168,6 @@ create -f install/cluster-operator -n my-cluster-operator-namespace
 [role="_additional-resources"]
 .Additional resources
 * xref:proc-config-kafka-str[Configuring Kafka]
-* xref:ref-operator-cluster-logging-configmap-str[Cluster Operator logging]
+* link:{BookURLConfiguring}#ref-operator-cluster-logging-configmap-str[Cluster Operator logging^]
 * xref:property-topic-operator-logging-reference[Topic Operator logging]
 * xref:property-user-operator-logging-reference[User Operator logging]

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -230,5 +230,5 @@ bin/kafka-reassign-partitions.sh --bootstrap-server my-cluster-kafka-bootstrap:9
 .Additional resources
 
 * xref:proc-config-kafka-{context}[]
-* xref:proc-configuring-kafka-topic-{context}[]
-* xref:proc-configuring-kafka-user-{context}[]
+* link:{BookURLConfiguring}#proc-configuring-kafka-topic-{context}[Configuring Kafka topics^]
+* link:{BookURLConfiguring}#proc-configuring-kafka-user-{context}[Configuring Kafka users^]

--- a/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
+++ b/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
@@ -16,7 +16,8 @@ You can specify the following namespaces:
 * xref:deploying-cluster-operator-to-watch-whole-cluster-{context}[All namespaces]
 
 NOTE: The Cluster Operator can watch one, multiple, or all namespaces in a Kubernetes cluster.
-The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in a single namespace. For more information, see link:{BookURLConfiguring}#con-operators-namespaces-str[Watching namespaces with Strimzi operators^].
+The Topic Operator and User Operator watch for `KafkaTopic` and `KafkaUser` resources in a single namespace. 
+For more information, see xref:con-operators-namespaces-str[].
 
 The Cluster Operator watches for changes to the following resources:
 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -107,4 +107,4 @@ spec: <1>
 .Additional resources
 
 * link:{BookURLConfiguring}#con-common-configuration-images-reference[Container image configuration and the `KafkaConnect.spec.image property`^]
-* link:{BookURLConfiguring}#ref-operator-cluster-str[Cluster Operator configuration and the `STRIMZI_KAFKA_CONNECT_IMAGES` variable^]
+* xref:ref-operator-cluster-str[Cluster Operator configuration and the `STRIMZI_KAFKA_CONNECT_IMAGES` variable]

--- a/documentation/modules/operators/con-operators-prometheus-metrics.adoc
+++ b/documentation/modules/operators/con-operators-prometheus-metrics.adoc
@@ -6,14 +6,13 @@
 
 = Monitoring operators using Prometheus metrics
 
+[role="_abstract"]
 Strimzi operators expose Prometheus metrics.
-The metrics are automatically enabled and contain information about:
+The metrics are automatically enabled and contain information about the following:
 
 * Number of reconciliations
 * Number of Custom Resources the operator is processing
 * Duration of reconciliations
 * JVM metrics from the operators
 
-Additionally, we provide an example Grafana dashboard.
-
-For more information about Prometheus, see the link:{BookURLDeploying}#assembly-metrics-{context}[Introducing Metrics to Kafka] in the _Deploying and Upgrading Strimzi_ guide.
+Additionally, Strimzi provides xref:ref-metrics-dashboards-{context}[an example Grafana dashboard for the operator].

--- a/documentation/modules/operators/con-topic-operator-store.adoc
+++ b/documentation/modules/operators/con-topic-operator-store.adoc
@@ -111,6 +111,6 @@ To be able to do this, `delete.topic.enable` must be set to `true` (default) in 
 
 [role="_additional-resources"]
 .Additional resources
-* link:{BookURLDeploying}#assembly-downgrade-{context}[Downgrading Strimzi^]
-* xref:con-partition-reassignment-str[Scaling cluster and partition reassignment]
-* xref:cruise-control-concepts-str[Cruise Control for cluster rebalancing]
+* xref:assembly-downgrade-{context}[Downgrading Strimzi]
+* link:{BookURLConfiguring}#con-partition-reassignment-str[Scaling clusters and partition reassignment^]
+* link:{BookURLConfiguring}#cruise-control-concepts-str[Cruise Control for cluster rebalancing^]

--- a/documentation/modules/operators/proc-configuring-kafka-topic.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-topic.adoc
@@ -30,7 +30,7 @@ It is important that you consider the following before making your changes:
 .Prerequisites
 
 * A running Kafka cluster configured with a Kafka broker listener using mTLS authentication and TLS encryption.
-* A running Topic Operator (typically xref:assembly-kafka-entity-operator-str[deployed with the Entity Operator]).
+* A running Topic Operator (typically deployed with the Entity Operator).
 * For deleting a topic, `delete.topic.enable=true` (default) in the `spec.kafka.config` of the `Kafka` resource.
 
 .Procedure

--- a/documentation/modules/operators/proc-configuring-kafka-user.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-user.adoc
@@ -18,12 +18,12 @@ For example:
 Users represent Kafka clients.
 When you configure Kafka users, you enable the user authentication and authorization mechanisms required by clients to access Kafka.
 The mechanism used must match the equivalent `Kafka` configuration.
-For more information on using `Kafka` and `KafkaUser` resources to secure access to Kafka brokers, see link:{BookURLDeploying}#assembly-securing-kafka-{context}[Securing access to Kafka brokers^].
+For more information on using `Kafka` and `KafkaUser` resources to secure access to Kafka brokers, see xref:assembly-securing-kafka-{context}[Securing access to Kafka brokers].
 
 .Prerequisites
 
 * A running Kafka cluster configured with a Kafka broker listener using mTLS authentication and TLS encryption.
-* A running User Operator (typically xref:assembly-kafka-entity-operator-str[deployed with the Entity Operator]).
+* A running User Operator (typically deployed with the Entity Operator).
 
 .Procedure
 

--- a/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
+++ b/documentation/modules/operators/proc-configuring-proxy-config-cluster-operator.adoc
@@ -70,5 +70,5 @@ kubectl create -f install/cluster-operator/060-Deployment-strimzi-cluster-operat
 [role="_additional-resources"]
 .Additional resources
 
-* xref:property-hostaliases-config-reference[Host aliases]
-* link:{BookURLDeploying}#adding-users-the-strimzi-admin-role-str[Designating Strimzi administrators^]
+* link:{BookURLConfiguring}#property-hostaliases-config-reference[Host aliases^]
+* xref:adding-users-the-strimzi-admin-role-str[Designating Strimzi administrators]

--- a/documentation/modules/operators/ref-operator-cluster.adoc
+++ b/documentation/modules/operators/ref-operator-cluster.adoc
@@ -9,8 +9,8 @@
 You can configure the Cluster Operator using environment variables.
 The supported environment variables are listed here. 
 
-NOTE: The environment variables relate to the container configuration for the deployment of the Cluster Operator image.
-For more information on `image` configuration, see, xref:con-common-configuration-images-reference[].
+NOTE: The environment variables are specified for the container image of the Cluster Operator in its `Deployment` configuration file. 
+(`install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml`)
 
 `STRIMZI_NAMESPACE`:: A comma-separated list of namespaces that the operator operates in.
 When not set, set to empty string, or set to `*`, the Cluster Operator operates in all namespaces.
@@ -44,7 +44,7 @@ If you require a higher timeout, change the `maxSessionTimeout` ZooKeeper server
 The worker thread pool size, which is used for various asynchronous and blocking operations that are run by the Cluster Operator.
 
 `STRIMZI_OPERATOR_NAME`:: Optional, defaults to the pod's hostname.
-The operator name identifies the Strimzi instance when link:{BookURLDeploying}#proc-operator-restart-events-str[emitting Kubernetes events^].
+The operator name identifies the Strimzi instance when xref:proc-operator-restart-events-str[emitting Kubernetes events].
 
 `STRIMZI_OPERATOR_NAMESPACE`:: The name of the namespace where the Cluster Operator is running.
 Do not configure this variable manually. Use the downward API.

--- a/documentation/modules/operators/ref-operator-topic.adoc
+++ b/documentation/modules/operators/ref-operator-topic.adoc
@@ -7,7 +7,7 @@
 
 The `KafkaTopic` resource is used to configure topics, including the number of partitions and replicas.
 
-The full schema for `KafkaTopic` is described in xref:type-KafkaTopic-reference[`KafkaTopic` schema reference].
+The full schema for `KafkaTopic` is described in link:{BookURLConfiguring}#type-KafkaTopic-reference[`KafkaTopic` schema reference^].
 
 == Identifying a Kafka cluster for topic handling
 

--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -135,7 +135,7 @@ Each listener can have a different link:{BookURLConfiguring}#configuration-liste
 For more information on network policy peers, refer to the {K8sNetworkPolicyPeerAPI}.
 
 If you want to use custom network policies, you can set the `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` in the Cluster Operator configuration.
-For more information, see link:{BookURLConfiguring}#ref-operator-cluster-{context}[Cluster Operator configuration^].
+For more information, see xref:ref-operator-cluster-{context}[].
 
 NOTE: Your configuration of Kubernetes must support ingress `NetworkPolicies` in order to use network policies in Strimzi.
 

--- a/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-brokers-older-kafka.adoc
@@ -88,4 +88,4 @@ kubectl run kafka-admin -ti --image={DockerKafkaImageCurrent} --rm=true --restar
 
 [role="_additional-resources"]
 .Additional resources
-* link:{BookURLConfiguring}#ref-topic-operator-store-{context}[Topic Operator topic store^]
+* xref:ref-topic-operator-store-{context}[]


### PR DESCRIPTION
### Type of change
**Documentation**
Content from the Configuring guide is being moved to the Deploying guide.
The Configuring guide is being positioned as a pure schema reference guide.
Instructions to deploy, configure and administer Strimzi will sit together in the Deploying guide.

This PR moves content related to using operators.
Some minor edits to content, but mostly restructuring.

![image](https://user-images.githubusercontent.com/47596553/219361034-f8f2c3c2-b7a4-4834-a0fb-39b46b7bb4da.png)


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

