### PR TITLE
Move volume configuration, configuration and replicas from `AbstractModel`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/EntityOperatorSpec.java
@@ -29,9 +29,6 @@ public class EntityOperatorSpec implements UnknownPropertyPreserving, Serializab
 
     private static final long serialVersionUID = 1L;
 
-    public static final int DEFAULT_REPLICAS = 1;
-    public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
-
     private EntityTopicOperatorSpec topicOperator;
     private EntityUserOperatorSpec userOperator;
     private TlsSidecar tlsSidecar;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -29,8 +29,6 @@ public abstract class AbstractModel {
 
     protected static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractModel.class.getName());
 
-    protected static final String DEFAULT_JVM_XMS = "128M";
-
     /**
      * Init container related configuration
      */
@@ -58,23 +56,9 @@ public abstract class AbstractModel {
 
     // Docker image configuration
     protected String image;
-    // Number of replicas
-    protected int replicas;
 
-    /**
-     * Application configuration
-     */
-    protected AbstractConfiguration configuration;
     protected boolean gcLoggingEnabled = true;
     protected JvmOptions jvmOptions;
-
-    /**
-     * Base name used to name data volumes
-     */
-    public static final String VOLUME_NAME = "data";
-    protected String mountPath;
-    protected String logAndMetricsConfigMountPath;
-    protected String logAndMetricsConfigVolumeName;
 
     /**
      * Container configuration
@@ -114,13 +98,6 @@ public abstract class AbstractModel {
     }
 
     /**
-     * @return The number of replicas
-     */
-    public int getReplicas() {
-        return replicas;
-    }
-
-    /**
      * @return the default Kubernetes resource name.
      */
     public String getComponentName() {
@@ -132,22 +109,6 @@ public abstract class AbstractModel {
      */
     public Labels getSelectorLabels() {
         return labels.strimziSelectorLabels();
-    }
-
-    /**
-     * @return an implementation of AbstractConfiguration configured by a user for a component.
-     */
-    public AbstractConfiguration getConfiguration() {
-        return configuration;
-    }
-
-    /**
-     * Set the configuration object which may be configured by the user for some components.
-     *
-     * @param configuration Configuration settings for a component.
-     */
-    protected void setConfiguration(AbstractConfiguration configuration) {
-        this.configuration = configuration;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -100,7 +100,6 @@ public class EntityOperator extends AbstractModel {
     protected EntityOperator(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, KafkaResources.entityOperatorDeploymentName(resource.getMetadata().getName()), COMPONENT_TYPE);
 
-        this.replicas = EntityOperatorSpec.DEFAULT_REPLICAS;
         this.zookeeperConnect = KafkaResources.zookeeperServiceName(cluster) + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
     }
 
@@ -189,7 +188,7 @@ public class EntityOperator extends AbstractModel {
                 labels,
                 ownerReference,
                 templateDeployment,
-                replicas,
+                1,
                 null,
                 WorkloadUtils.deploymentStrategy(RECREATE), // we intentionally ignore the template here as EO doesn't support RU strategy
                 WorkloadUtils.createPodTemplateSpec(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -44,6 +44,9 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
     private static final String NAME_SUFFIX = "-entity-topic-operator";
     private static final String CERT_SECRET_KEY_NAME = "entity-operator";
 
+    private static final String LOG_AND_METRICS_CONFIG_VOLUME_NAME = "entity-topic-operator-metrics-and-logging";
+    private static final String LOG_AND_METRICS_CONFIG_VOLUME_MOUNT = "/opt/topic-operator/custom-config/";
+
     // Port configuration
     protected static final int HEALTHCHECK_PORT = 8080;
     protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
@@ -108,9 +111,6 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
         this.zookeeperSessionTimeoutMs = EntityTopicOperatorSpec.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_SECONDS * 1_000;
         this.resourceLabels = ModelUtils.defaultResourceLabels(cluster);
         this.topicMetadataMaxAttempts = EntityTopicOperatorSpec.DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
-
-        this.logAndMetricsConfigVolumeName = "entity-topic-operator-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/topic-operator/custom-config/";
     }
 
     /**
@@ -202,12 +202,12 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
     }
 
     protected List<Volume> getVolumes() {
-        return List.of(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, KafkaResources.entityTopicOperatorLoggingConfigMapName(cluster)));
+        return List.of(VolumeUtils.createConfigMapVolume(LOG_AND_METRICS_CONFIG_VOLUME_NAME, KafkaResources.entityTopicOperatorLoggingConfigMapName(cluster)));
     }
 
     private List<VolumeMount> getVolumeMounts() {
         return List.of(VolumeUtils.createTempDirVolumeMount(TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
-                VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
+                VolumeUtils.createVolumeMount(LOG_AND_METRICS_CONFIG_VOLUME_NAME, LOG_AND_METRICS_CONFIG_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.ETO_CERTS_VOLUME_NAME, EntityOperator.ETO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -45,6 +45,9 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
     private static final String NAME_SUFFIX = "-entity-user-operator";
     private static final String CERT_SECRET_KEY_NAME = "entity-operator";
 
+    private static final String LOG_AND_METRICS_CONFIG_VOLUME_NAME = "entity-user-operator-metrics-and-logging";
+    private static final String LOG_AND_METRICS_CONFIG_VOLUME_MOUNT = "/opt/user-operator/custom-config/";
+
     // Port configuration
     protected static final int HEALTHCHECK_PORT = 8081;
     protected static final String HEALTHCHECK_PORT_NAME = "healthcheck";
@@ -105,8 +108,6 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
         this.secretPrefix = EntityUserOperatorSpec.DEFAULT_SECRET_PREFIX;
         this.resourceLabels = ModelUtils.defaultResourceLabels(cluster);
 
-        this.logAndMetricsConfigVolumeName = "entity-user-operator-metrics-and-logging";
-        this.logAndMetricsConfigMountPath = "/opt/user-operator/custom-config/";
         this.clientsCaValidityDays = CertificateAuthority.DEFAULT_CERTS_VALIDITY_DAYS;
         this.clientsCaRenewalDays = CertificateAuthority.DEFAULT_CERTS_RENEWAL_DAYS;
     }
@@ -229,12 +230,12 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
     }
 
     protected List<Volume> getVolumes() {
-        return List.of(VolumeUtils.createConfigMapVolume(logAndMetricsConfigVolumeName, KafkaResources.entityUserOperatorLoggingConfigMapName(cluster)));
+        return List.of(VolumeUtils.createConfigMapVolume(LOG_AND_METRICS_CONFIG_VOLUME_NAME, KafkaResources.entityUserOperatorLoggingConfigMapName(cluster)));
     }
 
     private List<VolumeMount> getVolumeMounts() {
         return List.of(VolumeUtils.createTempDirVolumeMount(USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME),
-                VolumeUtils.createVolumeMount(logAndMetricsConfigVolumeName, logAndMetricsConfigMountPath),
+                VolumeUtils.createVolumeMount(LOG_AND_METRICS_CONFIG_VOLUME_NAME, LOG_AND_METRICS_CONFIG_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.EUO_CERTS_VOLUME_NAME, EntityOperator.EUO_CERTS_VOLUME_MOUNT),
                 VolumeUtils.createVolumeMount(EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT));
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JmxTrans.java
@@ -106,7 +106,6 @@ public class JmxTrans extends AbstractModel {
     protected JmxTrans(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, JmxTransResources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE);
 
-        this.replicas = 1;
         this.readinessProbeOptions = READINESS_PROBE_OPTIONS;
     }
 
@@ -176,7 +175,7 @@ public class JmxTrans extends AbstractModel {
                 labels,
                 ownerReference,
                 templateDeployment,
-                replicas,
+                1,
                 null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -89,14 +89,12 @@ public class KafkaExporter extends AbstractModel {
     protected KafkaExporter(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, KafkaExporterResources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE);
 
-        this.replicas = 1;
         this.readinessPath = "/healthz";
         this.readinessProbeOptions = READINESS_PROBE_OPTIONS;
         this.livenessPath = "/healthz";
         this.livenessProbeOptions = READINESS_PROBE_OPTIONS;
 
         this.saramaLoggingEnabled = false;
-        this.mountPath = "/var/lib/kafka";
     }
 
     /**
@@ -176,7 +174,7 @@ public class KafkaExporter extends AbstractModel {
                 labels,
                 ownerReference,
                 templateDeployment,
-                replicas,
+                1,
                 null,
                 WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
                 WorkloadUtils.createPodTemplateSpec(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -111,7 +111,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
                     .findFirst()
                     .orElseThrow(() -> new InvalidResourceException("connectCluster with alias " + connectClusterAlias + " cannot be found in the list of clusters at spec.clusters"));
         }        
-        result.setConfiguration(new KafkaMirrorMaker2Configuration(reconciliation, connectCluster.getConfig().entrySet()));
+        result.configuration = new KafkaMirrorMaker2Configuration(reconciliation, connectCluster.getConfig().entrySet());
 
         return fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, result);
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -52,6 +52,10 @@ import static java.util.Collections.emptyMap;
  * These are generally to be used within the classes that extend the AbstractModel class
  */
 public class ModelUtils {
+    /**
+     * Default JVM -Xms setting
+     */
+    protected static final String DEFAULT_JVM_XMS = "128M";
 
     private ModelUtils() {}
 
@@ -491,7 +495,7 @@ public class ModelUtils {
             } else if (xms == null) {
                 // When no memory limit, `Xms`, and `Xmx` are defined then set a default `Xms` and
                 // leave `Xmx` undefined.
-                kafkaHeapOpts.append("-Xms").append(AbstractModel.DEFAULT_JVM_XMS);
+                kafkaHeapOpts.append("-Xms").append(DEFAULT_JVM_XMS);
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -40,6 +40,10 @@ import io.strimzi.operator.common.Util;
  * Shared methods for working with Volume
  */
 public class VolumeUtils {
+    /**
+     * Base name used to name data volumes
+     */
+    public static final String DATA_VOLUME_NAME = "data";
     /*
      * Default values for the Strimzi temporary directory
      */
@@ -459,9 +463,9 @@ public class VolumeUtils {
                 throw new InvalidResourceException("The 'id' property is required for volumes in JBOD storage.");
             }
 
-            return AbstractModel.VOLUME_NAME + "-" + id;
+            return DATA_VOLUME_NAME + "-" + id;
         } else {
-            return AbstractModel.VOLUME_NAME;
+            return DATA_VOLUME_NAME;
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -189,7 +189,7 @@ public class CruiseControlTest {
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_USER).withValue(API_USER_NAME).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_PORT).withValue(Integer.toString(CruiseControl.REST_API_PORT)).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_HEALTHCHECK_PATH).withValue(API_HEALTHCHECK_PATH).build());
-        expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_KAFKA_HEAP_OPTS).withValue("-Xms" + AbstractModel.DEFAULT_JVM_XMS).build());
+        expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_KAFKA_HEAP_OPTS).withValue("-Xms" + ModelUtils.DEFAULT_JVM_XMS).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_CRUISE_CONTROL_CONFIGURATION).withValue(ccConfiguration.getConfiguration()).build());
 
         return expected;
@@ -933,7 +933,7 @@ public class CruiseControlTest {
         CruiseControl cruiseControlWithCustomGoals = createCruiseControl(resourceWithCustomGoals);
 
         String anomalyDetectionGoals =  cruiseControlWithCustomGoals
-                .getConfiguration().asOrderedProperties().asMap()
+                .configuration.asOrderedProperties().asMap()
                 .get(ANOMALY_DETECTION_CONFIG_KEY.getValue());
 
         assertThat(anomalyDetectionGoals, is(customGoals));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -127,7 +127,7 @@ public class EntityOperatorTest {
 
         assertThat(dep.getMetadata().getName(), is(KafkaResources.entityOperatorDeploymentName(cluster)));
         assertThat(dep.getMetadata().getNamespace(), is(namespace));
-        assertThat(dep.getSpec().getReplicas(), is(EntityOperatorSpec.DEFAULT_REPLICAS));
+        assertThat(dep.getSpec().getReplicas(), is(1));
         TestUtils.checkOwnerReference(dep, resource);
 
         assertThat(containers.size(), is(3));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -148,7 +148,7 @@ public class KafkaBridgeClusterTest {
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ResourceUtils.createEmptyKafkaBridge(namespace, cluster));
 
         assertThat(kbc.image, is("quay.io/strimzi/kafka-bridge:latest"));
-        assertThat(kbc.replicas, is(KafkaBridgeCluster.DEFAULT_REPLICAS));
+        assertThat(kbc.getReplicas(), is(KafkaBridgeCluster.DEFAULT_REPLICAS));
         assertThat(kbc.readinessProbeOptions.getInitialDelaySeconds(), is(KafkaBridgeCluster.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(kbc.readinessProbeOptions.getTimeoutSeconds(), is(KafkaBridgeCluster.DEFAULT_HEALTHCHECK_TIMEOUT));
         assertThat(kbc.livenessProbeOptions.getInitialDelaySeconds(), is(KafkaBridgeCluster.DEFAULT_HEALTHCHECK_DELAY));
@@ -157,7 +157,7 @@ public class KafkaBridgeClusterTest {
 
     @ParallelTest
     public void testFromCrd() {
-        assertThat(kbc.replicas, is(replicas));
+        assertThat(kbc.getReplicas(), is(replicas));
         assertThat(kbc.image, is(image));
         assertThat(kbc.readinessProbeOptions.getInitialDelaySeconds(), is(healthDelay));
         assertThat(kbc.readinessProbeOptions.getTimeoutSeconds(), is(healthTimeout));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -750,7 +750,7 @@ public class KafkaClusterTest {
 
         for (int i = 0; i < REPLICAS; i++) {
             assertThat(pvcs.get(0).getMetadata().getName() + "-" + KafkaResources.kafkaPodName(CLUSTER, i),
-                    is(KafkaCluster.VOLUME_NAME + "-" + KafkaResources.kafkaPodName(CLUSTER, i)));
+                    is(VolumeUtils.DATA_VOLUME_NAME + "-" + KafkaResources.kafkaPodName(CLUSTER, i)));
         }
 
         assembly = new KafkaBuilder(KAFKA)
@@ -771,7 +771,7 @@ public class KafkaClusterTest {
             int id = 0;
             for (PersistentVolumeClaim pvc : pvcs) {
                 assertThat(pvc.getMetadata().getName() + "-" + KafkaResources.kafkaPodName(CLUSTER, i),
-                        is(KafkaCluster.VOLUME_NAME + "-" + id++ + "-" + KafkaResources.kafkaPodName(CLUSTER, i)));
+                        is(VolumeUtils.DATA_VOLUME_NAME + "-" + id++ + "-" + KafkaResources.kafkaPodName(CLUSTER, i)));
             }
         }
     }
@@ -799,7 +799,7 @@ public class KafkaClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -824,7 +824,7 @@ public class KafkaClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -865,7 +865,7 @@ public class KafkaClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -911,7 +911,7 @@ public class KafkaClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -926,7 +926,7 @@ public class KafkaClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-st1-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -955,7 +955,7 @@ public class KafkaClusterTest {
             PersistentVolumeClaim pvc = pvcs.get(i);
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -964,7 +964,7 @@ public class KafkaClusterTest {
             PersistentVolumeClaim pvc = pvcs.get(i);
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("1000Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-st1"));
-            assertThat(pvc.getMetadata().getName().startsWith(KafkaCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -121,7 +121,7 @@ public class KafkaConnectClusterTest {
     private final JmxPrometheusExporterMetrics jmxMetricsConfig = io.strimzi.operator.cluster.TestUtils.getJmxPrometheusExporterMetrics("metrics-config.yml", metricsCMName);
     private final String configurationJson = "foo: bar";
     private final String bootstrapServers = "foo-kafka:9092";
-    private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
+    private final String kafkaHeapOpts = "-Xms" + ModelUtils.DEFAULT_JVM_XMS;
 
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
             .addPair("offset.storage.topic", "connect-cluster-offsets")
@@ -205,23 +205,23 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ResourceUtils.createEmptyKafkaConnect(namespace, clusterName), VERSIONS);
 
         assertThat(kc.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_CONNECT_IMAGE));
-        assertThat(kc.replicas, is(KafkaConnectCluster.DEFAULT_REPLICAS));
+        assertThat(kc.getReplicas(), is(KafkaConnectCluster.DEFAULT_REPLICAS));
         assertThat(kc.readinessProbeOptions.getInitialDelaySeconds(), is(KafkaConnectCluster.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(kc.readinessProbeOptions.getTimeoutSeconds(), is(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT));
         assertThat(kc.livenessProbeOptions.getInitialDelaySeconds(), is(KafkaConnectCluster.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(kc.livenessProbeOptions.getTimeoutSeconds(), is(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT));
-        assertThat(kc.getConfiguration().asOrderedProperties(), is(defaultConfiguration));
+        assertThat(kc.configuration.asOrderedProperties(), is(defaultConfiguration));
     }
 
     @ParallelTest
     public void testFromCrd() {
-        assertThat(kc.replicas, is(replicas));
+        assertThat(kc.getReplicas(), is(replicas));
         assertThat(kc.image, is(image));
         assertThat(kc.readinessProbeOptions.getInitialDelaySeconds(), is(healthDelay));
         assertThat(kc.readinessProbeOptions.getTimeoutSeconds(), is(healthTimeout));
         assertThat(kc.livenessProbeOptions.getInitialDelaySeconds(), is(healthDelay));
         assertThat(kc.livenessProbeOptions.getTimeoutSeconds(), is(healthTimeout));
-        assertThat(kc.getConfiguration().asOrderedProperties(), is(expectedConfiguration));
+        assertThat(kc.configuration.asOrderedProperties(), is(expectedConfiguration));
         assertThat(kc.bootstrapServers, is(bootstrapServers));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -109,7 +109,7 @@ public class KafkaMirrorMaker2ClusterTest {
     private final String configurationJson = "foo: bar";
     private final String bootstrapServers = "foo-kafka:9092";
     private final String targetClusterAlias = "target";
-    private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
+    private final String kafkaHeapOpts = "-Xms" + ModelUtils.DEFAULT_JVM_XMS;
 
     private final OrderedProperties defaultConfiguration = new OrderedProperties()
             .addPair("config.storage.topic", "mirrormaker2-cluster-configs")
@@ -206,23 +206,23 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, clusterName), VERSIONS);
 
         assertThat(kmm2.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_CONNECT_IMAGE));
-        assertThat(kmm2.replicas, is(KafkaMirrorMaker2Cluster.DEFAULT_REPLICAS));
+        assertThat(kmm2.getReplicas(), is(KafkaMirrorMaker2Cluster.DEFAULT_REPLICAS));
         assertThat(kmm2.readinessProbeOptions.getInitialDelaySeconds(), is(KafkaMirrorMaker2Cluster.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(kmm2.readinessProbeOptions.getTimeoutSeconds(), is(KafkaMirrorMaker2Cluster.DEFAULT_HEALTHCHECK_TIMEOUT));
         assertThat(kmm2.livenessProbeOptions.getInitialDelaySeconds(), is(KafkaMirrorMaker2Cluster.DEFAULT_HEALTHCHECK_DELAY));
         assertThat(kmm2.livenessProbeOptions.getTimeoutSeconds(), is(KafkaMirrorMaker2Cluster.DEFAULT_HEALTHCHECK_TIMEOUT));
-        assertThat(kmm2.getConfiguration().asOrderedProperties(), is(defaultConfiguration));
+        assertThat(kmm2.configuration.asOrderedProperties(), is(defaultConfiguration));
     }
 
     @ParallelTest
     public void testFromCrd() {
-        assertThat(kmm2.replicas, is(replicas));
+        assertThat(kmm2.getReplicas(), is(replicas));
         assertThat(kmm2.image, is(image));
         assertThat(kmm2.readinessProbeOptions.getInitialDelaySeconds(), is(healthDelay));
         assertThat(kmm2.readinessProbeOptions.getTimeoutSeconds(), is(healthTimeout));
         assertThat(kmm2.livenessProbeOptions.getInitialDelaySeconds(), is(healthDelay));
         assertThat(kmm2.livenessProbeOptions.getTimeoutSeconds(), is(healthTimeout));
-        assertThat(kmm2.getConfiguration().asOrderedProperties(), is(expectedConfiguration));
+        assertThat(kmm2.configuration.asOrderedProperties(), is(expectedConfiguration));
         assertThat(kmm2.bootstrapServers, is(bootstrapServers));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -97,7 +97,7 @@ public class KafkaMirrorMakerClusterTest {
     private final String include = ".*";
     private final int offsetCommitInterval = 42000;
     private final boolean abortOnSendFailure = false;
-    private final String kafkaHeapOpts = "-Xms" + AbstractModel.DEFAULT_JVM_XMS;
+    private final String kafkaHeapOpts = "-Xms" + ModelUtils.DEFAULT_JVM_XMS;
 
     private final KafkaMirrorMakerProducerSpec producer = new KafkaMirrorMakerProducerSpecBuilder()
             .withBootstrapServers(producerBootstrapServers)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -326,7 +326,7 @@ public class ModelUtilsTest {
     @ParallelTest
     public void testJvmMemoryOptionsDefaultWithNoMemoryLimitOrJvmOptions() {
         Map<String, String> env = heapOptions(jvmOptions(null, null), 50, 5_000_000_000L, null);
-        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms" + AbstractModel.DEFAULT_JVM_XMS));
+        assertThat(env.get(AbstractModel.ENV_VAR_KAFKA_HEAP_OPTS), is("-Xms" + ModelUtils.DEFAULT_JVM_XMS));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_PERCENTAGE), is(nullValue()));
         assertThat(env.get(AbstractModel.ENV_VAR_DYNAMIC_HEAP_MAX), is(nullValue()));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -122,7 +122,7 @@ public class ZookeeperClusterPodSetTest {
             assertThat(io.strimzi.operator.cluster.TestUtils.containerEnvVars(pod.getSpec().getContainers().get(0)).get(ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is(Boolean.toString(JvmOptions.DEFAULT_GC_LOGGING_ENABLED)));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.VOLUME_NAME));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(VolumeUtils.DATA_VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/lib/zookeeper"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("zookeeper-metrics-and-logging"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/opt/kafka/custom-config/"));
@@ -338,7 +338,7 @@ public class ZookeeperClusterPodSetTest {
             assertThat(io.strimzi.operator.cluster.TestUtils.containerEnvVars(pod.getSpec().getContainers().get(0)).get(ZookeeperCluster.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED), is("true"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(0).getMountPath(), is(VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH));
-            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(AbstractModel.VOLUME_NAME));
+            assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getName(), is(VolumeUtils.DATA_VOLUME_NAME));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(1).getMountPath(), is("/var/lib/zookeeper"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getName(), is("zookeeper-metrics-and-logging"));
             assertThat(pod.getSpec().getContainers().get(0).getVolumeMounts().get(2).getMountPath(), is("/opt/kafka/custom-config/"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -390,7 +390,7 @@ public class ZookeeperClusterTest {
 
         for (int i = 0; i < REPLICAS; i++) {
             assertThat(pvc.getMetadata().getName() + "-" + KafkaResources.zookeeperPodName(CLUSTER, i),
-                    is(ZookeeperCluster.VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(CLUSTER, i)));
+                    is(VolumeUtils.DATA_VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(CLUSTER, i)));
         }
     }
 
@@ -659,7 +659,7 @@ public class ZookeeperClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(1));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("true"));
         }
@@ -684,7 +684,7 @@ public class ZookeeperClusterTest {
         for (PersistentVolumeClaim pvc : pvcs) {
             assertThat(pvc.getSpec().getResources().getRequests().get("storage"), is(new Quantity("100Gi")));
             assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd"));
-            assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }
@@ -725,7 +725,7 @@ public class ZookeeperClusterTest {
                 assertThat(pvc.getSpec().getStorageClassName(), is("gp2-ssd-az1"));
             }
 
-            assertThat(pvc.getMetadata().getName().startsWith(ZookeeperCluster.VOLUME_NAME), is(true));
+            assertThat(pvc.getMetadata().getName().startsWith(VolumeUtils.DATA_VOLUME_NAME), is(true));
             assertThat(pvc.getMetadata().getOwnerReferences().size(), is(0));
             assertThat(pvc.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM), is("false"));
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/JbodStorageMockTest.java
@@ -23,7 +23,6 @@ import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.VolumeUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -316,7 +315,7 @@ public class JbodStorageMockTest {
         for (int i = 0; i < kafka.getSpec().getKafka().getReplicas(); i++) {
             for (SingleVolumeStorage volume : ((JbodStorage) kafka.getSpec().getKafka().getStorage()).getVolumes()) {
                 if (volume instanceof PersistentClaimStorage) {
-                    expectedPvcs.add(AbstractModel.VOLUME_NAME + "-" + volume.getId() + "-"
+                    expectedPvcs.add(VolumeUtils.DATA_VOLUME_NAME + "-" + volume.getId() + "-"
                             + KafkaResources.kafkaPodName(NAME, i));
                 }
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -54,7 +54,6 @@ import io.strimzi.operator.cluster.ClusterOperator;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
-import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.KafkaCluster;
@@ -544,7 +543,7 @@ public class KafkaAssemblyOperatorTest {
         when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         Map<String, PersistentVolumeClaim> zkPvcs = createPvcs(kafkaNamespace, zookeeperCluster.getStorage(), zookeeperCluster.getReplicas(),
-            (replica, storageId) -> AbstractModel.VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(kafkaName, replica));
+            (replica, storageId) -> VolumeUtils.DATA_VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(kafkaName, replica));
 
         Map<String, PersistentVolumeClaim> kafkaPvcs = createPvcs(kafkaNamespace, kafkaCluster.getStorage(), kafkaCluster.getReplicas(),
             (replica, storageId) -> {
@@ -918,9 +917,9 @@ public class KafkaAssemblyOperatorTest {
 
         Map<String, PersistentVolumeClaim> zkPvcs =
                 createPvcs(clusterNamespace, originalZookeeperCluster.getStorage(), originalZookeeperCluster.getReplicas(),
-                    (replica, storageId) -> AbstractModel.VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(clusterName, replica));
+                    (replica, storageId) -> VolumeUtils.DATA_VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(clusterName, replica));
         zkPvcs.putAll(createPvcs(clusterNamespace, updatedZookeeperCluster.getStorage(), updatedZookeeperCluster.getReplicas(),
-            (replica, storageId) -> AbstractModel.VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(clusterName, replica)));
+            (replica, storageId) -> VolumeUtils.DATA_VOLUME_NAME + "-" + KafkaResources.zookeeperPodName(clusterName, replica)));
 
         Map<String, PersistentVolumeClaim> kafkaPvcs =
                 createPvcs(clusterNamespace, originalKafkaCluster.getStorage(), originalKafkaCluster.getReplicas(),


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR contains another set of refactorings for the AbstractModel and its subclasses. It removes some object variables to static variables such as the volume mount paths and volume names which are used only in the Kafka and ZooKeeper classes or the log and metrics mount paths and volume names which differ in every subclass, but are used only within the subclass ad are also static in their nature.

It also moves some of the object variables used only in some subclasses from `AbstractModel` to the lower levels - this includes `configuration` and `replicas`. And it moves some static variables not used in the AbstractModel and its subclasses directly to other places (e.g. the `VOLUME_NAME` to `VolumeUtils`).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally