### PR TITLE
Move more logic for generating services, routes and ingresses to the `KafkaCluster` model class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -297,22 +297,23 @@ public class ListenersUtils {
      * @throws  UnsupportedOperationException Throws UnsupportedOperationException if called for internal service
      *                                          which does not have per-pod services
      *
-     * @param clusterName Name of the cluster to which this service belongs
-     * @param pod         Number of the pod for which this service will be used
+     * @param baseName  The base name which should be used to generate the Service name - for example my-cluster-kafka
+     * @param pod       Number of the pod for which this service will be used
      * @param listener  Listener for which the name should be generated
+     *
      * @return          Name of the bootstrap service
      */
-    public static String backwardsCompatibleBrokerServiceName(String clusterName, int pod, GenericKafkaListener listener) {
+    public static String backwardsCompatiblePerBrokerServiceName(String baseName, int pod, GenericKafkaListener listener) {
         if (listener.getPort() == 9092 && "plain".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
             throw new UnsupportedOperationException("Per-broker services are not used for internal listener");
         } else if (listener.getPort() == 9093 && "tls".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
             throw new UnsupportedOperationException("Per-broker services are not used for internal listener");
         } else if (listener.getPort() == 9094 && "external".equals(listener.getName()))   {
-            return clusterName + "-kafka-" + pod;
+            return baseName + "-" + pod;
         } else if (KafkaListenerType.INTERNAL == listener.getType()) {
             throw new UnsupportedOperationException("Per-broker services are not used for internal listener");
         } else {
-            return clusterName + "-kafka-" + listener.getName() + "-" + pod;
+            return baseName + "-" + listener.getName() + "-" + pod;
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -597,7 +597,7 @@ public class KafkaClusterTest {
         assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(exSvcAnnotations.entrySet()), is(true));
 
         // Check per pod service
-        svc = kc.generateExternalServices(0).get(0);
+        svc = kc.generatePerPodServices().get(0);
         assertThat(svc.getMetadata().getLabels().entrySet().containsAll(perPodSvcLabels.entrySet()), is(true));
         assertThat(svc.getMetadata().getAnnotations().entrySet().containsAll(perPodSvcAnnotations.entrySet()), is(true));
 
@@ -607,7 +607,7 @@ public class KafkaClusterTest {
         assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(exRouteAnnotations.entrySet()), is(true));
 
         // Check PerPodRoute
-        rt = kc.generateExternalRoutes(0).get(0);
+        rt = kc.generateExternalRoutes().get(0);
         assertThat(rt.getMetadata().getLabels().entrySet().containsAll(perPodRouteLabels.entrySet()), is(true));
         assertThat(rt.getMetadata().getAnnotations().entrySet().containsAll(perPodRouteAnnotations.entrySet()), is(true));
 
@@ -1490,8 +1490,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
@@ -1514,8 +1516,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(brt, KAFKA);
 
         // Check per pod router
+        List<Route> routes = kc.generateExternalRoutes();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Route rt = kc.generateExternalRoutes(i).get(0);
+            Route rt = routes.get(i);
             assertThat(rt.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(rt.getSpec().getTls().getTermination(), is("passthrough"));
             assertThat(rt.getSpec().getTo().getKind(), is("Service"));
@@ -1568,8 +1572,10 @@ public class KafkaClusterTest {
         assertThat(brt.getSpec().getHost(), is("my-boostrap.cz"));
 
         // Check per pod router
+        List<Route> routes = kc.generateExternalRoutes();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Route rt = kc.generateExternalRoutes(i).get(0);
+            Route rt = routes.get(i);
             assertThat(rt.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(rt.getSpec().getHost(), is("my-host-" + i + ".cz"));
         }
@@ -1623,8 +1629,10 @@ public class KafkaClusterTest {
         assertThat(brt.getMetadata().getLabels().get("label"), is("label-value"));
 
         // Check per pod router
+        List<Route> routes = kc.generateExternalRoutes();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Route rt = kc.generateExternalRoutes(i).get(0);
+            Route rt = routes.get(i);
             assertThat(rt.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(rt.getMetadata().getAnnotations().get("anno"), is("anno-value-" + i));
             assertThat(rt.getMetadata().getLabels().get("label"), is("label-value-" + i));
@@ -1671,8 +1679,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getMetadata().getFinalizers(), is(emptyList()));
             assertThat(srv.getSpec().getType(), is("LoadBalancer"));
@@ -1739,8 +1749,10 @@ public class KafkaClusterTest {
         assertThat(ext.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.LOCAL.toValue()));
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.LOCAL.toValue()));
         }
     }
@@ -1769,8 +1781,10 @@ public class KafkaClusterTest {
         assertThat(ext.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.CLUSTER.toValue()));
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getSpec().getExternalTrafficPolicy(), is(ExternalTrafficPolicy.CLUSTER.toValue()));
         }
     }
@@ -1801,8 +1815,10 @@ public class KafkaClusterTest {
         assertThat(ext.getMetadata().getFinalizers(), is(finalizers));
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getFinalizers(), is(finalizers));
         }
     }
@@ -1833,8 +1849,10 @@ public class KafkaClusterTest {
         assertThat(ext.getSpec().getLoadBalancerSourceRanges(), is(sourceRanges));
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getSpec().getLoadBalancerSourceRanges(), is(sourceRanges));
         }
     }
@@ -1879,12 +1897,14 @@ public class KafkaClusterTest {
         // Check annotations
         assertThat(kc.generateExternalBootstrapServices().get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "bootstrap.myingress.com.")));
         assertThat(kc.generateExternalBootstrapServices().get(0).getMetadata().getLabels().get("label"), is("label-value"));
-        assertThat(kc.generateExternalServices(0).get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-0.myingress.com.")));
-        assertThat(kc.generateExternalServices(0).get(0).getMetadata().getLabels().get("label"), is("label-value"));
-        assertThat(kc.generateExternalServices(1).get(0).getMetadata().getAnnotations().isEmpty(), is(true));
-        assertThat(kc.generateExternalServices(1).get(0).getMetadata().getLabels().get("label"), is(nullValue()));
-        assertThat(kc.generateExternalServices(2).get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-2.myingress.com.")));
-        assertThat(kc.generateExternalServices(2).get(0).getMetadata().getLabels().get("label"), is("label-value"));
+
+        List<Service> services = kc.generatePerPodServices();
+        assertThat(services.get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-0.myingress.com.")));
+        assertThat(services.get(0).getMetadata().getLabels().get("label"), is("label-value"));
+        assertThat(services.get(1).getMetadata().getAnnotations().isEmpty(), is(true));
+        assertThat(services.get(1).getMetadata().getLabels().get("label"), is(nullValue()));
+        assertThat(services.get(2).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-2.myingress.com.")));
+        assertThat(services.get(2).getMetadata().getLabels().get("label"), is("label-value"));
     }
 
     @ParallelTest
@@ -1923,9 +1943,11 @@ public class KafkaClusterTest {
 
         // Check annotations
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getLoadBalancerIP(), is("10.0.0.1"));
-        assertThat(kc.generateExternalServices(0).get(0).getSpec().getLoadBalancerIP(), is("10.0.0.2"));
-        assertThat(kc.generateExternalServices(1).get(0).getSpec().getLoadBalancerIP(), is(nullValue()));
-        assertThat(kc.generateExternalServices(2).get(0).getSpec().getLoadBalancerIP(), is("10.0.0.3"));
+
+        List<Service> services = kc.generatePerPodServices();
+        assertThat(services.get(0).getSpec().getLoadBalancerIP(), is("10.0.0.2"));
+        assertThat(services.get(1).getSpec().getLoadBalancerIP(), is(nullValue()));
+        assertThat(services.get(2).getSpec().getLoadBalancerIP(), is("10.0.0.3"));
     }
 
     @ParallelTest
@@ -1951,8 +1973,10 @@ public class KafkaClusterTest {
         Service ext = kc.generateExternalBootstrapServices().get(0);
         assertThat(ext.getSpec().getLoadBalancerClass(), is("metallb-class"));
 
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++) {
-            Service service = kc.generateExternalServices(i).get(0);
+            Service service = services.get(i);
             assertThat(service.getSpec().getLoadBalancerClass(), is("metallb-class"));
         }
     }
@@ -1997,12 +2021,14 @@ public class KafkaClusterTest {
         // Check annotations
         assertThat(kc.generateExternalBootstrapServices().get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "bootstrap.myingress.com.")));
         assertThat(kc.generateExternalBootstrapServices().get(0).getMetadata().getLabels().get("label"), is("label-value"));
-        assertThat(kc.generateExternalServices(0).get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-0.myingress.com.")));
-        assertThat(kc.generateExternalServices(0).get(0).getMetadata().getLabels().get("label"), is("label-value"));
-        assertThat(kc.generateExternalServices(1).get(0).getMetadata().getAnnotations().isEmpty(), is(true));
-        assertThat(kc.generateExternalServices(1).get(0).getMetadata().getLabels().get("label"), is(nullValue()));
-        assertThat(kc.generateExternalServices(2).get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-2.myingress.com.")));
-        assertThat(kc.generateExternalServices(2).get(0).getMetadata().getLabels().get("label"), is("label-value"));
+
+        List<Service> services = kc.generatePerPodServices();
+        assertThat(services.get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-0.myingress.com.")));
+        assertThat(services.get(0).getMetadata().getLabels().get("label"), is("label-value"));
+        assertThat(services.get(1).getMetadata().getAnnotations().isEmpty(), is(true));
+        assertThat(services.get(1).getMetadata().getLabels().get("label"), is(nullValue()));
+        assertThat(services.get(2).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "broker-2.myingress.com.")));
+        assertThat(services.get(2).getMetadata().getLabels().get("label"), is("label-value"));
 
     }
 
@@ -2042,8 +2068,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("NodePort"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
@@ -2128,8 +2156,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("NodePort"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
@@ -2186,7 +2216,7 @@ public class KafkaClusterTest {
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getTargetPort().getIntVal(), is(9094));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32189));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(kc.generateExternalServices(0).get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
+        assertThat(kc.generatePerPodServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
 
         assertThat(ListenersUtils.bootstrapNodePort(kc.getListeners().get(0)), is(32189));
         assertThat(ListenersUtils.brokerNodePort(kc.getListeners().get(0), 0), is(32001));
@@ -2218,7 +2248,7 @@ public class KafkaClusterTest {
             .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        assertThat(kc.generateExternalServices(0).get(0).getSpec().getPorts().get(0).getNodePort(), is(32101));
+        assertThat(kc.generatePerPodServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32101));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
         assertThat(ListenersUtils.bootstrapNodePort(kc.getListeners().get(0)), is(32001));
         assertThat(ListenersUtils.brokerNodePort(kc.getListeners().get(0), 0), is(32101));
@@ -2251,7 +2281,7 @@ public class KafkaClusterTest {
             .build();
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
 
-        assertThat(kc.generateExternalServices(0).get(0).getSpec().getPorts().get(0).getNodePort(), is(32101));
+        assertThat(kc.generatePerPodServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32101));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
 
         assertThat(ListenersUtils.bootstrapNodePort(kc.getListeners().get(0)), is(32001));
@@ -2641,9 +2671,7 @@ public class KafkaClusterTest {
 
         List<Service> services = new ArrayList<>();
         services.addAll(kc.generateExternalBootstrapServices());
-        services.addAll(kc.generateExternalServices(0));
-        services.addAll(kc.generateExternalServices(1));
-        services.addAll(kc.generateExternalServices(2));
+        services.addAll(kc.generatePerPodServices());
 
         for (Service svc : services)    {
             assertThat(svc.getSpec().getIpFamilyPolicy(), is("PreferDualStack"));
@@ -3010,8 +3038,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));
@@ -3042,8 +3072,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(bing, KAFKA);
 
         // Check per pod ingress
+        List<Ingress> ingresses = kc.generateExternalIngresses();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Ingress ing = kc.generateExternalIngresses(i).get(0);
+            Ingress ing = ingresses.get(i);
             assertThat(ing.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(ing.getSpec().getIngressClassName(), is(nullValue()));
             assertThat(ing.getMetadata().getAnnotations().get("dns-annotation"), is("my-kafka-broker.com"));
@@ -3106,8 +3138,10 @@ public class KafkaClusterTest {
         assertThat(bing.getSpec().getIngressClassName(), is("nginx-internal"));
 
         // Check per pod ingress
+        List<Ingress> ingresses = kc.generateExternalIngresses();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Ingress ing = kc.generateExternalIngresses(i).get(0);
+            Ingress ing = ingresses.get(i);
             assertThat(ing.getSpec().getIngressClassName(), is("nginx-internal"));
         }
     }
@@ -3204,8 +3238,10 @@ public class KafkaClusterTest {
         TestUtils.checkOwnerReference(ext, KAFKA);
 
         // Check per pod services
+        List<Service> services = kc.generatePerPodServices();
+
         for (int i = 0; i < REPLICAS; i++)  {
-            Service srv = kc.generateExternalServices(i).get(0);
+            Service srv = services.get(i);
             assertThat(srv.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER) + "-" + i));
             assertThat(srv.getSpec().getType(), is("ClusterIP"));
             assertThat(srv.getSpec().getSelector().get(Labels.KUBERNETES_STATEFULSET_POD_LABEL), is(KafkaResources.kafkaPodName(CLUSTER, i)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -412,16 +412,16 @@ public class ListenersUtilsTest {
 
     @ParallelTest
     public void testBackwardsCompatibleBrokerServiceName()    {
-        String clusterName = "my-cluster";
+        String componentName = "my-cluster-kafka";
 
-        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, oldPlain));
-        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, oldTls));
-        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, newPlain));
-        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, newTls));
-        assertThat(ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, oldExternal), is(clusterName + "-kafka-1"));
-        assertThat(ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, newLoadBalancer), is(clusterName + "-kafka-lb1-1"));
-        assertThat(ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, newNodePort), is(clusterName + "-kafka-np1-1"));
-        assertThat(ListenersUtils.backwardsCompatibleBrokerServiceName(clusterName, 1, newRoute), is(clusterName + "-kafka-route-1"));
+        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, oldPlain));
+        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, oldTls));
+        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, newPlain));
+        assertThrows(UnsupportedOperationException.class, () -> ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, newTls));
+        assertThat(ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, oldExternal), is(componentName + "-1"));
+        assertThat(ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, newLoadBalancer), is(componentName + "-lb1-1"));
+        assertThat(ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, newNodePort), is(componentName + "-np1-1"));
+        assertThat(ListenersUtils.backwardsCompatiblePerBrokerServiceName(componentName, 1, newRoute), is(componentName + "-route-1"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -431,11 +431,7 @@ public class KafkaAssemblyOperatorTest {
         createdServices.add(kafkaCluster.generateService());
         createdServices.add(kafkaCluster.generateHeadlessService());
         createdServices.addAll(kafkaCluster.generateExternalBootstrapServices());
-
-        int replicas = kafkaCluster.getReplicas();
-        for (int i = 0; i < replicas; i++) {
-            createdServices.addAll(kafkaCluster.generateExternalServices(i));
-        }
+        createdServices.addAll(kafkaCluster.generatePerPodServices());
 
         Map<String, Service> expectedServicesMap = createdServices.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
@@ -466,9 +462,7 @@ public class KafkaAssemblyOperatorTest {
         // Route Mocks
         if (openShift) {
             Set<Route> expectedRoutes = new HashSet<>(kafkaCluster.generateExternalBootstrapRoutes());
-            for (int i = 0; i < replicas; i++) {
-                expectedRoutes.addAll(kafkaCluster.generateExternalRoutes(i));
-            }
+            expectedRoutes.addAll(kafkaCluster.generateExternalRoutes());
 
             Map<String, Route> expectedRoutesMap = expectedRoutes.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
@@ -653,7 +647,7 @@ public class KafkaAssemblyOperatorTest {
                         expectedServices.add(ListenersUtils.backwardsCompatibleBootstrapServiceName(kafkaName, listener));
 
                         for (int i = 0; i < kafkaCluster.getReplicas(); i++) {
-                            expectedServices.add(ListenersUtils.backwardsCompatibleBrokerServiceName(kafkaName, i, listener));
+                            expectedServices.add(ListenersUtils.backwardsCompatiblePerBrokerServiceName(kafkaCluster.getComponentName(), i, listener));
                         }
                     }
                 }
@@ -969,11 +963,7 @@ public class KafkaAssemblyOperatorTest {
         expectedServices.add(updatedKafkaCluster.generateService());
         expectedServices.add(updatedKafkaCluster.generateHeadlessService());
         expectedServices.addAll(updatedKafkaCluster.generateExternalBootstrapServices());
-
-        int replicas = updatedKafkaCluster.getReplicas();
-        for (int i = 0; i < replicas; i++) {
-            expectedServices.addAll(updatedKafkaCluster.generateExternalServices(i));
-        }
+        expectedServices.addAll(updatedKafkaCluster.generatePerPodServices());
 
         Map<String, Service> expectedServicesMap = expectedServices.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 
@@ -1013,9 +1003,8 @@ public class KafkaAssemblyOperatorTest {
         // Route Mocks
         if (openShift) {
             Set<Route> expectedRoutes = new HashSet<>(originalKafkaCluster.generateExternalBootstrapRoutes());
-            for (int i = 0; i < replicas; i++) {
-                expectedRoutes.addAll(originalKafkaCluster.generateExternalRoutes(i));
-            }
+            // We use the updatedKafkaCluster here to mock the Route status even for the scaled up replicas
+            expectedRoutes.addAll(updatedKafkaCluster.generateExternalRoutes());
 
             Map<String, Route> expectedRoutesMap = expectedRoutes.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Currently, the logic for generating per-broker services, ingresses and routes is split between the reconciler and model classes. The model class has a method for generating the resources for one broker and the reconciler iterates through these methods based on the number of replicas.

This split does not seem to make sense => the reconciler anyway gets the number of replicas from the model class and loops through it. This PR moves the whole logic into the `KafkaCluster` model class. It also changes the method for generating the _backwards-compatible_ service name to be based on a component name (e.g. `my-cluster-kafka`) and not a cluster name (e.g. `my-cluster`).

This should make it easier to change the way these are generated and do things such as add support for node pools.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally