### PR TITLE
Update Cruise Control to 2.5.112

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.111</cruise-control.version>
+        <cruise-control.version>2.5.112</cruise-control.version>
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.111</cruise-control.version>
+        <cruise-control.version>2.5.112</cruise-control.version>
         <opa-authorizer.version>1.5.0</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.111</cruise-control.version>
+        <cruise-control.version>2.5.112</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR bumps used Cruise Control version form 2.5.111 to 2.5.112.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

