### PR TITLE
Allow scale up/down in KRaft mode

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -63,6 +63,11 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
     echo "Kraft storage is already formatted"
   fi
 
+  if [ -f "$KRAFT_LOG_DIR/__cluster_metadata-0/quorum-state" ]; then
+    echo "Removing quorum-state file"
+    rm -f "$KRAFT_LOG_DIR/__cluster_metadata-0/quorum-state"
+  fi
+
 else
   rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
   KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -63,6 +63,7 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
     echo "Kraft storage is already formatted"
   fi
 
+  # remove quorum-state file so that we won't enter voter not match error after scaling up/down
   if [ -f "$KRAFT_LOG_DIR/__cluster_metadata-0/quorum-state" ]; then
     echo "Removing quorum-state file"
     rm -f "$KRAFT_LOG_DIR/__cluster_metadata-0/quorum-state"

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -467,7 +467,7 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     protected void testDockerImagesForKafkaCluster(String clusterName, String clusterOperatorNamespaceName, String kafkaNamespaceName,
-                                                   int kafkaPods, int zkPods, boolean rackAwareEnabled, boolean isKRaftEnabled) {
+                                                   int kafkaPods, int zkPods, boolean rackAwareEnabled) {
         LOGGER.info("Verifying docker image names");
         //Verifying docker image for cluster-operator
 
@@ -478,7 +478,7 @@ public abstract class AbstractST implements TestSeparator {
             kafkaVersion = Environment.ST_KAFKA_VERSION;
         }
 
-        if (!isKRaftEnabled) {
+        if (!Environment.isKRaftModeEnabled()) {
             //Verifying docker image for zookeeper pods
             for (int i = 0; i < zkPods; i++) {
                 String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, KafkaResources.zookeeperPodName(clusterName, i), "zookeeper");
@@ -503,7 +503,7 @@ public abstract class AbstractST implements TestSeparator {
         String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "user-operator");
         assertThat(imgFromPod, containsString(imgFromDeplConf.get(UO_IMAGE)));
 
-        if (!isKRaftEnabled) {
+        if (!Environment.isKRaftModeEnabled()) {
             imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "topic-operator");
             assertThat(imgFromPod, containsString(imgFromDeplConf.get(TO_IMAGE)));
             imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "tls-sidecar");

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -467,7 +467,7 @@ public abstract class AbstractST implements TestSeparator {
     }
 
     protected void testDockerImagesForKafkaCluster(String clusterName, String clusterOperatorNamespaceName, String kafkaNamespaceName,
-                                                   int kafkaPods, int zkPods, boolean rackAwareEnabled) {
+                                                   int kafkaPods, int zkPods, boolean rackAwareEnabled, boolean isKRaftEnabled) {
         LOGGER.info("Verifying docker image names");
         //Verifying docker image for cluster-operator
 
@@ -478,10 +478,12 @@ public abstract class AbstractST implements TestSeparator {
             kafkaVersion = Environment.ST_KAFKA_VERSION;
         }
 
-        //Verifying docker image for zookeeper pods
-        for (int i = 0; i < zkPods; i++) {
-            String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, KafkaResources.zookeeperPodName(clusterName, i), "zookeeper");
-            assertThat("Zookeeper pod " + i + " uses wrong image", imgFromPod, containsString(TestUtils.parseImageMap(imgFromDeplConf.get(KAFKA_IMAGE_MAP)).get(kafkaVersion)));
+        if (!isKRaftEnabled) {
+            //Verifying docker image for zookeeper pods
+            for (int i = 0; i < zkPods; i++) {
+                String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, KafkaResources.zookeeperPodName(clusterName, i), "zookeeper");
+                assertThat("Zookeeper pod " + i + " uses wrong image", imgFromPod, containsString(TestUtils.parseImageMap(imgFromDeplConf.get(KAFKA_IMAGE_MAP)).get(kafkaVersion)));
+            }
         }
 
         //Verifying docker image for kafka pods
@@ -497,12 +499,16 @@ public abstract class AbstractST implements TestSeparator {
         //Verifying docker image for entity-operator
         String entityOperatorPodName = cmdKubeClient(kafkaNamespaceName).listResourcesByLabel("pod",
                 Labels.STRIMZI_NAME_LABEL + "=" + clusterName + "-entity-operator").get(0);
-        String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "topic-operator");
-        assertThat(imgFromPod, containsString(imgFromDeplConf.get(TO_IMAGE)));
-        imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "user-operator");
+
+        String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "user-operator");
         assertThat(imgFromPod, containsString(imgFromDeplConf.get(UO_IMAGE)));
-        imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "tls-sidecar");
-        assertThat(imgFromPod, containsString(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE)));
+
+        if (!isKRaftEnabled) {
+            imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "topic-operator");
+            assertThat(imgFromPod, containsString(imgFromDeplConf.get(TO_IMAGE)));
+            imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "tls-sidecar");
+            assertThat(imgFromPod, containsString(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE)));
+        }
 
         LOGGER.info("Docker images verified");
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -41,6 +41,7 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.systemtest.annotations.ParallelSuite;
@@ -342,8 +343,7 @@ class RollingUpdateST extends AbstractST {
         resourceManager.createResource(extensionContext, clients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForConsumerClientSuccess(testStorage);
 
-        assertThat(kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getClusterName()).stream()
-            .filter(pvc -> pvc.getMetadata().getName().contains("data-" + testStorage.getKafkaStatefulSetName())).collect(Collectors.toList()).size(), is(initialReplicas));
+        PersistentVolumeClaimUtils.waitForPersistentVolumeClaimDeletion(testStorage, initialReplicas);
 
         // Create new topic to ensure, that ZK or KRaft is working properly
         String newTopicName = KafkaTopicUtils.generateRandomNameOfTopic();

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -252,7 +252,7 @@ class RollingUpdateST extends AbstractST {
             .editSpec()
                 .editKafka()
                     .addToConfig(singletonMap("default.replication.factor", 1))
-                    .addToConfig("auto.create.topics.enable", "false")
+                    .addToConfig("auto.create.topics.enable", Environment.isKRaftModeEnabled())
                 .endKafka()
             .endSpec()
             .build(),
@@ -261,11 +261,7 @@ class RollingUpdateST extends AbstractST {
 
         Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
 
-        if (!Environment.isKRaftModeEnabled()) {
-            testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false);
-        } else {
-            testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 0, false);
-        }
+        testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false, Environment.isKRaftModeEnabled());
 
         LOGGER.info("Running kafkaScaleUpScaleDown {}", testStorage.getClusterName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -261,7 +261,7 @@ class RollingUpdateST extends AbstractST {
 
         Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
 
-        testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false, Environment.isKRaftModeEnabled());
+        testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false);
 
         LOGGER.info("Running kafkaScaleUpScaleDown {}", testStorage.getClusterName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -261,7 +261,11 @@ class RollingUpdateST extends AbstractST {
 
         Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
 
-        testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false);
+        if (!Environment.isKRaftModeEnabled()) {
+            testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 3, false);
+        } else {
+            testDockerImagesForKafkaCluster(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), 3, 0, false);
+        }
 
         LOGGER.info("Running kafkaScaleUpScaleDown {}", testStorage.getClusterName());
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

Fix https://github.com/strimzi/strimzi-kafka-operator/issues/6862 , to allow scale up/down in KRaft mode by removing `quorum-state` file before launching kafka

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

