### PR TITLE
feat: added the logger to REST API requests in KafkaConnectApiImpl

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -603,10 +603,10 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             boolean shouldPause = Boolean.TRUE.equals(connectorSpec.getPause());
             if ("RUNNING".equals(state) && shouldPause) {
                 LOGGER.debugCr(reconciliation, "Pausing connector {}", connectorName);
-                return apiClient.pause(host, port, connectorName);
+                return apiClient.pause(reconciliation, host, port, connectorName);
             } else if ("PAUSED".equals(state) && !shouldPause) {
                 LOGGER.debugCr(reconciliation, "Resuming connector {}", connectorName);
-                return apiClient.resume(host, port, connectorName);
+                return apiClient.resume(reconciliation, host, port, connectorName);
             } else {
                 return Future.succeededFuture();
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -386,7 +386,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         KafkaConnectApi apiClient = connectClientProvider.apply(vertx);
 
         return CompositeFuture.join(
-                apiClient.list(reconciliation,host, port),
+                apiClient.list(reconciliation, host, port),
                 connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())),
                 apiClient.listConnectorPlugins(reconciliation, host, port),
                 apiClient.updateConnectLoggers(reconciliation, host, port, desiredLogging, defaultLogging)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -386,7 +386,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         KafkaConnectApi apiClient = connectClientProvider.apply(vertx);
 
         return CompositeFuture.join(
-                apiClient.list(host, port),
+                apiClient.list(reconciliation,host, port),
                 connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())),
                 apiClient.listConnectorPlugins(reconciliation, host, port),
                 apiClient.updateConnectLoggers(reconciliation, host, port, desiredLogging, defaultLogging)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -133,12 +133,13 @@ public interface KafkaConnectApi {
 
     /**
      * Make a {@code GET} request to {@code /connectors}
+     * @param reconciliation The reconciliation
      * @param host The host to make the request to.
      * @param port The port to make the request to.
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connectors.
      */
-    Future<List<String>> list(String host, int port);
+    Future<List<String>> list(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code GET} request to {@code /connector-plugins}.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -113,21 +113,23 @@ public interface KafkaConnectApi {
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/pause}.
+     * @param reconciliation The reconciliation
      * @param host The host to make the request to.
      * @param port The port to make the request to.
      * @param connectorName The name of the connector to pause.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> pause(String host, int port, String connectorName);
+    Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/resume}.
+     * @param reconciliation The reconciliation
      * @param host The host to make the request to.
      * @param port The port to make the request to.
      * @param connectorName The name of the connector to resume.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> resume(String host, int port, String connectorName);
+    Future<Void> resume(Reconciliation reconciliation,  String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -167,6 +167,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     @Override
     public Future<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = "/connectors/" + connectorName;
+        LOGGER.debugCr(reconciliation, "Making DELETE request to {}", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
             httpClient.request(HttpMethod.DELETE, port, host, path, request -> {
                 if (request.succeeded()) {
@@ -285,6 +286,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     private Future<Void> pauseResume(String host, int port, String path) {
+
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.PUT, port, host, path, request -> {
                     if (request.succeeded()) {
@@ -350,6 +352,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     @Override
     public Future<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port) {
         String path = "/connector-plugins";
+        LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.GET, port, host, path, request -> {
                     if (request.succeeded()) {
@@ -360,6 +363,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                 if (response.result().statusCode() == 200) {
                                     response.result().bodyHandler(buffer -> {
                                         try {
+                                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", response.result().statusCode());
                                             result.complete(asList(mapper.readValue(buffer.getBytes(), ConnectorPlugin[].class)));
                                         } catch (IOException e) {
                                             LOGGER.warnCr(reconciliation, "Failed to parse list of connector plugins", e);
@@ -418,6 +422,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     @Override
     public Future<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port) {
         String path = "/admin/loggers/";
+        LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.GET, port, host, path, request -> {
                     if (request.succeeded()) {
@@ -428,6 +433,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                 if (response.result().statusCode() == 200) {
                                     response.result().bodyHandler(buffer -> {
                                         try {
+                                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", response.result().statusCode(), path);
                                             Map<String, Map<String, String>> fetchedLoggers = mapper.readValue(buffer.getBytes(), MAP_OF_MAP_OF_STRINGS);
                                             Map<String, String> loggerMap = new HashMap<>(fetchedLoggers.size());
                                             for (var e : fetchedLoggers.entrySet()) {
@@ -598,6 +604,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     @Override
     public Future<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/topics", connectorName);
+        LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
             httpClient.request(HttpMethod.GET, port, host, path, request -> {
                 if (request.succeeded()) {
@@ -613,6 +620,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                 response.result().bodyHandler(buffer -> {
                                     try {
                                         Map<String, Map<String, List<String>>> t = mapper.readValue(buffer.getBytes(), MAP_OF_MAP_OF_LIST_OF_STRING);
+                                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", response.result().statusCode(), path, t);
                                         result.complete(t.get(connectorName).get("topics"));
                                     } catch (IOException e) {
                                         LOGGER.warnCr(reconciliation, "Failed to parse list of connector topics", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -313,8 +313,9 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<List<String>> list(String host, int port) {
+    public Future<List<String>> list(Reconciliation reconciliation, String host, int port) {
         String path = "/connectors";
+        LOGGER.debugCr(reconciliation, "Making GET request to {} ", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.GET, port, host, path, request -> {
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -276,17 +276,17 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<Void> pause(String host, int port, String connectorName) {
-        return pauseResume(host, port, "/connectors/" + connectorName + "/pause");
+    public Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
+        return pauseResume(reconciliation, host, port, "/connectors/" + connectorName + "/pause");
     }
 
     @Override
-    public Future<Void> resume(String host, int port, String connectorName) {
-        return pauseResume(host, port, "/connectors/" + connectorName + "/resume");
+    public Future<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
+        return pauseResume(reconciliation, host, port, "/connectors/" + connectorName + "/resume");
     }
 
-    private Future<Void> pauseResume(String host, int port, String path) {
-
+    private Future<Void> pauseResume(Reconciliation reconciliation, String host, int port, String path) {
+        LOGGER.debugCr(reconciliation, "Making PUT request to {} ", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.PUT, port, host, path, request -> {
                     if (request.succeeded()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -336,7 +336,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         List<KafkaMirrorMaker2MirrorSpec> mirrors = ModelUtils.asListOrEmptyList(kafkaMirrorMaker2.getSpec().getMirrors());
         String host = KafkaMirrorMaker2Resources.qualifiedServiceName(mirrorMaker2Name, reconciliation.namespace());
         KafkaConnectApi apiClient = getKafkaConnectApi();
-        return apiClient.list(host, KafkaConnectCluster.REST_API_PORT).compose(deleteMirrorMaker2ConnectorNames -> {
+        return apiClient.list(reconciliation, host, KafkaConnectCluster.REST_API_PORT).compose(deleteMirrorMaker2ConnectorNames -> {
 
             for (Map.Entry<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> connectorEntry : MIRRORMAKER2_CONNECTORS.entrySet()) {
                 deleteMirrorMaker2ConnectorNames.removeAll(mirrors.stream()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -277,7 +277,7 @@ public class ConnectorMockTest {
             String connectorName = invocation.getArgument(3);
             return kafkaConnectApiStatusMock(host, connectorName);
         });
-        when(api.pause(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+        when(api.pause(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String host = invocation.getArgument(0);
             String connectorName = invocation.getArgument(2);
             ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
@@ -289,7 +289,7 @@ public class ConnectorMockTest {
             }
             return Future.succeededFuture();
         });
-        when(api.resume(any(), anyInt(), anyString())).thenAnswer(invocation -> {
+        when(api.resume(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String host = invocation.getArgument(0);
             String connectorName = invocation.getArgument(2);
             ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
@@ -1072,10 +1072,10 @@ public class ConnectorMockTest {
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
-        verify(api, never()).pause(
+        verify(api, never()).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
-        verify(api, never()).resume(
+        verify(api, never()).resume(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
 
@@ -1087,10 +1087,10 @@ public class ConnectorMockTest {
 
         waitForConnectorState(connectorName, "PAUSED");
 
-        verify(api, times(1)).pause(
+        verify(api, times(1)).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
-        verify(api, never()).resume(
+        verify(api, never()).resume(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
 
@@ -1102,10 +1102,10 @@ public class ConnectorMockTest {
 
         waitForConnectorState(connectorName, "RUNNING");
 
-        verify(api, times(1)).pause(
+        verify(api, times(1)).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
-        verify(api, times(1)).resume(
+        verify(api, times(1)).resume(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -204,7 +204,7 @@ public class ConnectorMockTest {
         runningConnectors = new HashMap<>();
 
         when(api.list(any(), any(), anyInt())).thenAnswer(i -> {
-            String host = i.getArgument(0);
+            String host = i.getArgument(1);
             String matchingKeyPrefix = host + "##";
             return Future.succeededFuture(runningConnectors.keySet().stream()
                     .filter(s -> s.startsWith(matchingKeyPrefix))
@@ -278,8 +278,8 @@ public class ConnectorMockTest {
             return kafkaConnectApiStatusMock(host, connectorName);
         });
         when(api.pause(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
-            String host = invocation.getArgument(0);
-            String connectorName = invocation.getArgument(2);
+            String host = invocation.getArgument(1);
+            String connectorName = invocation.getArgument(3);
             ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
             if (connectorState == null) {
                 return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
@@ -290,8 +290,8 @@ public class ConnectorMockTest {
             return Future.succeededFuture();
         });
         when(api.resume(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
-            String host = invocation.getArgument(0);
-            String connectorName = invocation.getArgument(2);
+            String host = invocation.getArgument(1);
+            String connectorName = invocation.getArgument(3);
             ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
             if (connectorState == null) {
                 return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -1487,7 +1487,7 @@ public class ConnectorMockTest {
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
-        when(api.list(any(),any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.list(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnectorConfig(any(), any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -203,7 +203,7 @@ public class ConnectorMockTest {
         api = mock(KafkaConnectApi.class);
         runningConnectors = new HashMap<>();
 
-        when(api.list(any(), anyInt())).thenAnswer(i -> {
+        when(api.list(any(), any(), anyInt())).thenAnswer(i -> {
             String host = i.getArgument(0);
             String matchingKeyPrefix = host + "##";
             return Future.succeededFuture(runningConnectors.keySet().stream()
@@ -639,7 +639,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
 
         verify(api, never()).createOrUpdatePutRequest(any(),
@@ -661,7 +661,7 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(connector).create();
         waitForConnectorReady(connectorName);
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -701,7 +701,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName, "NoSuchResourceException",
             "KafkaConnect resource 'cluster' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace ns.");
 
-        verify(api, never()).list(
+        verify(api, never()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -724,7 +724,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // Might be triggered multiple times (Connect creation, Connector Status update, Connect Status update), depending on the timing
         verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
@@ -765,7 +765,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -787,7 +787,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // triggered twice (Connect creation, Connector Status update)
         verify(api, times(1)).createOrUpdatePutRequest(any(),
@@ -828,7 +828,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName, "NoSuchResourceException",
                 "KafkaConnect resource 'cluster' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace ns.");
 
-        verify(api, never()).list(
+        verify(api, never()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -851,7 +851,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // Triggered once or twice (Connect creation, Connector Status update), depending on the timing
         verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
@@ -993,7 +993,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // triggered at least once (Connect creation)
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1013,7 +1013,7 @@ public class ConnectorMockTest {
         waitForConnectorNotReady(connectorName,
                 "ConnectRestException", "GET /foo returned 500 (Internal server error): Bad stuff happened");
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         // Might be triggered multiple times depending on the timing
         verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
@@ -1043,7 +1043,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1065,7 +1065,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
         waitForConnectorState(connectorName, "RUNNING");
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1131,7 +1131,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1153,7 +1153,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
         waitForConnectorState(connectorName, "RUNNING");
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1214,7 +1214,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1236,7 +1236,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
         waitForConnectorState(connectorName, "RUNNING");
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1295,7 +1295,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1317,7 +1317,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
         waitForConnectorState(connectorName, "RUNNING");
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1377,7 +1377,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1399,7 +1399,7 @@ public class ConnectorMockTest {
         waitForConnectorReady(connectorName);
         waitForConnectorState(connectorName, "RUNNING");
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1458,7 +1458,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
 
         verify(api, never()).createOrUpdatePutRequest(any(),
@@ -1480,14 +1480,14 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(connector).create();
         waitForConnectorReady(connectorName);
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
-        when(api.list(any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.list(any(),any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnectorConfig(any(), any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
@@ -1524,7 +1524,7 @@ public class ConnectorMockTest {
         waitForConnectReady(connectName);
 
         // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
-        verify(api, atLeastOnce()).list(
+        verify(api, atLeastOnce()).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
 
         verify(api, never()).createOrUpdatePutRequest(any(),
@@ -1546,14 +1546,14 @@ public class ConnectorMockTest {
         Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(connector).create();
         waitForConnectorReady(connectorName);
 
-        verify(api, times(2)).list(
+        verify(api, times(2)).list(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
         assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
-        when(api.list(any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
+        when(api.list(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.getConnectorConfig(any(), any(), any(), anyInt(), any())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
@@ -1666,7 +1666,7 @@ public class ConnectorMockTest {
         String connectName = "cluster";
 
         // this connector should be deleted on connect reconciliation
-        when(api.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(List.of("connector")));
+        when(api.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(List.of("connector")));
         when(api.delete(any(), anyString(), anyInt(), anyString())).thenReturn(Future.failedFuture(new RuntimeException("deletion error")));
 
         KafkaConnect kafkaConnect = new KafkaConnectBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -213,7 +213,7 @@ public class KafkaConnectApiIT {
                         containsString("Invalid value dog for configuration tasks.max: Not a number of type INT"));
             })))
             .recover(e -> Future.succeededFuture())
-            .compose(createResponse -> client.list(Reconciliation.DUMMY_RECONCILIATION,"localhost", port))
+            .compose(createResponse -> client.list(Reconciliation.DUMMY_RECONCILIATION, "localhost", port))
             .onComplete(context.succeeding(connectorNames -> context.verify(() ->
                     assertThat(connectorNames, is(singletonList("test"))))))
             .compose(connectorNames -> client.delete(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -107,7 +107,7 @@ public class KafkaConnectApiIT {
                 assertThat(fileSource.getVersion(), is(not(emptyString())));
             })))
 
-            .compose(connectorPlugins -> client.list("localhost", port))
+            .compose(connectorPlugins -> client.list(Reconciliation.DUMMY_RECONCILIATION, "localhost", port))
             .onComplete(context.succeeding(connectorNames -> context.verify(() -> assertThat(connectorNames, is(empty())))))
 
             .compose(connectorNames -> {
@@ -213,12 +213,12 @@ public class KafkaConnectApiIT {
                         containsString("Invalid value dog for configuration tasks.max: Not a number of type INT"));
             })))
             .recover(e -> Future.succeededFuture())
-            .compose(createResponse -> client.list("localhost", port))
+            .compose(createResponse -> client.list(Reconciliation.DUMMY_RECONCILIATION,"localhost", port))
             .onComplete(context.succeeding(connectorNames -> context.verify(() ->
                     assertThat(connectorNames, is(singletonList("test"))))))
             .compose(connectorNames -> client.delete(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
             .onComplete(context.succeedingThenComplete())
-            .compose(deletedConnector -> client.list("localhost", port))
+            .compose(deletedConnector -> client.list(Reconciliation.DUMMY_RECONCILIATION, "localhost", port))
             .onComplete(context.succeeding(connectorNames -> assertThat(connectorNames, is(empty()))))
             .compose(connectorNames -> client.delete(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "never-existed"))
             .onComplete(context.failing(error -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -172,10 +172,10 @@ public class KafkaConnectApiIT {
             })))
             .recover(error -> Future.succeededFuture())
 
-            .compose(ignored -> client.pause("localhost", port, "test"))
+            .compose(ignored -> client.pause(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
             .onComplete(context.succeedingThenComplete())
 
-            .compose(ignored -> client.resume("localhost", port, "test"))
+            .compose(ignored -> client.resume(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
             .onComplete(context.succeedingThenComplete())
 
             .compose(ignored -> client.restart("localhost", port, "test", true, true))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -154,7 +154,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 .endSpec()
             .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mock.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         Checkpoint async = context.checkpoint();
@@ -182,7 +182,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 .endSpec()
                 .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mock.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         Checkpoint async = context.checkpoint();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -171,7 +171,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
@@ -321,7 +321,7 @@ public class KafkaConnectAssemblyOperatorTest {
         ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
         when(mockPdbOps.reconcile(any(), anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());        
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
@@ -446,7 +446,7 @@ public class KafkaConnectAssemblyOperatorTest {
         }).when(mockCmOps).reconcile(any(), eq(kcNamespace), anyString(), any());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
@@ -622,7 +622,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new PodDisruptionBudget())));
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
@@ -698,7 +698,7 @@ public class KafkaConnectAssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new PodDisruptionBudget())));
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
 
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -159,7 +159,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 .endSpec()
             .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mock.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         Checkpoint async = context.checkpoint();
@@ -186,7 +186,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 .endSpec()
                 .build());
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mock.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         Checkpoint async = context.checkpoint();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -157,7 +157,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
@@ -278,7 +278,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
@@ -380,7 +380,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
@@ -481,7 +481,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
@@ -581,7 +581,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -144,7 +144,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockMirrorMaker2Ops.updateStatusAsync(any(), mirrorMaker2Captor.capture())).thenReturn(Future.succeededFuture());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -250,7 +250,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockPdbOps.reconcile(any(), anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -364,7 +364,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         }).when(mockCmOps).reconcile(any(), eq(kmm2Namespace), anyString(), any());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -525,7 +525,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockNetPolOps.reconcile(any(), eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -587,7 +587,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockNetPolOps.reconcile(any(), eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -756,7 +756,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockMirrorMaker2Ops.updateStatusAsync(any(), mirrorMaker2Captor.capture())).thenReturn(Future.succeededFuture());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -856,7 +856,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockMirrorMaker2Ops.updateStatusAsync(any(), mirrorMaker2Captor.capture())).thenReturn(Future.succeededFuture());
 
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
@@ -1059,7 +1059,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
     private KafkaConnectApi createConnectClientMock() {
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
         return mockConnectClient;
     }


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
 Pull request for  [issue](https://github.com/strimzi/strimzi-kafka-operator/issues/8055). Added logger for REST API at debug level. 
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_


- [ ] Make sure all tests pass
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

