### PR TITLE
[Doc] Fix description of the certificate configuration and add `STRIMZI_KRAFT_ENABLED` description

### DIFF
--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -135,9 +135,11 @@ This helps to avoid unnecessary exceptions in the Kafka cluster logs.
 The default is `true`.
 <18> (Optional) Semi-colon separated list of Cron Expressions defining the maintenance time windows during which the expiring user certificates will be renewed.
 <19> (Optional) Configuration options for configuring the Kafka Admin client used by the User Operator in the properties format.
-<20> (Optional) Indicates whether the Kafka cluster the User Operator is connecting to is using ZooKeeper or KRaft.
-When running against KRaft clusters, some features such as management of SCRAM-SHA-512 users is disabled because Apache Kafka does currently not support it.
+<20> (Optional) Indicates whether the Kafka cluster the User Operator is connecting to is using KRaft instead of ZooKeeper.
+Set this variable to `true` if the Kafka cluster uses KRaft.
 The default is `false`.
+Note that some features are not available when running against KRaft clusters. 
+For example, management of SCRAM-SHA-512 users is disabled because Apache Kafka currently does not support it.
 
 . If you are using mTLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.
 Otherwise, go to the next step.
@@ -154,7 +156,7 @@ env:
 # ..."
 ----
 <1> The Kubernetes `Secret` that contains the public key (`ca.crt`) value of the CA that signs Kafka broker certificates.
-<2> The Kubernetes `Secret` that contains the certificate public key (`entity-operator.crt`) and private key (`entity-operator.key`) that will be used for mTLS authentication against the Kafka cluster.
+<2> The Kubernetes `Secret` that contains the certificate public key (`entity-operator.crt`) and private key (`entity-operator.key`) that is used for mTLS authentication against the Kafka cluster.
 
 . Deploy the User Operator.
 +

--- a/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-user-operator-standalone.adoc
@@ -94,6 +94,8 @@ spec:
               value: |
                 default.api.timeout.ms=120000
                 request.timeout.ms=60000
+            - name: STRIMZI_KRAFT_ENABLED <20>
+              value: "false"
 ----
 <1> The Kubernetes namespace for the User Operator to watch for `KafkaUser` resources. Only one namespace can be specified.
 <2>  The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
@@ -133,6 +135,9 @@ This helps to avoid unnecessary exceptions in the Kafka cluster logs.
 The default is `true`.
 <18> (Optional) Semi-colon separated list of Cron Expressions defining the maintenance time windows during which the expiring user certificates will be renewed.
 <19> (Optional) Configuration options for configuring the Kafka Admin client used by the User Operator in the properties format.
+<20> (Optional) Indicates whether the Kafka cluster the User Operator is connecting to is using ZooKeeper or KRaft.
+When running against KRaft clusters, some features such as management of SCRAM-SHA-512 users is disabled because Apache Kafka does currently not support it.
+The default is `false`.
 
 . If you are using mTLS to connect to the Kafka cluster, specify the secrets used to authenticate connection.
 Otherwise, go to the next step.
@@ -149,8 +154,7 @@ env:
 # ..."
 ----
 <1> The Kubernetes `Secret` that contains the public key (`ca.crt`) value of the CA that signs Kafka broker certificates.
-<2> The Kubernetes `Secret` that contains the keystore (`entity-operator.p12`) with the private key and certificate for mTLS authentication against the Kafka cluster.
-The `Secret` must also contain the password (`entity-operator.password`) for accessing the keystore.
+<2> The Kubernetes `Secret` that contains the certificate public key (`entity-operator.crt`) and private key (`entity-operator.key`) that will be used for mTLS authentication against the Kafka cluster.
 
 . Deploy the User Operator.
 +


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes the certificate configuration in the docs about the standalone User Operator installation. We now use the PEM files instead of using the P12 certificate store.

It also adds the `STRIMZI_KRAFT_ENABLED` and its description.

This closes #8125.

### Checklist

- [x] Update documentation