### PR TITLE
Make clear separation between `Ca` and `ClusterCa` classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -4,11 +4,21 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
@@ -27,6 +37,12 @@ import io.strimzi.operator.common.Reconciliation;
  * Represents the Cluster CA
  */
 public class ClusterCa extends Ca {
+    /**
+     * Pattern used for the old CA certificate during CA renewal. This pattern is used to recognize this certificate
+     * and delete it when it is not needed anymore.
+     */
+    private static final Pattern OLD_CA_CERT_PATTERN = Pattern.compile("^ca-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}Z.crt$");
+
     private final String clusterName;
     private Secret entityTopicOperatorSecret;
     private Secret entityUserOperatorSecret;
@@ -79,27 +95,9 @@ public class ClusterCa extends Ca {
                 AbstractModel.clusterCaCertSecretName(clusterName),
                 forceRenewal(clusterCaCert, clusterCaKey, "cluster-ca.key"),
                 AbstractModel.clusterCaKeySecretName(clusterName),
-                adapt060ClusterCaSecret(clusterCaKey), validityDays, renewalDays, generateCa, policy);
+                clusterCaKey, validityDays, renewalDays, generateCa, policy);
         this.clusterName = clusterName;
     }
-
-    /**
-     * In Strimzi 0.6.0 the Secrets and keys used a different convention.
-     * Here we adapt the keys in the {@code *-cluster-ca} Secret to match what
-     * 0.7.0 expects.
-     * @param clusterCaKey The cluster CA key Secret
-     * @return The same Secret.
-     */
-    public static Secret adapt060ClusterCaSecret(Secret clusterCaKey) {
-        if (clusterCaKey != null && clusterCaKey.getData() != null) {
-            String key = clusterCaKey.getData().get("cluster-ca.key");
-            if (key != null) {
-                clusterCaKey.getData().put("ca.key", key);
-            }
-        }
-        return clusterCaKey;
-    }
-
 
     @Override
     public String toString() {
@@ -268,5 +266,222 @@ public class ClusterCa extends Ca {
                 hasCaCertGenerationChanged(entityTopicOperatorSecret) || hasCaCertGenerationChanged(entityUserOperatorSecret) ||
                 hasCaCertGenerationChanged(kafkaExporterSecret) || hasCaCertGenerationChanged(cruiseControlSecret) ||
                 hasCaCertGenerationChanged(clusterOperatorSecret);
+    }
+
+    /**
+     * Copy already existing certificates from provided Secret based on number of effective replicas
+     * and maybe generate new ones for new replicas (i.e. scale-up).
+     *
+     * @param reconciliation                        Reconciliation marker
+     * @param replicas                              Number of replicas
+     * @param subjectFn                             Function to generate certificate subject for given node / pod
+     * @param secret                                Secret with certificates
+     * @param podNameFn                             Function to generate pod name for given node ID
+     * @param isMaintenanceTimeWindowsSatisfied     Flag indicating if we are inside an maintenance window or not
+     *
+     * @return  Returns map with node certificates which can be used to create or update the certificate secret
+     *
+     * @throws IOException  Throws IOException when working with files fails
+     */
+    /* test */ Map<String, CertAndKey> maybeCopyOrGenerateCerts(
+            Reconciliation reconciliation,
+            int replicas,
+            Function<Integer, Subject> subjectFn,
+            Secret secret,
+            Function<Integer, String> podNameFn,
+            boolean isMaintenanceTimeWindowsSatisfied) throws IOException {
+        int replicasInSecret;
+        if (secret == null || secret.getData() == null || this.certRenewed())   {
+            replicasInSecret = 0;
+        } else {
+            replicasInSecret = (int) secret.getData().keySet().stream().filter(k -> k.contains(".crt")).count();
+        }
+
+        File brokerCsrFile = Files.createTempFile("tls", "broker-csr").toFile();
+        File brokerKeyFile = Files.createTempFile("tls", "broker-key").toFile();
+        File brokerCertFile = Files.createTempFile("tls", "broker-cert").toFile();
+        File brokerKeyStoreFile = Files.createTempFile("tls", "broker-p12").toFile();
+
+        int replicasInNewSecret = Math.min(replicasInSecret, replicas);
+        Map<String, CertAndKey> certs = new HashMap<>(replicasInNewSecret);
+        // copying the minimum number of certificates already existing in the secret
+        // scale up -> it will copy all certificates
+        // scale down -> it will copy just the requested number of replicas
+        for (int i = 0; i < replicasInNewSecret; i++) {
+            String podName = podNameFn.apply(i);
+            LOGGER.debugCr(reconciliation, "Certificate for {} already exists", podName);
+            Subject subject = subjectFn.apply(i);
+
+            CertAndKey certAndKey;
+
+            if (isNewVersion(secret, podName)) {
+                certAndKey = asCertAndKey(secret, podName);
+            } else {
+                // coming from an older operator version, the secret exists but without keystore and password
+                certAndKey = addKeyAndCertToKeyStore(subject.commonName(),
+                        Base64.getDecoder().decode(secretEntryDataForPod(secret, podName, SecretEntry.KEY)),
+                        Base64.getDecoder().decode(secretEntryDataForPod(secret, podName, SecretEntry.CRT)));
+            }
+
+            List<String> reasons = new ArrayList<>(2);
+
+            if (certSubjectChanged(certAndKey, subject, podName))   {
+                reasons.add("DNS names changed");
+            }
+
+            if (isExpiring(secret, podName + ".crt") && isMaintenanceTimeWindowsSatisfied)  {
+                reasons.add("certificate is expiring");
+            }
+
+            if (renewalType.equals(RenewalType.CREATE)) {
+                reasons.add("certificate added");
+            }
+
+            if (!reasons.isEmpty())  {
+                LOGGER.infoCr(reconciliation, "Certificate for pod {} need to be regenerated because: {}", podName, String.join(", ", reasons));
+
+                CertAndKey newCertAndKey = generateSignedCert(subject, brokerCsrFile, brokerKeyFile, brokerCertFile, brokerKeyStoreFile);
+                certs.put(podName, newCertAndKey);
+            }   else {
+                certs.put(podName, certAndKey);
+            }
+        }
+
+        // generate the missing number of certificates
+        // scale up -> generate new certificates for added replicas
+        // scale down -> does nothing
+        for (int i = replicasInSecret; i < replicas; i++) {
+            String podName = podNameFn.apply(i);
+
+            LOGGER.debugCr(reconciliation, "Certificate for pod {} to generate", podName);
+            CertAndKey k = generateSignedCert(subjectFn.apply(i),
+                    brokerCsrFile, brokerKeyFile, brokerCertFile, brokerKeyStoreFile);
+            certs.put(podName, k);
+        }
+        delete(reconciliation, brokerCsrFile);
+        delete(reconciliation, brokerKeyFile);
+        delete(reconciliation, brokerCertFile);
+        delete(reconciliation, brokerKeyStoreFile);
+
+        return certs;
+    }
+
+    /**
+     * Check if this secret is coming from newer versions of the operator or older ones. Secrets from an older version
+     * don't have a keystore and password.
+     *
+     * @param secret    Secret resource to check
+     * @param podName   Name of the pod with certificate and key entries in the secret
+     *
+     * @return  True if this secret was created by a newer version of the operator and false otherwise.
+     */
+    private boolean isNewVersion(Secret secret, String podName) {
+        String store = secretEntryDataForPod(secret, podName, SecretEntry.P12_KEYSTORE);
+        String password = secretEntryDataForPod(secret, podName, SecretEntry.P12_KEYSTORE_PASSWORD);
+
+        return store != null && !store.isEmpty() && password != null && !password.isEmpty();
+    }
+
+    /**
+     * Return given secret for pod as a CertAndKey object
+     *
+     * @param secret    Kubernetes Secret
+     * @param podName   Name of the pod
+     *
+     * @return  CertAndKey instance
+     */
+    private static CertAndKey asCertAndKey(Secret secret, String podName) {
+        return asCertAndKey(secret, secretEntryNameForPod(podName, SecretEntry.KEY),
+                secretEntryNameForPod(podName, SecretEntry.CRT),
+                secretEntryNameForPod(podName, SecretEntry.P12_KEYSTORE),
+                secretEntryNameForPod(podName, SecretEntry.P12_KEYSTORE_PASSWORD));
+    }
+
+    /**
+     * Checks whether subject alternate names changed and certificate needs a renewal
+     *
+     * @param certAndKey        Current certificate
+     * @param desiredSubject    Desired subject alternate names
+     * @param podName           Name of the pod to which this certificate belongs (used for log messages)
+     *
+     * @return  True if the subjects are different, false otherwise
+     */
+    /* test */ boolean certSubjectChanged(CertAndKey certAndKey, Subject desiredSubject, String podName)    {
+        Collection<String> desiredAltNames = desiredSubject.subjectAltNames().values();
+        Collection<String> currentAltNames = getSubjectAltNames(certAndKey.cert());
+
+        if (currentAltNames != null && desiredAltNames.containsAll(currentAltNames) && currentAltNames.containsAll(desiredAltNames))   {
+            LOGGER.traceCr(reconciliation, "Alternate subjects match. No need to refresh cert for pod {}.", podName);
+            return false;
+        } else {
+            LOGGER.infoCr(reconciliation, "Alternate subjects for pod {} differ", podName);
+            LOGGER.infoCr(reconciliation, "Current alternate subjects: {}", currentAltNames);
+            LOGGER.infoCr(reconciliation, "Desired alternate subjects: {}", desiredAltNames);
+            return true;
+        }
+    }
+
+    /**
+     * Extracts the alternate subject names out of existing certificate
+     *
+     * @param certificate   Existing X509 certificate as a byte array
+     *
+     * @return  List of certificate Subject Alternate Names
+     */
+    private List<String> getSubjectAltNames(byte[] certificate) {
+        List<String> subjectAltNames = null;
+
+        try {
+            X509Certificate cert = x509Certificate(certificate);
+            Collection<List<?>> altNames = cert.getSubjectAlternativeNames();
+            subjectAltNames = altNames.stream()
+                    .filter(name -> name.get(1) instanceof String)
+                    .map(item -> (String) item.get(1))
+                    .collect(Collectors.toList());
+        } catch (CertificateException | RuntimeException e) {
+            // TODO: We should mock the certificates properly so that this doesn't fail in tests (not now => long term :-o)
+            LOGGER.debugCr(reconciliation, "Failed to parse existing certificate", e);
+        }
+
+        return subjectAltNames;
+    }
+
+    /**
+     * Retrieve a specific secret entry for pod from the given Secret.
+     *
+     * @param secret    Kubernetes Secret containing desired entry
+     * @param podName   Name of the pod which secret entry is looked for
+     * @param entry     The SecretEntry type
+     *
+     * @return  The data of the secret entry if found or null otherwise
+     */
+    private static String secretEntryDataForPod(Secret secret, String podName, SecretEntry entry) {
+        return secret.getData().get(secretEntryNameForPod(podName, entry));
+    }
+
+    /**
+     * Get the name of secret entry of given SecretEntry type for podName
+     *
+     * @param podName   Name of the pod which secret entry is looked for
+     * @param entry     The SecretEntry type
+     *
+     * @return  The name of the secret entry
+     */
+    public static String secretEntryNameForPod(String podName, SecretEntry entry) {
+        return podName + entry.suffix;
+    }
+
+    /**
+     * Remove old certificates that are stored in the CA Secret matching the "ca-YYYY-MM-DDTHH-MM-SSZ.crt" naming pattern.
+     * NOTE: mostly used when a CA certificate is renewed by replacing the key
+     */
+    public void maybeDeleteOldCerts() {
+        // the operator doesn't have to touch Secret provided by the user with his own custom CA certificate
+        if (this.generateCa) {
+            this.caCertsRemoved = removeCerts(this.caCertSecret.getData(), entry -> OLD_CA_CERT_PATTERN.matcher(entry.getKey()).matches()) > 0;
+            if (this.caCertsRemoved) {
+                LOGGER.infoCr(reconciliation, "{}: Old CA certificates removed", this);
+            }
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -647,7 +647,7 @@ public class KafkaReconciler {
                                         kafkaServerCertificateHash.put(
                                                 i,
                                                 CertUtils.getCertificateThumbprint(patchResult.resource(),
-                                                        Ca.secretEntryNameForPod(podName, Ca.SecretEntry.CRT)
+                                                        ClusterCa.secretEntryNameForPod(podName, Ca.SecretEntry.CRT)
                                                 ));
                                     }
                                 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -425,7 +425,7 @@ public class ZooKeeperReconciler {
                                         zkCertificateHash.put(
                                                 podNum,
                                                 CertUtils.getCertificateThumbprint(patchResult.resource(),
-                                                        Ca.secretEntryNameForPod(podName, Ca.SecretEntry.CRT)
+                                                        ClusterCa.secretEntryNameForPod(podName, Ca.SecretEntry.CRT)
                                                 ));
                                     }
                                 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -29,10 +29,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ParallelSuite
 @ExtendWith(VertxExtension.class)
-public class CaRenewalTest {
+public class ClusterCaRenewalTest {
     @ParallelTest
     public void renewalOfCertificatesWithNullSecret() throws IOException {
-        Ca mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        ClusterCa mockedCa = new MockedClusterCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, 2, 1, true, null);
 
         int replicas = 3;
         Function<Integer, Subject> subjectFn = i -> new Subject.Builder().build();
@@ -63,7 +63,7 @@ public class CaRenewalTest {
 
     @ParallelTest
     public void renewalOfCertificatesWithCaRenewal() throws IOException {
-        MockedCa mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        MockedClusterCa mockedCa = new MockedClusterCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, 2, 1, true, null);
         mockedCa.setCertRenewed(true);
 
         Secret initialSecret = new SecretBuilder()
@@ -114,7 +114,7 @@ public class CaRenewalTest {
 
     @ParallelTest
     public void renewalOfCertificatesDelayedRenewalInWindow() throws IOException {
-        MockedCa mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        MockedClusterCa mockedCa = new MockedClusterCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, 2, 1, true, null);
         mockedCa.setCertExpiring(true);
 
         Secret initialSecret = new SecretBuilder()
@@ -165,7 +165,7 @@ public class CaRenewalTest {
 
     @ParallelTest
     public void renewalOfCertificatesDelayedRenewalOutsideWindow() throws IOException {
-        MockedCa mockedCa = new MockedCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, null, null, 2, 1, true, null);
+        MockedClusterCa mockedCa = new MockedClusterCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, 2, 1, true, null);
         mockedCa.setCertExpiring(true);
 
         Secret initialSecret = new SecretBuilder()
@@ -214,13 +214,13 @@ public class CaRenewalTest {
         assertThat(newCerts.get("pod2").storePassword(), is("old-password"));
     }
 
-    public static class MockedCa extends Ca {
+    public static class MockedClusterCa extends ClusterCa {
         private final AtomicInteger invocationCount = new AtomicInteger(0);
         private boolean isCertRenewed;
         private boolean isCertExpiring;
 
-        public MockedCa(Reconciliation reconciliation, CertManager certManager, PasswordGenerator passwordGenerator, String commonName, String caCertSecretName, Secret caCertSecret, String caKeySecretName, Secret caKeySecret, int validityDays, int renewalDays, boolean generateCa, CertificateExpirationPolicy policy) {
-            super(reconciliation, certManager, passwordGenerator, commonName, caCertSecretName, caCertSecret, caKeySecretName, caKeySecret, validityDays, renewalDays, generateCa, policy);
+        public MockedClusterCa(Reconciliation reconciliation, CertManager certManager, PasswordGenerator passwordGenerator, String commonName, Secret caCertSecret, Secret caKeySecret, int validityDays, int renewalDays, boolean generateCa, CertificateExpirationPolicy policy) {
+            super(reconciliation, certManager, passwordGenerator, commonName, caCertSecret, caKeySecret, validityDays, renewalDays, generateCa, policy);
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -29,6 +29,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.CertUtils;
+import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -196,7 +197,7 @@ public class KafkaAssemblyOperatorMockTest {
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
                     var brokersSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get();
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH,
-                            CertUtils.getCertificateThumbprint(brokersSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
+                            CertUtils.getCertificateThumbprint(brokersSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
                     ));
                 });
 
@@ -205,7 +206,7 @@ public class KafkaAssemblyOperatorMockTest {
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
                     var zooKeeperSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperSecretName(CLUSTER_NAME)).get();
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH,
-                            CertUtils.getCertificateThumbprint(zooKeeperSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
+                            CertUtils.getCertificateThumbprint(zooKeeperSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
                     ));
                 });
                 assertThat(client.configMaps().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperMetricsAndLogConfigMapName(CLUSTER_NAME)).get(), is(notNullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -21,6 +21,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.CertUtils;
+import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.PodRevision;
@@ -227,7 +228,7 @@ public class PartialRollingUpdateMockTest {
         for (int brokerId = 0; brokerId < cluster.getSpec().getKafka().getReplicas(); brokerId++) {
             var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, brokerId)).get();
             var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
-            var expectedCertHash = CertUtils.getCertificateThumbprint(brokersSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+            var expectedCertHash = CertUtils.getCertificateThumbprint(brokersSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
 
             assertThat("Pod " + brokerId + " had unexpected revision", podCertHash, is(expectedCertHash));
         }
@@ -243,7 +244,7 @@ public class PartialRollingUpdateMockTest {
                 final var finalBrokerId = brokerId;
                 var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.kafkaPodName(CLUSTER_NAME, brokerId)).get();
                 var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
-                var expectedCertHash = CertUtils.getCertificateThumbprint(brokersSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+                var expectedCertHash = CertUtils.getCertificateThumbprint(brokersSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
 
                 context.verify(() -> assertThat("Pod " + finalBrokerId + " had unexpected revision", podCertHash, is(expectedCertHash)));
             }
@@ -292,7 +293,7 @@ public class PartialRollingUpdateMockTest {
         for (int zkIndex = 0; zkIndex < cluster.getSpec().getZookeeper().getReplicas(); zkIndex++) {
             var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, zkIndex)).get();
             var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
-            var expectedCertHash = CertUtils.getCertificateThumbprint(zkSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+            var expectedCertHash = CertUtils.getCertificateThumbprint(zkSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
 
             assertThat("Pod " + zkIndex + " had unexpected revision", podCertHash, is(expectedCertHash));
         }
@@ -308,7 +309,7 @@ public class PartialRollingUpdateMockTest {
                 final var finalZkIndex = zkIndex;
                 var pod = client.pods().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperPodName(CLUSTER_NAME, zkIndex)).get();
                 var podCertHash = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH);
-                var expectedCertHash = CertUtils.getCertificateThumbprint(zkSecret, Ca.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
+                var expectedCertHash = CertUtils.getCertificateThumbprint(zkSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT));
 
                 context.verify(() -> assertThat("Pod " + finalZkIndex + " had unexpected revision", podCertHash, is(expectedCertHash)));
             }

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -37,24 +37,7 @@ public class ClientsCa extends Ca {
         super(reconciliation, certManager, passwordGenerator,
                 "clients-ca", caCertSecretName,
                 forceRenewal(clientsCaCert, clientsCaKey, "clients-ca.key"), caSecretKeyName,
-                adapt060ClientsCaSecret(clientsCaKey), validityDays, renewalDays, generateCa, policy);
-    }
-
-    /**
-     * In Strimzi 0.6.0 the Secrets and keys used a different convention.
-     * Here we adapt the keys in the {@code *-clients-ca} Secret to match what
-     * 0.7.0 expects.
-     * @param clientsCaKey The secret to adapt.
-     * @return The same Secret instance.
-     */
-    public static Secret adapt060ClientsCaSecret(Secret clientsCaKey) {
-        if (clientsCaKey != null && clientsCaKey.getData() != null) {
-            String key = clientsCaKey.getData().get("clients-ca.key");
-            if (key != null) {
-                clientsCaKey.getData().put("ca.key", key);
-            }
-        }
-        return clientsCaKey;
+                clientsCaKey, validityDays, renewalDays, generateCa, policy);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Our CA management currently consists of 3 different classes:
* Abstract parent class `Ca`
* `ClusterCa` class representing the cluster CA which extends and implements `Ca`. This class is used to issue server certificates for the different components in the Kafka cluster.
* `ClientsCa` class representing the clients CA which extends and implements `Ca`. This class is used to issue user certificates and establish a trust to them.

However, as of today, the separation between `Ca` and `ClusterCa` seems to be very messy. There are many methods which are used only by the cluster CA which are part of the `Ca` class. This includes for example the methods for generating the server certificates for each pod which has nothing to do with the clients CA functionality.

This PR tries to clean the separation at least a little bit and moves these methods from `Ca` to `ClusterCa`. It also updates the access modifiers of different methods where possible (e.g. from protected to private or the other way around). This refactoring should make it easier in the next step (future PR) to use the `NodeRef` as part of the certificate preparation. This would be useful in the future to support more different sets of node IDs. It should also help us to have the logic for transitioning between pod names and node IDs and vice versa only in one place.

It also removes the old methods which were used to adapt the keys of our certificate secrets after upgrading from Strimzi 0.6.0 to 0.7.0 (or newer). Direct upgrades from Strimzi 0.6.0 are for a long time not supported for many different reasons. So keeping these conversion methods seems not necessary anymore.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally