### PR TITLE
Update Kafka Kubernetes Config Provider to 1.1.1

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -21,7 +21,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
@@ -356,13 +356,6 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
-        <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
         </dependency>
         <!-- EnvVar Configuration Provider for Apache Kafka -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -21,7 +21,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.7</json-smart.version>
@@ -356,13 +356,6 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
-        <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
         </dependency>
         <!-- EnvVar Configuration Provider for Apache Kafka -->
         <dependency>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the version of the Kafka Kubernetes Config Provider to 1.1.1 which brings updated dependencies and used the Java HTTP client. This helps us to address some CVEs in transitive dependencies such as SnakeYAML and OkHttp.

This is currently a draft based on an RC1 to run the tests.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally