### PR TITLE
docs(clients): updates the client upgrade strategies

### DIFF
--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -7,7 +7,10 @@
 = Strategies for upgrading clients
 
 [role="_abstract"]
-The goal of upgrading Kafka clients is to enable them to consume new message formats produced by updated producers. 
+Upgrading Kafka clients ensures that they benefit from the features, fixes, and improvements that are introduced in new versions of Kafka. 
+Upgraded clients maintain compatibility with other upgraded Kafka components.
+The performance and stability of the clients might also be improved.
+
 The chosen upgrade strategy depends on whether you are upgrading brokers or clients first. 
 If you upgrade clients before brokers, some new features may not work as they are not yet supported by brokers. 
 However, brokers can handle producers and consumers running with different versions and supporting different log message versions.

--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -6,53 +6,31 @@
 
 = Strategies for upgrading clients
 
-The right approach to upgrading your client applications (including Kafka Connect connectors) depends on your particular circumstances.
+[role="_abstract"]
+The goal of upgrading clients is to enable them to consume new message formats produced by updated producers.
+You do this by upgrading all the consumers for a topic _before_ upgrading any of the producers.
+Upgrading consumers first ensures that consuming applications can understand the new message format before any new messages in that format are produced.
+The chosen upgrade strategy depends on a number of factors, such as the number of applications that need to be upgraded and how much downtime is tolerable. 
+You can combine more than one strategy.
 
-Consuming applications need to receive messages in a message format that they understand. You can ensure that this is the case in one of two ways:
+.Consumers first strategy
 
-* By upgrading all the consumers for a topic _before_ upgrading any of the producers.
-* By having the brokers down-convert messages to an older format.
+For the consumers first strategy, upgrade all the consuming applications, and then upgrade all the producing applications. 
 
-Using broker down-conversion puts extra load on the brokers, so it is not ideal to rely on down-conversion for all topics for a prolonged period of time.
-For brokers to perform optimally they should not be down converting messages at all.
+This strategy assumes that all consumers in your organization can be upgraded in a coordinated way, and it does not work for applications that are both consumers and producers.
+If there is a problem with the upgraded clients, there is a risk that messages in the new format might be added to the message log so that you cannot revert to the previous consumer version.
 
-Broker down-conversion is configured in two ways:
+IMPORTANT: If upgrading from a version of Kafka earlier than version 3.0.0, the log message format needs to be changed at the topic-level (`message.format.version`) or broker-level (`log.message.format.version`) after upgrading the consumer applications and before upgrading the producer applications. From Kafka 3.0, the log message version does not need to be set. 
 
-* The topic-level `message.format.version` configures it for a single topic.
+.Consumers first strategy with down-conversion at the topic level
 
-* The broker-level `log.message.format.version` is the default for topics that do not have the topic-level `message.format.version` configured.
+Broker down-conversion is the process of converting messages from a new version to an older version before delivering them to consumers. 
+You can use broker down-conversion if you are not upgrading all topics or applications. 
+The older message version needs to be supported. 
+You configure broker down-conversion by setting the topic-level (`message.format.version`) or broker-level (`log.message.format.version`) message version to the older version. 
+Broker down-conversion puts extra load on the brokers and should be avoided or only used temporarily. 
 
-Messages published to a topic in a new-version format will be visible to consumers, because brokers perform down-conversion when they receive messages from producers, not when they are sent to consumers.
-
-Common strategies you can use to upgrade your clients are described as follows.
-Other strategies for upgrading client applications are also possible.
-
-IMPORTANT: The steps outlined in each strategy change slightly when upgrading to Kafka 3.0.0 or later.
-From Kafka 3.0.0, the message format version values are assumed to match the `inter.broker.protocol.version` and don't need to be set.
-
-.Broker-level consumers first strategy
-
-. Upgrade all the consuming applications.
-. Change the broker-level `log.message.format.version` to the new version.
-. Upgrade all the producing applications.
-
-This strategy is straightforward, and avoids any broker down-conversion.
-However, it assumes that all consumers in your organization can be upgraded in a coordinated way, and it does not work for applications that are both consumers and producers.
-There is also a risk that, if there is a problem with the upgraded clients, new-format messages might get added to the message log so that you cannot revert to the previous consumer version.
-
-.Topic-level consumers first strategy
-
-For each topic:
-
-. Upgrade all the consuming applications.
-. Change the topic-level `message.format.version` to the new version.
-. Upgrade all the producing applications.
-
-This strategy avoids any broker down-conversion, and means you can proceed on a topic-by-topic basis. It does not work for applications that are both consumers and producers of the same topic. Again, it has the risk that, if there is a problem with the upgraded clients, new-format messages might get added to the message log.
-
-.Topic-level consumers first strategy with down conversion
-
-For each topic:
+For the consumers first strategy with down-conversion at the topic level, you perform the following steps to upgrade clients:
 
 . Change the topic-level `message.format.version` to the old version
 (or rely on the topic defaulting to the broker-level `log.message.format.version`).
@@ -60,11 +38,11 @@ For each topic:
 . Verify that the upgraded applications function correctly.
 . Change the topic-level `message.format.version` to the new version.
 
-This strategy requires broker down-conversion, but the load on the brokers is minimized because it is only required for a single topic (or small group of topics) at a time. It also works for applications that are both consumers and producers of the same topic. This approach ensures that the upgraded producers and consumers are working correctly before you commit to using the new message format version.
-
+Although this strategy uses broker down-conversion, the load on the brokers is minimized because it is only required for a single topic (or small group of topics) at a time. 
+It also works for applications that are both consumers and producers of the same topic. 
+The approach ensures that the upgraded producers and consumers are working correctly before you commit to using the new message format version.
 The main drawback of this approach is that it can be complicated to manage in a cluster with many topics and applications.
 
-NOTE: It is also possible to apply multiple strategies.
-For example, for the first few applications and topics the
-"per-topic consumers first, with down conversion" strategy can be used.
-When this has proved successful another, more efficient strategy can be considered acceptable to use instead.
+TIP: You can use Kafka metrics to monitor the performance of message down-conversion. 
+The _message conversion time_ metric measures the time taken to perform message conversion. 
+The _message conversion rate_ metric measures the number of messages converted over a period of time.  

--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -13,44 +13,28 @@ The performance and stability of the clients might also be improved.
 
 Consider the best approach for upgrading Kafka clients and brokers to ensure a smooth transition.
 The chosen upgrade strategy depends on whether you are upgrading brokers or clients first. 
+Since Kafka 3.0, you can upgrade brokers and client independently and in any order.
 The decision to upgrade clients or brokers first depends on several factors, such as the number of applications that need to be upgraded and how much downtime is tolerable.
-Absent of changes to the log message version, you can usually update in any order without risking downtime.
 
 If you upgrade clients before brokers, some new features may not work as they are not yet supported by brokers. 
 However, brokers can handle producers and consumers running with different versions and supporting different log message versions.
 
-It's usually better to upgrade brokers first, so that applications can start using new features as soon as they are upgraded.
-If you do upgrade brokers first, there may be a need for down-conversion or retention of older log message versions to ensure compatibility with older applications. 
+.Upgrading clients when using Kafka versions older than Kafka 3.0
 
-.Consumers first strategy
+Before Kafka 3.0, you would configure a specific message format for brokers using the `log.message.format.version` property (or the `message.format.version` property at the topic level). 
+This allowed brokers to support older Kafka clients that were using an outdated message format. 
+Otherwise, the brokers would need to convert the messages from the older clients, which came with a significant performance cost.
 
-For the consumers first strategy, upgrade all the consuming applications, and then upgrade all the producing applications. 
+Apache Kafka Java clients have supported the latest message format version since version 0.11. 
+If all of your clients are using the latest message version, you can remove the `log.message.format.version` or `message.format.version` overrides when upgrading your brokers.
 
-This strategy assumes that all consumers in your organization can be upgraded in a coordinated way, and it does not work for applications that are both consumers and producers.
-If there is a problem with the upgraded clients, there is a risk that messages in the new format might be added to the message log so that you cannot revert to the previous consumer version.
+However, if you still have clients that are using an older message format version, we recommend upgrading your clients first. 
+Start with the consumers, then upgrade the producers before removing the `log.message.format.version` or  `message.format.version` overrides when upgrading your brokers. 
+This will ensure that all of your clients can support the latest message format version and that the upgrade process goes smoothly.
 
-IMPORTANT: If upgrading from a version of Kafka earlier than version 3.0.0, the log message format needs to be changed at the topic-level (`message.format.version`) or broker-level (`log.message.format.version`) after upgrading the consumer applications and before upgrading the producer applications. From Kafka 3.0, the log message version does not need to be set. 
+You can track Kafka client names and versions using this metric:
 
-.Consumers first strategy with down-conversion at the topic level
-
-Broker down-conversion is the process of converting messages from a new version to an older version before delivering them to consumers. 
-You can use broker down-conversion if you are not upgrading all topics or applications. 
-The older message version needs to be supported. 
-You configure broker down-conversion by setting the topic-level (`message.format.version`) or broker-level (`log.message.format.version`) message version to the older version. 
-Broker down-conversion puts extra load on the brokers and should be avoided or only used temporarily. 
-
-For the consumers first strategy with down-conversion at the topic level, you perform the following steps to upgrade clients:
-
-. Change the topic-level `message.format.version` to the old version
-(or rely on the topic defaulting to the broker-level `log.message.format.version`).
-. Upgrade all the consuming and producing applications.
-. Verify that the upgraded applications function correctly.
-. Change the topic-level `message.format.version` to the new version.
-
-Although this strategy uses broker down-conversion, the load on the brokers is minimized because it is only required for a single topic (or small group of topics) at a time. 
-It also works for applications that are both consumers and producers of the same topic. 
-The approach ensures that the upgraded producers and consumers are working correctly before you commit to using the new message format version.
-The main drawback of this approach is that it can be complicated to manage in a cluster with many topics and applications.
+* `kafka.server:type=socket-server-metrics,clientSoftwareName=<name>,clientSoftwareVersion=<version>,listener=<listener>,networkProcessor=<processor>`  
 
 [TIP]
 ====
@@ -58,8 +42,4 @@ The following Kafka broker metrics help monitor the performance of message down-
 
 * `kafka.network:type=RequestMetrics,name=MessageConversionsTimeMs,request={Produce|Fetch}` provides metrics on the time taken to perform message conversion. 
 * `kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)` provides metrics on the number of messages converted over a period of time.  
-
-You can track Kafka client names and versions using this metric:
-
-* `kafka.server:type=socket-server-metrics,clientSoftwareName=<name>,clientSoftwareVersion=<version>,listener=<listener>,networkProcessor=<processor>`  
 ====

--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -7,11 +7,15 @@
 = Strategies for upgrading clients
 
 [role="_abstract"]
-The goal of upgrading clients is to enable them to consume new message formats produced by updated producers.
-You do this by upgrading all the consumers for a topic _before_ upgrading any of the producers.
-Upgrading consumers first ensures that consuming applications can understand the new message format before any new messages in that format are produced.
-The chosen upgrade strategy depends on a number of factors, such as the number of applications that need to be upgraded and how much downtime is tolerable. 
-You can combine more than one strategy.
+The goal of upgrading Kafka clients is to enable them to consume new message formats produced by updated producers. 
+The chosen upgrade strategy depends on whether you are upgrading brokers or clients first. 
+If you upgrade clients before brokers, some new features may not work as they are not yet supported by brokers. 
+However, brokers can handle producers and consumers running with different versions and supporting different log message versions.
+
+If you upgrade brokers first, there may be a need for down-conversion or retention of older log message versions to ensure compatibility with older applications. 
+The decision to upgrade clients or brokers first depends on several factors, such as the number of applications that need to be upgraded and how much downtime is tolerable.
+
+Therefore, it is important to carefully consider the best approach for upgrading Kafka clients and brokers to ensure a smooth transition.
 
 .Consumers first strategy
 
@@ -43,6 +47,14 @@ It also works for applications that are both consumers and producers of the same
 The approach ensures that the upgraded producers and consumers are working correctly before you commit to using the new message format version.
 The main drawback of this approach is that it can be complicated to manage in a cluster with many topics and applications.
 
-TIP: You can use Kafka metrics to monitor the performance of message down-conversion. 
-The _message conversion time_ metric measures the time taken to perform message conversion. 
-The _message conversion rate_ metric measures the number of messages converted over a period of time.  
+[TIP]
+====
+The following Kafka broker metrics help monitor the performance of message down-conversion:
+
+* `kafka.network:type=RequestMetrics,name=MessageConversionsTimeMs,request={Produce|Fetch}` provides metrics on the time taken to perform message conversion. 
+* `kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)` provides metrics on the number of messages converted over a period of time.  
+
+You can track Kafka client names and versions using this metric:
+
+* `kafka.server:type=socket-server-metrics,clientSoftwareName=<name>,clientSoftwareVersion=<version>,listener=<listener>,networkProcessor=<processor>`  
+====

--- a/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
+++ b/documentation/modules/upgrading/con-upgrade-strategies-for-upgrading-clients.adoc
@@ -11,14 +11,16 @@ Upgrading Kafka clients ensures that they benefit from the features, fixes, and 
 Upgraded clients maintain compatibility with other upgraded Kafka components.
 The performance and stability of the clients might also be improved.
 
+Consider the best approach for upgrading Kafka clients and brokers to ensure a smooth transition.
 The chosen upgrade strategy depends on whether you are upgrading brokers or clients first. 
+The decision to upgrade clients or brokers first depends on several factors, such as the number of applications that need to be upgraded and how much downtime is tolerable.
+Absent of changes to the log message version, you can usually update in any order without risking downtime.
+
 If you upgrade clients before brokers, some new features may not work as they are not yet supported by brokers. 
 However, brokers can handle producers and consumers running with different versions and supporting different log message versions.
 
-If you upgrade brokers first, there may be a need for down-conversion or retention of older log message versions to ensure compatibility with older applications. 
-The decision to upgrade clients or brokers first depends on several factors, such as the number of applications that need to be upgraded and how much downtime is tolerable.
-
-Therefore, it is important to carefully consider the best approach for upgrading Kafka clients and brokers to ensure a smooth transition.
+It's usually better to upgrade brokers first, so that applications can start using new features as soon as they are upgraded.
+If you do upgrade brokers first, there may be a need for down-conversion or retention of older log message versions to ensure compatibility with older applications. 
 
 .Consumers first strategy
 


### PR DESCRIPTION
### Type of change

**Documentation**

Updates **Strategies for upgrading clients** to reflect the changes introduced in Kafka 3.0 or newer. It puts more emphasis on strategies relevant to upgrades from later versions of Kafka (post version 3.0).
Now includes only two strategies: consumer-firsta nd consumer-first using broker-down conversion at the topic level.

The updated section also includes a clarification on the use of the `message.format.version` property when upgrading from Kafka versions earlier than 3.0.0, and how it can be used at the topic-level or broker-level.

It also includes a reference to the conversions metrics that can be used in the context of down-conversion.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

