### PR TITLE
[systemtest] Update test-clients to 0.5.2

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -167,7 +167,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.4.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.5.2";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -167,7 +167,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.4.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.5.0";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.5.1";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -167,7 +167,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.4.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.5.1";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     /**


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates the test-clients used in STs to `0.5.2`, which contains a fix for race condition between sending the messages and waiting for the acknowledgement - [test-clients#59](https://github.com/strimzi/test-clients/pull/59)

### Checklist

- [ ] Make sure all tests pass

