### PR TITLE
Update Open Policy Agent authorizer to 1.5.1

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <cruise-control.version>2.5.112</cruise-control.version>
-        <opa-authorizer.version>1.5.0</opa-authorizer.version>
+        <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <cruise-control.version>2.5.112</cruise-control.version>
-        <opa-authorizer.version>1.5.0</opa-authorizer.version>
+        <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Open Policy Agent authorizer to new version 1.5.1.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally