### PR TITLE
Turn off ExponentialBackoffIntervalCalculator during systemtests deug log

### DIFF
--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -30,9 +30,7 @@ logger.clients.level = info
 logger.okhttp.name = okhttp3
 logger.okhttp.level = INFO
 
-logger.cr.name = io.fabric8.kubernetes.client.CustomResource
-logger.cr.level = OFF
-logger.vuu.name = io.fabric8.kubernetes.client.dsl.internal.VersionUsageUtils
-logger.vuu.level = OFF
-logger.ebic.name = io.fabric8.kubernetes.client.utils.ExponentialBackoffIntervalCalculator
-logger.ebic.level = OFF
+logger.fabric8.name = io.fabric8.kubernetes.client
+logger.fabric8.level = OFF
+logger.jayway.name = com.jayway.jsonpath.internal.path.CompiledPath
+logger.jayway.level = OFF

--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@ name = STConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{5}:%L] %m%n
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
@@ -15,7 +15,7 @@ appender.rolling.policies.size.size=100MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 5
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} %-5p [%c{1}:%L] %m%n
+appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} %-5p [%c{5}:%L] %m%n
 
 rootLogger.level = ${env:STRIMZI_TEST_ROOT_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRef.console.ref = STDOUT
@@ -34,3 +34,5 @@ logger.cr.name = io.fabric8.kubernetes.client.CustomResource
 logger.cr.level = OFF
 logger.vuu.name = io.fabric8.kubernetes.client.dsl.internal.VersionUsageUtils
 logger.vuu.level = OFF
+logger.ebic.name = io.fabric8.kubernetes.client.utils.ExponentialBackoffIntervalCalculator
+logger.ebic.level = OFF

--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@ name = STConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{5}:%L] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
@@ -15,7 +15,7 @@ appender.rolling.policies.size.size=100MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 5
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} %-5p [%c{5}:%L] %m%n
+appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} %-5p [%c{1}:%L] %m%n
 
 rootLogger.level = ${env:STRIMZI_TEST_ROOT_LOG_LEVEL:-DEBUG}
 rootLogger.appenderRef.console.ref = STDOUT


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring


### Description

Debug lof of systemtests is full of lines likes this 
```
2023-03-27 07:23:58 DEBUG [ExponentialBackoffIntervalCalculator:61] Current reconnect backoff is 100 milliseconds (T0)
```
 This PR turn off this logger to make the debug log cleaner

### Checklist

- [ ] Make sure all tests pass

