### PR TITLE
Add Drain Cleaner 0.4.2 to the operators repository

### DIFF
--- a/packaging/helm-charts/index.yaml
+++ b/packaging/helm-charts/index.yaml
@@ -2,6 +2,20 @@ apiVersion: v1
 entries:
   strimzi-drain-cleaner:
   - apiVersion: v2
+    appVersion: 0.4.2
+    created: "2023-03-07T22:29:25.58052+01:00"
+    description: Utility which helps with moving the Apache Kafka pods deployed by
+      Strimzi from Kubernetes nodes which are being drained.
+    digest: 5a908d4eb78e359a7eff48568f7ae45ef93302270b9fcef6ff999b5cd5d42619
+    home: https://strimzi.io/
+    name: strimzi-drain-cleaner
+    sources:
+    - https://github.com/strimzi/drain-cleaner
+    type: application
+    urls:
+    - https://github.com/strimzi/drain-cleaner/releases/download/0.4.2/strimzi-drain-cleaner-helm-3-chart-0.4.2.tgz
+    version: 0.4.2
+  - apiVersion: v2
     appVersion: 0.4.1
     created: "2023-02-07T21:19:38.627334+01:00"
     description: Utility which helps with moving the Apache Kafka pods deployed by
@@ -1246,4 +1260,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2023-02-15T22:21:41.576029+01:00"
+generated: "2023-03-07T22:29:25.580043+01:00"

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.4.0
+          image: quay.io/strimzi/drain-cleaner:0.4.2
           ports:
             - containerPort: 8080
               name: http
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: tmp-dir
+              mountPath: "/tmp"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: tmp-dir
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.4.0
+          image: quay.io/strimzi/drain-cleaner:0.4.2
           ports:
             - containerPort: 8080
               name: http
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: tmp-dir
+              mountPath: "/tmp"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: tmp-dir
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.4.0
+          image: quay.io/strimzi/drain-cleaner:0.4.2
           ports:
             - containerPort: 8080
               name: http
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: tmp-dir
+              mountPath: "/tmp"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: tmp-dir
+          emptyDir: {}
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the new Drain Cleaner 0.4.2 release to the installation files in the main branch. It also updates the Helm Chart index with the new Drain Cleaner release.