### PR TITLE
Fix various warnings and typos, and remove some unused methods in some of the model classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -40,7 +40,7 @@ public class ClusterCa extends Ca {
     /**
      * Constructor
      *
-     * @param reconciliation        Reocnciliation marker
+     * @param reconciliation        Reconciliation marker
      * @param certManager           Certificate manager instance
      * @param passwordGenerator     Password generator instance
      * @param clusterName           Name of the Kafka cluster
@@ -54,7 +54,7 @@ public class ClusterCa extends Ca {
     /**
      * Constructor
      *
-     * @param reconciliation        Reocnciliation marker
+     * @param reconciliation        Reconciliation marker
      * @param certManager           Certificate manager instance
      * @param passwordGenerator     Password generator instance
      * @param clusterName           Name of the Kafka cluster

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ConfigMapUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ConfigMapUtils.java
@@ -22,7 +22,7 @@ public class ConfigMapUtils {
      * @param namespace         Namespace of the Config Map
      * @param labels            Labels of the Config Map
      * @param ownerReference    OwnerReference of the Config Map
-     * @param data              Data which will be stored int he Config Map
+     * @param data              Data which will be stored in the Config Map
      *
      * @return  New Config Map
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -666,7 +666,7 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
      * @return The list with generated Services
      */
     public List<Service> generateExternalBootstrapServices() {
-        List<GenericKafkaListener> externalListeners = ListenersUtils.externalListeners(listeners);
+        List<GenericKafkaListener> externalListeners = ListenersUtils.listenersWithOwnServices(listeners);
         List<Service> services = new ArrayList<>(externalListeners.size());
 
         for (GenericKafkaListener listener : externalListeners)   {
@@ -745,7 +745,7 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
      * @return The list with generated Services
      */
     public List<Service> generateExternalServices(int pod) {
-        List<GenericKafkaListener> externalListeners = ListenersUtils.externalListeners(listeners);
+        List<GenericKafkaListener> externalListeners = ListenersUtils.listenersWithOwnServices(listeners);
         List<Service> services = new ArrayList<>(externalListeners.size());
 
         for (GenericKafkaListener listener : externalListeners)   {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -230,21 +230,16 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
 
             KafkaClientAuthentication authentication = mirrorMaker2Cluster.getAuthentication();
             if (authentication != null) {
-                if (authentication instanceof KafkaClientAuthenticationTls) {
-                    KafkaClientAuthenticationTls tlsAuth = (KafkaClientAuthenticationTls) authentication;
+                if (authentication instanceof KafkaClientAuthenticationTls tlsAuth) {
                     if (tlsAuth.getCertificateAndKey() != null) {
                         appendCluster(clustersTlsAuthCerts, clusterAlias, () -> tlsAuth.getCertificateAndKey().getSecretName() + "/" + tlsAuth.getCertificateAndKey().getCertificate());
                         appendCluster(clustersTlsAuthKeys, clusterAlias, () -> tlsAuth.getCertificateAndKey().getSecretName() + "/" + tlsAuth.getCertificateAndKey().getKey());
                     }
-                } else if (authentication instanceof KafkaClientAuthenticationPlain) {
-                    KafkaClientAuthenticationPlain passwordAuth = (KafkaClientAuthenticationPlain) authentication;
+                } else if (authentication instanceof KafkaClientAuthenticationPlain passwordAuth) {
                     appendClusterPasswordSecretSource(clustersSaslPasswordFiles, clusterAlias, passwordAuth.getPasswordSecret());
-                } else if (authentication instanceof KafkaClientAuthenticationScram) {
-                    KafkaClientAuthenticationScram passwordAuth = (KafkaClientAuthenticationScram) authentication;
+                } else if (authentication instanceof KafkaClientAuthenticationScram passwordAuth) {
                     appendClusterPasswordSecretSource(clustersSaslPasswordFiles, clusterAlias, passwordAuth.getPasswordSecret());
-                } else if (authentication instanceof KafkaClientAuthenticationOAuth) {
-                    KafkaClientAuthenticationOAuth oauth = (KafkaClientAuthenticationOAuth) authentication;
-
+                } else if (authentication instanceof KafkaClientAuthenticationOAuth oauth) {
                     if (oauth.getTlsTrustedCertificates() != null && !oauth.getTlsTrustedCertificates().isEmpty()) {
                         hasClusterOauthTrustedCerts = true;
                     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -32,11 +32,12 @@ public class ListenersUtils {
      * Finds out if any of the listeners has OAuth authentication enabled
      *
      * @param listeners List of all listeners
-     * @return          List of used names
+     *
+     * @return          True if any listener in the list is using OAuth authentication. False otherwise.
      */
     public static boolean hasListenerWithOAuth(List<GenericKafkaListener> listeners)    {
         return listeners.stream()
-                .anyMatch(listener -> isListenerWithOAuth(listener));
+                .anyMatch(ListenersUtils::isListenerWithOAuth);
     }
 
     /**
@@ -91,12 +92,12 @@ public class ListenersUtils {
     }
 
     /**
-     * Returns list of all external listeners (i.e. not internal)
+     * Returns list of all listeners which use their own services (i.e. all apart from type=internal)
      *
      * @param listeners List of all listeners
-     * @return          List of external listeners
+     * @return          List of listeners with their own services
      */
-    public static List<GenericKafkaListener> externalListeners(List<GenericKafkaListener> listeners)    {
+    public static List<GenericKafkaListener> listenersWithOwnServices(List<GenericKafkaListener> listeners)    {
         return listeners.stream()
                 .filter(listener -> KafkaListenerType.INTERNAL != listener.getType())
                 .collect(Collectors.toList());
@@ -161,40 +162,7 @@ public class ListenersUtils {
      */
     private static boolean hasListenerOfType(List<GenericKafkaListener> listeners, KafkaListenerType type)    {
         return listeners.stream()
-                .filter(listener -> type == listener.getType())
-                .findFirst()
-                .isPresent();
-    }
-
-    /**
-     * Check whether we have at least one interface for access from outside of Kubernetes
-     *
-     * @param listeners List of all listeners
-     * @return          List of external listeners
-     */
-    public static boolean hasExternalListener(List<GenericKafkaListener> listeners)    {
-        return listeners.stream()
-                .anyMatch(listener -> KafkaListenerType.INTERNAL != listener.getType());
-    }
-
-    /**
-     * Checks whether we have at least one Route listener
-     *
-     * @param listeners List of all listeners
-     * @return          True if at least one Route listener exists. False otherwise.
-     */
-    public static boolean hasRouteListener(List<GenericKafkaListener> listeners)    {
-        return hasListenerOfType(listeners, KafkaListenerType.ROUTE);
-    }
-
-    /**
-     * Checks whether we have at least one Load Balancer listener
-     *
-     * @param listeners List of all listeners
-     * @return          True if at least one Load Balancer listener exists. False otherwise.
-     */
-    public static boolean hasLoadBalancerListener(List<GenericKafkaListener> listeners)    {
-        return hasListenerOfType(listeners, KafkaListenerType.LOADBALANCER);
+                .anyMatch(listener -> type == listener.getType());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -57,7 +57,7 @@ public class ListenersValidator {
             errors.add("every listener needs to have a unique name");
         }
 
-        List<String> invalidNames = names.stream().filter(name -> !LISTENER_NAME_PATTERN.matcher(name).matches()).collect(Collectors.toList());
+        List<String> invalidNames = names.stream().filter(name -> !LISTENER_NAME_PATTERN.matcher(name).matches()).toList();
         if (!invalidNames.isEmpty())    {
             errors.add("listener names " + invalidNames + " are invalid and do not match the pattern " + GenericKafkaListener.LISTENER_NAME_REGEX);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -31,28 +31,28 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ParallelSuite
 public class ListenersUtilsTest {
-    private GenericKafkaListener oldPlain = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener oldPlain = new GenericKafkaListenerBuilder()
             .withName("plain")
             .withPort(9092)
             .withType(KafkaListenerType.INTERNAL)
             .withTls(false)
             .build();
 
-    private GenericKafkaListener oldTls = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener oldTls = new GenericKafkaListenerBuilder()
             .withName("tls")
             .withPort(9093)
             .withType(KafkaListenerType.INTERNAL)
             .withTls(true)
             .build();
 
-    private GenericKafkaListener oldExternal = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener oldExternal = new GenericKafkaListenerBuilder()
             .withName("external")
             .withPort(9094)
             .withType(KafkaListenerType.ROUTE)
             .withTls(true)
             .build();
 
-    private GenericKafkaListener newPlain = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newPlain = new GenericKafkaListenerBuilder()
             .withName("plain2")
             .withPort(9900)
             .withType(KafkaListenerType.INTERNAL)
@@ -72,7 +72,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newTls = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newTls = new GenericKafkaListenerBuilder()
             .withName("tls2")
             .withPort(9901)
             .withType(KafkaListenerType.INTERNAL)
@@ -100,7 +100,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newRoute = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newRoute = new GenericKafkaListenerBuilder()
             .withName("route")
             .withPort(9902)
             .withType(KafkaListenerType.ROUTE)
@@ -131,7 +131,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newNodePort = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newNodePort = new GenericKafkaListenerBuilder()
             .withName("np1")
             .withPort(9903)
             .withType(KafkaListenerType.NODEPORT)
@@ -140,7 +140,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newNodePort2 = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newNodePort2 = new GenericKafkaListenerBuilder()
             .withName("np2")
             .withPort(9904)
             .withType(KafkaListenerType.NODEPORT)
@@ -175,7 +175,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newLoadBalancer = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newLoadBalancer = new GenericKafkaListenerBuilder()
             .withName("lb1")
             .withPort(9905)
             .withType(KafkaListenerType.LOADBALANCER)
@@ -189,7 +189,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newLoadBalancer2 = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newLoadBalancer2 = new GenericKafkaListenerBuilder()
             .withName("lb2")
             .withPort(9906)
             .withType(KafkaListenerType.LOADBALANCER)
@@ -199,7 +199,7 @@ public class ListenersUtilsTest {
                 .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                 .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                 .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-lb-1", "my-lb-2"))
                     .withLoadBalancerIP("130.211.204.1")
@@ -225,7 +225,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newIngress = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newIngress = new GenericKafkaListenerBuilder()
             .withName("ing1")
             .withPort(9907)
             .withType(KafkaListenerType.INGRESS)
@@ -245,7 +245,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newIngress2 = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newIngress2 = new GenericKafkaListenerBuilder()
             .withName("ing2")
             .withPort(9908)
             .withType(KafkaListenerType.INGRESS)
@@ -277,7 +277,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newNodePort3 = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newNodePort3 = new GenericKafkaListenerBuilder()
             .withName("np3")
             .withPort(9909)
             .withType(KafkaListenerType.NODEPORT)
@@ -289,7 +289,7 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    private GenericKafkaListener newClusterIP = new GenericKafkaListenerBuilder()
+    private final GenericKafkaListener newClusterIP = new GenericKafkaListenerBuilder()
             .withName("clusterIP")
             .withPort(9907)
             .withType(KafkaListenerType.CLUSTER_IP)
@@ -309,7 +309,6 @@ public class ListenersUtilsTest {
             .endConfiguration()
             .build();
 
-    List<GenericKafkaListener> oldListeners = asList(oldPlain, oldTls, oldExternal);
     List<GenericKafkaListener> simpleListeners = asList(oldPlain, oldTls, oldExternal, newNodePort, newLoadBalancer, newIngress, newClusterIP);
     List<GenericKafkaListener> internalListeners = asList(oldPlain, oldTls, newPlain, newTls);
     List<GenericKafkaListener> allListeners = asList(oldPlain, oldTls, oldExternal, newPlain, newTls, newRoute,
@@ -320,28 +319,6 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.internalListeners(allListeners), hasSize(4));
         assertThat(ListenersUtils.internalListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
                 containsInAnyOrder("plain", "tls", "plain2", "tls2"));
-    }
-
-    @ParallelTest
-    public void testExternalListeners()    {
-        assertThat(ListenersUtils.externalListeners(allListeners), hasSize(10));
-        assertThat(ListenersUtils.externalListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
-                containsInAnyOrder("external", "route", "np1", "np2", "np3", "lb1", "lb2", "ing1", "ing2", "clusterIP"));
-        assertThat(ListenersUtils.hasExternalListener(allListeners), is(true));
-
-        assertThat(ListenersUtils.externalListeners(internalListeners), hasSize(0));
-        assertThat(ListenersUtils.hasExternalListener(internalListeners), is(false));
-    }
-
-    @ParallelTest
-    public void testLoadBalancerListeners()    {
-        assertThat(ListenersUtils.loadBalancerListeners(allListeners), hasSize(2));
-        assertThat(ListenersUtils.loadBalancerListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
-                containsInAnyOrder("lb1", "lb2"));
-        assertThat(ListenersUtils.hasLoadBalancerListener(allListeners), is(true));
-
-        assertThat(ListenersUtils.loadBalancerListeners(internalListeners), hasSize(0));
-        assertThat(ListenersUtils.hasLoadBalancerListener(internalListeners), is(false));
     }
 
     @ParallelTest
@@ -375,17 +352,6 @@ public class ListenersUtilsTest {
 
         assertThat(ListenersUtils.clusterIPListeners(internalListeners), hasSize(0));
         assertThat(ListenersUtils.hasClusterIPListener(internalListeners), is(false));
-    }
-
-    @ParallelTest
-    public void testRouteListeners()    {
-        assertThat(ListenersUtils.routeListeners(allListeners), hasSize(2));
-        assertThat(ListenersUtils.routeListeners(allListeners).stream().map(GenericKafkaListener::getName).collect(Collectors.toList()),
-                containsInAnyOrder("external", "route"));
-        assertThat(ListenersUtils.hasRouteListener(allListeners), is(true));
-
-        assertThat(ListenersUtils.routeListeners(internalListeners), hasSize(0));
-        assertThat(ListenersUtils.hasRouteListener(internalListeners), is(false));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -694,7 +694,7 @@ public class KafkaAssemblyOperatorTest {
                         KafkaResources.brokersServiceName(kafkaName));
 
                 if (kafkaListeners != null) {
-                    List<GenericKafkaListener> externalListeners = ListenersUtils.externalListeners(kafkaListeners);
+                    List<GenericKafkaListener> externalListeners = ListenersUtils.listenersWithOwnServices(kafkaListeners);
 
                     for (GenericKafkaListener listener : externalListeners) {
                         expectedServices.add(ListenersUtils.backwardsCompatibleBootstrapServiceName(kafkaName, listener));


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR does a minor cleanup of some of the model classes and their utils. It fixes some IDE warnings, applies new Java 17 features such as pattern variables where possible and fixes typos. It also removes some unused methods in the `ListenerUtils` class and renames the `externalListeners` method there as it is now used to also get the internal `cluster-ip` listener and not just external listeners.

### Checklist

- [x] Make sure all tests pass