### PR TITLE
Fix incorrect exception message in User Operator when custom password Secret is not found

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -300,7 +300,7 @@ public class KafkaUserOperator {
             // User is a SCRAM-SHA-512 user and requested some specific password instead of generating a random password
             desiredPasswordSecret = client.secrets().inNamespace(reconciliation.namespace()).withName(user.desiredPasswordSecretName()).get();
             if (desiredPasswordSecret == null) {
-                throw new InvalidResourceException("Secret " + config.getCaCertSecretName() + " in namespace " + config.getCaNamespace() + " with requested password not found");
+                throw new InvalidResourceException("Secret " + user.desiredPasswordSecretName() + " in namespace " + reconciliation.namespace() + " with requested password not found");
             }
         }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes incorrect exception message due to bad copy paste. The original message was using a wrong namespace and secret name -> this PR fixes it to use the correct one.