### PR TITLE
Warning on `KafkaRebalance` deletion during rebalancing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1064,7 +1064,7 @@ public class KafkaRebalanceAssemblyOperator
                                 p.complete(new MapAndStatus<>(null, currentKafkaRebalance.getStatus()));
                             }
                         } else {
-                            LOGGER.debugCr(reconciliation, "Rebalance resource was deleted, stopping the request time");
+                            LOGGER.warnCr(reconciliation, "Rebalance resource was deleted, rebalancing is still in progress but the status won't be reported");
                             vertx.cancelTimer(t);
                             p.complete();
                         }


### PR DESCRIPTION
Trivial PR to log a WARN message when a `KafkaRebalance` resource is deleted during the rebalancing so it's not possible to report back the status of the task.
This is related to this discussion https://github.com/orgs/strimzi/discussions/8233