### PR TITLE
[systemtest] Update Keycloak to 21.0.0 in tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/keycloak/KeycloakInstance.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/keycloak/KeycloakInstance.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 public class KeycloakInstance {
 
     private static final Logger LOGGER = LogManager.getLogger(KeycloakInstance.class);
-    public static final String KEYCLOAK_SECRET_NAME = "sso-x509-https-secret";
+    public static final String KEYCLOAK_SECRET_NAME = "example-tls-secret";
     public static final String KEYCLOAK_SECRET_CERT = "tls.crt";
 
     private final int jwksExpireSeconds = 500;
@@ -37,12 +37,12 @@ public class KeycloakInstance {
         this.username = username;
         this.password = password;
         this.namespace = namespace;
-        this.httpsUri = "keycloak." + namespace + ".svc.cluster.local:8443";
-        this.httpUri = "keycloak-discovery." + namespace + ".svc.cluster.local:8080";
-        this.validIssuerUri = "https://" + httpsUri + "/auth/realms/internal";
-        this.jwksEndpointUri = "https://" + httpsUri + "/auth/realms/internal/protocol/openid-connect/certs";
-        this.oauthTokenEndpointUri = "https://" + httpsUri + "/auth/realms/internal/protocol/openid-connect/token";
-        this.introspectionEndpointUri = "https://" + httpsUri + "/auth/realms/internal/protocol/openid-connect/token/introspect";
+        this.httpsUri = "keycloak-service." + namespace + ".svc.cluster.local:8443";
+        this.httpUri = "keycloak-discovery." + namespace + ".svc.cluster.local:9595";
+        this.validIssuerUri = "https://" + httpsUri + "/realms/internal";
+        this.jwksEndpointUri = "https://" + httpsUri + "/realms/internal/protocol/openid-connect/certs";
+        this.oauthTokenEndpointUri = "https://" + httpsUri + "/realms/internal/protocol/openid-connect/token";
+        this.introspectionEndpointUri = "https://" + httpsUri + "/realms/internal/protocol/openid-connect/token/introspect";
         this.userNameClaim = "preferred_username";
     }
 
@@ -53,14 +53,14 @@ public class KeycloakInstance {
 
         if (tlsEnabled) {
             LOGGER.info("Using HTTPS endpoints");
-            validIssuerUri = "https://" + httpsUri + "/auth/realms/" + realmName;
-            jwksEndpointUri = "https://" + httpsUri + "/auth/realms/" + realmName + "/protocol/openid-connect/certs";
-            oauthTokenEndpointUri = "https://" + httpsUri + "/auth/realms/" + realmName + "/protocol/openid-connect/token";
+            validIssuerUri = "https://" + httpsUri + "/realms/" + realmName;
+            jwksEndpointUri = "https://" + httpsUri + "/realms/" + realmName + "/protocol/openid-connect/certs";
+            oauthTokenEndpointUri = "https://" + httpsUri + "/realms/" + realmName + "/protocol/openid-connect/token";
         } else {
             LOGGER.info("Using HTTP endpoints");
-            validIssuerUri = "http://" + httpUri + "/auth/realms/" + realmName;
-            jwksEndpointUri = "http://" + httpUri + "/auth/realms/" + realmName + "/protocol/openid-connect/certs";
-            oauthTokenEndpointUri = "http://" + httpUri + "/auth/realms/" + realmName + "/protocol/openid-connect/token";
+            validIssuerUri = "http://" + httpUri + "/realms/" + realmName;
+            jwksEndpointUri = "http://" + httpUri + "/realms/" + realmName + "/protocol/openid-connect/certs";
+            oauthTokenEndpointUri = "http://" + httpUri + "/realms/" + realmName + "/protocol/openid-connect/token";
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
@@ -100,14 +100,14 @@ public class SetupKeycloak {
                 .withName(POSTGRES_SECRET_NAME)
                 .withNamespace(namespaceName)
             .endMetadata()
-                .withType("Opaque")
-                .addToData("username", Base64.getEncoder().encodeToString(POSTGRES_USER_NAME.getBytes(StandardCharsets.UTF_8)))
-                .addToData("password", Base64.getEncoder().encodeToString(POSTGRES_PASSWORD.getBytes(StandardCharsets.UTF_8)))
+            .withType("Opaque")
+            .addToData("username", Base64.getEncoder().encodeToString(POSTGRES_USER_NAME.getBytes(StandardCharsets.UTF_8)))
+            .addToData("password", Base64.getEncoder().encodeToString(POSTGRES_PASSWORD.getBytes(StandardCharsets.UTF_8)))
             .build();
 
 
         kubeClient().createSecret(postgresSecret);
-        SecretUtils.waitForSecretReady(namespaceName, "keycloak-db-secret", () -> { });
+        SecretUtils.waitForSecretReady(namespaceName, POSTGRES_SECRET_NAME, () -> { });
     }
 
     private static KeycloakInstance createKeycloakInstance(String namespaceName) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.resources.keycloak;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
 import io.strimzi.systemtest.resources.ResourceItem;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -34,9 +35,10 @@ public class SetupKeycloak {
     private static final List<String> KEYCLOAK_REALMS_FILE_NAMES = List.of("internal_realm.json", "authorization_realm.json", "scope_audience_realm.json");
     private static final String KEYCLOAK_INSTALL_FILES_BASE_PATH = TestUtils.USER_PATH + "/../systemtest/src/test/resources/oauth2";
     private static final String KEYCLOAK_INSTANCE_FILE_PATH = KEYCLOAK_INSTALL_FILES_BASE_PATH + "/keycloak-instance.yaml";
+    private static final String POSTGRES_FILE_PATH = KEYCLOAK_INSTALL_FILES_BASE_PATH + "/postgres.yaml";
     private static final String KEYCLOAK_DEPLOYMENT_NAME = "example-keycloak";
     private static final String KEYCLOAK_OPERATOR_DEPLOYMENT_NAME = "keycloak-operator";
-    private static final String KEYCLOAK_SECRET_NAME = "credential-example-keycloak";
+    private static final String KEYCLOAK_SECRET_NAME = "keycloak-initial-admin";
 
     public final static String PATH_TO_KEYCLOAK_PREPARE_SCRIPT = "../systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh";
     public final static String PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT = "../systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh";
@@ -45,7 +47,7 @@ public class SetupKeycloak {
     public static void deployKeycloakOperator(ExtensionContext extensionContext, final String deploymentNamespace, final String watchNamespace) {
         LOGGER.info("Prepare Keycloak Operator in namespace {} with watching namespace {}", deploymentNamespace, watchNamespace);
 
-        Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_PREPARE_SCRIPT, deploymentNamespace, KeycloakUtils.getValidKeycloakVersion(), watchNamespace);
+        Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_PREPARE_SCRIPT, deploymentNamespace, KeycloakUtils.LATEST_KEYCLOAK_VERSION, watchNamespace);
         DeploymentUtils.waitForDeploymentAndPodsReady(deploymentNamespace, KEYCLOAK_OPERATOR_DEPLOYMENT_NAME, 1);
 
         ResourceManager.STORED_RESOURCES.get(extensionContext.getDisplayName()).push(new ResourceItem<>(() -> deleteKeycloakOperator(deploymentNamespace, watchNamespace)));
@@ -55,11 +57,12 @@ public class SetupKeycloak {
 
     public static void deleteKeycloakOperator(final String deploymentNamespace, final String watchNamespace) {
         LOGGER.info("Teardown Keycloak Operator in namespace {} with watching namespace {}", deploymentNamespace, watchNamespace);
-        Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT, deploymentNamespace, KeycloakUtils.getValidKeycloakVersion(), watchNamespace);
+        Exec.exec(Level.INFO, "/bin/bash", PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT, deploymentNamespace, KeycloakUtils.LATEST_KEYCLOAK_VERSION, watchNamespace);
         DeploymentUtils.waitForDeploymentDeletion(deploymentNamespace, KEYCLOAK_OPERATOR_DEPLOYMENT_NAME);
     }
 
     public static KeycloakInstance deployKeycloakAndImportRealms(ExtensionContext extensionContext, String namespaceName) {
+        deployPostgres(extensionContext, namespaceName);
         deployKeycloak(extensionContext, namespaceName);
         KeycloakInstance keycloakInstance = createKeycloakInstance(namespaceName);
         importRealms(namespaceName, keycloakInstance);
@@ -80,13 +83,36 @@ public class SetupKeycloak {
         LOGGER.info("Keycloak instance and Keycloak secret are ready");
     }
 
+    private static void deployPostgres(ExtensionContext extensionContext, String namespaceName) {
+        LOGGER.info("Deploying Postgres into namespace: {}", namespaceName);
+        cmdKubeClient(namespaceName).apply(POSTGRES_FILE_PATH);
+
+        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, "postgres", 1);
+
+        ResourceManager.STORED_RESOURCES.get(extensionContext.getDisplayName()).push(new ResourceItem<>(() -> deletePostgres(namespaceName)));
+
+        Secret postgresSecret = new SecretBuilder()
+            .withNewMetadata()
+                .withName("keycloak-db-secret")
+                .withNamespace(namespaceName)
+            .endMetadata()
+                .withType("Opaque")
+                .addToData("username", Base64.getEncoder().encodeToString("arnost".getBytes(StandardCharsets.UTF_8)))
+                .addToData("password", Base64.getEncoder().encodeToString("changeme".getBytes(StandardCharsets.UTF_8)))
+            .build();
+
+
+        kubeClient().createSecret(postgresSecret);
+        SecretUtils.waitForSecretReady(namespaceName, "keycloak-db-secret", () -> { });
+    }
+
     private static KeycloakInstance createKeycloakInstance(String namespaceName) {
         Secret keycloakSecret = kubeClient().getSecret(namespaceName, KEYCLOAK_SECRET_NAME);
 
-        String usernameEncoded = keycloakSecret.getData().get("ADMIN_USERNAME");
+        String usernameEncoded = keycloakSecret.getData().get("username");
         String username = new String(Base64.getDecoder().decode(usernameEncoded.getBytes()));
 
-        String passwordEncoded = keycloakSecret.getData().get("ADMIN_PASSWORD");
+        String passwordEncoded = keycloakSecret.getData().get("password");
         String password = new String(Base64.getDecoder().decode(passwordEncoded.getBytes()));
 
         return new KeycloakInstance(username, password, namespaceName);
@@ -119,5 +145,11 @@ public class SetupKeycloak {
         LOGGER.info("Deleting Keycloak in namespace {}", namespaceName);
         cmdKubeClient(namespaceName).delete(KEYCLOAK_INSTANCE_FILE_PATH);
         DeploymentUtils.waitForDeploymentDeletion(namespaceName, KEYCLOAK_DEPLOYMENT_NAME);
+    }
+
+    private static void deletePostgres(String namespaceName) {
+        LOGGER.info("Deleting Postgres in namespace {}", namespaceName);
+        cmdKubeClient(namespaceName).delete(POSTGRES_FILE_PATH);
+        DeploymentUtils.waitForDeploymentDeletion(namespaceName, "postgres");
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
@@ -39,9 +39,13 @@ public class SetupKeycloak {
     private static final String KEYCLOAK_DEPLOYMENT_NAME = "example-keycloak";
     private static final String KEYCLOAK_OPERATOR_DEPLOYMENT_NAME = "keycloak-operator";
     private static final String KEYCLOAK_SECRET_NAME = "keycloak-initial-admin";
+    private static final String POSTGRES_SECRET_NAME = "keycloak-db-secret";
+    private static final String POSTGRES_USER_NAME = "arnost";
+    private static final String POSTGRES_PASSWORD = "changeme";
 
     public final static String PATH_TO_KEYCLOAK_PREPARE_SCRIPT = "../systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh";
     public final static String PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT = "../systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh";
+
     private static final Logger LOGGER = LogManager.getLogger(SetupKeycloak.class);
 
     public static void deployKeycloakOperator(ExtensionContext extensionContext, final String deploymentNamespace, final String watchNamespace) {
@@ -93,12 +97,12 @@ public class SetupKeycloak {
 
         Secret postgresSecret = new SecretBuilder()
             .withNewMetadata()
-                .withName("keycloak-db-secret")
+                .withName(POSTGRES_SECRET_NAME)
                 .withNamespace(namespaceName)
             .endMetadata()
                 .withType("Opaque")
-                .addToData("username", Base64.getEncoder().encodeToString("arnost".getBytes(StandardCharsets.UTF_8)))
-                .addToData("password", Base64.getEncoder().encodeToString("changeme".getBytes(StandardCharsets.UTF_8)))
+                .addToData("username", Base64.getEncoder().encodeToString(POSTGRES_USER_NAME.getBytes(StandardCharsets.UTF_8)))
+                .addToData("password", Base64.getEncoder().encodeToString(POSTGRES_PASSWORD.getBytes(StandardCharsets.UTF_8)))
             .build();
 
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.utils.specific;
 
-import io.strimzi.test.k8s.KubeClusterResource;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -13,9 +12,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KeycloakUtils {
 
-    public final static String LATEST_KEYCLOAK_VERSION = "15.0.2";
-    public final static String OLD_KEYCLOAK_VERSION = "11.0.1";
-
+    public final static String LATEST_KEYCLOAK_VERSION = "21.0.0";
 
     private KeycloakUtils() {}
 
@@ -38,7 +35,7 @@ public class KeycloakUtils {
                 "-X",
                 "POST",
                 "-d", "client_id=admin-cli&client_secret=aGVsbG8td29ybGQtcHJvZHVjZXItc2VjcmV0&grant_type=password&username=" + userName + "&password=" + password,
-                baseURI + "/auth/realms/master/protocol/openid-connect/token"
+                baseURI + "/realms/master/protocol/openid-connect/token"
             ).out()).getString("access_token");
     }
 
@@ -59,7 +56,7 @@ public class KeycloakUtils {
             "--insecure",
             "-X",
             "GET",
-            baseURI + "/auth/admin/realms/" + desiredRealm,
+            baseURI + "/admin/realms/" + desiredRealm,
             "-H", "Authorization: Bearer " + token
         ).out());
     }
@@ -81,7 +78,7 @@ public class KeycloakUtils {
             "--insecure",
             "-X",
             "GET",
-            baseURI + "/auth/admin/realms/" + desiredRealm + "/clients",
+            baseURI + "/admin/realms/" + desiredRealm + "/clients",
             "-H", "Authorization: Bearer " + token
         ).out());
     }
@@ -118,7 +115,7 @@ public class KeycloakUtils {
             "--insecure",
             "-X",
             "GET",
-            baseURI + "/auth/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/" + endpoint,
+            baseURI + "/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/" + endpoint,
             "-H", "Authorization: Bearer " + token
         ).out());
     }
@@ -141,7 +138,7 @@ public class KeycloakUtils {
             "--insecure",
             "-X",
             "PUT",
-            baseURI + "/auth/admin/realms/" + desiredRealm,
+            baseURI + "/admin/realms/" + desiredRealm,
             "-H", "Authorization: Bearer " + token,
             "-d", config.toString(),
             "-H", "Content-Type: application/json"
@@ -167,7 +164,7 @@ public class KeycloakUtils {
             "--insecure",
             "-X",
             "PUT",
-            baseURI + "/auth/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/policy/" + policy.getValue("id"),
+            baseURI + "/admin/realms/" + desiredRealm + "/clients/" + clientId + "/authz/resource-server/policy/" + policy.getValue("id"),
             "-H", "Authorization: Bearer " + token,
             "-d", policy.toString(),
             "-H", "Content-Type: application/json"
@@ -193,16 +190,8 @@ public class KeycloakUtils {
                 "POST",
                 "-H", "Content-Type: application/json",
                 "-d", realmData,
-                baseURI + "/auth/admin/realms",
+                baseURI + "/admin/realms",
                 "-H", "Authorization: Bearer " + token
                 ).out().trim();
-    }
-
-    public static String getValidKeycloakVersion() {
-        if (Double.parseDouble(KubeClusterResource.getInstance().client().clusterKubernetesVersion()) >= 1.22) {
-            return LATEST_KEYCLOAK_VERSION;
-        } else {
-            return OLD_KEYCLOAK_VERSION;
-        }
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -492,9 +491,7 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
         LOGGER.info("Setting the master realm token's lifespan to 3600s");
 
         // get admin token for all operation on realms
-        String userName =  new String(Base64.getDecoder().decode(kubeClient().getSecret(clusterOperator.getDeploymentNamespace(), "credential-example-keycloak").getData().get("ADMIN_USERNAME").getBytes()));
-        String password = new String(Base64.getDecoder().decode(kubeClient().getSecret(clusterOperator.getDeploymentNamespace(), "credential-example-keycloak").getData().get("ADMIN_PASSWORD").getBytes()));
-        String token = KeycloakUtils.getToken(clusterOperator.getDeploymentNamespace(), baseUri, userName, password);
+        String token = KeycloakUtils.getToken(clusterOperator.getDeploymentNamespace(), baseUri, keycloakInstance.getUsername(), keycloakInstance.getPassword());
 
         // firstly we will increase token lifespan
         JsonObject masterRealm = KeycloakUtils.getKeycloakRealm(clusterOperator.getDeploymentNamespace(), baseUri, token, "master");
@@ -502,7 +499,7 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
         KeycloakUtils.putConfigurationToRealm(clusterOperator.getDeploymentNamespace(), baseUri, token, masterRealm, "master");
 
         // now we need to get the token with new lifespan
-        token = KeycloakUtils.getToken(clusterOperator.getDeploymentNamespace(), baseUri, userName, password);
+        token = KeycloakUtils.getToken(clusterOperator.getDeploymentNamespace(), baseUri, keycloakInstance.getUsername(), keycloakInstance.getPassword());
 
         LOGGER.info("Getting the {} kafka client for obtaining the Dev A Team policy for the x topics", TEST_REALM);
         // we need to get clients for kafka-authz realm to access auth policies in kafka client

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
@@ -414,7 +414,7 @@ public class OauthTlsIsolatedST extends OauthAbstractST {
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(oauthClusterName, topicName, clusterOperator.getDeploymentNamespace()).build());
 
-        keycloakInstance.setIntrospectionEndpointUri("https://" + keycloakInstance.getHttpsUri() + "/auth/realms/internal/protocol/openid-connect/token/introspect");
+        keycloakInstance.setIntrospectionEndpointUri("https://" + keycloakInstance.getHttpsUri() + "/realms/internal/protocol/openid-connect/token/introspect");
         String introspectionKafka = oauthClusterName + "-intro";
 
         CertSecretSource cert = new CertSecretSourceBuilder()

--- a/systemtest/src/test/resources/oauth2/keycloak-instance.yaml
+++ b/systemtest/src/test/resources/oauth2/keycloak-instance.yaml
@@ -1,14 +1,26 @@
-apiVersion: keycloak.org/v1alpha1
+apiVersion: k8s.keycloak.org/v2alpha1
 kind: Keycloak
 metadata:
-  name: example-keycloak
+  name: keycloak
   labels:
     app: sso
 spec:
   instances: 1
-  extensions:
-    - https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
-  externalAccess:
-    enabled: True
-  podDisruptionBudget:
-    enabled: True
+  db:
+    vendor: postgres
+    host: postgres
+    usernameSecret:
+      name: keycloak-db-secret
+      key: username
+    passwordSecret:
+      name: keycloak-db-secret
+      key: password
+  ingress:
+    enabled: false
+  http:
+    tlsSecret: example-tls-secret
+    httpEnabled: true
+    httpPort: 9595
+    httpsPort: 8443
+  hostname:
+    strict: false

--- a/systemtest/src/test/resources/oauth2/postgres.yaml
+++ b/systemtest/src/test/resources/oauth2/postgres.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+data:
+  POSTGRES_DB: keycloak
+  POSTGRES_USER: arnost
+  POSTGRES_PASSWORD: changeme
+  PGDATA: /var/lib/postgresql/data/pgdata
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:latest
+          envFrom:
+            - configMapRef:
+                name: postgres-config
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: postgres-tmp-storage
+              mountPath: /var/lib/postgresql/data
+              subPath: postgresql
+              readOnly: false
+      volumes:
+        - name: postgres-tmp-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
+++ b/systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
@@ -8,20 +8,16 @@ SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Generate keycloak secret"
 mkdir -p /tmp/keycloak
-openssl req  -nodes -new -x509  -keyout /tmp/keycloak/keycloak.key -out /tmp/keycloak/keycloak.crt -subj '/CN=keycloak'
-kubectl create secret -n ${KEYCLOAK_OPERATOR_NAMESPACE} generic sso-x509-https-secret --from-file=tls.crt=/tmp/keycloak/keycloak.crt --from-file=tls.key=/tmp/keycloak/keycloak.key
+
+openssl req -subj '/CN=test.keycloak.org/O=Test Keycloak./C=US' -newkey rsa:2048 -nodes -keyout /tmp/keycloak/key.pem -x509 -days 365 -out /tmp/keycloak/certificate.pem
+
+kubectl create secret tls example-tls-secret --cert /tmp/keycloak/certificate.pem --key /tmp/keycloak/key.pem -n ${KEYCLOAK_OPERATOR_NAMESPACE}
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Deploy Keycloak Operator"
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/service_account.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role_binding.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role.yaml
-curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role_binding.yaml | sed "s#namespace: .*#namespace: ${KEYCLOAK_OPERATOR_NAMESPACE}#g" | kubectl apply  -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f -
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakclients_crd.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloaks_crd.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakusers_crd.yaml
-kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/operator.yaml
+
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+kubectl apply -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+curl -s https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/kubernetes.yml | sed "s#namespace: .*#namespace: ${KEYCLOAK_OPERATOR_NAMESPACE}#g" | kubectl apply  -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f -
+
 
 

--- a/systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
+++ b/systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
@@ -7,14 +7,6 @@ KEYCLOAK_INSTANCE_NAMESPACE=$3
 SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 echo "[INFO] $(date -u +"%Y-%m-%d %H:%M:%S") Delete Keycloak Operator"
-kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/operator.yaml
-kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakusers_crd.yaml
-kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloaks_crd.yaml
-kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakclients_crd.yaml
-kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
-kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
-kubectl delete -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role.yaml
-kubectl delete -f https://raw.githubusercontent.com/keycloak/keycloak-operator/${KEYCLOAK_VERSION}/deploy/cluster_roles/cluster_role_binding.yaml
-kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role.yaml
-kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/role_binding.yaml
-kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/${KEYCLOAK_VERSION}/deploy/service_account.yaml
+kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/kubernetes.yml
+kubectl delete -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+kubectl delete -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates Keycloak version used in STs to `21.0.0` and updates everything needed:

- newer versions of Keycloak need DB deployed before Keycloak installation, so I'm deploying Postgres here
- few services and configurations have changed
- `/auth` path is not used anymore

.. and more.

This PR should resolve issues deploying Keycloak on newer K8s (and OCP) versions because of outdated `apiVersion`s etc.

### Checklist

- [x] Make sure all tests pass
