### PR TITLE
Allow custom Java classpath configuration in our operators and init containers

### DIFF
--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -5,7 +5,7 @@ set -e
 # We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
 rm -rfv /tmp/* || true
 
-export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
+export JAVA_CLASSPATH=$JAVA_CLASSPATH:lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.operator.cluster.Main
 
 if [ -z "$KUBERNETES_SERVICE_DNS_DOMAIN" ]; then

--- a/kafka-init/scripts/kafka_init_run.sh
+++ b/kafka-init/scripts/kafka_init_run.sh
@@ -4,6 +4,6 @@ set -e
 # The java.util.logging.manager is set because of OkHttp client which is using JUL logging
 export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
 
-export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
+export JAVA_CLASSPATH=$JAVA_CLASSPATH:lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.kafka.init.Main
 exec "${STRIMZI_HOME}/bin/launch_java.sh"

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -46,6 +46,6 @@ if [ "$STRIMZI_TLS_ENABLED" = "true" ] || [ "$STRIMZI_SECURITY_PROTOCOL" = "SSL"
     fi
 fi
 
-export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
+export JAVA_CLASSPATH=$JAVA_CLASSPATH:lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.operator.topic.Main
 exec "${STRIMZI_HOME}/bin/launch_java.sh"

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -21,6 +21,6 @@ if [ -n "$STRIMZI_JAVA_OPTS" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_OPTS}"
 fi
 
-export JAVA_CLASSPATH=lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
+export JAVA_CLASSPATH=$JAVA_CLASSPATH:lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.operator.user.Main
 exec "${STRIMZI_HOME}/bin/launch_java.sh"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, when running our operators and init containers, we do not configure the Java classpath as a path to the `lib/` directory but as an exact list of used JARs. This is intentional and works as expected. However, it makes it complicated for users to add any additional JARs - for example with custom Pod Security Providers plugins.

This PR adds a possibility to set the `JAVA_CLASSPATH` environment variable from outside and reuses it in the startup scripts. The value of this variable is appended to out own classpath configuration and as a result, when a user needs to add something to the classpath, it is now possible.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally