### PR TITLE
Initialize OpenTracing Tracer when using OpenTelemetry

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -130,6 +130,11 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-opentracing-shim</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -130,6 +130,11 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-opentracing-shim</artifactId>
+            <version>${opentelemetry.alpha-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <jaeger.version>1.8.1</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
+        <opentelemetry.version>1.18.0</opentelemetry.version>
         <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
         <jetty.version>9.4.48.v20220622</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
@@ -699,7 +700,17 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk</artifactId>
+                <version>${opentelemetry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+                <version>${opentelemetry.alpha-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-opentracing-shim</artifactId>
                 <version>${opentelemetry.alpha-version}</version>
             </dependency>
             <dependency>

--- a/tracing-agent/pom.xml
+++ b/tracing-agent/pom.xml
@@ -42,6 +42,16 @@
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-opentracing-shim</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
@@ -4,7 +4,9 @@
  */
 package io.strimzi.tracing.agent;
 
+import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentracing.util.GlobalTracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,7 +23,9 @@ public class OpenTelemetryTracing implements Tracing {
         if (serviceName != null) {
             LOGGER.info("Initializing OpenTelemetry tracing with service name {}", serviceName);
             System.setProperty("otel.metrics.exporter", "none"); // disable metrics
-            AutoConfiguredOpenTelemetrySdk.initialize();
+            var openTelemetry = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
+            var tracer = OpenTracingShim.createTracerShim(openTelemetry);
+            GlobalTracer.registerIfAbsent(tracer);
         } else {
             LOGGER.error("OpenTelemetry tracing cannot be initialized because OTEL_SERVICE_NAME environment variable is not defined");
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some third party connectors using OpenTracing API to access tracing functionality, eg. Debezium. When using Jaeger the GlobalTracer is initialized but not for OpenTelemetry.

This will allow use to migrate to OpenTelemetry as Jaeger is deprecated.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

