### PR TITLE
docs(reassignment): Changing topic replicas using the reassignment tool

### DIFF
--- a/documentation/assemblies/configuring/assembly-reassign-tool.adoc
+++ b/documentation/assemblies/configuring/assembly-reassign-tool.adoc
@@ -17,7 +17,7 @@ However, it is recommended to use xref:cruise-control-concepts-str[Cruise Contro
 Cruise Control can move topics from one broker to another without any downtime, and it is the most efficient way to reassign partitions.
 
 NOTE: It is recommended to run the `kafka-reassign-partitions.sh` tool as a separate interactive pod rather than within the broker container.
-Running the Kafka `/bin` scripts within the broker container may cause a JVM to start with the same settings as the Kafka broker, which can potentially cause disruptions.
+Running the Kafka `bin/` scripts within the broker container may cause a JVM to start with the same settings as the Kafka broker, which can potentially cause disruptions.
 By running the `kafka-reassign-partitions.sh` tool in a separate pod, you can avoid this issue.
 
 include::../../modules/configuring/con-partition-reassignment.adoc[leveloffset=+1]

--- a/documentation/assemblies/configuring/assembly-reassign-tool.adoc
+++ b/documentation/assemblies/configuring/assembly-reassign-tool.adoc
@@ -19,6 +19,7 @@ Cruise Control can move topics from one broker to another without any downtime, 
 NOTE: It is recommended to run the `kafka-reassign-partitions.sh` tool as a separate interactive pod rather than within the broker container.
 Running the Kafka `bin/` scripts within the broker container may cause a JVM to start with the same settings as the Kafka broker, which can potentially cause disruptions.
 By running the `kafka-reassign-partitions.sh` tool in a separate pod, you can avoid this issue.
+Running a pod with the `-ti` option creates an interactive pod with a terminal for running shell commands inside the pod.
 
 include::../../modules/configuring/con-partition-reassignment.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/configuring/assembly-reassign-tool.adoc
+++ b/documentation/assemblies/configuring/assembly-reassign-tool.adoc
@@ -16,10 +16,16 @@ The tool can also be used to reassign partitions and balance the distribution of
 However, it is recommended to use xref:cruise-control-concepts-str[Cruise Control for automated partition reassignments and cluster rebalancing]. 
 Cruise Control can move topics from one broker to another without any downtime, and it is the most efficient way to reassign partitions.
 
-NOTE: It is recommended to run the `kafka-reassign-partitions.sh` tool as a separate interactive pod rather than within the broker container.
+It is recommended to run the `kafka-reassign-partitions.sh` tool as a separate interactive pod rather than within the broker container.
 Running the Kafka `bin/` scripts within the broker container may cause a JVM to start with the same settings as the Kafka broker, which can potentially cause disruptions.
 By running the `kafka-reassign-partitions.sh` tool in a separate pod, you can avoid this issue.
 Running a pod with the `-ti` option creates an interactive pod with a terminal for running shell commands inside the pod.
+
+.Running an interactive pod with a terminal 
+[source,shell,subs="+quotes,attributes"]
+----
+kubectl run helper-pod -ti --image={DockerKafkaImage} --rm=true --restart=Never -- bash
+----
 
 include::../../modules/configuring/con-partition-reassignment.adoc[leveloffset=+1]
 

--- a/documentation/assemblies/configuring/assembly-reassign-tool.adoc
+++ b/documentation/assemblies/configuring/assembly-reassign-tool.adoc
@@ -1,6 +1,6 @@
 // This assembly is included in the following assemblies:
 //
-// assembly-config-kafka.adoc
+// deploying.adoc
 
 [id='assembly-reassign-tool-{context}']
 = Using the partition reassignment tool
@@ -16,6 +16,10 @@ The tool can also be used to reassign partitions and balance the distribution of
 However, it is recommended to use xref:cruise-control-concepts-str[Cruise Control for automated partition reassignments and cluster rebalancing]. 
 Cruise Control can move topics from one broker to another without any downtime, and it is the most efficient way to reassign partitions.
 
+NOTE: It is recommended to run the `kafka-reassign-partitions.sh` tool as a separate interactive pod rather than within the broker container.
+Running the Kafka `/bin` scripts within the broker container may cause a JVM to start with the same settings as the Kafka broker, which can potentially cause disruptions.
+By running the `kafka-reassign-partitions.sh` tool in a separate pod, you can avoid this issue.
+
 include::../../modules/configuring/con-partition-reassignment.adoc[leveloffset=+1]
 
 include::../../modules/configuring/proc-generating-reassignment-json-files.adoc[leveloffset=+1]
@@ -23,3 +27,5 @@ include::../../modules/configuring/proc-generating-reassignment-json-files.adoc[
 include::../../modules/configuring/proc-scaling-up-a-kafka-cluster.adoc[leveloffset=+1]
 
 include::../../modules/configuring/proc-scaling-down-a-kafka-cluster.adoc[leveloffset=+1]
+
+include::../../modules/configuring/proc-changing-topic-replicas.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-partition-reassignment.adoc
+++ b/documentation/modules/configuring/con-partition-reassignment.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// configuring/assembly-scaling-clusters.adoc
+// configuring/assembly-reassign-tool.adoc
 
 [id='con-partition-reassignment-{context}']
 

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -1,0 +1,125 @@
+// Module included in the following assemblies:
+//
+// configuring/assembly-reassign-tool.adoc
+
+[id='proc-changing-topic-replicas-{context}']
+
+= Changing the replication factor of topics
+
+[role="_abstract"]
+To change the replication factor of topics in a Kafka cluster, use the `kafka-reassign-partitions.sh` tool. 
+This can be done by running the tool from an interactive pod container that is connected to the Kafka cluster, 
+and using a reassignment file to describe how the topic replicas should be changed.
+
+This procedure describes a secure process that uses TLS.
+You'll need a Kafka cluster that uses TLS encryption and mTLS authentication.
+
+.Prerequisites
+
+* You have a running Kafka cluster based on a `Kafka` resource configured with internal TLS encryption and mTLS authentication.
+* You are running an interactive pod container that is connected to the running Kafka broker.
+* You have generated a reassignment JSON file named `reassignment.json`.
+* You are connected as a `KafkaUser` configured with ACL rules that specify permission to manage the Kafka cluster and its topics.
+
+See xref:proc-generating-reassignment-json-files-{context}[Generating reassignment JSON files].
+
+In this procedure, a topic called `my-topic` has 4 replicas and we want to reduce it to 3. 
+A JSON file named `topics.json` specifies the topic, and was used to generate the `reassignment.json` file.
+
+.Example JSON file specifies `my-topic` 
+[source,json]
+----
+{
+  "version": 1,
+  "topics": [
+    { "topic": "my-topic"}
+  ]
+}
+----
+
+.Procedure
+
+. If you haven't done so, xref:proc-generating-reassignment-json-files-{context}[run an interactive pod container to generate a reassignment JSON file] named `reassignment.json`.
++
+.Example reassignment JSON file showing the current and proposed replica assignment
+[source,shell,subs=+quotes]
+----
+Current partition replica assignment
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[3,4,2,0],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[0,2,3,1],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[1,3,0,4],"log_dirs":["any","any","any","any"]}]}
+
+Proposed partition reassignment configuration
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[0,1,2,3],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[1,2,3,4],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[2,3,4,0],"log_dirs":["any","any","any","any"]}]}
+----
++
+Save a copy of this file locally in case you need to revert the changes later on.
+
+. Edit the `reassignment.json` to remove a replica from each partition.
++
+For example use `jq` to remove the last replica in the list for each partition of the topic:
++
+.Removing the last topic replica for each partition
+[source,shell,subs=+quotes]
+----
+jq '.partitions[].replicas |= del(.[-1])' reassignment.json > reassignment.json
+----
++
+.Example reassignment file showing the updated replicas
+[source,shell,subs=+quotes]
+----
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[0,1,2],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[1,2,3],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[2,3,4],"log_dirs":["any","any","any","any"]}]}
+----
+
+. Copy the `reassignment.json` file to the interactive pod container.
++
+[source,shell,subs=+quotes]
+----
+kubectl cp reassignment.json _<interactive_pod_name>_:/tmp/reassignment.json
+----
++
+Replace _<interactive_pod_name>_ with the name of the pod.
+
+. Start a shell process in the interactive pod container.
++
+[source,shell,subs=+quotes]
+kubectl exec -n _<namespace>_ -ti _<interactive_pod_name>_ /bin/bash
++
+Replace _<namespace>_ with the Kubernetes namespace where the pod is running.
+
+. Make the topic replica change using the `kafka-reassign-partitions.sh` script from the interactive pod container.
++
+[source,shell,subs=+quotes]
+----
+bin/kafka-reassign-partitions.sh --bootstrap-server
+ _<cluster_name>_-kafka-bootstrap:9093 \
+ --command-config /tmp/config.properties \
+ --reassignment-json-file /tmp/reassignment.json \
+ --execute
+----
++
+NOTE: Removing replicas from a broker does not require any inter-broker data movement, so there is no need to throttle replication.
+If you are adding replicas, then you may want to change the throttle rate. 
+
+. Verify that the change to the topic replicas has completed using the `kafka-reassign-partitions.sh` command line tool from any of the broker pods.
+This is the same command as the previous step, but with the `--verify` option instead of the `--execute` option.
++
+[source,shell,subs=+quotes]
+----
+bin/kafka-reassign-partitions.sh --bootstrap-server
+  _<cluster_name>_-kafka-bootstrap:9093 \
+  --command-config /tmp/config.properties \
+  --reassignment-json-file /tmp/reassignment.json \
+  --verify
+----
++
+The reassignment has finished when the `--verify` command reports that each of the partitions being moved has completed successfully.
+This final `--verify` will also have the effect of removing any reassignment throttles.
++
+The topics should now show the reduced number of replicas. 
++
+.Results of reducing the number of replicas for a topic
+[source,shell]
+----
+my-topic  Partition: 0  Leader: 0  Replicas: 0,1,2 Isr: 0,1,2
+my-topic  Partition: 1  Leader: 2  Replicas: 1,2,3 Isr: 1,2,3
+my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
+----

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -113,8 +113,16 @@ bin/kafka-reassign-partitions.sh --bootstrap-server
 +
 The reassignment has finished when the `--verify` command reports that each of the partitions being moved has completed successfully.
 This final `--verify` will also have the effect of removing any reassignment throttles.
+
+. Run the `bin/kafka-topics.sh` command with the `--describe` option to see the results of the change to the topics.
 +
-The topics should now show the reduced number of replicas. 
+[source,shell,subs=+quotes]
+----
+bin/kafka-topics.sh --bootstrap-server
+  _<cluster_name>_-kafka-bootstrap:9093 \
+  --command-config /tmp/config.properties \
+  --describe
+----
 +
 .Results of reducing the number of replicas for a topic
 [source,shell]

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -64,7 +64,7 @@ metadata:
     strimzi.io/cluster: my-cluster
 spec:
   partitions: 10
-  replicas: 4
+  replicas: 3
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
@@ -218,7 +218,7 @@ Replace _<namespace>_ with the Kubernetes namespace where the pod is running.
 
 . Use the `kafka-reassign-partitions.sh` command to generate the reassignment JSON.
 +
-.Example command to move all the partitions of `my-topic` to brokers `0`, `1` and `2`
+.Example command to move the partitions of `my-topic` to specified brokers
 [source,shell,subs=+quotes]
 ----
 bin/kafka-reassign-partitions.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 \

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// configuring/assembly-scaling-clusters.adoc
+// configuring/assembly-reassign-tool.adoc
 
 [id='proc-generating-reassignment-json-files-{context}']
 = Generating a reassignment JSON file to reassign partitions
@@ -64,7 +64,7 @@ metadata:
     strimzi.io/cluster: my-cluster
 spec:
   partitions: 10
-  replicas: 3
+  replicas: 4
   config:
     retention.ms: 7200000
     segment.bytes: 1073741824
@@ -190,17 +190,18 @@ kubectl cp config.properties _<interactive_pod_name>_:/tmp/config.properties
 --
 Specify topic names as a comma-separated list.
 
-.Example JSON file to reassign all the partitions of `topic-a` and `topic-b`
+.Example JSON file to reassign all the partitions of `my-topic`
 [source,json]
 ----
 {
   "version": 1,
   "topics": [
-    { "topic": "topic-a"},
-    { "topic": "topic-b"}
+    { "topic": "my-topic"}
   ]
 }
 ----
+
+You can also use this file to xref:proc-changing-topic-replicas-{context}[change the replication factor of a topic]. 
 --
 
 . Copy the `_topics.json_` file to the interactive pod container.
@@ -217,13 +218,13 @@ Replace _<namespace>_ with the Kubernetes namespace where the pod is running.
 
 . Use the `kafka-reassign-partitions.sh` command to generate the reassignment JSON.
 +
-.Example command to move all the partitions of `topic-a` and `topic-b` to brokers `0`, `1` and `2`
+.Example command to move all the partitions of `my-topic` to brokers `0`, `1` and `2`
 [source,shell,subs=+quotes]
 ----
 bin/kafka-reassign-partitions.sh --bootstrap-server my-cluster-kafka-bootstrap:9093 \
   --command-config /tmp/config.properties \
   --topics-to-move-json-file /tmp/topics.json \
-  --broker-list 0,1,2 \
+  --broker-list 0,1,2,3,4 \
   --generate
 ----
 

--- a/documentation/modules/configuring/proc-scaling-down-a-kafka-cluster.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-a-kafka-cluster.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// configuring/assembly-scaling-clusters.adoc
+// configuring/assembly-reassign-tool.adoc
 
 [id='proc-scaling-down-a-kafka-cluster-{context}']
 

--- a/documentation/modules/configuring/proc-scaling-up-a-kafka-cluster.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-a-kafka-cluster.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// configuring/assembly-scaling-clusters.adoc
+// configuring/assembly-reassign-tool.adoc
 
 [id='proc-scaling-up-a-kafka-cluster-{context}']
 

--- a/documentation/modules/configuring/snip-reassign-partitions.adoc
+++ b/documentation/modules/configuring/snip-reassign-partitions.adoc
@@ -1,6 +1,6 @@
 . If you haven't done so, xref:proc-generating-reassignment-json-files-{context}[run an interactive pod container to generate a reassignment JSON file] named `reassignment.json`.
 
-. Copy the `_reassignment.json_` file to the interactive pod container.
+. Copy the `reassignment.json` file to the interactive pod container.
 +
 [source,shell,subs=+quotes]
 ----


### PR DESCRIPTION
### Type of change

**Documentation**

Introduces a new procedure to [Using the partition reassignment tool](https://strimzi.io/docs/operators/in-development/deploying.html#assembly-reassign-tool-str).

The new procedure, **_Changing the replication factor of topics_**, describes how to use the partition reassignment tool to change the replication factor of a topic.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

