### PR TITLE
default DOCKER_REGISTRY should be docker.io

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -269,7 +269,7 @@ To configure the `docker_tag` and `docker_push` targets you can set following en
 * `DOCKER_ORG` configures the Docker organization for tagging/pushing the images (defaults to the value of the `$USER`
   environment variable)
 * `DOCKER_TAG` configured Docker tag (default is `latest`)
-* `DOCKER_REGISTRY` configures the Docker registry where the image will be pushed (default is `quay.io`)
+* `DOCKER_REGISTRY` configures the Docker registry where the image will be pushed (default is `docker.io`)
 
 ### Docker build options
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The default `DOCKER_REGISTRY` is docker.io. Confirmed via manual running and [here](https://github.com/strimzi/strimzi-kafka-operator/blob/main/Makefile.docker#L13)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

