### PR TITLE
docs(rename): makes mm2 refs in docs consistent with naming conventions used by Kafka

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -52,7 +52,7 @@ import java.util.function.Predicate;
         additionalPrinterColumns = {
             @Crd.Spec.AdditionalPrinterColumn(
                 name = "Desired replicas",
-                description = "The desired number of Kafka MirrorMaker 2.0 replicas",
+                description = "The desired number of Kafka MirrorMaker 2 replicas",
                 jsonPath = ".spec.replicas",
                 type = "integer"),
             @Crd.Spec.AdditionalPrinterColumn(
@@ -112,13 +112,13 @@ public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, Kaf
     }
 
     @Override
-    @Description("The specification of the Kafka MirrorMaker 2.0 cluster.")
+    @Description("The specification of the Kafka MirrorMaker 2 cluster.")
     public KafkaMirrorMaker2Spec getSpec() {
         return super.getSpec();
     }
 
     @Override
-    @Description("The status of the Kafka MirrorMaker 2.0 cluster.")
+    @Description("The status of the Kafka MirrorMaker 2 cluster.")
     public KafkaMirrorMaker2Status getStatus() {
         return super.getStatus();
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2ClusterSpec.java
@@ -64,7 +64,7 @@ public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, 
         this.authentication = authentication;
     }
 
-    @Description("The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
+    @Description("The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
         return config;
@@ -74,7 +74,7 @@ public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, 
         this.config = config;
     }
 
-    @Description("TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.")
+    @Description("TLS configuration for connecting MirrorMaker 2 connectors to a cluster.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public ClientTls getTls() {
         return tls;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2MirrorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2MirrorSpec.java
@@ -104,7 +104,7 @@ public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropert
         this.groupsExcludePattern = groupsExcludePattern;
     }
 
-    @Description("The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.")
+    @Description("The alias of the source cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.")
     @JsonProperty(required = true)
     public String getSourceCluster() {
         return sourceCluster;
@@ -114,7 +114,7 @@ public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropert
         this.sourceCluster = sourceCluster;
     }
 
-    @Description("The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.")
+    @Description("The alias of the target cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.")
     @JsonProperty(required = true)
     public String getTargetCluster() {
         return targetCluster;
@@ -124,7 +124,7 @@ public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropert
         this.targetCluster = targetCluster;
     }
 
-    @Description("The specification of the Kafka MirrorMaker 2.0 source connector.")
+    @Description("The specification of the Kafka MirrorMaker 2 source connector.")
     public KafkaMirrorMaker2ConnectorSpec getSourceConnector() {
         return sourceConnector;
     }
@@ -133,7 +133,7 @@ public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropert
         this.sourceConnector = sourceConnector;
     }
 
-    @Description("The specification of the Kafka MirrorMaker 2.0 checkpoint connector.")
+    @Description("The specification of the Kafka MirrorMaker 2 checkpoint connector.")
     public KafkaMirrorMaker2ConnectorSpec getCheckpointConnector() {
         return checkpointConnector;
     }
@@ -142,7 +142,7 @@ public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropert
         this.checkpointConnector = checkpointConnector;
     }
 
-    @Description("The specification of the Kafka MirrorMaker 2.0 heartbeat connector.")
+    @Description("The specification of the Kafka MirrorMaker 2 heartbeat connector.")
     public KafkaMirrorMaker2ConnectorSpec getHeartbeatConnector() {
         return heartbeatConnector;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Resources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Resources.java
@@ -11,18 +11,18 @@ package io.strimzi.api.kafka.model;
 public class KafkaMirrorMaker2Resources {
     
     /**
-     * Returns the name of the Kafka MirrorMaker 2.0 {@code Deployment} for a {@code KafkaMirrorMaker2} cluster of the given name.
+     * Returns the name of the Kafka MirrorMaker 2 {@code Deployment} for a {@code KafkaMirrorMaker2} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker2} resource.
-     * @return The name of the corresponding Kafka MirrorMaker 2.0 {@code Deployment}.
+     * @return The name of the corresponding Kafka MirrorMaker 2 {@code Deployment}.
      */
     public static String deploymentName(String clusterName) {
         return clusterName + "-mirrormaker2";
     }
 
     /**
-     * Returns the name of the Kafka MirrorMaker 2.0 {@code ServiceAccount} for a {@code KafkaMirrorMaker2} cluster of the given name.
+     * Returns the name of the Kafka MirrorMaker 2 {@code ServiceAccount} for a {@code KafkaMirrorMaker2} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker2} resource.
-     * @return The name of the corresponding Kafka MirrorMaker 2.0 {@code ServiceAccount}.
+     * @return The name of the corresponding Kafka MirrorMaker 2 {@code ServiceAccount}.
      */
     public static String serviceAccountName(String clusterName) {
         return deploymentName(clusterName);
@@ -38,7 +38,7 @@ public class KafkaMirrorMaker2Resources {
     }
 
     /**
-     * Returns the name of the Kafka MirrorMaker 2.0 metrics and log {@code ConfigMap} for a {@code KafkaMirrorMaker2} cluster of the given name.
+     * Returns the name of the Kafka MirrorMaker 2 metrics and log {@code ConfigMap} for a {@code KafkaMirrorMaker2} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker2} resource.
      * @return The name of the corresponding KafkaMirrorMaker2 metrics and log {@code ConfigMap}.
      */
@@ -58,7 +58,7 @@ public class KafkaMirrorMaker2Resources {
     }
 
     /**
-     * Returns the URL of the Kafka MirrorMaker 2.0 REST API for a {@code KafkaMirrorMaker2} cluster of the given name.
+     * Returns the URL of the Kafka MirrorMaker 2 REST API for a {@code KafkaMirrorMaker2} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code KafkaMirrorMaker2} resource.
      * @param namespace The namespace where {@code KafkaMirrorMaker2} cluster is running.
      * @param port The port on which the {@code KafkaMirrorMaker2} API is available.

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
@@ -52,7 +52,7 @@ public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
         this.connectCluster = connectCluster;
     }
 
-    @Description("Configuration of the MirrorMaker 2.0 connectors.")
+    @Description("Configuration of the MirrorMaker 2 connectors.")
     public List<KafkaMirrorMaker2MirrorSpec> getMirrors() {
         return mirrors;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Rack.java
@@ -41,7 +41,7 @@ public class Rack implements UnknownPropertyPreserving, Serializable {
     }
 
     @Description("A key that matches labels assigned to the Kubernetes cluster nodes. " +
-            "The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0.")
+            "The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.")
     @Example("topology.kubernetes.io/zone")
     @JsonProperty(required = true)
     public String getTopologyKey() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaMirrorMaker2Status.java
@@ -18,7 +18,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * Represents a status of the Kafka MirrorMaker 2.0 resource
+ * Represents a status of the Kafka MirrorMaker 2 resource
  */
 @Buildable(
         editableEnabled = false,
@@ -35,7 +35,7 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
 
     private List<AutoRestartStatus> autoRestartStatuses = new ArrayList<>();
 
-    @Description("List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.")
+    @Description("List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<Map<String, Object>> getConnectors() {
         return connectors;
@@ -45,7 +45,7 @@ public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
         this.connectors = connectors;
     }
 
-    @Description("List of MirrorMaker 2.0 connector auto restart statuses")
+    @Description("List of MirrorMaker 2 connector auto restart statuses")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<AutoRestartStatus> getAutoRestartStatuses() {
         return autoRestartStatuses;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaMirrorMaker2Template.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Representation of a template for Kafka MirrorMaker 2.0 resources.
+ * Representation of a template for Kafka MirrorMaker 2 resources.
  */
 @Buildable(
         editableEnabled = false,
@@ -38,7 +38,7 @@ public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializ
     private ResourceTemplate jmxSecret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("Template for Kafka MirrorMaker 2.0 `Deployment`.")
+    @Description("Template for Kafka MirrorMaker 2 `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public DeploymentTemplate getDeployment() {
         return deployment;
@@ -48,7 +48,7 @@ public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializ
         this.deployment = deployment;
     }
 
-    @Description("Template for Kafka MirrorMaker 2.0 `Pods`.")
+    @Description("Template for Kafka MirrorMaker 2 `Pods`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public PodTemplate getPod() {
         return pod;
@@ -58,7 +58,7 @@ public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializ
         this.pod = pod;
     }
 
-    @Description("Template for Kafka MirrorMaker 2.0 API `Service`.")
+    @Description("Template for Kafka MirrorMaker 2 API `Service`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public InternalServiceTemplate getApiService() {
         return apiService;
@@ -68,7 +68,7 @@ public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializ
         this.apiService = apiService;
     }
 
-    @Description("Template for Kafka MirrorMaker 2.0 `PodDisruptionBudget`.")
+    @Description("Template for Kafka MirrorMaker 2 `PodDisruptionBudget`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public PodDisruptionBudgetTemplate getPodDisruptionBudget() {
         return podDisruptionBudget;
@@ -78,7 +78,7 @@ public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializ
         this.podDisruptionBudget = podDisruptionBudget;
     }
 
-    @Description("Template for the Kafka MirrorMaker 2.0 container")
+    @Description("Template for the Kafka MirrorMaker 2 container")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public ContainerTemplate getMirrorMaker2Container() {
         return mirrorMaker2Container;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -41,7 +41,7 @@ import static io.strimzi.operator.cluster.ClusterOperatorConfig.STRIMZI_DEFAULT_
 public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     protected static final String COMPONENT_TYPE = "kafka-mirror-maker-2";
 
-    // Kafka MirrorMaker 2.0 connector configuration keys (EnvVariables)
+    // Kafka MirrorMaker 2 connector configuration keys (EnvVariables)
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_CLUSTERS = "KAFKA_MIRRORMAKER_2_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_TLS_CLUSTERS = "KAFKA_MIRRORMAKER_2_TLS_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_TRUSTED_CERTS_CLUSTERS = "KAFKA_MIRRORMAKER_2_TRUSTED_CERTS_CLUSTERS";
@@ -89,8 +89,8 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
      *
      * @param reconciliation    The reconciliation
      * @param kafkaMirrorMaker2 The Custom Resource based on which the cluster model should be created.
-     * @param versions The image versions for MirrorMaker 2.0 clusters.
-     * @return The MirrorMaker 2.0 cluster model.
+     * @param versions The image versions for MirrorMaker 2 clusters.
+     * @return The MirrorMaker 2 cluster model.
      */
     public static KafkaMirrorMaker2Cluster fromCrd(Reconciliation reconciliation,
                                                    KafkaMirrorMaker2 kafkaMirrorMaker2,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Class for handling Kafka MirrorMaker 2.0 connect configuration passed by the user
+ * Class for handling Kafka MirrorMaker 2 connect configuration passed by the user
  */
 public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_PREFIXES;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -337,7 +337,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         }
 
        /**
-         * The Kafka MirrorMaker 2.0 image to use for a Kafka MirrorMaker 2.0 cluster.
+         * The Kafka MirrorMaker 2 image to use for a Kafka MirrorMaker 2 cluster.
          * @param image The image given in the CR.
          * @param version The version given in the CR.
          * @return The image to use.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -78,10 +78,10 @@ import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_RESTART_CON
 import static java.util.Collections.emptyMap;
 
 /**
- * <p>Assembly operator for a "Kafka MirrorMaker 2.0" assembly, which manages:</p>
+ * <p>Assembly operator for a "Kafka MirrorMaker 2" assembly, which manages:</p>
  * <ul>
  *     <li>A Kafka Connect Deployment and related Services</li>
- *     <li>A set of MirrorMaker 2.0 connectors</li>
+ *     <li>A set of MirrorMaker 2 connectors</li>
  * </ul>
  */
 public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List, Resource<KafkaMirrorMaker2>, KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> {
@@ -321,9 +321,9 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     }
 
     /**
-     * Reconcile all the MirrorMaker 2.0 connectors selected by the given MirrorMaker 2.0 instance.
+     * Reconcile all the MirrorMaker 2 connectors selected by the given MirrorMaker 2 instance.
      * @param reconciliation The reconciliation
-     * @param kafkaMirrorMaker2 The MirrorMaker 2.0
+     * @param kafkaMirrorMaker2 The MirrorMaker 2
      * @return A future, failed if any of the connectors could not be reconciled.
      */
     protected Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Cluster mirrorMaker2Cluster, KafkaMirrorMaker2Status mirrorMaker2Status, String desiredLogging) {
@@ -343,7 +343,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         .map(mirror -> mirror.getSourceCluster() + "->" + mirror.getTargetCluster() + connectorEntry.getKey())
                         .collect(Collectors.toSet()));
             }
-            LOGGER.debugCr(reconciliation, "delete MirrorMaker 2.0 connectors: {}", deleteMirrorMaker2ConnectorNames);
+            LOGGER.debugCr(reconciliation, "delete MirrorMaker 2 connectors: {}", deleteMirrorMaker2ConnectorNames);
             Stream<Future<Void>> deletionFutures = deleteMirrorMaker2ConnectorNames.stream()
                     .map(connectorName -> apiClient.delete(reconciliation, host, KafkaConnectCluster.REST_API_PORT, connectorName));
             Stream<Future<Void>> createUpdateFutures = mirrors.stream()
@@ -586,7 +586,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     private Future<Void> maybeUpdateMirrorMaker2Status(Reconciliation reconciliation, KafkaMirrorMaker2 mirrorMaker2, Throwable error) {
         KafkaMirrorMaker2Status status = new KafkaMirrorMaker2Status();
         if (error != null) {
-            LOGGER.warnCr(reconciliation, "Error reconciling MirrorMaker 2.0 {}", mirrorMaker2.getMetadata().getName(), error);
+            LOGGER.warnCr(reconciliation, "Error reconciling MirrorMaker 2 {}", mirrorMaker2.getMetadata().getName(), error);
         }
         StatusUtils.setStatusConditionAndObservedGeneration(mirrorMaker2, status, error != null ? Future.failedFuture(error) : Future.succeededFuture());
         return maybeUpdateStatusCommon(resourceOperator, mirrorMaker2, reconciliation, status,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -411,7 +411,7 @@ public class ResourceUtils {
     }
 
     /**
-     * Create an empty Kafka MirrorMaker 2.0 custom resource
+     * Create an empty Kafka MirrorMaker 2 custom resource
      */
     public static KafkaMirrorMaker2 createEmptyKafkaMirrorMaker2(String namespace, String name, Integer replicas) {
         KafkaMirrorMaker2Builder kafkaMirrorMaker2Builder = new KafkaMirrorMaker2Builder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -616,16 +616,16 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         KafkaMirrorMaker2 foo = ResourceUtils.createEmptyKafkaMirrorMaker2(kmm2Namespace, "foo");
         KafkaMirrorMaker2 bar = ResourceUtils.createEmptyKafkaMirrorMaker2(kmm2Namespace, "bar");
         when(mockMirrorMaker2Ops.listAsync(eq(kmm2Namespace), any(Optional.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
-        // when requested ConfigMap for a specific Kafka MirrorMaker 2.0 cluster
+        // when requested ConfigMap for a specific Kafka MirrorMaker 2 cluster
         when(mockMirrorMaker2Ops.get(eq(kmm2Namespace), eq("foo"))).thenReturn(foo);
         when(mockMirrorMaker2Ops.get(eq(kmm2Namespace), eq("bar"))).thenReturn(bar);
 
-        // providing the list of ALL Deployments for all the Kafka MirrorMaker 2.0 clusters
+        // providing the list of ALL Deployments for all the Kafka MirrorMaker 2 clusters
         Labels newLabels = Labels.forStrimziKind(KafkaMirrorMaker2.RESOURCE_KIND);
         when(mockDcOps.list(eq(kmm2Namespace), eq(newLabels))).thenReturn(
                 asList(KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, bar, VERSIONS).generateDeployment(3, null, new HashMap<>(), true, null, null, null)));
 
-        // providing the list Deployments for already "existing" Kafka MirrorMaker 2.0 clusters
+        // providing the list Deployments for already "existing" Kafka MirrorMaker 2 clusters
         Labels barLabels = Labels.forStrimziCluster("bar");
         when(mockDcOps.list(eq(kmm2Namespace), eq(barLabels))).thenReturn(
                 asList(KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, bar, VERSIONS).generateDeployment(3, null, new HashMap<>(), true, null, null, null))
@@ -655,7 +655,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
             }
         };
 
-        // Now try to reconcile all the Kafka MirrorMaker 2.0 clusters
+        // Now try to reconcile all the Kafka MirrorMaker 2 clusters
         ops.reconcileAll("test", kmm2Namespace,
             context.succeeding(v -> context.verify(() -> {
                 assertThat(createdOrUpdated, is(new HashSet<>(asList("foo", "bar"))));

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -10,7 +10,7 @@ export CERTS_STORE_PASSWORD
 mkdir -p /tmp/kafka/clusters
 
 # Import cluster certificates into keystores and truststores
-echo "Preparing MirrorMaker 2.0 cluster truststores and keystores"
+echo "Preparing MirrorMaker 2 cluster truststores and keystores"
 
 declare -A TLS_AUTH_CERTS
 if [ -n "$KAFKA_MIRRORMAKER_2_TLS_AUTH_CERTS_CLUSTERS" ]; then
@@ -46,7 +46,7 @@ if [ -n "$KAFKA_MIRRORMAKER_2_CLUSTERS" ]; then
     IFS=';' read -ra CLUSTERS <<< "$KAFKA_MIRRORMAKER_2_CLUSTERS" || true
     for clusterAlias in "${CLUSTERS[@]}"
     do
-        echo "Preparing MirrorMaker 2.0 truststores and keystores for cluster ${clusterAlias}"
+        echo "Preparing MirrorMaker 2 truststores and keystores for cluster ${clusterAlias}"
         echo "  with trusted certs ${TRUSTED_CERTS["${clusterAlias}"]}"
         echo "  with tls auth certs ${TLS_AUTH_CERTS["${clusterAlias}"]}"
         echo "  with tls auth keys ${TLS_AUTH_KEYS["${clusterAlias}"]}"
@@ -61,7 +61,7 @@ if [ -n "$KAFKA_MIRRORMAKER_2_CLUSTERS" ]; then
             "/opt/kafka/mm2-oauth-certs/${clusterAlias}" \
             "/tmp/kafka/clusters/${clusterAlias}-oauth.truststore.p12"
     done
-    echo "Preparing MirrorMaker 2.0 cluster truststores is complete"
+    echo "Preparing MirrorMaker 2 cluster truststores is complete"
 fi
 
 # Generate and print the connector config file

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -24,9 +24,9 @@ spec:
     enabled: true
 ----
 
-For MirrorMaker 2.0, use the `autoRestart` property of connectors in the `KafkaMirrorMaker2` resource to enable automatic restarts of failed connectors and tasks.
+For MirrorMaker 2, use the `autoRestart` property of connectors in the `KafkaMirrorMaker2` resource to enable automatic restarts of failed connectors and tasks.
 
-.Enabling automatic restarts of failed connectors for MirrorMaker 2.0
+.Enabling automatic restarts of failed connectors for MirrorMaker 2
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaJmxOptions.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaJmxOptions.adoc
@@ -1,6 +1,6 @@
 Configures JMX connection options.
 
-Get JMX metrics from Kafka brokers, ZooKeeper nodes, Kafka Connect, and MirrorMaker 2.0. by connecting to port 9999.
+Get JMX metrics from Kafka brokers, ZooKeeper nodes, Kafka Connect, and MirrorMaker 2. by connecting to port 9999.
 Use the `jmxOptions` property to configure a password-protected or an unprotected JMX port.
 Using password protection prevents unauthorized pods from accessing the port.
 

--- a/documentation/api/io.strimzi.api.kafka.model.Rack.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.Rack.adoc
@@ -79,7 +79,7 @@ If the rack ID is not specified, or if it cannot find a replica with the same ra
 .Example showing client consuming from replicas in the same availability zone
 image::rack-config-availability-zones.png[consuming from replicas in the same availability zone]
 
-You can also configure Kafka Connect, MirrorMaker 2.0 and Kafka Bridge so that connectors consume messages from the closest replicas.
+You can also configure Kafka Connect, MirrorMaker 2 and Kafka Bridge so that connectors consume messages from the closest replicas.
 You enable rack awareness in the `KafkaConnect`, `KafkaMirrorMaker2`, and `KafkaBridge` custom resources.
 The configuration does does not set affinity rules, but you can also configure `affinity` or `topologySpreadConstraints`.
 For more information see xref:assembly-scheduling-str[].
@@ -101,7 +101,7 @@ spec:
 
 When deploying MirrorMaker 2 using Strimzi, you can use the `rack` section in the `KafkaMirrorMaker2` custom resource to automatically configure the `client.rack` option.
 
-.Example `rack` configuration for MirrorMaker 2.0
+.Example `rack` configuration for MirrorMaker 2
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker.adoc
@@ -11,8 +11,8 @@ KafkaMirrorMaker replicates data between Kafka clusters.
 
 xref:type-KafkaMirrorMaker-reference[] describes the full schema of the `KafkaMirrorMaker` resource.
 
-You can use Strimzi with MirrorMaker or xref:assembly-mirrormaker-str[MirrorMaker 2.0].
-MirrorMaker 2.0 is the latest version, and offers a more efficient way to mirror data between Kafka clusters.
+You can use Strimzi with MirrorMaker or xref:assembly-mirrormaker-str[MirrorMaker 2].
+MirrorMaker 2 is the latest version, and offers a more efficient way to mirror data between Kafka clusters.
 
 IMPORTANT: Kafka MirrorMaker 1 (referred to as just _MirrorMaker_ in the documentation) has been deprecated in Apache Kafka 3.0.0 and will be removed in Apache Kafka 4.0.0.  
 As a result, the `KafkaMirrorMaker` custom resource which is used to deploy Kafka MirrorMaker 1 has been deprecated in Strimzi as well.

--- a/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
+++ b/documentation/assemblies/configuring/assembly-config-mirrormaker2.adoc
@@ -3,16 +3,16 @@
 // assembly-deployment-configuration-kafka-mirror-maker.adoc
 
 [id='assembly-mirrormaker-{context}']
-= Kafka MirrorMaker 2.0 cluster configuration
+= Kafka MirrorMaker 2 cluster configuration
 
 [role="_abstract"]
-Configure a Kafka MirrorMaker 2.0 deployment using the `KafkaMirrorMaker2` resource.
-MirrorMaker 2.0 replicates data between two or more Kafka clusters, within or across data centers.
+Configure a Kafka MirrorMaker 2 deployment using the `KafkaMirrorMaker2` resource.
+MirrorMaker 2 replicates data between two or more Kafka clusters, within or across data centers.
 
 xref:type-KafkaMirrorMaker2-reference[] describes the full schema of the `KafkaMirrorMaker2` resource.
 
-MirrorMaker 2.0 resource configuration differs from the previous version of MirrorMaker.
-If you choose to use MirrorMaker 2.0, there is currently no legacy support, so any resources must be manually converted into the new format.
+MirrorMaker 2 resource configuration differs from the previous version of MirrorMaker.
+If you choose to use MirrorMaker 2, there is currently no legacy support, so any resources must be manually converted into the new format.
 
 //Describes the underlying architecture and how it is used in replication
 include::../../modules/configuring/con-config-mirrormaker2-replication.adoc[leveloffset=+1]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -672,7 +672,7 @@ include::../api/io.strimzi.api.kafka.model.Rack.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property            |Description
-|topologyKey  1.2+<.<a|A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0.
+|topologyKey  1.2+<.<a|A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.
 |string
 |====
 
@@ -3137,9 +3137,9 @@ Used in: xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:
 [options="header"]
 |====
 |Property       |Description
-|spec    1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 cluster.
+|spec    1.2+<.<a|The specification of the Kafka MirrorMaker 2 cluster.
 |xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
-|status  1.2+<.<a|The status of the Kafka MirrorMaker 2.0 cluster.
+|status  1.2+<.<a|The status of the Kafka MirrorMaker 2 cluster.
 |xref:type-KafkaMirrorMaker2Status-{context}[`KafkaMirrorMaker2Status`]
 |====
 
@@ -3162,7 +3162,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |string
 |clusters               1.2+<.<a|Kafka clusters for mirroring.
 |xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array
-|mirrors                1.2+<.<a|Configuration of the MirrorMaker 2.0 connectors.
+|mirrors                1.2+<.<a|Configuration of the MirrorMaker 2 connectors.
 |xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2MirrorSpec`] array
 |resources              1.2+<.<a|The maximum limits for CPU and memory resources and the requested initial resources. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[external documentation for core/v1 resourcerequirements].
 
@@ -3212,11 +3212,11 @@ include::../api/io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec.adoc[lev
 |string
 |bootstrapServers  1.2+<.<a|A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
 |string
-|tls               1.2+<.<a|TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
+|tls               1.2+<.<a|TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
 |xref:type-ClientTls-{context}[`ClientTls`]
 |authentication    1.2+<.<a|Authentication configuration for connecting to the cluster. The type depends on the value of the `authentication.type` property within the given object, which must be one of [tls, scram-sha-256, scram-sha-512, plain, oauth].
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
-|config            1.2+<.<a|The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|config            1.2+<.<a|The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |map
 |====
 
@@ -3229,15 +3229,15 @@ Used in: xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 [options="header"]
 |====
 |Property                       |Description
-|sourceCluster           1.2+<.<a|The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+|sourceCluster           1.2+<.<a|The alias of the source cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.
 |string
-|targetCluster           1.2+<.<a|The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+|targetCluster           1.2+<.<a|The alias of the target cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.
 |string
-|sourceConnector         1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 source connector.
+|sourceConnector         1.2+<.<a|The specification of the Kafka MirrorMaker 2 source connector.
 |xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
-|heartbeatConnector      1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
+|heartbeatConnector      1.2+<.<a|The specification of the Kafka MirrorMaker 2 heartbeat connector.
 |xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
-|checkpointConnector     1.2+<.<a|The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
+|checkpointConnector     1.2+<.<a|The specification of the Kafka MirrorMaker 2 checkpoint connector.
 |xref:type-KafkaMirrorMaker2ConnectorSpec-{context}[`KafkaMirrorMaker2ConnectorSpec`]
 |topicsPattern           1.2+<.<a|A regular expression matching the topics to be mirrored, for example, "topic1\|topic2\|topic3". Comma-separated lists are also supported.
 |string
@@ -3287,11 +3287,11 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |integer
 |url                  1.2+<.<a|The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
 |string
-|autoRestartStatuses  1.2+<.<a|List of MirrorMaker 2.0 connector auto restart statuses.
+|autoRestartStatuses  1.2+<.<a|List of MirrorMaker 2 connector auto restart statuses.
 |xref:type-AutoRestartStatus-{context}[`AutoRestartStatus`] array
 |connectorPlugins     1.2+<.<a|The list of connector plugins available in this Kafka Connect deployment.
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
-|connectors           1.2+<.<a|List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.
+|connectors           1.2+<.<a|List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API.
 |map array
 |labelSelector        1.2+<.<a|Label selector for pods providing this resource.
 |string

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -490,7 +490,7 @@ The following table shows the default heap values.
 |75%
 |None
 
-|MirrorMaker 2.0
+|MirrorMaker 2
 |75%
 |None
 

--- a/documentation/modules/configuring/con-config-high-volume-messages.adoc
+++ b/documentation/modules/configuring/con-config-high-volume-messages.adoc
@@ -14,11 +14,11 @@ For more information on the configuration options, see the following:
 * {ApacheKafkaProducerConfig}
 * {ApacheKafkaConsumerConfig}
 
-You can also use the same configuration options with the producers and consumers used by the Kafka Connect runtime source connectors (including MirrorMaker 2.0) and sink connectors.
+You can also use the same configuration options with the producers and consumers used by the Kafka Connect runtime source connectors (including MirrorMaker 2) and sink connectors.
 
 Source connectors:: 
 * Producers from the Kafka Connect runtime send messages to the Kafka cluster.
-* For MirrorMaker 2.0, since the source system is Kafka, consumers retrieve messages from a source Kafka cluster. 
+* For MirrorMaker 2, since the source system is Kafka, consumers retrieve messages from a source Kafka cluster. 
 
 Sink connectors:: 
 * Consumers from the Kafka Connect runtime retrieve messages from the Kafka cluster.
@@ -27,7 +27,7 @@ For consumers, you might increase the amount of data fetched in a single fetch r
 You increase the fetch request size using the `fetch.max.bytes` and `max.partition.fetch.bytes` properties.
 You can also set a maximum limit on the number of messages returned from the consumer buffer using the `max.poll.records` property.
 
-For MirrorMaker 2.0, configure the `fetch.max.bytes`, `max.partition.fetch.bytes`, and `max.poll.records` values at the source connector level (`consumer.*`), as they relate to the specific consumer that fetches messages from the source.
+For MirrorMaker 2, configure the `fetch.max.bytes`, `max.partition.fetch.bytes`, and `max.poll.records` values at the source connector level (`consumer.*`), as they relate to the specific consumer that fetches messages from the source.
 
 For producers, you might increase the size of the message batches sent in a single produce request.
 You increase the batch size using the `batch.size` property.
@@ -54,9 +54,9 @@ For Kafka Connect sink connectors, the data streaming pipeline to the target ext
 .Data streaming pipeline for Kafka Connect sink connector
 *source Kafka topic -> (Kafka Connect tasks) sink message queue -> consumer buffer -> external data source*
 
-For MirrorMaker 2.0, the data mirroring pipeline to the target Kafka cluster is as follows:
+For MirrorMaker 2, the data mirroring pipeline to the target Kafka cluster is as follows:
 
-.Data mirroring pipeline for MirrorMaker 2.0
+.Data mirroring pipeline for MirrorMaker 2
 *source Kafka topic -> (Kafka Connect tasks) source message queue -> producer buffer -> target Kafka topic*
 
 The producer sends messages in its buffer to topics in the target Kafka cluster.
@@ -177,12 +177,12 @@ curl -X POST \
 }'
 ----
 
-== Configuring MirrorMaker 2.0 for high-volume messages 
-MirrorMaker 2.0 fetches data from the source cluster and hands it to the Kafka Connect runtime producers so that it's replicated to the target cluster.
+== Configuring MirrorMaker 2 for high-volume messages 
+MirrorMaker 2 fetches data from the source cluster and hands it to the Kafka Connect runtime producers so that it's replicated to the target cluster.
 
-The following example shows the configuration for MirrorMaker 2.0 using the `KafkaMirrorMaker2` custom resource. 
+The following example shows the configuration for MirrorMaker 2 using the `KafkaMirrorMaker2` custom resource. 
 
-.Example MirrorMaker 2.0 configuration for handling high volumes of messages
+.Example MirrorMaker 2 configuration for handling high volumes of messages
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}
@@ -221,11 +221,11 @@ spec:
       memory: 4Gi      
 ----
 
-== Checking the MirrorMaker 2.0 message flow
+== Checking the MirrorMaker 2 message flow
 
-If you are using Prometheus and Grafana to monitor your deployment, you can check the MirrorMaker 2.0 message flow.
+If you are using Prometheus and Grafana to monitor your deployment, you can check the MirrorMaker 2 message flow.
 
-The example MirrorMaker 2.0 Grafana dashboards provided with Strimzi show the following metrics related to the flush pipeline.
+The example MirrorMaker 2 Grafana dashboards provided with Strimzi show the following metrics related to the flush pipeline.
 
 * The number of messages in Kafka Connect's outstanding messages queue
 * The available bytes of the producer buffer

--- a/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-connectors.adoc
@@ -10,7 +10,7 @@ Use Mirrormaker 2.0 connector configuration for the internal connectors that orc
 
 The following table describes connector properties and the connectors you configure to use them.
 
-.MirrorMaker 2.0 connector configuration properties
+.MirrorMaker 2 connector configuration properties
 [cols="4a,2,2,2",options="header"]
 |===
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-producers-consumers.adoc
@@ -6,12 +6,12 @@
 = Connector producer and consumer configuration
 
 [role="_abstract"]
-MirrorMaker 2.0 connectors use internal producers and consumers.
+MirrorMaker 2 connectors use internal producers and consumers.
 If needed, you can configure these producers and consumers to override the default settings. 
 
 For example, you can increase the `batch.size` for the source producer that sends topics to the target Kafka cluster to better accommodate large volumes of messages.
 
-IMPORTANT: Producer and consumer configuration options depend on the MirrorMaker 2.0 implementation, and may be subject to change.  
+IMPORTANT: Producer and consumer configuration options depend on the MirrorMaker 2 implementation, and may be subject to change.  
 
 The following tables describe the producers and consumers for each of the connectors and where you can add configuration. 
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -3,7 +3,7 @@
 // assembly-config-mirrormaker2.adoc
 
 [id='con-mirrormaker-{context}']
-= MirrorMaker 2.0 data replication
+= MirrorMaker 2 data replication
 
 [role="_abstract"]
 Data replication across clusters supports scenarios that require:
@@ -17,21 +17,21 @@ include::../overview/con-overview-mirrormaker2.adoc[leveloffset=+1]
 
 == Topic configuration synchronization
 
-MirrorMaker 2.0 supports topic configuration synchronization between source and target clusters. 
-You specify source topics in the MirrorMaker 2.0 configuration.
-MirrorMaker 2.0 monitors the source topics.
-MirrorMaker 2.0 detects and propagates changes to the source topics to the remote topics.
+MirrorMaker 2 supports topic configuration synchronization between source and target clusters. 
+You specify source topics in the MirrorMaker 2 configuration.
+MirrorMaker 2 monitors the source topics.
+MirrorMaker 2 detects and propagates changes to the source topics to the remote topics.
 Changes might include automatically creating missing topics and partitions.
 
 NOTE: In most cases you write to local topics and read from remote topics. Though write operations are not prevented on remote topics, they should be avoided. 
 
 == Offset tracking
-MirrorMaker 2.0 tracks offsets for consumer groups using internal topics.
+MirrorMaker 2 tracks offsets for consumer groups using internal topics.
 
 `offset-syncs` topic:: The `offset-syncs` topic maps the source and target offsets for replicated topic partitions from record metadata.
 `checkpoints` topic:: The `checkpoints` topic maps the last committed offset in the source and target cluster for replicated topic partitions in each consumer group.
 
-As they used internally by MirrorMaker 2.0, you do not interact directly with these topics. 
+As they used internally by MirrorMaker 2, you do not interact directly with these topics. 
 
 `MirrorCheckpointConnector` emits _checkpoints_ for offset tracking.
 Offsets for the `checkpoints` topic are tracked at predetermined intervals through configuration.
@@ -40,7 +40,7 @@ Both topics enable replication to be fully restored from the correct offset posi
 The location of the `offset-syncs` topic is the `source` cluster by default.
 You can use the `offset-syncs.topic.location` connector configuration to change this to the `target` cluster.
 You need read/write access to the cluster that contains the topic.
-Using the target cluster as the location of the `offset-syncs` topic allows you to use MirrorMaker 2.0 even if you have only read access to the source cluster.
+Using the target cluster as the location of the `offset-syncs` topic allows you to use MirrorMaker 2 even if you have only read access to the source cluster.
 
 == Synchronizing consumer group offsets
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -66,15 +66,15 @@ spec:
   # ...
 ----
 
-By default, MirrorMaker 2.0 checks for new consumer groups every 10 minutes. 
+By default, MirrorMaker 2 checks for new consumer groups every 10 minutes. 
 You can adjust the `refresh.groups.interval.seconds` configuration to change the frequency.
 Take care when adjusting lower.
 More frequent checks can have a negative impact on performance.   
 
 == Checking connector task operations
 
-If you are using Prometheus and Grafana to monitor your deployment, you can check MirrorMaker 2.0 performance.
-The example MirrorMaker 2.0 Grafana dashboard provided with Strimzi shows the following metrics related to tasks and latency.
+If you are using Prometheus and Grafana to monitor your deployment, you can check MirrorMaker 2 performance.
+The example MirrorMaker 2 Grafana dashboard provided with Strimzi shows the following metrics related to tasks and latency.
 
 * The number of tasks
 * Replication latency

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -3,11 +3,11 @@
 // assembly-config-mirrormaker2.adoc
 
 [id='proc-mirrormaker-replication-{context}']
-= Configuring Kafka MirrorMaker 2.0
+= Configuring Kafka MirrorMaker 2
 
 [role="_abstract"]
-Use the properties of the `KafkaMirrorMaker2` resource to configure your Kafka MirrorMaker 2.0 deployment.
-Use MirrorMaker 2.0 to synchronize data between Kafka clusters.
+Use the properties of the `KafkaMirrorMaker2` resource to configure your Kafka MirrorMaker 2 deployment.
+Use MirrorMaker 2 to synchronize data between Kafka clusters.
 
 The configuration must specify:
 
@@ -19,12 +19,12 @@ The configuration must specify:
 
 NOTE: The previous version of MirrorMaker continues to be supported.
 If you wish to use the resources configured for the previous version,
-they must be updated to the format supported by MirrorMaker 2.0.
+they must be updated to the format supported by MirrorMaker 2.
 
-MirrorMaker 2.0 provides default configuration values for properties such as replication factors.
+MirrorMaker 2 provides default configuration values for properties such as replication factors.
 A minimal configuration, with defaults left unchanged, would be something like this example:
 
-.Minimal configuration for MirrorMaker 2.0
+.Minimal configuration for MirrorMaker 2
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}
@@ -219,9 +219,9 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <13> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
 <14> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
 <15> TLS encryption for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
-<16> xref:type-KafkaMirrorMaker2MirrorSpec-reference[MirrorMaker 2.0 connectors].
-<17> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the source cluster used by the MirrorMaker 2.0 connectors.
-<18> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the target cluster used by the MirrorMaker 2.0 connectors.
+<16> xref:type-KafkaMirrorMaker2MirrorSpec-reference[MirrorMaker 2 connectors].
+<17> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the source cluster used by the MirrorMaker 2 connectors.
+<18> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the target cluster used by the MirrorMaker 2 connectors.
 <19> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorSourceConnector`] that creates remote topics. The `config` overrides the default configuration options.
 <20> The maximum number of tasks that the connector may create. Tasks handle the data replication and run in parallel. If the infrastructure supports the processing overhead, increasing this value can improve throughput. Kafka Connect distributes the tasks between members of the cluster. If there are more tasks than workers, workers are assigned multiple tasks. For sink connectors, aim to have one task for each topic partition consumed. For source connectors, the number of tasks that can run in parallel may also depend on the external system. The connector creates fewer than the maximum number of tasks if it cannot achieve the parallelism.
 <21> Enables automatic restarts of failed connectors and tasks. Up to seven restart attempts are made, after which restarts must be made manually.

--- a/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
@@ -2,10 +2,10 @@
 // configuring/assembly-config-mirrormaker2.adoc
 
 [id='proc-config-mirrormaker2-securing-connection-{context}']
-= Securing a Kafka MirrorMaker 2.0 deployment
+= Securing a Kafka MirrorMaker 2 deployment
 
 [role="_abstract"]
-This procedure describes in outline the configuration required to secure a MirrorMaker 2.0 deployment.
+This procedure describes in outline the configuration required to secure a MirrorMaker 2 deployment.
 
 You need separate configuration for the source Kafka cluster and the target Kafka cluster.
 You also need separate user configuration to provide the credentials required for MirrorMaker to connect to the source and target Kafka clusters.
@@ -13,7 +13,7 @@ You also need separate user configuration to provide the credentials required fo
 For the Kafka clusters, you specify internal listeners for secure connections within a Kubernetes cluster and external listeners for connections outside the Kubernetes cluster.
 
 You can configure authentication and authorization mechanisms.
-The security options implemented for the source and target Kafka clusters must be compatible with the security options implemented for MirrorMaker 2.0.
+The security options implemented for the source and target Kafka clusters must be compatible with the security options implemented for MirrorMaker 2.
 
 After you have created the cluster and user authentication credentials, you specify them in your MirrorMaker configuration for secure connections.
 
@@ -22,10 +22,10 @@ You can also configure your listener to link:{BookURLDeploying}#proc-installing-
 
 .Before you start
 Before starting this procedure, take a look at the link:{BookURLDeploying}#deploy-examples-{context}[example configuration files^] provided by Strimzi.
-They include examples for securing a deployment of MirrorMaker 2.0 using mTLS or SCRAM-SHA-512 authentication.
+They include examples for securing a deployment of MirrorMaker 2 using mTLS or SCRAM-SHA-512 authentication.
 The examples specify internal listeners for connecting within a Kubernetes cluster.
 
-The examples provide the configuration for full authorization, including all the ACLs needed by MirrorMaker 2.0 to allow operations on the source and target Kafka clusters.
+The examples provide the configuration for full authorization, including all the ACLs needed by MirrorMaker 2 to allow operations on the source and target Kafka clusters.
 
 
 .Prerequisites
@@ -156,7 +156,7 @@ The certificates are created in the secret `_<cluster_name>_-cluster-ca-cert`.
 .. Configure the same authentication and authorization types as the corresponding source and target Kafka cluster.
 For example, if you used `tls` authentication and the `simple` authorization type in the `Kafka` configuration for the source Kafka cluster, use the same in the `KafkaUser` configuration.
 
-.. Configure the ACLs needed by MirrorMaker 2.0 to allow operations on the source and target Kafka clusters.
+.. Configure the ACLs needed by MirrorMaker 2 to allow operations on the source and target Kafka clusters.
 +
 The ACLs are used by the internal MirrorMaker connectors, and by the underlying Kafka Connect framework.
 --
@@ -312,7 +312,7 @@ The public key is contained in a user certificate, which is signed by the client
 
 . Configure a `KafkaMirrorMaker2` resource with the authentication details to connect to the source and target Kafka clusters.
 +
-.Example MirrorMaker 2.0 configuration with TLS encryption and mTLS authentication
+.Example MirrorMaker 2 configuration with TLS encryption and mTLS authentication
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}

--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -2,9 +2,9 @@
 // configuring/assembly-config-mirrormaker2.adoc
 
 [id='proc-manual-restart-mirrormaker2-connector-task-{context}']
-= Performing a restart of a Kafka MirrorMaker 2.0 connector task
+= Performing a restart of a Kafka MirrorMaker 2 connector task
 
-This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2.0 connector task by using a Kubernetes annotation.
+This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2 connector task by using a Kubernetes annotation.
 
 .Prerequisites
 
@@ -12,14 +12,14 @@ This procedure describes how to manually trigger a restart of a Kafka MirrorMake
 
 .Procedure
 
-. Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2.0 connector you want to restart:
+. Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2 connector you want to restart:
 +
 [source,shell,subs="+quotes"]
 ----
 kubectl get KafkaMirrorMaker2
 ----
 
-. Find the name of the Kafka MirrorMaker 2.0 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource.
+. Find the name of the Kafka MirrorMaker 2 connector and the ID of the task to be restarted from the `KafkaMirrorMaker2` custom resource.
 Task IDs are non-negative integers, starting from 0.
 +
 [source,shell,subs="+quotes"]
@@ -37,10 +37,10 @@ kubectl annotate KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_ "strimzi.io/restart
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 +
-The Kafka MirrorMaker 2.0 connector task is restarted, as long as the annotation was detected by the reconciliation process.
+The Kafka MirrorMaker 2 connector task is restarted, as long as the annotation was detected by the reconciliation process.
 When the restart task request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2.0 cluster configuration].
+* xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2 cluster configuration].

--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector.adoc
@@ -2,9 +2,9 @@
 // configuring/assembly-config-mirrormaker2.adoc
 
 [id='proc-manual-restart-mirrormaker2-connector-{context}']
-= Performing a restart of a Kafka MirrorMaker 2.0 connector
+= Performing a restart of a Kafka MirrorMaker 2 connector
 
-This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2.0 connector by using a Kubernetes annotation.
+This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2 connector by using a Kubernetes annotation.
 
 .Prerequisites
 
@@ -12,14 +12,14 @@ This procedure describes how to manually trigger a restart of a Kafka MirrorMake
 
 .Procedure
 
-. Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2.0 connector you want to restart:
+. Find the name of the `KafkaMirrorMaker2` custom resource that controls the Kafka MirrorMaker 2 connector you want to restart:
 +
 [source,shell,subs="+quotes"]
 ----
 kubectl get KafkaMirrorMaker2
 ----
 
-. Find the name of the Kafka MirrorMaker 2.0 connector to be restarted from the `KafkaMirrorMaker2` custom resource.
+. Find the name of the Kafka MirrorMaker 2 connector to be restarted from the `KafkaMirrorMaker2` custom resource.
 +
 [source,shell,subs="+quotes"]
 ----
@@ -36,10 +36,10 @@ kubectl annotate KafkaMirrorMaker2 _KAFKAMIRRORMAKER-2-NAME_ "strimzi.io/restart
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 +
-The Kafka MirrorMaker 2.0 connector is restarted, as long as the annotation was detected by the reconciliation process.
+The Kafka MirrorMaker 2 connector is restarted, as long as the annotation was detected by the reconciliation process.
 When the restart request is accepted, the annotation is removed from the `KafkaMirrorMaker2` custom resource.
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2.0 cluster configuration].
+* xref:assembly-mirrormaker-{context}[Kafka MirrorMaker 2 cluster configuration].

--- a/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
+++ b/documentation/modules/deploying/con-deploy-cluster-operator-watch-options.adoc
@@ -25,7 +25,7 @@ The Cluster Operator watches for changes to the following resources:
 * `KafkaConnect` for the Kafka Connect cluster.
 * `KafkaConnector` for creating and managing connectors in a Kafka Connect cluster.
 * `KafkaMirrorMaker` for the Kafka MirrorMaker instance.
-* `KafkaMirrorMaker2` for the Kafka MirrorMaker 2.0 instance.
+* `KafkaMirrorMaker2` for the Kafka MirrorMaker 2 instance.
 * `KafkaBridge` for the Kafka Bridge instance.
 * `KafkaRebalance` for the Cruise Control optimization requests.
 

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -36,7 +36,7 @@ For MirrorMaker:
 kubectl apply -f examples/mirror-maker/kafka-mirror-maker.yaml
 ----
 +
-For MirrorMaker 2.0:
+For MirrorMaker 2:
 +
 [source,shell,subs="attributes+"]
 ----
@@ -59,7 +59,7 @@ my-mm2-cluster-mirrormaker2   1/1    1           1
 ----
 +
 `my-mirror-maker` is the name of the Kafka MirrorMaker cluster.
-`my-mm2-cluster` is the name of the Kafka MirrorMaker 2.0 cluster.
+`my-mm2-cluster` is the name of the Kafka MirrorMaker 2 cluster.
 +
 `READY` shows the number of replicas that are ready/expected.
 The deployment is successful when the `AVAILABLE` output shows `1`.

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -42,7 +42,7 @@ m¦KafkaConnector
 
 m¦KafkaMirrorMaker2
 ¦`KafkaMirrorMaker2Status` schema reference
-¦The Kafka MirrorMaker 2.0 cluster
+¦The Kafka MirrorMaker 2 cluster
 
 m¦KafkaMirrorMaker
 ¦`KafkaMirrorMakerStatus` schema reference

--- a/documentation/modules/metrics/ref-prometheus-metrics-config.adoc
+++ b/documentation/modules/metrics/ref-prometheus-metrics-config.adoc
@@ -34,7 +34,7 @@ When deploying Prometheus metrics configuration, you can can deploy the example 
 |`KafkaConnect`
 |`kafka-connect-metrics.yaml`
 
-|Kafka MirrorMaker 2.0
+|Kafka MirrorMaker 2
 |`KafkaMirrorMaker2`
 |`kafka-mirror-maker-2-metrics.yaml`
 

--- a/documentation/modules/metrics/ref_metrics-dashboards.adoc
+++ b/documentation/modules/metrics/ref_metrics-dashboards.adoc
@@ -36,7 +36,7 @@ The dashboards are populated with a representative set of metrics for monitoring
 |Kafka Connect
 |`strimzi-kafka-connect.json`
 
-|Kafka MirrorMaker 2.0
+|Kafka MirrorMaker 2
 |`strimzi-kafka-mirror-maker-2.json`
 
 |Kafka Bridge

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -84,7 +84,7 @@ To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATU
 
 The `StableConnectIdentities` feature gate has a default state of _disabled_.
 
-The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2  pods instead of using Kubernetes Deployment resources.
+The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes Deployment resources.
 `StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
 This helps to minimize the number of rebalances of connector tasks.
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -84,7 +84,7 @@ To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATU
 
 The `StableConnectIdentities` feature gate has a default state of _disabled_.
 
-The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2.0  pods instead of using Kubernetes Deployment resources.
+The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2  pods instead of using Kubernetes Deployment resources.
 `StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
 This helps to minimize the number of rebalances of connector tasks.
 

--- a/documentation/modules/operators/ref-operator-cluster-rbac-resources.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-rbac-resources.adoc
@@ -47,7 +47,7 @@ The following tables describe the RBAC resources created by the Cluster Operator
 |MirrorMaker pods
 
 |_<cluster_name>_-mirrormaker2
-|MirrorMaker 2.0 pods
+|MirrorMaker 2 pods
 
 |_<cluster_name>_-bridge
 |Kafka Bridge pods

--- a/documentation/modules/overview/con-configuration-points-broker.adoc
+++ b/documentation/modules/overview/con-configuration-points-broker.adoc
@@ -68,7 +68,7 @@ Kafka brokers use the IDs to spread partition replicas across racks.
 You can also specify the `RackAwareReplicaSelector` selector plugin to use with rack awareness. 
 The plugin matches the rack IDs of brokers and consumers, so that messages are consumed from the closest replica. 
 To use the plugin, consumers must also have rack awareness enabled. 
-You can enable rack awareness in Kafka Connect, MirrorMaker 2.0, and the Kafka Bridge.   
+You can enable rack awareness in Kafka Connect, MirrorMaker 2, and the Kafka Bridge.   
 
 [discrete]
 == Example YAML showing Kafka configuration

--- a/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
+++ b/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
@@ -8,12 +8,12 @@
 [role="_abstract"]
 To set up MirrorMaker, a source and target (destination) Kafka cluster must be running.
 
-You can use Strimzi with MirrorMaker 2.0, although the earlier version of MirrorMaker continues to be supported.
+You can use Strimzi with MirrorMaker 2, although the earlier version of MirrorMaker continues to be supported.
 
 include::con-overview-mirrormaker2.adoc[leveloffset=+1]
 
 [discrete]
-=== Example YAML showing MirrorMaker 2.0 configuration
+=== Example YAML showing MirrorMaker 2 configuration
 
 [source,yaml,subs="+quotes,attributes"]
 ----

--- a/documentation/modules/overview/con-key-features-kafka-connect.adoc
+++ b/documentation/modules/overview/con-key-features-kafka-connect.adoc
@@ -33,13 +33,13 @@ Plugins provide the implementation for Kafka Connect to run connector instances.
 Connector instances create the tasks required to transfer data in and out of Kafka.
 The Kafka Connect runtime orchestrates the tasks to split the work required between the worker pods.
 
-MirrorMaker 2.0 also uses the Kafka Connect framework.
+MirrorMaker 2 also uses the Kafka Connect framework.
 In this case, the external data system is another Kafka cluster.
-Specialized connectors for MirrorMaker 2.0 manage data replication between source and target Kafka clusters.
+Specialized connectors for MirrorMaker 2 manage data replication between source and target Kafka clusters.
 
 [NOTE]
 ====
-In addition to the MirrorMaker 2.0 connectors, Kafka provides two connectors as examples:
+In addition to the MirrorMaker 2 connectors, Kafka provides two connectors as examples:
 
 * `FileStreamSourceConnector` streams data from a file on the worker's filesystem to Kafka, reading the input file and sending each line to a given Kafka topic.
 * `FileStreamSinkConnector` streams data from Kafka to the worker's filesystem, reading messages from a Kafka topic and writing a line for each in an output file.
@@ -137,4 +137,4 @@ NOTE: You can also specify converters for specific connectors to override the ge
 .Additional resources
 * http://kafka.apache.org[Apache Kafka documentation^]
 * link:{BookURLConfiguring}#property-kafka-connect-config-reference[Kafka Connect configuration of workers^]
-* link:{BookURLConfiguring}#proc-mirrormaker-replication-str[Synchronizing data between Kafka clusters using MirrorMaker 2.0^]
+* link:{BookURLConfiguring}#proc-mirrormaker-replication-str[Synchronizing data between Kafka clusters using MirrorMaker 2^]

--- a/documentation/modules/overview/con-overview-mirrormaker2.adoc
+++ b/documentation/modules/overview/con-overview-mirrormaker2.adoc
@@ -3,21 +3,21 @@
 // overview/assembly-configuration-points.adoc
 
 [id="con-overview-mm2-{context}"]
-= MirrorMaker 2.0 configuration
+= MirrorMaker 2 configuration
 
 [role="_abstract"]
-MirrorMaker 2.0 consumes messages from a source Kafka cluster and writes them to a target Kafka cluster.
+MirrorMaker 2 consumes messages from a source Kafka cluster and writes them to a target Kafka cluster.
 
-MirrorMaker 2.0 uses:
+MirrorMaker 2 uses:
 
 * Source cluster configuration to consume data from the source cluster
 * Target cluster configuration to output data to the target cluster
 
-MirrorMaker 2.0 is based on the Kafka Connect framework, _connectors_ managing the transfer of data between clusters.
+MirrorMaker 2 is based on the Kafka Connect framework, _connectors_ managing the transfer of data between clusters.
 
-You configure MirrorMaker 2.0 to define the Kafka Connect deployment, including the connection details of the source and target clusters, and then run a set of MirrorMaker 2.0 connectors to make the connection.
+You configure MirrorMaker 2 to define the Kafka Connect deployment, including the connection details of the source and target clusters, and then run a set of MirrorMaker 2 connectors to make the connection.
 
-MirrorMaker 2.0 consists of the following connectors:
+MirrorMaker 2 consists of the following connectors:
 
 `MirrorSourceConnector`:: The source connector replicates topics from a source cluster to a target cluster. It also replicates ACLs and is necessary for the `MirrorCheckpointConnector` to run. 
 `MirrorCheckpointConnector`:: The checkpoint connector periodically tracks offsets. If enabled, it also synchronizes consumer group offsets between the source and target cluster.
@@ -26,35 +26,35 @@ MirrorMaker 2.0 consists of the following connectors:
 NOTE: If you are using the User Operator to manage ACLs, ACL replication through the connector is not possible.    
 
 The process of _mirroring_ data from a source cluster to a target cluster is asynchronous.
-Each MirrorMaker 2.0 instance mirrors data from one source cluster to one target cluster. 
-You can use more than one MirrorMaker 2.0 instance to mirror data between any number of clusters.
+Each MirrorMaker 2 instance mirrors data from one source cluster to one target cluster. 
+You can use more than one MirrorMaker 2 instance to mirror data between any number of clusters.
 
 .Replication across two clusters
-image::mirrormaker.png[MirrorMaker 2.0 replication]
+image::mirrormaker.png[MirrorMaker 2 replication]
 
 By default, a check for new topics in the source cluster is made every 10 minutes.
 You can change the frequency by adding `refresh.topics.interval.seconds` to the source connector configuration.
 
 == Cluster configuration
 
-You can use MirrorMaker 2.0 in _active/passive_ or _active/active_ cluster configurations.
+You can use MirrorMaker 2 in _active/passive_ or _active/active_ cluster configurations.
 
 active/active cluster configuration:: An active/active configuration has two active clusters replicating data bidirectionally. Applications can use either cluster. Each cluster can provide the same data. In this way,  you can make the same data available in different geographical locations. As consumer groups are active in both clusters, consumer offsets for replicated topics are not synchronized back to the source cluster. 
 active/passive cluster configuration:: An active/passive configuration has an active cluster replicating data to a passive cluster. The passive cluster remains on standby. You might use the passive cluster for data recovery in the event of system failure.
 
 The expectation is that producers and consumers connect to active clusters only.
-A MirrorMaker 2.0 cluster is required at each target destination.
+A MirrorMaker 2 cluster is required at each target destination.
 
 == Bidirectional replication (active/active)
 
-The MirrorMaker 2.0 architecture supports bidirectional replication in an _active/active_ cluster configuration.
+The MirrorMaker 2 architecture supports bidirectional replication in an _active/active_ cluster configuration.
 
 Each cluster replicates the data of the other cluster using the concept of _source_ and _remote_ topics.
-As the same topics are stored in each cluster, remote topics are automatically renamed by MirrorMaker 2.0 to represent the source cluster.
+As the same topics are stored in each cluster, remote topics are automatically renamed by MirrorMaker 2 to represent the source cluster.
 The name of the originating cluster is prepended to the name of the topic.
 
 .Topic renaming
-image::mirrormaker-renaming.png[MirrorMaker 2.0 bidirectional architecture]
+image::mirrormaker-renaming.png[MirrorMaker 2 bidirectional architecture]
 
 By flagging the originating cluster, topics are not replicated back to that cluster.
 
@@ -64,7 +64,7 @@ Consumers can subscribe to source and remote topics within the same cluster, wit
 [id=unidirectional_replication_activepassive]
 == Unidirectional replication (active/passive)
 
-The MirrorMaker 2.0 architecture supports unidirectional replication in an _active/passive_ cluster configuration.
+The MirrorMaker 2 architecture supports unidirectional replication in an _active/passive_ cluster configuration.
 
 You can use an _active/passive_ cluster configuration to make backups or migrate data to another cluster.
 In this situation, you might not want automatic renaming of remote topics.

--- a/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
+++ b/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
@@ -6,22 +6,22 @@
 = Enabling tracing in MirrorMaker, Kafka Connect, and Kafka Bridge resources
 
 [role="_abstract"]
-Distributed tracing is supported for MirrorMaker, MirrorMaker 2.0, Kafka Connect, and the Strimzi Kafka Bridge.
+Distributed tracing is supported for MirrorMaker, MirrorMaker 2, Kafka Connect, and the Strimzi Kafka Bridge.
 Configure the custom resource of the component to specify and enable a tracer service. 
 
 Enabling tracing in a resource triggers the following events:
 
 * Interceptor classes are updated in the integrated consumers and producers of the component.
 
-* For MirrorMaker, MirrorMaker 2.0, and Kafka Connect, the tracing agent initializes a tracer based on the tracing configuration defined in the resource.
+* For MirrorMaker, MirrorMaker 2, and Kafka Connect, the tracing agent initializes a tracer based on the tracing configuration defined in the resource.
 
 * For the Kafka Bridge, a tracer based on the tracing configuration defined in the resource is initialized by the Kafka Bridge itself.
 
 You can enable tracing that uses OpenTelemetry or OpenTracing.
 
-.Tracing in MirrorMaker and MirrorMaker 2.0
+.Tracing in MirrorMaker and MirrorMaker 2
 
-For MirrorMaker and MirrorMaker 2.0, messages are traced from the source cluster to the target cluster. The trace data records messages entering and leaving the MirrorMaker or MirrorMaker 2.0 component.
+For MirrorMaker and MirrorMaker 2, messages are traced from the source cluster to the target cluster. The trace data records messages entering and leaving the MirrorMaker or MirrorMaker 2 component.
 
 .Tracing in Kafka Connect
 
@@ -87,7 +87,7 @@ spec:
 #...
 ----
 
-.Example tracing configuration for MirrorMaker 2.0 using OpenTelemetry
+.Example tracing configuration for MirrorMaker 2 using OpenTelemetry
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}
@@ -175,7 +175,7 @@ spec:
 #...
 ----
 
-.Example tracing configuration for MirrorMaker 2.0 using OpenTracing
+.Example tracing configuration for MirrorMaker 2 using OpenTracing
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -99,7 +99,7 @@ If required, set the `version` property for Kafka Connect and MirrorMaker as the
 +
 .. For Kafka Connect, update `KafkaConnect.spec.version`.
 .. For MirrorMaker, update `KafkaMirrorMaker.spec.version`.
-.. For MirrorMaker 2.0, update `KafkaMirrorMaker2.spec.version`.
+.. For MirrorMaker 2, update `KafkaMirrorMaker2.spec.version`.
 
 . If configured, update the Kafka resource to use the new `inter.broker.protocol.version` version. Otherwise, go to step 9.
 +

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -657,7 +657,7 @@ spec:
                         topologyKey:
                           type: string
                           example: topology.kubernetes.io/zone
-                          description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                          description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                       required:
                         - topologyKey
                       description: Configuration of the `broker.rack` broker config.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -369,7 +369,7 @@ spec:
                     topologyKey:
                       type: string
                       example: topology.kubernetes.io/zone
-                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                   required:
                     - topologyKey
                   description: Configuration of the node label which will be used as the `client.rack` consumer configuration.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -354,7 +354,7 @@ spec:
                     topologyKey:
                       type: string
                       example: topology.kubernetes.io/zone
-                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                   required:
                     - topologyKey
                   description: Configuration of the node label which will be used as the client.rack consumer configuration.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -32,7 +32,7 @@ spec:
           labelSelectorPath: .status.labelSelector
       additionalPrinterColumns:
         - name: Desired replicas
-          description: The desired number of Kafka MirrorMaker 2.0 replicas
+          description: The desired number of Kafka MirrorMaker 2 replicas
           jsonPath: .spec.replicas
           type: integer
         - name: Ready
@@ -88,7 +88,7 @@ spec:
                                 - certificate
                                 - secretName
                             description: Trusted certificates for TLS connection.
-                        description: TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
+                        description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                       authentication:
                         type: object
                         properties:
@@ -230,7 +230,7 @@ spec:
                       config:
                         x-kubernetes-preserve-unknown-fields: true
                         type: object
-                        description: "The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                        description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                     required:
                       - alias
                       - bootstrapServers
@@ -242,10 +242,10 @@ spec:
                     properties:
                       sourceCluster:
                         type: string
-                        description: The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+                        description: The alias of the source cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.
                       targetCluster:
                         type: string
-                        description: The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+                        description: The alias of the target cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.
                       sourceConnector:
                         type: object
                         properties:
@@ -267,7 +267,7 @@ spec:
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
-                        description: The specification of the Kafka MirrorMaker 2.0 source connector.
+                        description: The specification of the Kafka MirrorMaker 2 source connector.
                       heartbeatConnector:
                         type: object
                         properties:
@@ -289,7 +289,7 @@ spec:
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
-                        description: The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
+                        description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                       checkpointConnector:
                         type: object
                         properties:
@@ -311,7 +311,7 @@ spec:
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
-                        description: The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
+                        description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                       topicsPattern:
                         type: string
                         description: "A regular expression matching the topics to be mirrored, for example, \"topic1\\|topic2\\|topic3\". Comma-separated lists are also supported."
@@ -333,7 +333,7 @@ spec:
                     required:
                       - sourceCluster
                       - targetCluster
-                  description: Configuration of the MirrorMaker 2.0 connectors.
+                  description: Configuration of the MirrorMaker 2 connectors.
                 resources:
                   type: object
                   properties:
@@ -484,7 +484,7 @@ spec:
                     topologyKey:
                       type: string
                       example: topology.kubernetes.io/zone
-                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                      description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                   required:
                     - topologyKey
                   description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
@@ -1960,7 +1960,7 @@ spec:
                   description: Metrics configuration.
               required:
                 - connectCluster
-              description: The specification of the Kafka MirrorMaker 2.0 cluster.
+              description: The specification of the Kafka MirrorMaker 2 cluster.
             status:
               type: object
               properties:
@@ -2005,7 +2005,7 @@ spec:
                       lastRestartTimestamp:
                         type: string
                         description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
-                  description: List of MirrorMaker 2.0 connector auto restart statuses.
+                  description: List of MirrorMaker 2 connector auto restart statuses.
                 connectorPlugins:
                   type: array
                   items:
@@ -2026,11 +2026,11 @@ spec:
                   items:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
-                  description: "List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API."
+                  description: "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API."
                 labelSelector:
                   type: string
                   description: Label selector for pods providing this resource.
                 replicas:
                   type: integer
                   description: The current number of pods being used to provide this resource.
-              description: The status of the Kafka MirrorMaker 2.0 cluster.
+              description: The status of the Kafka MirrorMaker 2 cluster.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -656,7 +656,7 @@ spec:
                       topologyKey:
                         type: string
                         example: topology.kubernetes.io/zone
-                        description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                        description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                     required:
                     - topologyKey
                     description: Configuration of the `broker.rack` broker config.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -368,7 +368,7 @@ spec:
                   topologyKey:
                     type: string
                     example: topology.kubernetes.io/zone
-                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                 required:
                 - topologyKey
                 description: Configuration of the node label which will be used as the `client.rack` consumer configuration.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -353,7 +353,7 @@ spec:
                   topologyKey:
                     type: string
                     example: topology.kubernetes.io/zone
-                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                 required:
                 - topologyKey
                 description: Configuration of the node label which will be used as the client.rack consumer configuration.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -31,7 +31,7 @@ spec:
         labelSelectorPath: .status.labelSelector
     additionalPrinterColumns:
     - name: Desired replicas
-      description: The desired number of Kafka MirrorMaker 2.0 replicas
+      description: The desired number of Kafka MirrorMaker 2 replicas
       jsonPath: .spec.replicas
       type: integer
     - name: Ready
@@ -87,7 +87,7 @@ spec:
                             - certificate
                             - secretName
                           description: Trusted certificates for TLS connection.
-                      description: TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
+                      description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                     authentication:
                       type: object
                       properties:
@@ -229,7 +229,7 @@ spec:
                     config:
                       x-kubernetes-preserve-unknown-fields: true
                       type: object
-                      description: "The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                      description: "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                   required:
                   - alias
                   - bootstrapServers
@@ -241,10 +241,10 @@ spec:
                   properties:
                     sourceCluster:
                       type: string
-                      description: The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+                      description: The alias of the source cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.
                     targetCluster:
                       type: string
-                      description: The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+                      description: The alias of the target cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.
                     sourceConnector:
                       type: object
                       properties:
@@ -266,7 +266,7 @@ spec:
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
-                      description: The specification of the Kafka MirrorMaker 2.0 source connector.
+                      description: The specification of the Kafka MirrorMaker 2 source connector.
                     heartbeatConnector:
                       type: object
                       properties:
@@ -288,7 +288,7 @@ spec:
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
-                      description: The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
+                      description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                     checkpointConnector:
                       type: object
                       properties:
@@ -310,7 +310,7 @@ spec:
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
-                      description: The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
+                      description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                     topicsPattern:
                       type: string
                       description: "A regular expression matching the topics to be mirrored, for example, \"topic1\\|topic2\\|topic3\". Comma-separated lists are also supported."
@@ -332,7 +332,7 @@ spec:
                   required:
                   - sourceCluster
                   - targetCluster
-                description: Configuration of the MirrorMaker 2.0 connectors.
+                description: Configuration of the MirrorMaker 2 connectors.
               resources:
                 type: object
                 properties:
@@ -483,7 +483,7 @@ spec:
                   topologyKey:
                     type: string
                     example: topology.kubernetes.io/zone
-                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2."
                 required:
                 - topologyKey
                 description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
@@ -1959,7 +1959,7 @@ spec:
                 description: Metrics configuration.
             required:
             - connectCluster
-            description: The specification of the Kafka MirrorMaker 2.0 cluster.
+            description: The specification of the Kafka MirrorMaker 2 cluster.
           status:
             type: object
             properties:
@@ -2004,7 +2004,7 @@ spec:
                     lastRestartTimestamp:
                       type: string
                       description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
-                description: List of MirrorMaker 2.0 connector auto restart statuses.
+                description: List of MirrorMaker 2 connector auto restart statuses.
               connectorPlugins:
                 type: array
                 items:
@@ -2025,11 +2025,11 @@ spec:
                 items:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
-                description: "List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API."
+                description: "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API."
               labelSelector:
                 type: string
                 description: Label selector for pods providing this resource.
               replicas:
                 type: integer
                 description: The current number of pods being used to provide this resource.
-            description: The status of the Kafka MirrorMaker 2.0 cluster.
+            description: The status of the Kafka MirrorMaker 2 cluster.

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -188,7 +188,7 @@ class MirrorMaker2IsolatedST extends AbstractST {
     }
 
     /**
-     * Test mirroring messages by MirrorMaker 2.0 over tls transport using mutual tls auth
+     * Test mirroring messages by MirrorMaker 2 over tls transport using mutual tls auth
      */
     @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelNamespaceTest
@@ -321,7 +321,7 @@ class MirrorMaker2IsolatedST extends AbstractST {
     }
 
     /**
-     * Test mirroring messages by MirrorMaker 2.0 over tls transport using scram-sha-512 auth
+     * Test mirroring messages by MirrorMaker 2 over tls transport using scram-sha-512 auth
      */
     @ParallelNamespaceTest
     @KRaftNotSupported("Scram-sha is not supported by KRaft mode and is used in this test case")
@@ -963,7 +963,7 @@ class MirrorMaker2IsolatedST extends AbstractST {
     }
 
     /**
-     * Test mirroring messages by MirrorMaker 2.0 over tls transport using scram-sha-512 auth
+     * Test mirroring messages by MirrorMaker 2 over tls transport using scram-sha-512 auth
      * while user Scram passwords, CA cluster and clients certificates are changed.
      */
     @ParallelNamespaceTest


### PR DESCRIPTION
**Documentation**

Updates the documentation to use _MirrorMaker 2_ instead of _MirrorMaker 2.0_ to be consistent with the naming convention used in Apache Kafka

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

