### PR TITLE
Refactor metrics and logging in model classes

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -25,13 +25,12 @@ import lombok.EqualsAndHashCode;
     "livenessProbe", "readinessProbe", "jvmOptions",  "jmxOptions",
     "logging", "clientRackInitImage", "rack", "metricsConfig", "tracing",
     "template", "externalConfiguration" })
-@EqualsAndHashCode(doNotUseGetters = true)
-public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics, HasJmxOptions {
+@EqualsAndHashCode(doNotUseGetters = true, callSuper = true)
+public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions {
     private static final long serialVersionUID = 1L;
 
     private Logging logging;
     private Integer replicas;
-
     private String version;
     private String image;
     private ResourceRequirements resources;
@@ -54,10 +53,12 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
 
     @Description("Logging configuration for Kafka Connect")
     @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -30,7 +30,7 @@ import lombok.EqualsAndHashCode;
     "image", "tlsSidecar", "resources", "livenessProbe", "readinessProbe", "jvmOptions", "logging", "template",
     "brokerCapacity", "config", "metricsConfig"})
 @EqualsAndHashCode
-public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropertyPreserving, Serializable {
+public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurableLogging, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     // For the full configuration list refer to https://github.com/linkedin/cruise-control/wiki/Configurations
@@ -112,10 +112,12 @@ public class CruiseControlSpec implements HasConfigurableMetrics, UnknownPropert
 
     @Description("Logging configuration (Log4j 2) for Cruise Control.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityTopicOperatorSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
     "startupProbe", "livenessProbe", "readinessProbe",
     "resources", "topicMetadataMaxAttempts", "logging", "jvmOptions"})
 @EqualsAndHashCode
-public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Serializable {
+public class EntityTopicOperatorSpec implements HasConfigurableLogging, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -153,10 +153,12 @@ public class EntityTopicOperatorSpec implements UnknownPropertyPreserving, Seria
 
     @Description("Logging configuration")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityUserOperatorSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
     "secretPrefix", "livenessProbe", "readinessProbe",
     "resources", "logging", "jvmOptions"})
 @EqualsAndHashCode
-public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serializable {
+public class EntityUserOperatorSpec implements HasConfigurableLogging, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -131,10 +131,12 @@ public class EntityUserOperatorSpec implements UnknownPropertyPreserving, Serial
 
     @Description("Logging configuration")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableLogging.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+/**
+ * This interface is used for sections of our custom resources which support configurable logging.
+ */
+public interface HasConfigurableLogging {
+    /**
+     * Gets the logging configuration
+     *
+     * @return  Logging configuration
+     */
+    Logging getLogging();
+
+    /**
+     * Sets the logging configuration
+     *
+     * @param logging   Logging configuration
+     */
+    void setLogging(Logging logging);
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/HasConfigurableMetrics.java
@@ -5,10 +5,21 @@
 package io.strimzi.api.kafka.model;
 
 /**
- * This interface is used for sections of our custom resources which support configurable metrics - either using the
- * inlined Map or using the reference to the ConfigMp with the configuration.
+ * This interface is used for sections of our custom resources which support configurable metrics using a reference to
+ * a ConfigMp with the configuration.
  */
 public interface HasConfigurableMetrics {
+    /**
+     * Gets the metrics configuration
+     *
+     * @return  Metrics configuration
+     */
     MetricsConfig getMetricsConfig();
+
+    /**
+     * Sets the metrics configuration
+     *
+     * @param metricsConfig     Metrics configuration
+     */
     void setMetricsConfig(MetricsConfig metricsConfig);
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -29,7 +29,7 @@ import lombok.EqualsAndHashCode;
     "producer", "resources", "jvmOptions", "logging", "clientRackInitImage", "rack",
     "enableMetrics", "livenessProbe", "readinessProbe", "template", "tracing"})
 @EqualsAndHashCode
-public class KafkaBridgeSpec extends Spec {
+public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging {
     private static final long serialVersionUID = 1L;
     private static final int DEFAULT_REPLICAS = 1;
 
@@ -77,10 +77,12 @@ public class KafkaBridgeSpec extends Spec {
 
     @Description("Logging configuration for Kafka Bridge.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -37,7 +37,7 @@ import java.util.Map;
     "version", "replicas", "image", "listeners", "config", "storage", "authorization", "rack", "brokerRackInitImage",
     "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
-public class KafkaClusterSpec implements HasConfigurableMetrics, HasJmxOptions, UnknownPropertyPreserving, Serializable {
+public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -126,10 +126,12 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasJmxOptions, 
 
     @Description("Logging configuration for Kafka")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMakerSpec.java
@@ -31,7 +31,7 @@ import lombok.EqualsAndHashCode;
     "logging", "metricsConfig", "tracing", "template"})
 @OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("include")), @OneOf.Alternative(@OneOf.Alternative.Property("whitelist"))})
 @EqualsAndHashCode
-public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics {
+public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging {
     private static final long serialVersionUID = 1L;
 
     private static final int DEFAULT_REPLICAS = 3;
@@ -153,10 +153,12 @@ public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics
 
     @Description("Logging configuration for MirrorMaker.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
     "replicas", "image", "storage", "config", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources",
     "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
-public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasJmxOptions, UnknownPropertyPreserving, Serializable {
+public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -82,10 +82,12 @@ public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasJmxOptio
 
     @Description("Logging configuration for ZooKeeper")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Override
     public Logging getLogging() {
         return logging;
     }
 
+    @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -23,6 +23,7 @@ import io.strimzi.api.kafka.model.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.template.KafkaExporterTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.model.securityprofiles.ContainerSecurityProviderContextImpl;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderContextImpl;
 import io.strimzi.operator.common.Reconciliation;
@@ -96,10 +97,6 @@ public class KafkaExporter extends AbstractModel {
 
         this.saramaLoggingEnabled = false;
         this.mountPath = "/var/lib/kafka";
-
-        // Kafka Exporter is all about metrics - they are always enabled
-        this.isMetricsEnabled = true;
-
     }
 
     /**
@@ -159,7 +156,7 @@ public class KafkaExporter extends AbstractModel {
 
     protected List<ContainerPort> getContainerPortList() {
         List<ContainerPort> portList = new ArrayList<>(1);
-        portList.add(ContainerUtils.createContainerPort(METRICS_PORT_NAME, METRICS_PORT));
+        portList.add(ContainerUtils.createContainerPort(MetricsModel.METRICS_PORT_NAME, MetricsModel.METRICS_PORT));
         return portList;
     }
 
@@ -210,8 +207,8 @@ public class KafkaExporter extends AbstractModel {
                 List.of(VolumeUtils.createTempDirVolumeMount(),
                         VolumeUtils.createVolumeMount(KAFKA_EXPORTER_CERTS_VOLUME_NAME, KAFKA_EXPORTER_CERTS_VOLUME_MOUNT),
                         VolumeUtils.createVolumeMount(CLUSTER_CA_CERTS_VOLUME_NAME, CLUSTER_CA_CERTS_VOLUME_MOUNT)),
-                ProbeGenerator.httpProbe(livenessProbeOptions, livenessPath, METRICS_PORT_NAME),
-                ProbeGenerator.httpProbe(readinessProbeOptions, readinessPath, METRICS_PORT_NAME),
+                ProbeGenerator.httpProbe(livenessProbeOptions, livenessPath, MetricsModel.METRICS_PORT_NAME),
+                ProbeGenerator.httpProbe(readinessProbeOptions, readinessPath, MetricsModel.METRICS_PORT_NAME),
                 imagePullPolicy
         );
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -81,7 +81,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         super(reconciliation, resource, KafkaMirrorMaker2Resources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE);
 
         this.serviceName = KafkaMirrorMaker2Resources.serviceName(cluster);
-        this.ancillaryConfigMapName = KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(cluster);
+        this.loggingAndMetricsConfigMapName = KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(cluster);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/MetricsAndLoggingUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/MetricsAndLoggingUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.strimzi.api.kafka.model.ExternalLogging;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.logging.SupportsLogging;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
+import io.strimzi.operator.common.MetricsAndLogging;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Shared methods for working with Metrics and Logging configurations. These methods are bundled because we store both
+ * logging and metrics in the same configuration map. So some parts of the logging and metrics processing are coupled.
+ */
+public class MetricsAndLoggingUtils {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(MetricsAndLoggingUtils.class.getName());
+
+    /**
+     * Creates a Metrics and Logging holder based on the operand logging configuration
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param configMapOperations   ConfigMap operator
+     * @param logging               Logging configuration
+     * @param metrics               Metrics configuration
+     *
+     * @return Future with the metrics and logging configuration holder
+     */
+    public static Future<MetricsAndLogging> metricsAndLogging(Reconciliation reconciliation,
+                                                              ConfigMapOperator configMapOperations,
+                                                              LoggingModel logging,
+                                                              MetricsModel metrics) {
+        return CompositeFuture
+                .join(metricsConfigMap(reconciliation, configMapOperations, metrics), loggingConfigMap(reconciliation, configMapOperations, logging))
+                .map(result -> new MetricsAndLogging(result.resultAt(0), result.resultAt(1)));
+    }
+
+    private static Future<ConfigMap> metricsConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, MetricsModel metrics) {
+        if (metrics != null && metrics.isEnabled()) {
+            return configMapOperations.getAsync(reconciliation.namespace(), metrics.getConfigMapName());
+        } else {
+            return Future.succeededFuture(null);
+        }
+    }
+
+    private static Future<ConfigMap> loggingConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, LoggingModel logging) {
+        if (logging != null && logging.getLogging() instanceof ExternalLogging externalLogging) {
+            if (externalLogging.getValueFrom() != null
+                    && externalLogging.getValueFrom().getConfigMapKeyRef() != null
+                    && externalLogging.getValueFrom().getConfigMapKeyRef().getName() != null) {
+                return configMapOperations.getAsync(reconciliation.namespace(), externalLogging.getValueFrom().getConfigMapKeyRef().getName());
+            } else {
+                LOGGER.warnCr(reconciliation, "External logging configuration does not specify logging ConfigMap");
+                throw new InvalidResourceException("External logging configuration does not specify logging ConfigMap");
+            }
+        } else {
+            return Future.succeededFuture(null);
+        }
+    }
+
+    /**
+     * Generates a metrics and logging ConfigMap according to configured defaults. This is used with most operands, but
+     * not all of them. Kafka brokers have own methods in the KafkaCluster class. So does the Bridge. And Kafka Exporter
+     * has no metrics or logging ConfigMap at all.
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param model                 AbstractModel instance possibly implementing SupportsLogging and SupportsMetrics interfaces
+     * @param metricsAndLogging     ConfigMaps with external logging and metrics configuration
+     *
+     * @return The generated ConfigMap.
+     */
+    public static Map<String, String> generateMetricsAndLogConfigMapData(Reconciliation reconciliation, AbstractModel model, MetricsAndLogging metricsAndLogging) {
+        Map<String, String> data = new HashMap<>(2);
+
+        if (model instanceof SupportsLogging supportsLogging) {
+            data.put(supportsLogging.logging().configMapKey(), supportsLogging.logging().loggingConfiguration(reconciliation, metricsAndLogging.loggingCm()));
+        }
+
+        if (model instanceof SupportsMetrics supportMetrics) {
+            String parseResult = supportMetrics.metrics().metricsJson(reconciliation, metricsAndLogging.metricsCm());
+            if (parseResult != null) {
+                data.put(MetricsModel.CONFIG_MAP_KEY, parseResult);
+            }
+        }
+
+        return data;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.CertificateAuthority;
-import io.strimzi.api.kafka.model.HasConfigurableMetrics;
 import io.strimzi.api.kafka.model.JvmOptions;
 import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.TlsSidecar;
@@ -551,19 +550,6 @@ public class ModelUtils {
                     .endNodeAffinity();
         }
         return builder;
-    }
-
-    /**
-     * Checks if the section of the custom resource has any metrics configuration and sets it in the AbstractModel.
-     *
-     * @param model                     The cluster model where the metrics will be configured
-     * @param resourceWithMetrics       The section of the resource with metrics configuration
-     */
-    public static void parseMetrics(AbstractModel model, HasConfigurableMetrics resourceWithMetrics)   {
-        if (resourceWithMetrics.getMetricsConfig() != null)    {
-            model.isMetricsEnabled = true;
-            model.setMetricsConfigInCm(resourceWithMetrics.getMetricsConfig());
-        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingModel.java
@@ -10,7 +10,7 @@ import io.strimzi.api.kafka.model.Logging;
 import io.strimzi.operator.common.Reconciliation;
 
 /**
- * Represents a model for components with enabled JMX access
+ * Represents a model for logging configuration
  */
 public class LoggingModel {
     /**
@@ -29,9 +29,9 @@ public class LoggingModel {
     private final boolean shouldPatchLoggerAppender;
 
     /**
-     * Constructs the JMX Model for managing JMX access to Strimzi
+     * Constructs the Logging Model for managing logging
      *
-     * @param specSection                   Custom resource section configuring the JMX access
+     * @param specSection                   Custom resource section configuring logging
      * @param defaultLogConfigBaseName      Base of the file name with the default logging configuration
      * @param isLog4j2                      Indicates whether this logging is based on Log4j1 or Log4j2
      * @param shouldPatchLoggerAppender     Indicates whether logger appenders should be patched or not

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingModel.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.logging;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.strimzi.api.kafka.model.HasConfigurableLogging;
+import io.strimzi.api.kafka.model.Logging;
+import io.strimzi.operator.common.Reconciliation;
+
+/**
+ * Represents a model for components with enabled JMX access
+ */
+public class LoggingModel {
+    /**
+     * Key under which the Log4j1 properties are stored in the ConfigMap
+     */
+    public static final String LOG4J1_CONFIG_MAP_KEY = "log4j.properties";
+
+    /**
+     * Key under which the Log4j2 properties are stored in the ConfigMap
+     */
+    public static final String LOG4J2_CONFIG_MAP_KEY = "log4j2.properties";
+
+    private final Logging logging;
+    private final String defaultLogConfigBaseName;
+    private final boolean isLog4j2; // Indicates whether Log4j2 is used => if set to false, uses Log4j1
+    private final boolean shouldPatchLoggerAppender;
+
+    /**
+     * Constructs the JMX Model for managing JMX access to Strimzi
+     *
+     * @param specSection                   Custom resource section configuring the JMX access
+     * @param defaultLogConfigBaseName      Base of the file name with the default logging configuration
+     * @param isLog4j2                      Indicates whether this logging is based on Log4j1 or Log4j2
+     * @param shouldPatchLoggerAppender     Indicates whether logger appenders should be patched or not
+     */
+    public LoggingModel(HasConfigurableLogging specSection, String defaultLogConfigBaseName, boolean isLog4j2, boolean shouldPatchLoggerAppender) {
+        LoggingUtils.validateLogging(specSection.getLogging());
+
+        this.logging = specSection.getLogging();
+        this.defaultLogConfigBaseName = defaultLogConfigBaseName;
+        this.isLog4j2 = isLog4j2;
+        this.shouldPatchLoggerAppender = shouldPatchLoggerAppender;
+    }
+
+    /**
+     * Generates the logging configuration as a String. The configuration is generated based on the default logging
+     * configuration files from resources, the (optional) inline logging configuration from the custom resource
+     * and the (optional) external logging configuration in a user-provided ConfigMap.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param externalCm        The user-provided ConfigMap with custom Log4j / Log4j2 file
+     *
+     * @return String with the Log4j / Log4j2 properties used for configuration
+     */
+    public String loggingConfiguration(Reconciliation reconciliation, ConfigMap externalCm) {
+        return LoggingUtils
+                .loggingConfiguration(
+                        reconciliation,
+                        this,
+                        externalCm
+                );
+    }
+
+    /**
+     * @return  The key under which the logging configuration should be stored in the Config Map
+     */
+    public String configMapKey()    {
+        return isLog4j2 ? LOG4J2_CONFIG_MAP_KEY : LOG4J1_CONFIG_MAP_KEY;
+    }
+
+    /**
+     * @return  The logging configuration from the custom resource
+     */
+    public Logging getLogging() {
+        return logging;
+    }
+
+    /**
+     * @return  Base of the file name with the default logging configuration
+     */
+    public String getDefaultLogConfigBaseName() {
+        return defaultLogConfigBaseName;
+    }
+
+    /**
+     * @return  Indicates whether this logging is based on Log4j1 or Log4j2
+     */
+    public boolean isLog4j2() {
+        return isLog4j2;
+    }
+
+    /**
+     * @return  Indicates whether logger appenders should be patched or not
+     */
+    public boolean isShouldPatchLoggerAppender() {
+        return shouldPatchLoggerAppender;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/SupportsLogging.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/SupportsLogging.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.logging;
+
+/**
+ * This interface is used for models which implement Logging support
+ */
+public interface SupportsLogging {
+    /**
+     * @return  Logging model
+     */
+    LoggingModel logging();
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/MetricsModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/MetricsModel.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.strimzi.api.kafka.model.HasConfigurableMetrics;
+import io.strimzi.api.kafka.model.JmxPrometheusExporterMetrics;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a model for components with configurable metrics
+ */
+public class MetricsModel {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(MetricsModel.class.getName());
+
+    /**
+     * Name of the Prometheus metrics port
+     */
+    public static final String METRICS_PORT_NAME = "tcp-prometheus";
+
+    /**
+     * Number of the Prometheus metrics port
+     */
+    public static final int METRICS_PORT = 9404;
+
+    /**
+     * Key under which the metrics configuration is stored in the ConfigMap
+     */
+    public static final String CONFIG_MAP_KEY = "metrics-config.json";
+
+    private final boolean isEnabled;
+    private final String configMapName;
+    private final String configMapKey;
+
+    /**
+     * Constructs the Metrics Model for managing configurable metrics to Strimzi
+     *
+     * @param specSection       Custom resource section configuring metrics
+     */
+    public MetricsModel(HasConfigurableMetrics specSection) {
+        if (specSection.getMetricsConfig() != null) {
+            if (specSection.getMetricsConfig() instanceof JmxPrometheusExporterMetrics jmxMetrics) {
+                validateJmxPrometheusExporterMetricsConfiguration(jmxMetrics);
+
+                this.isEnabled = true;
+                this.configMapName = jmxMetrics.getValueFrom().getConfigMapKeyRef().getName();
+                this.configMapKey = jmxMetrics.getValueFrom().getConfigMapKeyRef().getKey();
+            } else {
+                throw new InvalidResourceException("Unsupported metrics type " + specSection.getMetricsConfig().getType());
+            }
+        } else {
+            this.isEnabled = false;
+            this.configMapName = null;
+            this.configMapKey = null;
+        }
+    }
+
+    /**
+     * @return  True if metrics are enabled. False otherwise.
+     */
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    /**
+     * @return  The name of the Config Map with the metrics configuration
+     */
+    public String getConfigMapName() {
+        return configMapName;
+    }
+
+    /**
+     * @return  The key under which the metrics configuration is stored in the Config Map
+     */
+    public String getConfigMapKey() {
+        return configMapKey;
+    }
+
+    /**
+     * Generates Prometheus metrics configuration based on the JMXExporter configuration from the user-provided
+     * ConfigMap. When metrics are not enabled, returns null.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param configMap         ConfigMap with the metrics exporter configuration
+     *
+     * @return  String with JSON formatted metrics configuration or null if metrics are not enabled
+     */
+    public String metricsJson(Reconciliation reconciliation, ConfigMap configMap) {
+        if (isEnabled)  {
+            if (configMap == null) {
+                LOGGER.warnCr(reconciliation, "ConfigMap {} does not exist.", configMapName);
+                throw new InvalidConfigurationException("ConfigMap " + configMapName + " does not exist");
+            } else {
+                String data = configMap.getData().get(configMapKey);
+
+                if (data == null) {
+                    LOGGER.warnCr(reconciliation, "ConfigMap {} does not contain specified key {}.", configMapName, configMapKey);
+                    throw new InvalidConfigurationException("ConfigMap " + configMapName + " does not contain specified key " + configMapKey);
+                } else {
+                    if (data.isEmpty()) {
+                        return "{}";
+                    }
+
+                    try {
+                        ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+                        Object yaml = yamlReader.readValue(data, Object.class);
+                        ObjectMapper jsonWriter = new ObjectMapper();
+
+                        return jsonWriter.writeValueAsString(yaml);
+                    } catch (JsonProcessingException e) {
+                        throw new InvalidConfigurationException("Failed to parse metrics configuration", e);
+                    }
+                }
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Validates the JMX Prometheus Exporter Metrics configuration
+     *
+     * @param jmxMetrics    JMX Prometheus Exporter Metrics configuration which should be validated
+     */
+    /* test */ static void validateJmxPrometheusExporterMetricsConfiguration(JmxPrometheusExporterMetrics jmxMetrics)   {
+        List<String> errors = new ArrayList<>();
+
+        if (jmxMetrics.getValueFrom() != null
+                && jmxMetrics.getValueFrom().getConfigMapKeyRef() != null)   {
+            // The Config Map reference exists
+            if (jmxMetrics.getValueFrom().getConfigMapKeyRef().getName() == null
+                    || jmxMetrics.getValueFrom().getConfigMapKeyRef().getName().isEmpty())  {
+                errors.add("Name of the Config Map with metrics configuration is missing");
+            }
+
+            if (jmxMetrics.getValueFrom().getConfigMapKeyRef().getKey() == null
+                    || jmxMetrics.getValueFrom().getConfigMapKeyRef().getKey().isEmpty())  {
+                errors.add("The key under which the metrics configuration is stored in the ConfigMap is missing");
+            }
+        } else {
+            // The Config Map reference is missing
+            errors.add("Config Map reference is missing");
+        }
+
+        if (!errors.isEmpty())  {
+            throw new InvalidResourceException("Metrics configuration is invalid: " + errors);
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/SupportsMetrics.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/SupportsMetrics.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+/**
+ * This interface is used for models which implement Metrics support
+ */
+public interface SupportsMetrics {
+    /**
+     * @return  Metrics model
+     */
+    MetricsModel metrics();
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -45,6 +45,7 @@ import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaConnectorConfiguration;
+import io.strimzi.operator.cluster.model.MetricsAndLoggingUtils;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -352,7 +353,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @return                     Future for tracking the asynchronous result of getting the metrics and logging config map
      */
     protected Future<ConfigMap> generateMetricsAndLoggingConfigMap(Reconciliation reconciliation, String namespace, KafkaConnectCluster kafkaConnectCluster) {
-        return Util.metricsAndLogging(reconciliation, configMapOperations, namespace, kafkaConnectCluster.getLogging(), kafkaConnectCluster.getMetricsConfigInCm())
+        return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, kafkaConnectCluster.logging(), kafkaConnectCluster.metrics())
                 .compose(metricsAndLoggingCm -> Future.succeededFuture(kafkaConnectCluster.generateMetricsAndLogConfigMap(metricsAndLoggingCm)));
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -17,6 +17,7 @@ import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.MetricsAndLoggingUtils;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
@@ -164,7 +165,7 @@ public class CruiseControlReconciler {
      */
     protected Future<Void> metricsAndLoggingConfigMap() {
         if (cruiseControl != null)  {
-            return Util.metricsAndLogging(reconciliation, configMapOperator, reconciliation.namespace(), cruiseControl.getLogging(), cruiseControl.getMetricsConfigInCm())
+            return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, cruiseControl.logging(), cruiseControl.metrics())
                     .compose(metricsAndLogging -> {
                         ConfigMap logAndMetricsConfigMap = cruiseControl.generateMetricsAndLogConfigMap(metricsAndLogging);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.MetricsAndLoggingUtils;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
@@ -271,7 +272,7 @@ public class EntityOperatorReconciler {
      */
     protected Future<Void> topicOperagorConfigMap() {
         if (entityOperator != null && entityOperator.topicOperator() != null) {
-            return Util.metricsAndLogging(reconciliation, configMapOperator, reconciliation.namespace(), entityOperator.topicOperator().getLogging(), null)
+            return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.topicOperator().logging(), null)
                     .compose(logging ->
                             configMapOperator.reconcile(
                                     reconciliation,
@@ -295,7 +296,7 @@ public class EntityOperatorReconciler {
      */
     protected Future<Void> userOperatorConfigMap() {
         if (entityOperator != null && entityOperator.userOperator() != null) {
-            return Util.metricsAndLogging(reconciliation, configMapOperator, reconciliation.namespace(), entityOperator.userOperator().getLogging(), null)
+            return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, entityOperator.userOperator().logging(), null)
                     .compose(logging ->
                             configMapOperator.reconcile(
                                     reconciliation,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -22,7 +22,6 @@ import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectBuild;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
@@ -175,10 +174,10 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 .compose(i -> serviceOperations.reconcile(reconciliation, namespace, connect.getComponentName(), stableIdentities ? connect.generateHeadlessService() : null))
                 .compose(i -> generateMetricsAndLoggingConfigMap(reconciliation, namespace, connect))
                 .compose(logAndMetricsConfigMap -> {
-                    String logging = logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG);
+                    String logging = logAndMetricsConfigMap.getData().get(connect.logging().configMapKey());
                     podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     desiredLogging.set(logging);
-                    return configMapOperations.reconcile(reconciliation, namespace, connect.getAncillaryConfigMapName(), logAndMetricsConfigMap);
+                    return configMapOperations.reconcile(reconciliation, namespace, logAndMetricsConfigMap.getMetadata().getName(), logAndMetricsConfigMap);
                 })
                 .compose(i -> ReconcilerUtils.reconcileJmxSecret(reconciliation, secretOperations, connect))
                 .compose(i -> pfa.hasPodDisruptionBudgetV1() ? podDisruptionBudgetOperator.reconcile(reconciliation, namespace, connect.getComponentName(), connect.generatePodDisruptionBudget(stableIdentities)) : Future.succeededFuture())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -33,7 +33,6 @@ import io.strimzi.api.kafka.model.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.tracing.OpenTelemetryTracing;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.AuthenticationUtils;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
@@ -184,10 +183,10 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(i -> serviceOperations.reconcile(reconciliation, namespace, mirrorMaker2Cluster.getComponentName(), stableIdentities ? mirrorMaker2Cluster.generateHeadlessService() : null))
                 .compose(i -> generateMetricsAndLoggingConfigMap(reconciliation, namespace, mirrorMaker2Cluster))
                 .compose(logAndMetricsConfigMap -> {
-                    String logging = logAndMetricsConfigMap.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG);
+                    String logging = logAndMetricsConfigMap.getData().get(mirrorMaker2Cluster.logging().configMapKey());
                     podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     desiredLogging.set(logging);
-                    return configMapOperations.reconcile(reconciliation, namespace, mirrorMaker2Cluster.getAncillaryConfigMapName(), logAndMetricsConfigMap);
+                    return configMapOperations.reconcile(reconciliation, namespace, logAndMetricsConfigMap.getMetadata().getName(), logAndMetricsConfigMap);
                 })
                 .compose(i -> ReconcilerUtils.reconcileJmxSecret(reconciliation, secretOperations, mirrorMaker2Cluster))
                 .compose(i -> pfa.hasPodDisruptionBudgetV1() ? podDisruptionBudgetOperator.reconcile(reconciliation, namespace, mirrorMaker2Cluster.getComponentName(), mirrorMaker2Cluster.generatePodDisruptionBudget(stableIdentities)) : Future.succeededFuture())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -25,6 +25,7 @@ import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.DnsNameGenerator;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
+import io.strimzi.operator.cluster.model.MetricsAndLoggingUtils;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -464,11 +465,11 @@ public class ZooKeeperReconciler {
      * @return  Completes when the ConfigMap was successfully created or updated
      */
     protected Future<Void> loggingAndMetricsConfigMap() {
-        return Util.metricsAndLogging(reconciliation, configMapOperator, reconciliation.namespace(), zk.getLogging(), zk.getMetricsConfigInCm())
+        return MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperator, zk.logging(), zk.metrics())
                 .compose(metricsAndLogging -> {
                     ConfigMap logAndMetricsConfigMap = zk.generateConfigurationConfigMap(metricsAndLogging);
 
-                    loggingHash = Util.hashStub(logAndMetricsConfigMap.getData().get(zk.getAncillaryConfigMapKeyLogConfig()));
+                    loggingHash = Util.hashStub(logAndMetricsConfigMap.getData().get(zk.logging().configMapKey()));
 
                     return configMapOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.zookeeperMetricsAndLogConfigMapName(reconciliation.name()), logAndMetricsConfigMap)
                             .map((Void) null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -954,8 +954,9 @@ public class CruiseControlTest {
         Kafka kafkaAssembly = createKafka(cruiseControlSpec);
         CruiseControl cc = createCruiseControl(kafkaAssembly);
 
-        assertThat(cc.isMetricsEnabled(), is(true));
-        assertThat(cc.getMetricsConfigInCm(), is(metrics));
+        assertThat(cc.metrics().isEnabled(), is(true));
+        assertThat(cc.metrics().getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(cc.metrics().getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
@@ -965,8 +966,9 @@ public class CruiseControlTest {
 
         CruiseControl cc = createCruiseControl(kafkaAssembly);
 
-        assertThat(cc.isMetricsEnabled(), is(false));
-        assertThat(cc.getMetricsConfigInCm(), is(nullValue()));
+        assertThat(cc.metrics().isEnabled(), is(false));
+        assertThat(cc.metrics().getConfigMapName(), is(nullValue()));
+        assertThat(cc.metrics().getConfigMapKey(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -158,8 +158,8 @@ public class EntityTopicOperatorTest {
         assertThat(entityTopicOperator.kafkaBootstrapServers, is(KafkaResources.bootstrapServiceName(cluster) + ":" + KafkaCluster.REPLICATION_PORT));
         assertThat(entityTopicOperator.resourceLabels, is(ModelUtils.defaultResourceLabels(cluster)));
         assertThat(entityTopicOperator.topicMetadataMaxAttempts, is(toTopicMetadataMaxAttempts));
-        assertThat(entityTopicOperator.getLogging().getType(), is(topicOperatorLogging.getType()));
-        assertThat(((InlineLogging) entityTopicOperator.getLogging()).getLoggers(), is(topicOperatorLogging.getLoggers()));
+        assertThat(entityTopicOperator.logging().getLogging().getType(), is(topicOperatorLogging.getType()));
+        assertThat(((InlineLogging) entityTopicOperator.logging().getLogging()).getLoggers(), is(topicOperatorLogging.getLoggers()));
     }
 
     @ParallelTest
@@ -189,7 +189,7 @@ public class EntityTopicOperatorTest {
         assertThat(entityTopicOperator.readinessProbeOptions.getTimeoutSeconds(), is(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT));
         assertThat(entityTopicOperator.livenessProbeOptions.getInitialDelaySeconds(), is(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(entityTopicOperator.livenessProbeOptions.getTimeoutSeconds(), is(EntityTopicOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT));
-        assertThat(entityTopicOperator.getLogging(), is(nullValue()));
+        assertThat(entityTopicOperator.logging().getLogging(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -29,6 +29,7 @@ import io.strimzi.api.kafka.model.SystemProperty;
 import io.strimzi.api.kafka.model.SystemPropertyBuilder;
 import io.strimzi.api.kafka.model.template.EntityOperatorTemplateBuilder;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -82,7 +83,7 @@ public class EntityUserOperatorTest {
     private final int uoReconciliationInterval = 120;
 
     private final String metricsCMName = "metrics-cm";
-    private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics(AbstractModel.ANCILLARY_CM_KEY_METRICS, metricsCMName);
+    private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics(MetricsModel.CONFIG_MAP_KEY, metricsCMName);
     private final List<SystemProperty> javaSystemProperties = new ArrayList<>() {{
             add(new SystemPropertyBuilder().withName("javax.net.debug").withValue("verbose").build());
             add(new SystemPropertyBuilder().withName("something.else").withValue("42").build());
@@ -177,8 +178,8 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator.watchedNamespace(), is(uoWatchedNamespace));
         assertThat(entityUserOperator.reconciliationIntervalMs, is(uoReconciliationInterval * 1000L));
         assertThat(entityUserOperator.kafkaBootstrapServers, is(String.format("%s:%d", KafkaResources.bootstrapServiceName(cluster), EntityUserOperatorSpec.DEFAULT_BOOTSTRAP_SERVERS_PORT)));
-        assertThat(entityUserOperator.getLogging().getType(), is(userOperatorLogging.getType()));
-        assertThat(((InlineLogging) entityUserOperator.getLogging()).getLoggers(), is(userOperatorLogging.getLoggers()));
+        assertThat(entityUserOperator.logging().getLogging().getType(), is(userOperatorLogging.getType()));
+        assertThat(((InlineLogging) entityUserOperator.logging().getLogging()).getLoggers(), is(userOperatorLogging.getLoggers()));
         assertThat(entityUserOperator.secretPrefix, is(secretPrefix));
     }
 
@@ -205,7 +206,7 @@ public class EntityUserOperatorTest {
         assertThat(entityUserOperator.livenessProbeOptions.getInitialDelaySeconds(), is(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(entityUserOperator.livenessProbeOptions.getTimeoutSeconds(), is(EntityUserOperatorSpec.DEFAULT_HEALTHCHECK_TIMEOUT));
         assertThat(entityUserOperator.kafkaBootstrapServers, is(KafkaResources.bootstrapServiceName(cluster) + ":" + EntityUserOperatorSpec.DEFAULT_BOOTSTRAP_SERVERS_PORT));
-        assertThat(entityUserOperator.getLogging(), is(nullValue()));
+        assertThat(entityUserOperator.logging().getLogging(), is(nullValue()));
         assertThat(entityUserOperator.secretPrefix, is(EntityUserOperatorSpec.DEFAULT_SECRET_PREFIX));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -68,6 +68,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.Reconciliation;
@@ -160,7 +161,7 @@ public class KafkaConnectClusterTest {
     }
 
     private void checkMetricsConfigMap(ConfigMap metricsCm) {
-        assertThat(metricsCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS), is(metricsCmJson));
+        assertThat(metricsCm.getData().get(MetricsModel.CONFIG_MAP_KEY), is(metricsCmJson));
     }
 
     private Map<String, String> expectedLabels(String name)    {
@@ -1748,7 +1749,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(Map.of()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
-        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
+        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(MetricsModel.METRICS_PORT));
     }
 
     @ParallelTest
@@ -1770,7 +1771,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
-        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
+        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(MetricsModel.METRICS_PORT));
     }
 
     @ParallelTest
@@ -1792,7 +1793,7 @@ public class KafkaConnectClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(Collections.singletonMap("nsLabelKey", "nsLabelValue")));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
-        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
+        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(MetricsModel.METRICS_PORT));
     }
 
     @ParallelTest
@@ -1909,16 +1910,18 @@ public class KafkaConnectClusterTest {
 
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaConnect, VERSIONS);
 
-        assertThat(kc.isMetricsEnabled(), is(true));
-        assertThat(kc.getMetricsConfigInCm(), is(metrics));
+        assertThat(kc.metrics().isEnabled(), is(true));
+        assertThat(kc.metrics().getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(kc.metrics().getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, this.resource, VERSIONS);
 
-        assertThat(kc.isMetricsEnabled(), is(false));
-        assertThat(kc.getMetricsConfigInCm(), is(nullValue()));
+        assertThat(kc.metrics().isEnabled(), is(false));
+        assertThat(kc.metrics().getConfigMapName(), is(nullValue()));
+        assertThat(kc.metrics().getConfigMapKey(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -38,6 +38,7 @@ import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.TestUtils;
@@ -67,7 +68,7 @@ public class KafkaExporterTest {
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
     private final String metricsCMName = "metrics-cm";
-    private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics(AbstractModel.ANCILLARY_CM_KEY_METRICS, metricsCMName);
+    private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics(MetricsModel.CONFIG_MAP_KEY, metricsCMName);
     private final Map<String, Object> kafkaConfig = singletonMap("foo", "bar");
     private final Map<String, Object> zooConfig = singletonMap("foo", "bar");
     private final Storage kafkaStorage = new EphemeralStorage();
@@ -166,19 +167,19 @@ public class KafkaExporterTest {
         assertThat(containers.get(0).getImage(), is(ke.image));
         assertThat(containers.get(0).getEnv(), is(getExpectedEnvVars()));
         assertThat(containers.get(0).getPorts().size(), is(1));
-        assertThat(containers.get(0).getPorts().get(0).getName(), is(KafkaExporter.METRICS_PORT_NAME));
+        assertThat(containers.get(0).getPorts().get(0).getName(), is(MetricsModel.METRICS_PORT_NAME));
         assertThat(containers.get(0).getPorts().get(0).getProtocol(), is("TCP"));
         assertThat(dep.getSpec().getStrategy().getType(), is("RollingUpdate"));
 
         // Test healthchecks
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getHttpGet().getPath(), is("/healthz"));
-        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getHttpGet().getPort(), is(new IntOrString(KafkaExporter.METRICS_PORT_NAME)));
+        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getHttpGet().getPort(), is(new IntOrString(MetricsModel.METRICS_PORT_NAME)));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds(), is(KafkaExporter.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getPeriodSeconds(), is(KafkaExporter.DEFAULT_HEALTHCHECK_PERIOD));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds(), is(KafkaExporter.DEFAULT_HEALTHCHECK_TIMEOUT));
 
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getHttpGet().getPath(), is("/healthz"));
-        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getHttpGet().getPort(), is(new IntOrString(KafkaExporter.METRICS_PORT_NAME)));
+        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getHttpGet().getPort(), is(new IntOrString(MetricsModel.METRICS_PORT_NAME)));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds(), is(KafkaExporter.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getPeriodSeconds(), is(KafkaExporter.DEFAULT_HEALTHCHECK_PERIOD));
         assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds(), is(KafkaExporter.DEFAULT_HEALTHCHECK_TIMEOUT));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -61,6 +61,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -162,7 +163,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     private void checkMetricsConfigMap(ConfigMap metricsCm) {
-        assertThat(metricsCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS), is(metricsCmJson));
+        assertThat(metricsCm.getData().get(MetricsModel.CONFIG_MAP_KEY), is(metricsCmJson));
     }
 
     private Map<String, String> expectedLabels(String name)    {
@@ -1849,7 +1850,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(Map.of()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
-        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
+        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(MetricsModel.METRICS_PORT));
     }
 
     @ParallelTest
@@ -1872,7 +1873,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector(), is(nullValue()));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
-        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
+        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(MetricsModel.METRICS_PORT));
     }
 
     @ParallelTest
@@ -1895,7 +1896,7 @@ public class KafkaMirrorMaker2ClusterTest {
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getPodSelector().getMatchLabels(), is(singletonMap(Labels.STRIMZI_KIND_LABEL, "cluster-operator")));
         assertThat(np.getSpec().getIngress().get(0).getFrom().get(1).getNamespaceSelector().getMatchLabels(), is(Collections.singletonMap("nsLabelKey", "nsLabelValue")));
         assertThat(np.getSpec().getIngress().get(1).getPorts().size(), is(1));
-        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(KafkaConnectCluster.METRICS_PORT));
+        assertThat(np.getSpec().getIngress().get(1).getPorts().get(0).getPort().getIntVal(), is(MetricsModel.METRICS_PORT));
     }
 
 
@@ -1915,8 +1916,9 @@ public class KafkaMirrorMaker2ClusterTest {
 
         KafkaMirrorMaker2Cluster kmm = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, VERSIONS);
 
-        assertThat(kmm.isMetricsEnabled(), is(true));
-        assertThat(kmm.getMetricsConfigInCm(), is(metrics));
+        assertThat(kmm.metrics().isEnabled(), is(true));
+        assertThat(kmm.metrics().getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(kmm.metrics().getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
@@ -1963,8 +1965,9 @@ public class KafkaMirrorMaker2ClusterTest {
     public void testMetricsParsingNoMetrics() {
         KafkaMirrorMaker2Cluster kmm = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, this.resource, VERSIONS);
 
-        assertThat(kmm.isMetricsEnabled(), is(false));
-        assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
+        assertThat(kmm.metrics().isEnabled(), is(false));
+        assertThat(kmm.metrics().getConfigMapName(), is(nullValue()));
+        assertThat(kmm.metrics().getConfigMapKey(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -45,6 +45,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -137,7 +138,7 @@ public class KafkaMirrorMakerClusterTest {
     }
 
     private void checkMetricsConfigMap(ConfigMap metricsCm) {
-        assertThat(metricsCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS), is(metricsCmJson));
+        assertThat(metricsCm.getData().get(MetricsModel.CONFIG_MAP_KEY), is(metricsCmJson));
     }
 
     private Map<String, String> expectedLabels(String name)    {
@@ -1687,15 +1688,17 @@ public class KafkaMirrorMakerClusterTest {
 
         KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, mirrorMaker, VERSIONS);
 
-        assertThat(kmm.isMetricsEnabled(), is(true));
-        assertThat(kmm.getMetricsConfigInCm(), is(metrics));
+        assertThat(kmm.metrics().isEnabled(), is(true));
+        assertThat(kmm.metrics().getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(kmm.metrics().getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
     public void testMetricsParsingNoMetrics() {
         KafkaMirrorMakerCluster kmm = KafkaMirrorMakerCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, this.resource, VERSIONS);
 
-        assertThat(kmm.isMetricsEnabled(), is(false));
-        assertThat(kmm.getMetricsConfigInCm(), is(nullValue()));
+        assertThat(kmm.metrics().isEnabled(), is(false));
+        assertThat(kmm.metrics().getConfigMapName(), is(nullValue()));
+        assertThat(kmm.metrics().getConfigMapKey(), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/MetricsAndLoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/MetricsAndLoggingUtilsTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.strimzi.api.kafka.model.ExternalLoggingBuilder;
+import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectSpec;
+import io.strimzi.api.kafka.model.KafkaConnectSpecBuilder;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.logging.SupportsLogging;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
+import io.strimzi.operator.common.MetricsAndLogging;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
+import io.vertx.core.Future;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class MetricsAndLoggingUtilsTest {
+    @Test
+    public void testNoMetricsAndNoExternalLogging(VertxTestContext context)   {
+        LoggingModel logging = new LoggingModel(new KafkaConnectSpec(), "KafkaConnectCluster", false, true);
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().build());
+
+        ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
+
+        Checkpoint async = context.checkpoint();
+        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(v.loggingCm(), is(nullValue()));
+                    assertThat(v.metricsCm(), is(nullValue()));
+
+                    verify(mockCmOps, never()).getAsync(any(), any());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMetricsAndExternalLogging(VertxTestContext context)   {
+        LoggingModel logging = new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster", false, true);
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
+
+        ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
+        when(mockCmOps.getAsync(any(), eq("logging-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of()).build()));
+        when(mockCmOps.getAsync(any(), eq("metrics-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of()).build()));
+
+        Checkpoint async = context.checkpoint();
+        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(v.loggingCm(), is(notNullValue()));
+                    assertThat(v.loggingCm().getMetadata().getName(), is("logging-cm"));
+
+                    assertThat(v.metricsCm(), is(notNullValue()));
+                    assertThat(v.metricsCm().getMetadata().getName(), is("metrics-cm"));
+
+                    verify(mockCmOps, times(2)).getAsync(any(), any());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testNoMetricsAndExternalLogging(VertxTestContext context)   {
+        LoggingModel logging = new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster", false, true);
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().build());
+
+        ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
+        when(mockCmOps.getAsync(any(), eq("logging-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of()).build()));
+
+        Checkpoint async = context.checkpoint();
+        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(v.loggingCm(), is(notNullValue()));
+                    assertThat(v.loggingCm().getMetadata().getName(), is("logging-cm"));
+
+                    assertThat(v.metricsCm(), is(nullValue()));
+
+                    verify(mockCmOps, times(1)).getAsync(any(), any());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testMetricsAndNoExternalLogging(VertxTestContext context)   {
+        LoggingModel logging = new LoggingModel(new KafkaConnectSpec(), "KafkaConnectCluster", false, true);
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
+
+        ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
+        when(mockCmOps.getAsync(any(), eq("metrics-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of()).build()));
+
+        Checkpoint async = context.checkpoint();
+        MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(v.loggingCm(), is(nullValue()));
+
+                    assertThat(v.metricsCm(), is(notNullValue()));
+                    assertThat(v.metricsCm().getMetadata().getName(), is("metrics-cm"));
+
+                    verify(mockCmOps, times(1)).getAsync(any(), any());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testConfigMapDataNoMetricsNoLogging()   {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .build();
+
+        Map<String, String> data = MetricsAndLoggingUtils.generateMetricsAndLogConfigMapData(Reconciliation.DUMMY_RECONCILIATION, new ModelWithoutMetricsAndLogging(kafka), new MetricsAndLogging(null, null));
+
+        assertThat(data.size(), is(0));
+    }
+
+    @Test
+    public void testConfigMapDataWithMetricsAndLogging()   {
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                .endMetadata()
+                .build();
+
+        Map<String, String> data = MetricsAndLoggingUtils.generateMetricsAndLogConfigMapData(Reconciliation.DUMMY_RECONCILIATION, new ModelWithMetricsAndLogging(kafka), new MetricsAndLogging(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of("metrics.yaml", "")).build(), new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of("log4j.properties", "")).build()));
+
+        assertThat(data.size(), is(2));
+        assertThat(data.get(MetricsModel.CONFIG_MAP_KEY), is(notNullValue()));
+        assertThat(data.get(LoggingModel.LOG4J1_CONFIG_MAP_KEY), is(notNullValue()));
+    }
+
+    private static class ModelWithoutMetricsAndLogging extends AbstractModel   {
+        public ModelWithoutMetricsAndLogging(HasMetadata resource) {
+            super(new Reconciliation("test", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()), resource, resource.getMetadata().getName() + "-model-app", "model-app");
+        }
+    }
+
+    private static class ModelWithMetricsAndLogging extends AbstractModel implements SupportsMetrics, SupportsLogging {
+        public ModelWithMetricsAndLogging(HasMetadata resource) {
+            super(new Reconciliation("test", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()), resource, resource.getMetadata().getName() + "-model-app", "model-app");
+        }
+
+        @Override
+        public LoggingModel logging() {
+            return new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster", false, true);
+        }
+
+        @Override
+        public MetricsModel metrics() {
+            return new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -43,6 +43,7 @@ import io.strimzi.api.kafka.model.template.IpFamily;
 import io.strimzi.api.kafka.model.template.IpFamilyPolicy;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.PasswordGenerator;
@@ -170,9 +171,9 @@ public class ZookeeperClusterTest {
                 .build();
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS);
 
-        ConfigMap brokerCm = zc.generateMetricsAndLogConfigMap(new MetricsAndLogging(metricsCm, null));
+        ConfigMap brokerCm = zc.generateConfigurationConfigMap(new MetricsAndLogging(metricsCm, null));
         TestUtils.checkOwnerReference(brokerCm, KAFKA);
-        assertThat(brokerCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_METRICS), is("{\"animal\":\"wombat\"}"));
+        assertThat(brokerCm.getData().get(MetricsModel.CONFIG_MAP_KEY), is("{\"animal\":\"wombat\"}"));
     }
 
     @ParallelTest
@@ -970,14 +971,16 @@ public class ZookeeperClusterTest {
 
         ZookeeperCluster zc = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        assertThat(zc.isMetricsEnabled(), is(true));
-        assertThat(zc.getMetricsConfigInCm(), is(metrics));
+        assertThat(zc.metrics().isEnabled(), is(true));
+        assertThat(zc.metrics().getConfigMapName(), is("zoo-metrics-config"));
+        assertThat(zc.metrics().getConfigMapKey(), is("zoo-metrics-config.yml"));
     }
 
     @ParallelTest
     public void testMetricsParsingNoMetrics() {
-        assertThat(ZC.isMetricsEnabled(), is(false));
-        assertThat(ZC.getMetricsConfigInCm(), is(nullValue()));
+        assertThat(ZC.metrics().isEnabled(), is(false));
+        assertThat(ZC.metrics().getConfigMapName(), is(nullValue()));
+        assertThat(ZC.metrics().getConfigMapKey(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingModelTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.logging;
+
+import io.strimzi.api.kafka.model.InlineLoggingBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectSpecBuilder;
+import io.strimzi.operator.common.Reconciliation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class LoggingModelTest {
+    @Test
+    public void testLog4j1()   {
+        LoggingModel model = new LoggingModel(
+                new KafkaConnectSpecBuilder()
+                        .withLogging(new InlineLoggingBuilder().withLoggers(Map.of("log4j.logger.org.reflections", "DEBUG", "logger.myclass.level", "TRACE")).build())
+                        .build(),
+                "KafkaConnectCluster",
+                false,
+                true
+        );
+
+        assertThat(model.configMapKey(), is("log4j.properties"));
+        assertThat(model.getDefaultLogConfigBaseName(), is("KafkaConnectCluster"));
+        assertThat(model.isLog4j2(), is(false));
+        assertThat(model.isShouldPatchLoggerAppender(), is(true));
+        assertThat(model.loggingConfiguration(Reconciliation.DUMMY_RECONCILIATION, null), is("""
+                # Do not change this generated file. Logging can be configured in the corresponding Kubernetes resource.
+                log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+                log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+                log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
+                connect.root.logger.level=INFO
+                log4j.rootLogger=${connect.root.logger.level}, CONSOLE
+                log4j.logger.org.apache.zookeeper=ERROR
+                log4j.logger.org.I0Itec.zkclient=ERROR
+                log4j.logger.org.reflections=DEBUG
+                logger.myclass.level=TRACE
+                """));
+    }
+
+    @Test
+    public void testLog4j2()   {
+        LoggingModel model = new LoggingModel(
+                new KafkaConnectSpecBuilder().build(),
+                "KafkaConnectCluster",
+                true,
+                false
+        );
+
+        assertThat(model.configMapKey(), is("log4j2.properties"));
+        assertThat(model.getDefaultLogConfigBaseName(), is("KafkaConnectCluster"));
+        assertThat(model.isLog4j2(), is(true));
+        assertThat(model.isShouldPatchLoggerAppender(), is(false));
+        assertThat(model.loggingConfiguration(Reconciliation.DUMMY_RECONCILIATION, null), is("""
+                # Do not change this generated file. Logging can be configured in the corresponding Kubernetes resource.
+                log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+                log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+                log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
+                connect.root.logger.level=INFO
+                log4j.rootLogger=${connect.root.logger.level}, CONSOLE
+                log4j.logger.org.apache.zookeeper=ERROR
+                log4j.logger.org.I0Itec.zkclient=ERROR
+                log4j.logger.org.reflections=ERROR
+                                
+                monitorInterval=30
+                """));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/MetricsModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/MetricsModelTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
+import io.strimzi.api.kafka.model.JmxPrometheusExporterMetricsBuilder;
+import io.strimzi.api.kafka.model.KafkaConnectSpecBuilder;
+import io.strimzi.api.kafka.model.MetricsConfig;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.Reconciliation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MetricsModelTest {
+    @Test
+    public void testDisabled()   {
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().build());
+
+        assertThat(metrics.isEnabled(), is(false));
+        assertThat(metrics.getConfigMapName(), is(nullValue()));
+        assertThat(metrics.getConfigMapKey(), is(nullValue()));
+    }
+
+    @Test
+    public void testMetrics()   {
+        MetricsConfig metricsConfig = new JmxPrometheusExporterMetricsBuilder()
+                .withNewValueFrom()
+                    .withConfigMapKeyRef(new ConfigMapKeySelector("my-key", "my-name", false))
+                .endValueFrom()
+                .build();
+
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(metricsConfig).build());
+
+        assertThat(metrics.isEnabled(), is(true));
+        assertThat(metrics.getConfigMapName(), is("my-name"));
+        assertThat(metrics.getConfigMapKey(), is("my-key"));
+        assertThat(metrics.metricsJson(Reconciliation.DUMMY_RECONCILIATION, new ConfigMapBuilder().withData(Map.of("my-key", "")).build()), is("{}"));
+        assertThat(metrics.metricsJson(Reconciliation.DUMMY_RECONCILIATION, new ConfigMapBuilder().withData(Map.of("my-key", "foo: bar")).build()), is("{\"foo\":\"bar\"}"));
+    }
+
+    @Test
+    public void testProblemWithConfigMap()   {
+        MetricsConfig metricsConfig = new JmxPrometheusExporterMetricsBuilder()
+                .withNewValueFrom()
+                .withConfigMapKeyRef(new ConfigMapKeySelector("my-key", "my-name", false))
+                .endValueFrom()
+                .build();
+
+        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(metricsConfig).build());
+
+        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> metrics.metricsJson(Reconciliation.DUMMY_RECONCILIATION, null));
+        assertThat(ex.getMessage(), is("ConfigMap my-name does not exist"));
+
+        ex = assertThrows(InvalidConfigurationException.class, () -> metrics.metricsJson(Reconciliation.DUMMY_RECONCILIATION, new ConfigMapBuilder().withData(Map.of("other-key", "foo: bar")).build()));
+        assertThat(ex.getMessage(), is("ConfigMap my-name does not contain specified key my-key"));
+
+        ex = assertThrows(InvalidConfigurationException.class, () -> metrics.metricsJson(Reconciliation.DUMMY_RECONCILIATION, new ConfigMapBuilder().withData(Map.of("my-key", "foo: -")).build()));
+        assertThat(ex.getMessage(), startsWith("Failed to parse metrics configuration"));
+    }
+
+    @Test
+    public void testPrometheusJmxMetricsValidation() {
+        assertDoesNotThrow(() -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("my-key", "my-name", false)).endValueFrom().build()));
+
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector()).endValueFrom().build()));
+        assertThat(ex.getMessage(), is("Metrics configuration is invalid: [Name of the Config Map with metrics configuration is missing, The key under which the metrics configuration is stored in the ConfigMap is missing]"));
+
+        ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector(null, "my-name", false)).endValueFrom().build()));
+        assertThat(ex.getMessage(), is("Metrics configuration is invalid: [The key under which the metrics configuration is stored in the ConfigMap is missing]"));
+
+        ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().endValueFrom().build()));
+        assertThat(ex.getMessage(), is("Metrics configuration is invalid: [Config Map reference is missing]"));
+
+        ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().build()));
+        assertThat(ex.getMessage(), is("Metrics configuration is invalid: [Config Map reference is missing]"));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -61,6 +61,8 @@ import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.KafkaExporter;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.ListenersUtils;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.model.VolumeUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
@@ -986,7 +988,7 @@ public class KafkaAssemblyOperatorTest {
                 .withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(clusterName))
                 .withNamespace(clusterNamespace)
                 .endMetadata()
-                .withData(singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, TestUtils.toYamlString(METRICS_CONFIG)))
+                .withData(singletonMap(MetricsModel.CONFIG_MAP_KEY, TestUtils.toYamlString(METRICS_CONFIG)))
                 .build();
         when(mockCmOps.get(clusterNamespace, KafkaResources.zookeeperMetricsAndLogConfigMapName(clusterName))).thenReturn(zkMetricsCm);
 
@@ -994,8 +996,8 @@ public class KafkaAssemblyOperatorTest {
                 .withName(KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName))
                 .withNamespace(clusterNamespace)
                 .endMetadata()
-                .withData(singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG,
-                        updatedKafkaCluster.loggingConfiguration(null)))
+                .withData(singletonMap(LoggingModel.LOG4J1_CONFIG_MAP_KEY,
+                        updatedKafkaCluster.logging().loggingConfiguration(Reconciliation.DUMMY_RECONCILIATION, null)))
                 .build();
         when(mockCmOps.get(clusterNamespace, KafkaResources.kafkaMetricsAndLogConfigMapName(clusterName))).thenReturn(logCm);
 
@@ -1003,8 +1005,8 @@ public class KafkaAssemblyOperatorTest {
                 .withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(clusterName))
                 .withNamespace(clusterNamespace)
                 .endMetadata()
-                .withData(singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG,
-                        updatedZookeeperCluster.loggingConfiguration(null)))
+                .withData(singletonMap(LoggingModel.LOG4J1_CONFIG_MAP_KEY,
+                        updatedZookeeperCluster.logging().loggingConfiguration(Reconciliation.DUMMY_RECONCILIATION, null)))
                 .build();
         when(mockCmOps.get(clusterNamespace, KafkaResources.zookeeperMetricsAndLogConfigMapName(clusterName))).thenReturn(zklogsCm);
         when(mockCmOps.getAsync(clusterNamespace, metricsCMName)).thenReturn(Future.succeededFuture(metricsCM));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -19,13 +19,13 @@ import io.strimzi.api.kafka.model.KafkaBridgeHttpConfig;
 import io.strimzi.api.kafka.model.KafkaBridgeProducerSpec;
 import io.strimzi.api.kafka.model.KafkaBridgeResources;
 import io.strimzi.api.kafka.model.status.KafkaBridgeStatus;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.operator.resource.ClusterRoleBindingOperator;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaBridgeCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -317,7 +317,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                     .withName(KafkaBridgeResources.metricsAndLogConfigMapName(kbName))
                     .withNamespace(kbNamespace)
                 .endMetadata()
-                .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
+                .withData(Collections.singletonMap(MetricsModel.CONFIG_MAP_KEY, METRICS_CONFIG))
                 .build();
         when(mockCmOps.get(kbNamespace, KafkaBridgeResources.metricsAndLogConfigMapName(kbName))).thenReturn(metricsCm);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -27,13 +27,14 @@ import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.connect.build.BuildBuilder;
 import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
-import io.strimzi.operator.cluster.model.LoggingUtils;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.logging.LoggingUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -425,7 +426,7 @@ public class KafkaConnectAssemblyOperatorTest {
                     .withName(KafkaConnectResources.metricsAndLogConfigMapName(kcName))
                     .withNamespace(kcNamespace)
                 .endMetadata()
-                .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
+                .withData(Collections.singletonMap(MetricsModel.CONFIG_MAP_KEY, METRICS_CONFIG))
                 .build();
         when(mockCmOps.get(kcNamespace, KafkaConnectResources.metricsAndLogConfigMapName(kcName))).thenReturn(metricsCm);
 
@@ -433,7 +434,7 @@ public class KafkaConnectAssemblyOperatorTest {
                     .withName(KafkaConnectResources.metricsAndLogConfigMapName(kcName))
                     .withNamespace(kcNamespace)
                     .endMetadata()
-                    .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG, LOGGING_CONFIG))
+                    .withData(Collections.singletonMap(LoggingModel.LOG4J1_CONFIG_MAP_KEY, LOGGING_CONFIG))
                     .build();
 
         when(mockCmOps.get(kcNamespace, KafkaConnectResources.metricsAndLogConfigMapName(kcName))).thenReturn(metricsCm);
@@ -479,7 +480,7 @@ public class KafkaConnectAssemblyOperatorTest {
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(compareTo.getComponentName()));
 
-                String loggingConfiguration = loggingCm.getData().get(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG);
+                String loggingConfiguration = loggingCm.getData().get(LoggingModel.LOG4J1_CONFIG_MAP_KEY);
                 String dynamicallyUnmodifiableEntries = Util.getLoggingDynamicallyUnmodifiableEntries(loggingConfiguration);
                 String hashedLoggingConf = Util.hashStub(dynamicallyUnmodifiableEntries);
                 Map<String, String> annotations = new HashMap<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -19,13 +19,14 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2MirrorSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.status.KafkaMirrorMaker2Status;
-import io.strimzi.operator.cluster.model.LoggingUtils;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.logging.LoggingUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaMirrorMaker2Cluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -157,7 +158,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
-                if (mirrorMaker2.isMetricsEnabled()) {
+                if (mirrorMaker2.metrics().isEnabled()) {
                     metricsNames.add(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(kmm2Name));
                 }
 
@@ -343,7 +344,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                     .withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(kmm2Name))
                     .withNamespace(kmm2Namespace)
                 .endMetadata()
-                .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
+                .withData(Collections.singletonMap(MetricsModel.CONFIG_MAP_KEY, METRICS_CONFIG))
                 .build();
         when(mockCmOps.get(kmm2Namespace, KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(kmm2Name))).thenReturn(metricsCm);
 
@@ -351,7 +352,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                     .withName(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(kmm2Name))
                     .withNamespace(kmm2Namespace)
                     .endMetadata()
-                    .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG, LOGGING_CONFIG))
+                    .withData(Collections.singletonMap(LoggingModel.LOG4J1_CONFIG_MAP_KEY, LOGGING_CONFIG))
                     .build();
 
         when(mockCmOps.get(kmm2Namespace, KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(kmm2Name))).thenReturn(metricsCm);
@@ -390,7 +391,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(compareTo.getComponentName()));
                 Map<String, String> annotations = Map.of(
-                        Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(loggingCm.getData().get(KafkaMirrorMaker2Cluster.ANCILLARY_CM_KEY_LOG_CONFIG))),
+                        Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(loggingCm.getData().get(LoggingModel.LOG4J1_CONFIG_MAP_KEY))),
                         Annotations.ANNO_STRIMZI_AUTH_HASH, "0"
                 );
                 assertThat(dc, is(compareTo.generateDeployment(3, null, annotations, true, null, null, null)));
@@ -869,7 +870,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     // No metrics config  => no CMs created
                     Set<String> metricsNames = new HashSet<>();
-                    if (mirrorMaker2.isMetricsEnabled()) {
+                    if (mirrorMaker2.metrics().isEnabled()) {
                         metricsNames.add(KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(kmm2Name));
                     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -15,12 +15,13 @@ import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpecBuilder;
 import io.strimzi.api.kafka.model.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.status.KafkaMirrorMakerStatus;
-import io.strimzi.operator.cluster.model.LoggingUtils;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.logging.LoggingUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaMirrorMakerCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -151,7 +152,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // No metrics config  => no CMs created
                 Set<String> metricsNames = new HashSet<>();
-                if (mirror.isMetricsEnabled()) {
+                if (mirror.metrics().isEnabled()) {
                     metricsNames.add(KafkaMirrorMakerResources.metricsAndLogConfigMapName(kmmName));
                 }
 
@@ -316,7 +317,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                     .withName(KafkaMirrorMakerResources.metricsAndLogConfigMapName(kmmName))
                     .withNamespace(kmmNamespace)
                 .endMetadata()
-                .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_METRICS, METRICS_CONFIG))
+                .withData(Collections.singletonMap(MetricsModel.CONFIG_MAP_KEY, METRICS_CONFIG))
                 .build();
         when(mockCmOps.get(kmmNamespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(kmmName))).thenReturn(metricsCm);
 
@@ -324,7 +325,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                     .withName(KafkaMirrorMakerResources.metricsAndLogConfigMapName(kmmName))
                     .withNamespace(kmmNamespace)
                     .endMetadata()
-                    .withData(Collections.singletonMap(AbstractModel.ANCILLARY_CM_KEY_LOG_CONFIG, LOGGING_CONFIG))
+                    .withData(Collections.singletonMap(LoggingModel.LOG4J1_CONFIG_MAP_KEY, LOGGING_CONFIG))
                     .build();
 
         when(mockCmOps.get(kmmNamespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(kmmName))).thenReturn(metricsCm);
@@ -354,7 +355,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 Deployment dc = capturedDc.get(0);
                 assertThat(dc.getMetadata().getName(), is(compareTo.getComponentName()));
                 Map<String, String> annotations = new HashMap<>();
-                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(compareTo.ANCILLARY_CM_KEY_LOG_CONFIG));
+                annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, loggingCm.getData().get(LoggingModel.LOG4J1_CONFIG_MAP_KEY));
                 annotations.put(Annotations.ANNO_STRIMZI_AUTH_HASH, "0");
                 assertThat("Deployments are not equal", dc, is(compareTo.generateDeployment(annotations, true, null, null)));
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/MetricsAndLogging.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MetricsAndLogging.java
@@ -7,52 +7,6 @@ package io.strimzi.operator.common;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 
 /**
- * Holder class for Metrics and Logging configuration
+ * Holder record for ConfigMaps with Metrics and Logging configuration
  */
-public class MetricsAndLogging {
-    private ConfigMap metricsCm;
-    private ConfigMap loggingCm;
-
-    /**
-     * Constructs the holder
-     *
-     * @param metricsCm The Config Map with metrics configuration
-     * @param loggingCm The Config Map with logging configuration
-     */
-    public MetricsAndLogging(ConfigMap metricsCm, ConfigMap loggingCm) {
-        this.setMetricsCm(metricsCm);
-        this.setLoggingCm(loggingCm);
-    }
-
-    /**
-     * @return  Returns the metrics config map
-     */
-    public ConfigMap getMetricsCm() {
-        return metricsCm;
-    }
-
-    /**
-     * Sets the metrics config map
-     *
-     * @param metricsCm     Config Map with metrics configuration
-     */
-    public void setMetricsCm(ConfigMap metricsCm) {
-        this.metricsCm = metricsCm;
-    }
-
-    /**
-     * @return  Logging config map
-     */
-    public ConfigMap getLoggingCm() {
-        return loggingCm;
-    }
-
-    /**
-     * Sets the logging config map
-     *
-     * @param loggingCm Config Map with logging configuration
-     */
-    public void setLoggingCm(ConfigMap loggingCm) {
-        this.loggingCm = loggingCm;
-    }
-}
+public record MetricsAndLogging(ConfigMap metricsCm, ConfigMap loggingCm) { }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors metrics and logging handling in the `AbstractModel` class and its subclasses. It creates 2 new classes: `MetricsModel` and `LoggingModel` which wraps the logic with the help of some static methods in utils classes. This allows us to free the metrics and logging from the `AbstractModel` and use it only in the subclasses where they are actually applicable. (This is similar to how it was already done for JMX)

It also creates a new utils class `MetricsAndLoggingUtils` which groups some static methods to help with the metrics and logging Config Map. While the metrics and logging are seemingly unrelated, they end up in the same ConfigMap for the operands. So these methods deal with both and are grouped together.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally