### PR TITLE
Unify the name of the new cluster in the `fromCrd` methods

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -187,58 +187,58 @@ public class CruiseControl extends AbstractModel {
         KafkaClusterSpec kafkaClusterSpec = kafkaCr.getSpec().getKafka();
 
         if (ccSpec != null) {
-            CruiseControl cruiseControl = new CruiseControl(reconciliation, kafkaCr);
+            CruiseControl result = new CruiseControl(reconciliation, kafkaCr);
 
-            cruiseControl.replicas = DEFAULT_REPLICAS;
+            result.replicas = DEFAULT_REPLICAS;
 
             String image = ccSpec.getImage();
             if (image == null) {
                 image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE, versions.kafkaImage(kafkaClusterSpec.getImage(), versions.defaultVersion().version()));
             }
-            cruiseControl.image = image;
+            result.image = image;
 
-            cruiseControl.updateConfiguration(ccSpec);
-            CruiseControlConfiguration ccConfiguration = (CruiseControlConfiguration) cruiseControl.getConfiguration();
-            cruiseControl.sslEnabled = ccConfiguration.isApiSslEnabled();
-            cruiseControl.authEnabled = ccConfiguration.isApiAuthEnabled();
+            result.updateConfiguration(ccSpec);
+            CruiseControlConfiguration ccConfiguration = (CruiseControlConfiguration) result.getConfiguration();
+            result.sslEnabled = ccConfiguration.isApiSslEnabled();
+            result.authEnabled = ccConfiguration.isApiAuthEnabled();
 
             KafkaConfiguration configuration = new KafkaConfiguration(reconciliation, kafkaClusterSpec.getConfig().entrySet());
             if (configuration.getConfigOption(MIN_INSYNC_REPLICAS) != null) {
-                cruiseControl.minInsyncReplicas = configuration.getConfigOption(MIN_INSYNC_REPLICAS);
+                result.minInsyncReplicas = configuration.getConfigOption(MIN_INSYNC_REPLICAS);
             }
 
             // To avoid illegal storage configurations provided by the user,
             // we rely on the storage configuration provided by the KafkaAssemblyOperator
-            cruiseControl.capacity = new Capacity(reconciliation, kafkaCr.getSpec(), storage);
+            result.capacity = new Capacity(reconciliation, kafkaCr.getSpec(), storage);
 
             // Parse different types of metrics configurations
-            ModelUtils.parseMetrics(cruiseControl, ccSpec);
+            ModelUtils.parseMetrics(result, ccSpec);
 
             if (ccSpec.getReadinessProbe() != null) {
-                cruiseControl.readinessProbeOptions = ccSpec.getReadinessProbe();
+                result.readinessProbeOptions = ccSpec.getReadinessProbe();
             }
 
             if (ccSpec.getLivenessProbe() != null) {
-                cruiseControl.livenessProbeOptions = ccSpec.getLivenessProbe();
+                result.livenessProbeOptions = ccSpec.getLivenessProbe();
             }
 
-            cruiseControl.logging = ccSpec.getLogging();
+            result.logging = ccSpec.getLogging();
 
-            cruiseControl.gcLoggingEnabled = ccSpec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : ccSpec.getJvmOptions().isGcLoggingEnabled();
-            cruiseControl.jvmOptions = ccSpec.getJvmOptions();
-            cruiseControl.resources = ccSpec.getResources();
+            result.gcLoggingEnabled = ccSpec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : ccSpec.getJvmOptions().isGcLoggingEnabled();
+            result.jvmOptions = ccSpec.getJvmOptions();
+            result.resources = ccSpec.getResources();
 
             if (ccSpec.getTemplate() != null) {
                 CruiseControlTemplate template = ccSpec.getTemplate();
 
-                cruiseControl.templateDeployment = template.getDeployment();
-                cruiseControl.templatePod = template.getPod();
-                cruiseControl.templateService = template.getApiService();
-                cruiseControl.templateServiceAccount = template.getServiceAccount();
-                cruiseControl.templateContainer = template.getCruiseControlContainer();
+                result.templateDeployment = template.getDeployment();
+                result.templatePod = template.getPod();
+                result.templateService = template.getApiService();
+                result.templateServiceAccount = template.getServiceAccount();
+                result.templateContainer = template.getCruiseControlContainer();
             }
 
-            return cruiseControl;
+            return result;
         } else {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -183,60 +183,60 @@ public class KafkaBridgeCluster extends AbstractModel {
     @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static KafkaBridgeCluster fromCrd(Reconciliation reconciliation, KafkaBridge kafkaBridge) {
 
-        KafkaBridgeCluster kafkaBridgeCluster = new KafkaBridgeCluster(reconciliation, kafkaBridge);
+        KafkaBridgeCluster result = new KafkaBridgeCluster(reconciliation, kafkaBridge);
 
         KafkaBridgeSpec spec = kafkaBridge.getSpec();
-        kafkaBridgeCluster.tracing = spec.getTracing();
-        kafkaBridgeCluster.resources = spec.getResources();
-        kafkaBridgeCluster.logging = spec.getLogging();
-        kafkaBridgeCluster.gcLoggingEnabled = spec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : spec.getJvmOptions().isGcLoggingEnabled();
-        kafkaBridgeCluster.jvmOptions = spec.getJvmOptions();
+        result.tracing = spec.getTracing();
+        result.resources = spec.getResources();
+        result.logging = spec.getLogging();
+        result.gcLoggingEnabled = spec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : spec.getJvmOptions().isGcLoggingEnabled();
+        result.jvmOptions = spec.getJvmOptions();
         String image = spec.getImage();
         if (image == null) {
             image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE, "quay.io/strimzi/kafka-bridge:latest");
         }
-        kafkaBridgeCluster.image = image;
-        kafkaBridgeCluster.replicas = spec.getReplicas();
-        kafkaBridgeCluster.setBootstrapServers(spec.getBootstrapServers());
-        kafkaBridgeCluster.setKafkaAdminClientConfiguration(spec.getAdminClient());
-        kafkaBridgeCluster.setKafkaConsumerConfiguration(spec.getConsumer());
-        kafkaBridgeCluster.setKafkaProducerConfiguration(spec.getProducer());
-        kafkaBridgeCluster.rack = spec.getRack();
+        result.image = image;
+        result.replicas = spec.getReplicas();
+        result.setBootstrapServers(spec.getBootstrapServers());
+        result.setKafkaAdminClientConfiguration(spec.getAdminClient());
+        result.setKafkaConsumerConfiguration(spec.getConsumer());
+        result.setKafkaProducerConfiguration(spec.getProducer());
+        result.rack = spec.getRack();
         String initImage = spec.getClientRackInitImage();
         if (initImage == null) {
             initImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "quay.io/strimzi/operator:latest");
         }
-        kafkaBridgeCluster.initImage = initImage;
+        result.initImage = initImage;
         if (kafkaBridge.getSpec().getLivenessProbe() != null) {
-            kafkaBridgeCluster.livenessProbeOptions = kafkaBridge.getSpec().getLivenessProbe();
+            result.livenessProbeOptions = kafkaBridge.getSpec().getLivenessProbe();
         }
 
         if (kafkaBridge.getSpec().getReadinessProbe() != null) {
-            kafkaBridgeCluster.readinessProbeOptions = kafkaBridge.getSpec().getReadinessProbe();
+            result.readinessProbeOptions = kafkaBridge.getSpec().getReadinessProbe();
         }
 
-        kafkaBridgeCluster.isMetricsEnabled = spec.getEnableMetrics();
+        result.isMetricsEnabled = spec.getEnableMetrics();
 
-        kafkaBridgeCluster.setTls(spec.getTls() != null ? spec.getTls() : null);
+        result.setTls(spec.getTls() != null ? spec.getTls() : null);
 
         String warnMsg = AuthenticationUtils.validateClientAuthentication(spec.getAuthentication(), spec.getTls() != null);
         if (!warnMsg.isEmpty()) {
             LOGGER.warnCr(reconciliation, warnMsg);
         }
-        kafkaBridgeCluster.setAuthentication(spec.getAuthentication());
+        result.setAuthentication(spec.getAuthentication());
 
         if (spec.getTemplate() != null) {
-            fromCrdTemplate(kafkaBridgeCluster, spec);
+            fromCrdTemplate(result, spec);
         }
 
         if (spec.getHttp() != null) {
-            kafkaBridgeCluster.setKafkaBridgeHttpConfig(spec.getHttp());
+            result.setKafkaBridgeHttpConfig(spec.getHttp());
         } else {
             LOGGER.warnCr(reconciliation, "The spec.http property is missing.");
             throw new InvalidResourceException("The HTTP configuration for the bridge is not specified.");
         }
 
-        return kafkaBridgeCluster;
+        return result;
     }
 
     private static void fromCrdTemplate(final KafkaBridgeCluster kafkaBridgeCluster, final KafkaBridgeSpec spec) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -92,7 +92,7 @@ public class KafkaConnectBuild extends AbstractModel {
      */
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
     public static KafkaConnectBuild fromCrd(Reconciliation reconciliation, KafkaConnect kafkaConnect, KafkaVersion.Lookup versions) {
-        KafkaConnectBuild build = new KafkaConnectBuild(reconciliation, kafkaConnect);
+        KafkaConnectBuild result = new KafkaConnectBuild(reconciliation, kafkaConnect);
         KafkaConnectSpec spec = kafkaConnect.getSpec();
 
         if (spec == null) {
@@ -108,40 +108,40 @@ public class KafkaConnectBuild extends AbstractModel {
                 if (dockerOutput.getAdditionalKanikoOptions() != null
                         && !dockerOutput.getAdditionalKanikoOptions().isEmpty())  {
                     validateAdditionalKanikoOptions(dockerOutput.getAdditionalKanikoOptions());
-                    build.additionalKanikoOptions = dockerOutput.getAdditionalKanikoOptions();
+                    result.additionalKanikoOptions = dockerOutput.getAdditionalKanikoOptions();
                 }
             }
 
-            build.resources = spec.getBuild().getResources();
+            result.resources = spec.getBuild().getResources();
         }
 
-        build.baseImage = versions.kafkaConnectVersion(spec.getImage(), spec.getVersion());
+        result.baseImage = versions.kafkaConnectVersion(spec.getImage(), spec.getVersion());
 
         if (spec.getTemplate() != null) {
             KafkaConnectTemplate template = spec.getTemplate();
 
             if (template.getBuildConfig() != null) {
-                build.pullSecret = template.getBuildConfig().getPullSecret();
+                result.pullSecret = template.getBuildConfig().getPullSecret();
 
                 if (template.getBuildConfig().getMetadata() != null) {
                     if (template.getBuildConfig().getMetadata().getLabels() != null) {
-                        build.templateBuildConfigLabels = template.getBuildConfig().getMetadata().getLabels();
+                        result.templateBuildConfigLabels = template.getBuildConfig().getMetadata().getLabels();
                     }
 
                     if (template.getBuildConfig().getMetadata().getAnnotations() != null) {
-                        build.templateBuildConfigAnnotations = template.getBuildConfig().getMetadata().getAnnotations();
+                        result.templateBuildConfigAnnotations = template.getBuildConfig().getMetadata().getAnnotations();
                     }
                 }
             }
 
-            build.templatePod = template.getBuildPod();
-            build.templateServiceAccount = template.getBuildServiceAccount();
-            build.templateContainer = template.getBuildContainer();
+            result.templatePod = template.getBuildPod();
+            result.templateServiceAccount = template.getBuildServiceAccount();
+            result.templateContainer = template.getBuildContainer();
         }
 
-        build.build = spec.getBuild();
+        result.build = spec.getBuild();
 
-        return build;
+        return result;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -115,43 +115,43 @@ public class KafkaExporter extends AbstractModel {
         KafkaExporterSpec spec = kafkaAssembly.getSpec().getKafkaExporter();
 
         if (spec != null) {
-            KafkaExporter kafkaExporter = new KafkaExporter(reconciliation, kafkaAssembly);
+            KafkaExporter result = new KafkaExporter(reconciliation, kafkaAssembly);
 
-            kafkaExporter.resources = spec.getResources();
+            result.resources = spec.getResources();
 
             if (spec.getReadinessProbe() != null) {
-                kafkaExporter.readinessProbeOptions = spec.getReadinessProbe();
+                result.readinessProbeOptions = spec.getReadinessProbe();
             }
 
             if (spec.getLivenessProbe() != null) {
-                kafkaExporter.livenessProbeOptions = spec.getLivenessProbe();
+                result.livenessProbeOptions = spec.getLivenessProbe();
             }
 
-            kafkaExporter.groupRegex = spec.getGroupRegex();
-            kafkaExporter.topicRegex = spec.getTopicRegex();
+            result.groupRegex = spec.getGroupRegex();
+            result.topicRegex = spec.getTopicRegex();
 
             String image = spec.getImage();
             if (image == null) {
                 KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
                 image = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE, versions.kafkaImage(kafkaClusterSpec.getImage(), versions.defaultVersion().version()));
             }
-            kafkaExporter.image = image;
+            result.image = image;
 
-            kafkaExporter.exporterLogging = spec.getLogging();
-            kafkaExporter.saramaLoggingEnabled = spec.getEnableSaramaLogging();
+            result.exporterLogging = spec.getLogging();
+            result.saramaLoggingEnabled = spec.getEnableSaramaLogging();
 
             if (spec.getTemplate() != null) {
                 KafkaExporterTemplate template = spec.getTemplate();
 
-                kafkaExporter.templateDeployment = template.getDeployment();
-                kafkaExporter.templatePod = template.getPod();
-                kafkaExporter.templateServiceAccount = template.getServiceAccount();
-                kafkaExporter.templateContainer = template.getContainer();
+                result.templateDeployment = template.getDeployment();
+                result.templatePod = template.getPod();
+                result.templateServiceAccount = template.getServiceAccount();
+                result.templateContainer = template.getContainer();
             }
 
-            kafkaExporter.version = versions.supportedVersion(kafkaAssembly.getSpec().getKafka().getVersion()).version();
+            result.version = versions.supportedVersion(kafkaAssembly.getSpec().getKafka().getVersion()).version();
 
-            return kafkaExporter;
+            return result;
         } else {
             return null;
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -95,13 +95,13 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     public static KafkaMirrorMaker2Cluster fromCrd(Reconciliation reconciliation,
                                                    KafkaMirrorMaker2 kafkaMirrorMaker2,
                                                    KafkaVersion.Lookup versions) {
-        KafkaMirrorMaker2Cluster cluster = new KafkaMirrorMaker2Cluster(reconciliation, kafkaMirrorMaker2);
+        KafkaMirrorMaker2Cluster result = new KafkaMirrorMaker2Cluster(reconciliation, kafkaMirrorMaker2);
         KafkaMirrorMaker2Spec spec = kafkaMirrorMaker2.getSpec();
 
-        cluster.image = versions.kafkaMirrorMaker2Version(spec.getImage(), spec.getVersion());
+        result.image = versions.kafkaMirrorMaker2Version(spec.getImage(), spec.getVersion());
 
         List<KafkaMirrorMaker2ClusterSpec> clustersList = ModelUtils.asListOrEmptyList(spec.getClusters());
-        cluster.setClusters(clustersList);
+        result.setClusters(clustersList);
 
         KafkaMirrorMaker2ClusterSpec connectCluster = new KafkaMirrorMaker2ClusterSpecBuilder().build();
         String connectClusterAlias = spec.getConnectCluster();        
@@ -111,9 +111,9 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                     .findFirst()
                     .orElseThrow(() -> new InvalidResourceException("connectCluster with alias " + connectClusterAlias + " cannot be found in the list of clusters at spec.clusters"));
         }        
-        cluster.setConfiguration(new KafkaMirrorMaker2Configuration(reconciliation, connectCluster.getConfig().entrySet()));
+        result.setConfiguration(new KafkaMirrorMaker2Configuration(reconciliation, connectCluster.getConfig().entrySet()));
 
-        return fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, cluster);
+        return fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, result);
     }
 
     private static KafkaConnectSpec buildKafkaConnectSpec(KafkaMirrorMaker2Spec spec, KafkaMirrorMaker2ClusterSpec connectCluster) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -160,19 +160,19 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
      */
     @SuppressWarnings("deprecation")
     public static KafkaMirrorMakerCluster fromCrd(Reconciliation reconciliation, KafkaMirrorMaker kafkaMirrorMaker, KafkaVersion.Lookup versions) {
-        KafkaMirrorMakerCluster kafkaMirrorMakerCluster = new KafkaMirrorMakerCluster(reconciliation, kafkaMirrorMaker);
+        KafkaMirrorMakerCluster result = new KafkaMirrorMakerCluster(reconciliation, kafkaMirrorMaker);
 
         KafkaMirrorMakerSpec spec = kafkaMirrorMaker.getSpec();
         if (spec != null) {
-            kafkaMirrorMakerCluster.replicas = spec.getReplicas();
-            kafkaMirrorMakerCluster.resources = spec.getResources();
+            result.replicas = spec.getReplicas();
+            result.resources = spec.getResources();
 
             if (spec.getReadinessProbe() != null) {
-                kafkaMirrorMakerCluster.readinessProbeOptions = spec.getReadinessProbe();
+                result.readinessProbeOptions = spec.getReadinessProbe();
             }
 
             if (spec.getLivenessProbe() != null) {
-                kafkaMirrorMakerCluster.livenessProbeOptions = spec.getLivenessProbe();
+                result.livenessProbeOptions = spec.getLivenessProbe();
             }
 
             String whitelist = spec.getWhitelist();
@@ -184,45 +184,45 @@ public class KafkaMirrorMakerCluster extends AbstractModel {
                 LOGGER.warnCr(reconciliation, "Both include and whitelist fields are present. Whitelist is deprecated and will be ignored.");
             }
 
-            kafkaMirrorMakerCluster.include = include != null ? include : whitelist;
+            result.include = include != null ? include : whitelist;
 
             String warnMsg = AuthenticationUtils.validateClientAuthentication(spec.getProducer().getAuthentication(), spec.getProducer().getTls() != null);
             if (!warnMsg.isEmpty()) {
                 LOGGER.warnCr(reconciliation, warnMsg);
             }
 
-            kafkaMirrorMakerCluster.producer = spec.getProducer();
+            result.producer = spec.getProducer();
 
             warnMsg = AuthenticationUtils.validateClientAuthentication(spec.getConsumer().getAuthentication(), spec.getConsumer().getTls() != null);
             if (!warnMsg.isEmpty()) {
                 LOGGER.warnCr(reconciliation, warnMsg);
             }
 
-            kafkaMirrorMakerCluster.consumer = spec.getConsumer();
+            result.consumer = spec.getConsumer();
 
-            kafkaMirrorMakerCluster.image = versions.kafkaMirrorMakerImage(spec.getImage(), spec.getVersion());
+            result.image = versions.kafkaMirrorMakerImage(spec.getImage(), spec.getVersion());
 
-            kafkaMirrorMakerCluster.logging = spec.getLogging();
-            kafkaMirrorMakerCluster.gcLoggingEnabled = spec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : spec.getJvmOptions().isGcLoggingEnabled();
-            kafkaMirrorMakerCluster.jvmOptions = spec.getJvmOptions();
+            result.logging = spec.getLogging();
+            result.gcLoggingEnabled = spec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : spec.getJvmOptions().isGcLoggingEnabled();
+            result.jvmOptions = spec.getJvmOptions();
 
             // Parse different types of metrics configurations
-            ModelUtils.parseMetrics(kafkaMirrorMakerCluster, spec);
+            ModelUtils.parseMetrics(result, spec);
 
             if (spec.getTemplate() != null) {
                 KafkaMirrorMakerTemplate template = spec.getTemplate();
 
-                kafkaMirrorMakerCluster.templatePodDisruptionBudget = template.getPodDisruptionBudget();
-                kafkaMirrorMakerCluster.templateDeployment = template.getDeployment();
-                kafkaMirrorMakerCluster.templatePod = template.getPod();
-                kafkaMirrorMakerCluster.templateServiceAccount = template.getServiceAccount();
-                kafkaMirrorMakerCluster.templateContainer = template.getMirrorMakerContainer();
+                result.templatePodDisruptionBudget = template.getPodDisruptionBudget();
+                result.templateDeployment = template.getDeployment();
+                result.templatePod = template.getPod();
+                result.templateServiceAccount = template.getServiceAccount();
+                result.templateContainer = template.getMirrorMakerContainer();
             }
 
-            kafkaMirrorMakerCluster.tracing = spec.getTracing();
+            result.tracing = spec.getTracing();
         }
 
-        return kafkaMirrorMakerCluster;
+        return result;
     }
 
     protected List<ContainerPort> getContainerPortList() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `fromCrd` methods are used in the `AbstractModel` subclasses. They are static methods that create new model objects. Right now, most of them are using different names => but because they are using often the same or similar logic, this makes it hard to search for some code or copy-paste some of the shared logic. 

This PR renames all of them to `result` - that is a name that is already used in some of them, so it makes it easier to do the changes only in some places. This should make it easier to do the next refactorings of the model classes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally