### PR TITLE
feat: Use Strimzi Kind label constant instead of inlined string

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
@@ -83,7 +83,7 @@ public class UserController {
         // Selector for the secrets contains the original KafkaUSer selector adn the Strimzi Kind label
         Map<String, String> secretSelector = new HashMap<>(userSelector.size() + 1);
         secretSelector.putAll(userSelector);
-        secretSelector.put("strimzi.io/kind", RESOURCE_KIND);
+        secretSelector.put(Labels.STRIMZI_KIND_LABEL, RESOURCE_KIND);
 
         // Set up the metrics holder
         this.metrics = new ControllerMetricsHolder(RESOURCE_KIND, Labels.fromMap(userSelector), metricsProvider);


### PR DESCRIPTION
### Type of change


- Refactoring

### Description

The replaced string already existed in the labels class Use this constant

### Checklist

None of the following apply, correct me if I'm mistaken!

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

