### PR TITLE
Reinstall timezone data so that users can change the timezone of the logs

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -9,6 +9,7 @@ USER root
 
 RUN microdnf update \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf reinstall -y tzdata \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-17


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like the base image we use is missing timezone data. So when users want the operands to log in the ir own timezone, it might not work for all of them. Java seems to have its own handling of timezones and seems to work fine. But non-java tools such as Kafka Exporter ignore the timezone and always log in UTC.

This PR reinstalls the timezone data which restores them and allows configuring custom logging timezone even for operands such as Kafka Exporter. It seems to add 4.4 MB to the image which seems acceptable given this is a feature users are asking for from time to time.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally