### PR TITLE
Update the Kaniko container images builder to 1.9.2

### DIFF
--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.9.1
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.9.2
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr updates the Kaniko container image builder used by the Kafka Connect Build feature to the a patch release 1.9.2.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally