### PR TITLE
Use node references instead of replica count in `ClusterCa`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1136,7 +1136,7 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
         Map<String, String> data = new HashMap<>(replicas * 4);
 
         try {
-            brokerCerts = clusterCa.generateBrokerCerts(namespace, cluster, replicas, externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied);
+            brokerCerts = clusterCa.generateBrokerCerts(namespace, cluster, nodes(), externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare Kafka certificates", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -416,7 +416,7 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsM
         Map<String, CertAndKey> certs;
 
         try {
-            certs = clusterCa.generateZkCerts(namespace, cluster, replicas, isMaintenanceTimeWindowsSatisfied);
+            certs = clusterCa.generateZkCerts(namespace, cluster, nodes(), isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare ZooKeeper certificates", e);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `ClusterCa` class should use a list of `NodeRef` objects instead of a replica count when generating or renewing certificates. This should remove the separate methods for generating pod names from the `ClusterCa` class and use the centrally generated names. It also prepares it for future support of clusters which will not have always a continuous set of node IDs and uniform pod names.

The changed method - `maybeCopyOrGenerateCerts` - is also used by Cruise Control. The calls from Cruise Control have been modified as well. Although in that case, it is not using a real pod name. But that was the case already before when it passed the custom pod name and replica count to this method. This PR just adjusts to the changes done mainly for Kafka and ZooKeeper clusters

This PR also adds additional tests covering more situations in which `maybeCopyOrGenerateCerts` might be called.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally