### PR TITLE
Move unnecessary methods out of `KafkaCluster`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1572,42 +1572,6 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
     }
 
     /**
-     * Returns the advertised URL for given broker.
-     * It will take into account the overrides specified by the user.
-     *
-     * @param listener Listener where the configuration should be found
-     * @param brokerId Broker ID
-     * @param address  The advertised hostname
-     *
-     * @return The advertised hostname
-     */
-    public String getAdvertisedHostname(GenericKafkaListener listener, int brokerId, String address) {
-        String advertisedHost = ListenersUtils.brokerAdvertisedHost(listener, brokerId);
-
-        if (advertisedHost == null && address == null)  {
-            return null;
-        }
-
-        return advertisedHost != null ? advertisedHost : address;
-    }
-
-    /**
-     * Returns the advertised port for given broker.
-     * It will take into account the overrides specified by the user.
-     *
-     * @param listener Listener where the configuration should be found
-     * @param brokerId Broker ID
-     * @param port     The advertised port
-     *
-     * @return The advertised port as String
-     */
-    public String getAdvertisedPort(GenericKafkaListener listener, int brokerId, Integer port) {
-        Integer advertisedPort = ListenersUtils.brokerAdvertisedPort(listener, brokerId);
-
-        return String.valueOf(advertisedPort != null ? advertisedPort : port);
-    }
-
-    /**
      * Returns the configuration of the Kafka cluster. This method is currently used by the KafkaSpecChecker to get the
      * Kafka configuration and check it for warnings.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -660,4 +660,43 @@ public class ListenersUtils {
             return "ClusterIP";
         }
     }
+
+
+    /**
+     * Returns the advertised host for given broker. If user specified some override in the listener configuration, it
+     * will return this override. If no override is specified, it will return the host obtained from Kubernetes
+     * passes as parameter to this method.
+     *
+     * @param listener  Listener where the configuration should be found
+     * @param nodeId    Kafka node ID
+     * @param hostname  The advertised hostname which will be used if there is no listener override
+     *
+     * @return  The advertised hostname
+     */
+    public static String advertisedHostnameFromOverrideOrParameter(GenericKafkaListener listener, int nodeId, String hostname) {
+        String advertisedHost = ListenersUtils.brokerAdvertisedHost(listener, nodeId);
+
+        if (advertisedHost == null && hostname == null)  {
+            return null;
+        }
+
+        return advertisedHost != null ? advertisedHost : hostname;
+    }
+
+    /**
+     * Returns the advertised port for given broker. If user specified some override in the listener configuration, it
+     * will return this override. If no override is specified, it will return the port obtained from Kubernetes
+     * passes as parameter to this method.
+     *
+     * @param listener  Listener where the configuration should be found
+     * @param nodeId    Kafka node ID
+     * @param port      The advertised port
+     *
+     * @return  The advertised port as String
+     */
+    public static String advertisedPortFromOverrideOrParameter(GenericKafkaListener listener, int nodeId, Integer port) {
+        Integer advertisedPort = ListenersUtils.brokerAdvertisedPort(listener, nodeId);
+
+        return String.valueOf(advertisedPort != null ? advertisedPort : port);
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -194,7 +194,7 @@ public class KafkaListenersReconciler {
     private void registerAdvertisedHostname(int brokerId, GenericKafkaListener listener, String brokerHostname)   {
         result.advertisedHostnames
                 .computeIfAbsent(brokerId, id -> new HashMap<>())
-                .put(ListenersUtils.envVarIdentifier(listener), kafka.getAdvertisedHostname(listener, brokerId, brokerHostname));
+                .put(ListenersUtils.envVarIdentifier(listener), ListenersUtils.advertisedHostnameFromOverrideOrParameter(listener, brokerId, brokerHostname));
     }
 
     /**
@@ -209,7 +209,7 @@ public class KafkaListenersReconciler {
     private void registerAdvertisedPort(int brokerId, GenericKafkaListener listener, int brokerPort)   {
         result.advertisedPorts
                 .computeIfAbsent(brokerId, id -> new HashMap<>())
-                .put(ListenersUtils.envVarIdentifier(listener), kafka.getAdvertisedPort(listener, brokerId, brokerPort));
+                .put(ListenersUtils.envVarIdentifier(listener), ListenersUtils.advertisedPortFromOverrideOrParameter(listener, brokerId, brokerPort));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2728,14 +2728,14 @@ public class KafkaClusterTest {
     public void testGetExternalServiceWithoutAdvertisedHostAndPortOverride() {
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
-                    .editKafka()
-                        .withListeners(new GenericKafkaListenerBuilder()
-                                .withName("external")
-                                .withPort(9094)
-                                .withType(KafkaListenerType.NODEPORT)
-                                .withTls(true)
-                                .build())
-                    .endKafka()
+                .editKafka()
+                .withListeners(new GenericKafkaListenerBuilder()
+                        .withName("external")
+                        .withPort(9094)
+                        .withType(KafkaListenerType.NODEPORT)
+                        .withTls(true)
+                        .build())
+                .endKafka()
                 .endSpec()
                 .build();
 
@@ -2749,66 +2749,6 @@ public class KafkaClusterTest {
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 2), is(nullValue()));
         assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 2), is(nullValue()));
-    }
-
-    @ParallelTest
-    public void testGetExternalAdvertisedUrlWithOverrides() {
-        GenericKafkaListenerConfigurationBroker nodePortListenerBrokerConfig0 = new GenericKafkaListenerConfigurationBroker();
-        nodePortListenerBrokerConfig0.setBroker(0);
-        nodePortListenerBrokerConfig0.setAdvertisedHost("my-host-0.cz");
-        nodePortListenerBrokerConfig0.setAdvertisedPort(10000);
-
-        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editKafka()
-                        .withListeners(new GenericKafkaListenerBuilder()
-                                .withName("external")
-                                .withPort(9094)
-                                .withType(KafkaListenerType.NODEPORT)
-                                .withTls(true)
-                                .withNewConfiguration()
-                                    .withBrokers(nodePortListenerBrokerConfig0)
-                                .endConfiguration()
-                                .build())
-                    .endKafka()
-                .endSpec()
-                .build();
-
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
-
-        assertThat(kc.getAdvertisedHostname(kc.getListeners().get(0), 0, "some-host.com"), is("my-host-0.cz"));
-        assertThat(kc.getAdvertisedHostname(kc.getListeners().get(0), 0, ""), is("my-host-0.cz"));
-        assertThat(kc.getAdvertisedHostname(kc.getListeners().get(0), 1, "some-host.com"), is("some-host.com"));
-        assertThat(kc.getAdvertisedHostname(kc.getListeners().get(0), 1, ""), is(""));
-
-        assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 0, 12345), is("10000"));
-        assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 0, 12345), is("10000"));
-        assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 1, 12345), is("12345"));
-        assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 1, 12345), is("12345"));
-    }
-
-    @ParallelTest
-    public void testGetExternalAdvertisedUrlWithoutOverrides() {
-        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editKafka()
-                        .withListeners(new GenericKafkaListenerBuilder()
-                                .withName("external")
-                                .withPort(9094)
-                                .withType(KafkaListenerType.NODEPORT)
-                                .withTls(true)
-                                .build())
-                    .endKafka()
-                .endSpec()
-                .build();
-
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, VERSIONS);
-
-        assertThat(kc.getAdvertisedHostname(kc.getListeners().get(0), 0, "some-host.com"), is("some-host.com"));
-        assertThat(kc.getAdvertisedHostname(kc.getListeners().get(0), 0, ""), is(""));
-
-        assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 0, 12345), is("12345"));
-        assertThat(kc.getAdvertisedPort(kc.getListeners().get(0), 0, 12345), is("12345"));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The methods `getAdvertisedHostname` and `getAdvertisedPort` are part of `KafkaCluster` model class. But they do not really need to be there as they are essentially static (they are not declared currently as static -> but do not use anything from the `KafkaCluster` instance) utility methods for working with listeners. This PR moves them out of the `KafkaCluster` class into the `ListenersUtils` class. It also moves the tests.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally