### PR TITLE
docs(ssl): fixes config that produces syntax error

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
@@ -38,9 +38,9 @@ spec:
     config:
       auto.offset.reset: earliest
       enable.auto.commit: true
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
       ssl.endpoint.identification.algorithm: HTTPS
     # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
@@ -37,9 +37,9 @@ spec:
     config:
       acks: 1
       delivery.timeout.ms: 300000
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
       ssl.endpoint.identification.algorithm: HTTPS
     # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc
@@ -100,9 +100,9 @@ spec:
       socket.receive.buffer.bytes: 102400
       socket.request.max.bytes: 104857600
       group.initial.rebalance.delay.ms: 0
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
       zookeeper.connection.timeout.ms: 6000
     # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
@@ -74,9 +74,9 @@ spec:
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3
-    ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-    ssl.enabled.protocols: "TLSv1.2"
-    ssl.protocol: "TLSv1.2"
+    ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    ssl.enabled.protocols: TLSv1.2
+    ssl.protocol: TLSv1.2
     ssl.endpoint.identification.algorithm: HTTPS
   # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
@@ -50,9 +50,9 @@ spec:
     config:
       autopurge.snapRetainCount: 3
       autopurge.purgeInterval: 1
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
     # ...
 ----
 

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -60,9 +60,9 @@ Use the `ssl.endpoint.identification.algorithm` property to enable or disable ho
 ----
 # ...
 config:
-  ssl.cipher.suites: "TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" # <1>
-  ssl.enabled.protocols: "TLSv1.3", "TLSv1.2" # <2>
-  ssl.protocol: "TLSv1.3" # <3>
+  ssl.cipher.suites: TLS_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 # <1>
+  ssl.enabled.protocols: TLSv1.3, TLSv1.2 # <2>
+  ssl.protocol: TLSv1.3 # <3>
   ssl.endpoint.identification.algorithm: HTTPS # <4>
 # ...
 ----

--- a/documentation/modules/configuring/con-partition-reassignment.adoc
+++ b/documentation/modules/configuring/con-partition-reassignment.adoc
@@ -49,7 +49,7 @@ Unless removed, throttles will continue to affect the cluster even after the rea
 It is only possible to have one reassignment running in a cluster at any given time, and it is not possible to cancel a running reassignment.
 If you must cancel a reassignment, wait for it to complete and then perform another reassignment to revert the effects of the first reassignment.
 The `kafka-reassign-partitions.sh` will print the reassignment JSON for this reversion as part of its output.
-Very large reassignments should be broken down into a number of smaller reassignments in case there is a must stop in-progress reassignment.
+Very large reassignments should be broken down into a number of smaller reassignments in case there is a need to stop in-progress reassignment.
 
 == Specifying topics in a partition reassignment JSON file
 

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -110,9 +110,9 @@ spec:
       default.replication.factor: 3
       min.insync.replicas: 2
       inter.broker.protocol.version: "{DefaultInterBrokerVersion}"
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <19>
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 <19>
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
     storage: <20>
       type: persistent-claim <21>
       size: 10000Gi <22>

--- a/documentation/modules/configuring/proc-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker.adoc
@@ -49,9 +49,9 @@ spec:
     config: <8>
       max.poll.records: 100
       receive.buffer.bytes: 32768
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <9>
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 <9>
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
       ssl.endpoint.identification.algorithm: HTTPS <10>
   producer:
     bootstrapServers: my-target-cluster-kafka-bootstrap:9092
@@ -69,9 +69,9 @@ spec:
     config:
       compression.type: gzip
       batch.size: 8192
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" <12>
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 <12>
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
       ssl.endpoint.identification.algorithm: HTTPS <13>
   include: "my-topic|other-topic" <14>
   resources: <15>

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -105,9 +105,9 @@ spec:
       config.storage.replication.factor: 1
       offset.storage.replication.factor: 1
       status.storage.replication.factor: 1
-      ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" # <13>
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 # <13>
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
       ssl.endpoint.identification.algorithm: HTTPS # <14>
     tls: # <15>
       trustedCertificates:


### PR DESCRIPTION
### Type of change

**Documentation**

The examples for configuring ssl on Kafka were incorrect.
Quotes around the values cause syntax errors when parsing the configuration YAML. This PR fixes the examples by removing the quotes. 

**Before**
```
ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
ssl.enabled.protocols: "TLSv1.2"
ssl.protocol: "TLSv1.2"
```

**After**
```
ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
ssl.enabled.protocols: TLSv1.2
ssl.protocol: TLSv1.2
```


_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

