### PR TITLE
Use `NodeRef` classes when generating PVCs

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -430,6 +430,16 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
     }
 
     /**
+     * Generates list of references to Kafka nodes for this Kafka cluster. The references contain both the pod name and
+     * the ID of the Kafka node.
+     *
+     * @return  List with Kafka node references
+     */
+    private List<NodeRef> nodes() {
+        return nodes(cluster, replicas);
+    }
+
+    /**
      * Generates list of references to Kafka nodes. The references contain both the pod name and the ID of the Kafka node
      *
      * @param cluster   Name of the Kafka cluster
@@ -1181,7 +1191,15 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
      */
     public List<PersistentVolumeClaim> generatePersistentVolumeClaims(Storage storage) {
         return PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(componentName, namespace, replicas, storage, false, labels, ownerReference, templatePersistentVolumeClaims);
+                .createPersistentVolumeClaims(
+                        namespace,
+                        nodes(),
+                        storage,
+                        false,
+                        labels,
+                        ownerReference,
+                        templatePersistentVolumeClaims
+                );
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -531,7 +531,15 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsM
      */
     public List<PersistentVolumeClaim> generatePersistentVolumeClaims() {
         return PersistentVolumeClaimUtils
-                .createPersistentVolumeClaims(componentName, namespace, replicas, storage, false, labels, ownerReference, templatePersistentVolumeClaims);
+                .createPersistentVolumeClaims(
+                        namespace,
+                        nodes(),
+                        storage,
+                        false,
+                        labels,
+                        ownerReference,
+                        templatePersistentVolumeClaims
+                );
     }
 
     private List<VolumeMount> getVolumeMounts() {
@@ -613,5 +621,18 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsM
      */
     public LoggingModel logging()   {
         return logging;
+    }
+
+    /**
+     * @return  List of node references for this ZooKeeper cluster
+     */
+    private List<NodeRef> nodes()   {
+        List<NodeRef> nodes = new ArrayList<>();
+
+        for (int i = 0; i < replicas; i++)  {
+            nodes.add(new NodeRef(getPodName(i), i));
+        }
+
+        return nodes;
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Following PR #8294, this PR continues replacing the places where we are mixing up the pod IDs with pod names and replacing them with the use of the `NodeRef` class. This particular PR introduces the use of the `NodeRef` class to the methods we use to generate PersistentVolumeClaims (which have names based on the pod names). 

Use of the `NodeRef` class helps us to reduce the places where we create the Pod names from the pod IDs and also add support for having possibly non-continuous sequences of the pod names / node IDs in the future.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally