### PR TITLE
Use `PodRef` more widely in model and reconciler classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -430,18 +430,18 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
     }
 
     /**
-     * Generates list of Kafka pods
+     * Generates list of references to Kafka nodes. The references contain both the pod name and the ID of the Kafka node
      *
      * @param cluster   Name of the Kafka cluster
      * @param replicas  Number of replicas
      *
-     * @return  List with the Kafka pod names
+     * @return  List with Kafka node references
      */
-    public static List<String> generatePodList(String cluster, int replicas) {
-        ArrayList<String> podNames = new ArrayList<>(replicas);
+    public static List<NodeRef> nodes(String cluster, int replicas) {
+        ArrayList<NodeRef> podNames = new ArrayList<>(replicas);
 
-        for (int podId = 0; podId < replicas; podId++) {
-            podNames.add(KafkaResources.kafkaPodName(cluster, podId));
+        for (int nodeId = 0; nodeId < replicas; nodeId++) {
+            podNames.add(new NodeRef(KafkaResources.kafkaPodName(cluster, nodeId), nodeId));
         }
 
         return podNames;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NodeRef.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NodeRef.java
@@ -13,6 +13,6 @@ package io.strimzi.operator.cluster.model;
 public record NodeRef(String podName, int nodeId) {
     @Override
     public String toString() {
-        return podName;
+        return podName + "/" + nodeId;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NodeRef.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/NodeRef.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+/**
+ * Record used to keep reference to a Kafka node through its pod name and node ID.
+ *
+ * @param podName   Name of the pod which represents this node
+ * @param nodeId    ID of the Kafka node
+ */
+public record NodeRef(String podName, int nodeId) {
+    @Override
+    public String toString() {
+        return podName;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.operator.cluster.model.KafkaCluster;
-import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.StorageUtils;
 import io.strimzi.operator.cluster.model.VolumeUtils;
 import io.strimzi.operator.cluster.operator.resource.Quantities;
@@ -354,12 +354,11 @@ public class Capacity {
             // requires a distinct broker capacity entry for every broker because the
             // Kafka volume paths are not homogeneous across brokers and include
             // the broker pod index in their names.
-            List<String> podList = KafkaCluster.generatePodList(reconciliation.name(), replicas);
-            for (int podIndex = 0; podIndex < podList.size(); podIndex++) {
-                int id = ModelUtils.idOfPod(podList.get(podIndex));
-                disk = processDisk(storage, id);
-                BrokerCapacity broker = new BrokerCapacity(id, cpu, disk, inboundNetwork, outboundNetwork);
-                capacityEntries.put(id, broker);
+            List<NodeRef> nodeList = KafkaCluster.nodes(reconciliation.name(), replicas);
+            for (NodeRef node : nodeList)   {
+                disk = processDisk(storage, node.nodeId());
+                BrokerCapacity broker = new BrokerCapacity(node.nodeId(), cpu, disk, inboundNetwork, outboundNetwork);
+                capacityEntries.put(node.nodeId(), broker);
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -401,7 +401,7 @@ public class KafkaReconciler {
                                 1_000,
                                 operationTimeoutMs,
                                 () -> new BackOff(250, 2, 10),
-                                KafkaCluster.generatePodList(reconciliation.name(), replicas),
+                                KafkaCluster.nodes(reconciliation.name(), replicas),
                                 compositeFuture.resultAt(0),
                                 compositeFuture.resultAt(1),
                                 adminClientProvider,


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Today, we have many places where we convert broker IDs to pod names or extract broker IDs from pod names. For example, `KafkaCluster` has a method to return a list of pod names which are later converted to broker IDs and later pod name is generated from it again.

Inside the `KafkaRoller` class, we already have a subclass `PodRef` which is used internally in some places to carry the pod name and broker ID. This PR moves it to Java record and into a separate class in the model. It also renames it to `NodeRef` to better correspond to the use (it represents Kafka node)That way it can be used in more places. 

It also already starts using it in the `KafkaCluster` class and in the reconcilers. It also fixes some minor typos and Javadoc issues in the `KafkaRoller` class.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally