### PR TITLE
Add bridge pipeline

### DIFF
--- a/.azure/bridge-pipeline.yaml
+++ b/.azure/bridge-pipeline.yaml
@@ -23,5 +23,6 @@ jobs:
   - template: 'templates/jobs/system-tests/bridge_jobs.yaml'
     parameters:
       releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
 
 

--- a/.azure/bridge-pipeline.yaml
+++ b/.azure/bridge-pipeline.yaml
@@ -1,0 +1,22 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then images will be built as part of the pipeline
+    default: "latest"
+
+jobs:
+  - template: 'templates/jobs/system-tests/bridge_jobs.yaml'
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
+
+

--- a/.azure/bridge-pipeline.yaml
+++ b/.azure/bridge-pipeline.yaml
@@ -13,6 +13,11 @@ parameters:
     type: string
     # If releaseVersion == latest then images will be built as part of the pipeline
     default: "latest"
+  - name: kafkaVersion
+    displayName: Kafka Version
+    type: string
+    # If kafkaVersion == latest, the latest supported version of Kafka is used
+    default: "latest"
 
 jobs:
   - template: 'templates/jobs/system-tests/bridge_jobs.yaml'

--- a/.azure/templates/jobs/system-tests/bridge_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/bridge_jobs.yaml
@@ -7,3 +7,4 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 240
       releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/bridge_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/bridge_jobs.yaml
@@ -1,0 +1,9 @@
+jobs:
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'bridge'
+      display_name: 'bridge-bundle'
+      profile: 'bridge'
+      cluster_operator_install_type: 'bundle'
+      timeout: 240
+      releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/jobs/system-tests/bridge_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/bridge_jobs.yaml
@@ -3,7 +3,7 @@ jobs:
     parameters:
       name: 'bridge'
       display_name: 'bridge-bundle'
-      profile: 'bridge'
+      profile: 'azp_bridge'
       cluster_operator_install_type: 'bundle'
       timeout: 240
       releaseVersion: '${{ parameters.releaseVersion }}'

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -524,6 +524,17 @@
         </profile>
 
         <profile>
+            <id>azp_bridge</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>bridge</groups>
+                <it.test>
+                    !olm/**/*ST,
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
             <id>scalability</id>
             <properties>
                 <skipTests>false</skipTests>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds a new pipeline to our Azure (i.e., bridge pipeline). When Paolo is doing a release of Bridge, and he wants to double-check it, he would need to run the whole regression instead of only the Bridge profile. So this should resolve such an issue.

### Checklist

- [x] Make sure all tests pass