### PR TITLE
Update upgrade scenario for StableConnectIdentities feature gate

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
@@ -93,15 +93,15 @@ public class VersionModificationDataLoader {
         return olmUpgradeData;
     }
 
-    public List<BundleVersionModificationData> getBundleUpgradeDataList() {
+    public List<BundleVersionModificationData> getBundleUpgradeOrDowngradeDataList() {
         return bundleVersionModificationDataList;
     }
 
-    public BundleVersionModificationData getBundleUpgradeData(final int index) {
+    public BundleVersionModificationData getBundleUpgradeOrDowngradeData(final int index) {
         return bundleVersionModificationDataList.get(index);
     }
 
-    public int getBundleUpgradeDataSize() {
+    public int getBundleUpgradeOrDowngradeDataSize() {
         return bundleVersionModificationDataList.size();
     }
 
@@ -109,7 +109,7 @@ public class VersionModificationDataLoader {
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
         TestKafkaVersion latestKafkaSupported = sortedVersions.get(sortedVersions.size() - 1);
 
-        BundleVersionModificationData acrossUpgradeData = getBundleUpgradeData(getBundleUpgradeDataList().size() - 1);
+        BundleVersionModificationData acrossUpgradeData = getBundleUpgradeOrDowngradeData(getBundleUpgradeOrDowngradeDataList().size() - 1);
         BundleVersionModificationData startingVersion = acrossUpgradeData;
 
         startingVersion.setDefaultKafka(acrossUpgradeData.getDefaultKafkaVersionPerStrimzi());
@@ -135,7 +135,7 @@ public class VersionModificationDataLoader {
         VersionModificationDataLoader dataLoader = new VersionModificationDataLoader(ModificationType.BUNDLE_DOWNGRADE);
         List<Arguments> parameters = new LinkedList<>();
 
-        dataLoader.getBundleUpgradeDataList().forEach(downgradeData -> {
+        dataLoader.getBundleUpgradeOrDowngradeDataList().forEach(downgradeData -> {
             parameters.add(Arguments.of(downgradeData.getFromVersion(), downgradeData.getToVersion(), downgradeData));
         });
 
@@ -152,7 +152,7 @@ public class VersionModificationDataLoader {
         // Generate procedures for upgrade
         UpgradeKafkaVersion procedures = new UpgradeKafkaVersion(testKafkaVersion.version());
 
-        upgradeDataList.getBundleUpgradeDataList().forEach(upgradeData -> {
+        upgradeDataList.getBundleUpgradeOrDowngradeDataList().forEach(upgradeData -> {
             upgradeData.setProcedures(procedures);
             parameters.add(Arguments.of(
                 upgradeData.getFromVersion(), upgradeData.getToVersion(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 @Tag(UPGRADE)
 @IsolatedSuite
-@KRaftNotSupported("Strimzi and Kafka downgrade is not supported with KRaft mode")
+@KRaftNotSupported("Strimzi and Kafka upgrade is not supported with KRaft mode")
 public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(StrimziUpgradeIsolatedST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -6,12 +6,17 @@ package io.strimzi.systemtest.upgrade;
 
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -33,6 +38,7 @@ import java.util.Map;
 
 import static io.strimzi.systemtest.Constants.UPGRADE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -150,6 +156,50 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
 
+        // Check errors in CO log
+        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
+    }
+
+    @Test
+    void testUpgradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
+        final TestStorage testStorage = new TestStorage(extensionContext);
+        final UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
+
+        this.deployCoWithWaitForReadiness(extensionContext, acrossUpgradeData, testStorage.getNamespaceName());
+        this.deployKafkaClusterWithWaitForReadiness(extensionContext, acrossUpgradeData, upgradeKafkaVersion);
+        this.deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(extensionContext, acrossUpgradeData, testStorage);
+
+        final KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(500)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .build();
+
+        resourceManager.createResource(extensionContext, clients.producerStrimzi());
+
+        makeSnapshots();
+        logPodImages(clusterName);
+
+        // upgrade CO to HEAD and wait for readiness of ClusterOperator
+        changeClusterOperator(acrossUpgradeData, clusterOperator.getDeploymentNamespace(), extensionContext);
+
+        // Wait for Kafka cluster rolling update
+        waitForKafkaClusterRollingUpdate();
+        // Verify that KafkaConnect pods are rolling and KafkaConnector is ready
+        RollingUpdateUtils.waitTillComponentHasRolled(clusterOperator.getDeploymentNamespace(), connectLabelSelector, 1, connectPods);
+        KafkaConnectorUtils.waitForConnectorReady(testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        // Verify FileSink KafkaConnector
+        final String connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), testStorage.getClusterName() + "-connect").get(0).getMetadata().getName();
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, Constants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
+
+        // Verify that pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(clusterOperator.getDeploymentNamespace(), clusterName);
+        // Verify upgrade
+        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
         // Check errors in CO log
         assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -63,4 +63,4 @@
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: "-UseStrimziPodSets"
-  featureGatesAfter: "+UseStrimziPodSets"
+  featureGatesAfter: "+UseStrimziPodSets,+StableConnectIdentities"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds two test cases for upgrade and downgrade. This upgrade differs from the current one in that we also use KafkaConnect and KafkaConnector in such test cases. Also, it is using a recent feature gate `StableConnectIdentities` (upgrade only). The downgrade scenario is just testing the upgrade of (Deployment -> Deployment). When `0.35.0` is ready, we can change the behaviour of downgrade only just changing the `downgrade` yaml file to use a `StableConnectIdentities` feature gate.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass