### PR TITLE
Remove the deprecated Fabric8 method createOrReplace from the project

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -35,7 +35,7 @@ public class KafkaBridgeResource implements ResourceType<KafkaBridge> {
     }
     @Override
     public void create(KafkaBridge resource) {
-        kafkaBridgeClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaBridgeClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaBridge resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
@@ -26,7 +26,7 @@ public class KafkaClientsResource implements ResourceType<Deployment> {
 
     @Override
     public void create(Deployment resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceDeployment(resource);
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createDeployment(resource);
     }
     @Override
     public void delete(Deployment resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -35,7 +35,7 @@ public class KafkaConnectResource implements ResourceType<KafkaConnect> {
     }
     @Override
     public void create(KafkaConnect resource) {
-        kafkaConnectClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaConnectClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaConnect resource)    {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -31,7 +31,7 @@ public class KafkaConnectorResource implements ResourceType<KafkaConnector> {
 
     @Override
     public void create(KafkaConnector resource) {
-        kafkaConnectorClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaConnectorClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaConnector resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -33,7 +33,7 @@ public class KafkaMirrorMaker2Resource implements ResourceType<KafkaMirrorMaker2
     }
     @Override
     public void create(KafkaMirrorMaker2 resource) {
-        kafkaMirrorMaker2Client().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaMirrorMaker2Client().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaMirrorMaker2 resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -30,7 +30,7 @@ public class KafkaMirrorMakerResource implements ResourceType<KafkaMirrorMaker> 
     }
     @Override
     public void create(KafkaMirrorMaker resource) {
-        kafkaMirrorMakerClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaMirrorMakerClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaMirrorMaker resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
@@ -32,7 +32,7 @@ public class KafkaRebalanceResource implements ResourceType<KafkaRebalance> {
     }
     @Override
     public void create(KafkaRebalance resource) {
-        kafkaRebalanceClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaRebalanceClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaRebalance resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -51,7 +51,7 @@ public class KafkaResource implements ResourceType<Kafka> {
 
     @Override
     public void create(Kafka resource) {
-        kafkaClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -31,7 +31,7 @@ public class KafkaTopicResource implements ResourceType<KafkaTopic> {
     }
     @Override
     public void create(KafkaTopic resource) {
-        kafkaTopicClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaTopicClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
     @Override
     public void delete(KafkaTopic resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -31,7 +31,7 @@ public class KafkaUserResource implements ResourceType<KafkaUser> {
     }
     @Override
     public void create(KafkaUser resource) {
-        kafkaUserClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        kafkaUserClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/StrimziPodSetResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/StrimziPodSetResource.java
@@ -29,7 +29,7 @@ public class StrimziPodSetResource implements ResourceType<StrimziPodSet> {
 
     @Override
     public void create(StrimziPodSet resource) {
-        strimziPodSetClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        strimziPodSetClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/DrainCleanerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/DrainCleanerResource.java
@@ -30,7 +30,7 @@ public class DrainCleanerResource implements ResourceType<Deployment> {
 
     @Override
     public void create(Deployment resource) {
-        ResourceManager.kubeClient().createOrReplaceDeployment(resource);
+        ResourceManager.kubeClient().createDeployment(resource);
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterOperatorCustomResourceDefinition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterOperatorCustomResourceDefinition.java
@@ -22,7 +22,7 @@ public class ClusterOperatorCustomResourceDefinition implements ResourceType<Cus
     }
     @Override
     public void create(CustomResourceDefinition resource) {
-        kubeClient().createOrReplaceCustomResourceDefinition(resource);
+        kubeClient().createCustomResourceDefinition(resource);
     }
     @Override
     public void delete(CustomResourceDefinition resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterOperatorCustomResourceDefinition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterOperatorCustomResourceDefinition.java
@@ -22,7 +22,7 @@ public class ClusterOperatorCustomResourceDefinition implements ResourceType<Cus
     }
     @Override
     public void create(CustomResourceDefinition resource) {
-        kubeClient().createCustomResourceDefinition(resource);
+        kubeClient().createOrUpdateCustomResourceDefinition(resource);
     }
     @Override
     public void delete(CustomResourceDefinition resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
@@ -32,7 +32,7 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
     }
     @Override
     public void create(ClusterRoleBinding resource) {
-        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createClusterRoleBinding(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrUpdateClusterRoleBinding(resource);
     }
     @Override
     public void delete(ClusterRoleBinding resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
@@ -32,7 +32,7 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
     }
     @Override
     public void create(ClusterRoleBinding resource) {
-        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrReplaceClusterRoleBinding(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createClusterRoleBinding(resource);
     }
     @Override
     public void delete(ClusterRoleBinding resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
@@ -24,7 +24,7 @@ public class ClusterRoleResource implements ResourceType<ClusterRole> {
     @Override
     public void create(ClusterRole resource) {
         // ClusterRole his operation namespace is only 'default'
-        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrReplaceClusterRoles(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createClusterRoles(resource);
     }
     @Override
     public void delete(ClusterRole resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
@@ -24,7 +24,7 @@ public class ClusterRoleResource implements ResourceType<ClusterRole> {
     @Override
     public void create(ClusterRole resource) {
         // ClusterRole his operation namespace is only 'default'
-        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createClusterRoles(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrUpdateClusterRoles(resource);
     }
     @Override
     public void delete(ClusterRole resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ConfigMapResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ConfigMapResource.java
@@ -22,7 +22,7 @@ public class ConfigMapResource implements ResourceType<ConfigMap> {
     }
     @Override
     public void create(ConfigMap resource) {
-        kubeClient().createOrReplaceConfigMap(resource);
+        kubeClient().createConfigMap(resource);
     }
     @Override
     public void delete(ConfigMap resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -27,7 +27,7 @@ public class DeploymentResource implements ResourceType<Deployment> {
     }
     @Override
     public void create(Deployment resource) {
-        ResourceManager.kubeClient().createOrReplaceDeployment(resource);
+        ResourceManager.kubeClient().createDeployment(resource);
     }
     @Override
     public void delete(Deployment resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/LeaseResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/LeaseResource.java
@@ -23,7 +23,7 @@ public class LeaseResource implements ResourceType<Lease> {
 
     @Override
     public void create(Lease resource) {
-        kubeClient().getClient().leases().resource(resource).createOrReplace();
+        kubeClient().getClient().leases().resource(resource).serverSideApply();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/LeaseResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/LeaseResource.java
@@ -23,7 +23,7 @@ public class LeaseResource implements ResourceType<Lease> {
 
     @Override
     public void create(Lease resource) {
-        kubeClient().getClient().leases().resource(resource).serverSideApply();
+        kubeClient().getClient().leases().resource(resource).create();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -28,7 +28,7 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
     }
     @Override
     public void create(RoleBinding resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceRoleBinding(resource);
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createRoleBinding(resource);
     }
     @Override
     public void delete(RoleBinding resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -28,7 +28,7 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
     }
     @Override
     public void create(RoleBinding resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createRoleBinding(resource);
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrUpdateRoleBinding(resource);
     }
     @Override
     public void delete(RoleBinding resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
@@ -28,7 +28,7 @@ public class RoleResource implements ResourceType<Role> {
     }
     @Override
     public void create(Role resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createRole(resource);
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrUpdateRole(resource);
     }
     @Override
     public void delete(Role resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
@@ -28,7 +28,7 @@ public class RoleResource implements ResourceType<Role> {
     }
     @Override
     public void create(Role resource) {
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrReplaceRole(resource);
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createRole(resource);
     }
     @Override
     public void delete(Role resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceAccountResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceAccountResource.java
@@ -22,7 +22,7 @@ public class ServiceAccountResource implements ResourceType<ServiceAccount> {
     }
     @Override
     public void create(ServiceAccount resource) {
-        kubeClient().createOrReplaceServiceAccount(resource);
+        kubeClient().createServiceAccount(resource);
     }
     @Override
     public void delete(ServiceAccount resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceAccountResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceAccountResource.java
@@ -22,7 +22,7 @@ public class ServiceAccountResource implements ResourceType<ServiceAccount> {
     }
     @Override
     public void create(ServiceAccount resource) {
-        kubeClient().createServiceAccount(resource);
+        kubeClient().createOrUpdateServiceAccount(resource);
     }
     @Override
     public void delete(ServiceAccount resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/OperatorGroupResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/OperatorGroupResource.java
@@ -27,7 +27,7 @@ public class OperatorGroupResource implements ResourceType<OperatorGroup> {
 
     @Override
     public void create(OperatorGroup resource) {
-        operatorGroupClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).serverSideApply();
+        operatorGroupClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/OperatorGroupResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/OperatorGroupResource.java
@@ -27,7 +27,7 @@ public class OperatorGroupResource implements ResourceType<OperatorGroup> {
 
     @Override
     public void create(OperatorGroup resource) {
-        operatorGroupClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        operatorGroupClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).serverSideApply();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/SubscriptionResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/SubscriptionResource.java
@@ -29,7 +29,7 @@ public class SubscriptionResource implements ResourceType<Subscription> {
 
     @Override
     public void create(Subscription resource) {
-        subscriptionClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).serverSideApply();
+        subscriptionClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/SubscriptionResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/SubscriptionResource.java
@@ -29,7 +29,7 @@ public class SubscriptionResource implements ResourceType<Subscription> {
 
     @Override
     public void create(Subscription resource) {
-        subscriptionClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).createOrReplace();
+        subscriptionClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).serverSideApply();
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -49,7 +49,7 @@ public class BundleResource implements ResourceType<Deployment> {
     }
     @Override
     public void create(Deployment resource) {
-        ResourceManager.kubeClient().createOrReplaceDeployment(resource);
+        ResourceManager.kubeClient().createDeployment(resource);
     }
     @Override
     public void delete(Deployment resource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -260,6 +260,11 @@ public class BundleResource implements ResourceType<Deployment> {
                                 .withNewSizeLimit("2Mi")
                             .endEmptyDir()
                         .endVolume()
+                        .editLastVolume()
+                            .editConfigMap()
+                                .withName(name)
+                            .endConfigMap()
+                        .endVolume()
                     .endSpec()
                 .endTemplate()
             .endSpec();

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -649,6 +649,7 @@ public class SetupClusterOperator {
                     ResourceManager.getInstance().createResource(extensionContext, new ConfigMapBuilder(configMap)
                         .editMetadata()
                             .withNamespace(namespace)
+                            .withName(clusterOperatorName)
                         .endMetadata()
                         .build());
                     break;
@@ -659,6 +660,7 @@ public class SetupClusterOperator {
                     ResourceManager.getInstance().createResource(extensionContext, new LeaseBuilder(lease)
                             .editMetadata()
                                 .withNamespace(namespace)
+                                .withName(clusterOperatorName)
                             .endMetadata()
                             .build());
                     break;

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertHolder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertHolder.java
@@ -84,7 +84,10 @@ public class SystemTestCertHolder {
             SecretUtils.deleteSecretWithWait(this.caKeySecretName, namespaceName);
             final File strimziKeyPKCS8 = convertPrivateKeyToPKCS8File(this.systemTestCa.getPrivateKey());
             //      b) Create the new (custom) secret.
-            SecretUtils.createSecretFromFile(strimziKeyPKCS8.getAbsolutePath(), "ca.key", this.caKeySecretName, namespaceName, additionalSecretLabels);
+
+            Secret secret = SecretUtils.createSecretFromFile(strimziKeyPKCS8.getAbsolutePath(), "ca.key", this.caKeySecretName, namespaceName, additionalSecretLabels);
+            kubeClient().namespace(namespaceName).createSecret(secret);
+            SecretUtils.waitForSecretReady(namespaceName, this.caKeySecretName, () -> { });
 
             // 4. Annotate the secrets
             SecretUtils.annotateSecret(namespaceName, this.caCertSecretName, Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "0");

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -16,11 +16,11 @@ import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.KubeClusterResource;
 
 import java.util.Random;
 
 import static io.strimzi.operator.common.Util.hashStub;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class KafkaConnectTemplates {
 
@@ -56,7 +56,7 @@ public class KafkaConnectTemplates {
 
     private static void createOrReplaceConnectMetrics(String namespaceName) {
         ConfigMap metricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, "connect-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(metricsCm).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, metricsCm);
     }
 
     private static KafkaConnectBuilder defaultKafkaConnect(KafkaConnect kafkaConnect, final String namespaceName, String name, String kafkaClusterName, int kafkaConnectReplicas) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -20,6 +20,8 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
 public class KafkaMirrorMaker2Templates {
 
     private KafkaMirrorMaker2Templates() {}
@@ -32,7 +34,7 @@ public class KafkaMirrorMaker2Templates {
     public static KafkaMirrorMaker2Builder kafkaMirrorMaker2WithMetrics(String namespaceName, String name, String targetClusterName, String sourceClusterName, int kafkaMirrorMaker2Replicas, String sourceNs, String targetNs) {
         KafkaMirrorMaker2 kafkaMirrorMaker2 = getKafkaMirrorMaker2FromYaml(Constants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG);
         ConfigMap metricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, "mirror-maker-2-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(metricsCm).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, metricsCm);
         return defaultKafkaMirrorMaker2(kafkaMirrorMaker2, name, targetClusterName, sourceClusterName, kafkaMirrorMaker2Replicas, false, sourceNs, targetNs);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -18,7 +18,6 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.KubeClusterResource;
 
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -84,7 +84,7 @@ public class KafkaTemplates {
         Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG);
 
         ConfigMap metricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespace).resource(metricsCm).createOrReplace();
+        KubeClusterResource.kubeClient().createConfigMapInNamespace(namespace, metricsCm);
         return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
             .editOrNewMetadata()
                 .withNamespace(namespace)
@@ -103,9 +103,9 @@ public class KafkaTemplates {
     public static KafkaBuilder kafkaWithMetricsAndCruiseControlWithMetrics(String namespaceName, String name, int kafkaReplicas, int zookeeperReplicas) {
         Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG);
         ConfigMap kafkaMetricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(kafkaMetricsCm).createOrReplace();
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(kafkaMetricsCm).serverSideApply();
         ConfigMap zkMetricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(zkMetricsCm).createOrReplace();
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(zkMetricsCm).serverSideApply();
 
         ConfigMap ccCm = new ConfigMapBuilder()
                 .withApiVersion("v1")
@@ -120,7 +120,7 @@ public class KafkaTemplates {
                         "  name: kafka_cruisecontrol_$1_$2\n" +
                         "  type: GAUGE"))
                 .build();
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(ccCm).createOrReplace();
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(ccCm).serverSideApply();
 
         ConfigMapKeySelector cmks = new ConfigMapKeySelectorBuilder()
                 .withName("cruise-control-metrics-test")

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -103,9 +103,9 @@ public class KafkaTemplates {
     public static KafkaBuilder kafkaWithMetricsAndCruiseControlWithMetrics(String namespaceName, String name, int kafkaReplicas, int zookeeperReplicas) {
         Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG);
         ConfigMap kafkaMetricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(kafkaMetricsCm).serverSideApply();
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(kafkaMetricsCm).create();
         ConfigMap zkMetricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(zkMetricsCm).serverSideApply();
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(zkMetricsCm).create();
 
         ConfigMap ccCm = new ConfigMapBuilder()
                 .withApiVersion("v1")
@@ -120,7 +120,7 @@ public class KafkaTemplates {
                         "  name: kafka_cruisecontrol_$1_$2\n" +
                         "  type: GAUGE"))
                 .build();
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(ccCm).serverSideApply();
+        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(ccCm).create();
 
         ConfigMapKeySelector cmks = new ConfigMapKeySelectorBuilder()
                 .withName("cruise-control-metrics-test")

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -104,8 +104,6 @@ public class KafkaTemplates {
         Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG);
         ConfigMap kafkaMetricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
         KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(kafkaMetricsCm).create();
-        ConfigMap zkMetricsCm = TestUtils.configMapFromYaml(Constants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(zkMetricsCm).create();
 
         ConfigMap ccCm = new ConfigMapBuilder()
                 .withApiVersion("v1")

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -87,10 +87,6 @@ public class KafkaRebalanceUtils {
         if (!autoApproval) {
             // it can sometimes happen that KafkaRebalance is already in the ProposalReady state -> race condition prevention
             if (!rebalanceStateCondition(reconciliation, namespaceName, rebalanceName).getType().equals(KafkaRebalanceState.ProposalReady.name())) {
-                LOGGER.infoCr(reconciliation, "Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.PendingProposal);
-
-                waitForKafkaRebalanceCustomResourceState(namespaceName, rebalanceName, KafkaRebalanceState.PendingProposal);
-
                 LOGGER.infoCr(reconciliation, "Verifying that KafkaRebalance resource is in {} state", KafkaRebalanceState.ProposalReady);
 
                 waitForKafkaRebalanceCustomResourceState(namespaceName, rebalanceName, KafkaRebalanceState.ProposalReady);

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1200,9 +1200,9 @@ class ConnectIsolatedST extends AbstractST {
 
         kubeClient(namespaceName).createSecret(connectSecret);
         kubeClient(namespaceName).createSecret(dotedConnectSecret);
-        
-        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
-        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(dotedConfigMap).createOrReplace();
+
+        kubeClient().createConfigMapInNamespace(namespaceName, configMap);
+        kubeClient().createConfigMapInNamespace(namespaceName, dotedConfigMap);
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(clusterName, namespaceName, 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -49,6 +49,7 @@ import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
@@ -1401,7 +1402,6 @@ class ConnectIsolatedST extends AbstractST {
 
         resourceManager.createResource(extensionContext, kafkaUser);
 
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.scramShaUser(namespaceName, clusterName, userName).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(clusterName, topicName).build());
         resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnect(clusterName, namespaceName, 1)
                 .withNewSpec()
@@ -1432,7 +1432,7 @@ class ConnectIsolatedST extends AbstractST {
                     .withName("new-custom-pwd-secret")
                     .withNamespace(namespaceName)
                 .endMetadata()
-                .addToStringData("pwd", "completely_different_secret_password")
+                .addToStringData("pwd", "completely_different_secret_password_long_enough_for_fips")
                 .build();
 
         kubeClient(namespaceName).createSecret(newPasswordSecret);
@@ -1449,7 +1449,7 @@ class ConnectIsolatedST extends AbstractST {
                 .endSpec()
                 .build();
 
-        resourceManager.createResource(extensionContext, kafkaUser);
+        KafkaUserResource.kafkaUserClient().inNamespace(namespaceName).resource(kafkaUser).update();
 
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, labelSelector, 1, connectSnapshot);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -134,7 +134,7 @@ public class ConfigProviderST extends AbstractST {
             .endRule()
             .build();
 
-        kubeClient().createRole(configRole);
+        kubeClient().createOrUpdateRole(configRole);
 
         String configPrefix = "configmaps:" + namespaceName + "/connector-config:";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -134,7 +134,7 @@ public class ConfigProviderST extends AbstractST {
             .endRule()
             .build();
 
-        kubeClient().getClient().resource(configRole).createOrReplace();
+        kubeClient().createRole(configRole);
 
         String configPrefix = "configmaps:" + namespaceName + "/connector-config:";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1705,8 +1705,8 @@ public class ListenersST extends AbstractST {
         resourceManager.createResource(extensionContext, kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount() * 3);
 
-        SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
-        SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);
+        SecretUtils.updateCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
+        SecretUtils.updateCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);
 
         kafkaSnapshot = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaSnapshot);
 
@@ -2264,7 +2264,7 @@ public class ListenersST extends AbstractST {
             .addToData("password", secondEncodedPassword)
             .build();
 
-        kubeClient().namespace(testStorage.getNamespaceName()).createSecret(password);
+        kubeClient().namespace(testStorage.getNamespaceName()).updateSecret(password);
         SecretUtils.waitForUserPasswordChange(testStorage.getNamespaceName(), testStorage.getUserName(), secondEncodedPassword);
 
         LOGGER.info("Receiving messages with new password");

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -202,7 +202,7 @@ class LoggingChangeST extends AbstractST {
         kubeClient().createConfigMapInNamespace(namespaceName, configMapKafka);
         kubeClient().createConfigMapInNamespace(namespaceName, configMapOperators);
         kubeClient().createConfigMapInNamespace(namespaceName, configMapZookeeper);
-        kubeClient().createConfigMapInNamespace(clusterOperator.getDeploymentNamespace(), configMapCO);
+        kubeClient().updateConfigMapInNamespace(clusterOperator.getDeploymentNamespace(), configMapCO);
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3)
             .editOrNewSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -199,10 +199,10 @@ class LoggingChangeST extends AbstractST {
             .addToData("log4j2.properties", loggersConfigCO)
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapKafka).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapOperators).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapZookeeper).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(configMapCO).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, configMapKafka);
+        kubeClient().createConfigMapInNamespace(namespaceName, configMapOperators);
+        kubeClient().createConfigMapInNamespace(namespaceName, configMapZookeeper);
+        kubeClient().createConfigMapInNamespace(clusterOperator.getDeploymentNamespace(), configMapCO);
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3)
             .editOrNewSpec()
@@ -255,7 +255,7 @@ class LoggingChangeST extends AbstractST {
 
         // set loggers of CO back to original
         configMapCO.getData().put("log4j2.properties", originalCoLoggers);
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(configMapCO).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(namespaceName, configMapCO);
     }
 
     @ParallelNamespaceTest
@@ -348,8 +348,8 @@ class LoggingChangeST extends AbstractST {
                 "rootLogger.additivity=false"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapTo).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapUo).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, configMapTo);
+        kubeClient().createConfigMapInNamespace(namespaceName, configMapUo);
 
         ExternalLogging elTo = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -431,8 +431,8 @@ class LoggingChangeST extends AbstractST {
                 "rootLogger.additivity=false"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapTo).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapUo).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(namespaceName, configMapTo);
+        kubeClient().updateConfigMapInNamespace(namespaceName, configMapUo);
 
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -544,7 +544,7 @@ class LoggingChangeST extends AbstractST {
                     "logger.ready.level = OFF"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(configMapBridge).createOrReplace();
+        kubeClient().createConfigMapInNamespace(testStorage.getNamespaceName(), configMapBridge);
 
         ExternalLogging bridgeXternalLogging = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -622,7 +622,7 @@ class LoggingChangeST extends AbstractST {
         assertThat(log4jConfig, not(equalTo(cmdKubeClient().namespace(clusterOperator.getDeploymentNamespace()).execInPod(coPodName, "/bin/bash", "-c", command).out().trim())));
 
         LOGGER.info("Changing logging for cluster-operator");
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coMap).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(clusterOperator.getDeploymentNamespace(), coMap);
 
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -648,7 +648,7 @@ class LoggingChangeST extends AbstractST {
         coMap.setData(Collections.singletonMap("log4j2.properties", log4jConfig));
 
         LOGGER.info("Changing logging for cluster-operator");
-        kubeClient().getClient().configMaps().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coMap).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(clusterOperator.getDeploymentNamespace(), coMap);
 
         LOGGER.info("Waiting for log4j2.properties will contain desired settings");
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -751,7 +751,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", log4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(connectLoggingMap).createOrReplace();
+        kubeClient().createConfigMapInNamespace(testStorage.getNamespaceName(), connectLoggingMap);
 
         ExternalLogging connectXternalLogging = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -883,7 +883,7 @@ class LoggingChangeST extends AbstractST {
                 "log4j.logger.kafka.authorizer.logger=INFO"))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, configMap);
 
         ExternalLogging elKafka = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -1002,7 +1002,8 @@ class LoggingChangeST extends AbstractST {
                         ))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, configMap);
+
         ExternalLogging el = new ExternalLoggingBuilder()
             .withNewValueFrom()
                 .withConfigMapKeyRef(
@@ -1052,7 +1053,7 @@ class LoggingChangeST extends AbstractST {
                         ))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(namespaceName, configMap);
         RollingUpdateUtils.waitForNoRollingUpdate(namespaceName, kafkaSelector, kafkaPods);
         assertThat("Kafka pod should not roll", RollingUpdateUtils.componentHasRolled(namespaceName, kafkaSelector, kafkaPods), is(false));
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -1084,7 +1085,7 @@ class LoggingChangeST extends AbstractST {
                 ))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(namespaceName, configMap);
         RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, kafkaPods);
 
         TestUtils.waitFor("Verify logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
@@ -1169,7 +1170,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", log4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(mm2LoggingMap).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, mm2LoggingMap);
 
         ExternalLogging mm2XternalLogging = new ExternalLoggingBuilder()
             .withNewValueFrom()
@@ -1235,7 +1236,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", log4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(mm2LoggingMap).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, mm2LoggingMap);
 
         ExternalLogging mm2XternalLogging = new ExternalLoggingBuilder()
                 .withNewValueFrom()
@@ -1284,7 +1285,7 @@ class LoggingChangeST extends AbstractST {
                 .withData(Collections.singletonMap("log4j.properties", updatedLog4jConfig))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(mm2LoggingMap).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(namespaceName, mm2LoggingMap);
 
         TestUtils.waitFor("Logger change", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
             () -> cmdKubeClient().namespace(namespaceName).execInPod(kafkaMM2PodName, "curl", "http://localhost:8083/admin/loggers/root").out().contains("INFO")
@@ -1324,7 +1325,7 @@ class LoggingChangeST extends AbstractST {
             .withData(Collections.singletonMap("log4j.properties", cmData))
             .build();
 
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, configMap);
 
         LOGGER.info("Deploying Kafka with custom logging");
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 1)

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -255,7 +255,7 @@ class LoggingChangeST extends AbstractST {
 
         // set loggers of CO back to original
         configMapCO.getData().put("log4j2.properties", originalCoLoggers);
-        kubeClient().updateConfigMapInNamespace(namespaceName, configMapCO);
+        kubeClient().updateConfigMapInNamespace(clusterOperator.getDeploymentNamespace(), configMapCO);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -435,7 +435,7 @@ public class MetricsIsolatedST extends AbstractST {
                 .endMetadata()
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(SECOND_NAMESPACE).resource(externalMetricsCm).createOrReplace();
+        kubeClient().createConfigMapInNamespace(SECOND_NAMESPACE, externalMetricsCm);
 
         // spec.kafka.metrics -> spec.kafka.jmxExporterMetrics
         ConfigMapKeySelector cmks = new ConfigMapKeySelectorBuilder()
@@ -467,7 +467,7 @@ public class MetricsIsolatedST extends AbstractST {
                 .endMetadata()
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(SECOND_NAMESPACE).resource(externalMetricsUpdatedCm).createOrReplace();
+        kubeClient().createConfigMapInNamespace(SECOND_NAMESPACE, externalMetricsUpdatedCm);
         PodUtils.verifyThatRunningPodsAreStable(SECOND_NAMESPACE, SECOND_CLUSTER);
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(SECOND_CLUSTER, 1)) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -467,7 +467,7 @@ public class MetricsIsolatedST extends AbstractST {
                 .endMetadata()
                 .build();
 
-        kubeClient().createConfigMapInNamespace(SECOND_NAMESPACE, externalMetricsUpdatedCm);
+        kubeClient().updateConfigMapInNamespace(SECOND_NAMESPACE, externalMetricsUpdatedCm);
         PodUtils.verifyThatRunningPodsAreStable(SECOND_NAMESPACE, SECOND_CLUSTER);
 
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(SECOND_CLUSTER, 1)) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -216,7 +216,7 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
 
         assertThat(PodUtils.podSnapshot(DEFAULT_NAMESPACE, kafkaSelector).size(), is(scaleTo));
 
-        KafkaRebalanceUtils.doRebalancingProcess(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND, SECOND_NAMESPACE, clusterName), DEFAULT_NAMESPACE, clusterName);
+        KafkaRebalanceUtils.doRebalancingProcess(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND, DEFAULT_NAMESPACE, clusterName), DEFAULT_NAMESPACE, clusterName);
     }
 
     void deployCOInNamespace(ExtensionContext extensionContext, String coName, String coNamespace, List<EnvVar> extraEnvs, boolean multipleNamespaces) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -504,7 +504,7 @@ class RollingUpdateST extends AbstractST {
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
             ConfigMap configMap = kubeClient(namespaceName).getConfigMap(namespaceName, cmName);
             configMap.getData().put("new.kafka.config", "new.config.value");
-            kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(configMap).createOrReplace();
+            kubeClient().updateConfigMapInNamespace(namespaceName, configMap);
         }
 
         PodUtils.verifyThatRunningPodsAreStable(namespaceName, clusterName);
@@ -562,7 +562,7 @@ class RollingUpdateST extends AbstractST {
                 .withKey("log4j-custom.properties")
                 .build();
 
-        kubeClient(namespaceName).getClient().configMaps().inNamespace(namespaceName).resource(configMapLoggers).createOrReplace();
+        kubeClient().createConfigMapInNamespace(namespaceName, configMapLoggers);
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             kafka.getSpec().getKafka().setLogging(new ExternalLoggingBuilder()
@@ -585,7 +585,7 @@ class RollingUpdateST extends AbstractST {
         kafkaPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, kafkaSelector, 3, kafkaPods);
 
         configMapLoggers.getData().put("log4j-custom.properties", loggersConfig.replace("%p %m (%c) [%t]", "%p %m (%c) [%t]%n"));
-        kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(configMapLoggers).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(namespaceName, configMapLoggers);
 
         if (!Environment.isKRaftModeEnabled()) {
             RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, zkSelector, 3, zkPods);
@@ -714,8 +714,8 @@ class RollingUpdateST extends AbstractST {
                 .endValueFrom()
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMK).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMZk).createOrReplace();
+        kubeClient().createConfigMapInNamespace(testStorage.getNamespaceName(), metricsCMK);
+        kubeClient().createConfigMapInNamespace(testStorage.getNamespaceName(), metricsCMZk);
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3, 3)
             .editMetadata()
@@ -787,8 +787,8 @@ class RollingUpdateST extends AbstractST {
                 .withData(singletonMap("metrics-config.yml", mapper.writeValueAsString(kafkaMetrics)))
                 .build();
 
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMK).createOrReplace();
-        kubeClient().getClient().configMaps().inNamespace(testStorage.getNamespaceName()).resource(metricsCMZk).createOrReplace();
+        kubeClient().updateConfigMapInNamespace(testStorage.getNamespaceName(), metricsCMK);
+        kubeClient().updateConfigMapInNamespace(testStorage.getNamespaceName(), metricsCMZk);
 
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), testStorage.getZookeeperStatefulSetName());
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), testStorage.getKafkaStatefulSetName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesIsolatedST.java
@@ -302,6 +302,6 @@ public class PodSecurityProfilesIsolatedST extends AbstractST {
         final Map<String, String> namespaceLabels = namespace.getMetadata().getLabels();
         namespaceLabels.put("pod-security.kubernetes.io/enforce", "restricted");
         namespace.getMetadata().setLabels(namespaceLabels);
-        kubeClient().createOrReplaceNamespace(namespace);
+        kubeClient().updateNamespace(namespace);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -712,12 +712,6 @@ class SecurityST extends AbstractST {
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> kafka.getSpec().setMaintenanceTimeWindows(maintenanceTimeWindows), testStorage.getNamespaceName());
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 1)
-            .editSpec()
-                .addToMaintenanceTimeWindows(maintenanceWindowCron)
-            .endSpec()
-            .build());
-
         LOGGER.info("Wait until rolling update is triggered during maintenanceTimeWindows");
         RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 3, kafkaPods);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
@@ -28,6 +28,7 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.strimzi.test.WaitException;
 import io.vertx.core.cli.annotations.Description;
@@ -52,7 +53,6 @@ import java.util.Map;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(OAUTH)
@@ -589,9 +589,9 @@ public class OauthAuthorizationIsolatedST extends OauthAbstractST {
         TestStorage testStorage = new TestStorage(extensionContext);
 
         // we have to create keycloak, team-a-client and team-b-client secret from `infra-namespace` to the new namespace
-        resourceManager.createResource(extensionContext, kubeClient().getSecret(clusterOperator.getDeploymentNamespace(), KeycloakInstance.KEYCLOAK_SECRET_NAME));
-        resourceManager.createResource(extensionContext, kubeClient().getSecret(clusterOperator.getDeploymentNamespace(), TEAM_A_CLIENT_SECRET));
-        resourceManager.createResource(extensionContext, kubeClient().getSecret(clusterOperator.getDeploymentNamespace(), TEAM_B_CLIENT_SECRET));
+        resourceManager.createResource(extensionContext, SecretUtils.createCopyOfSecret(clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), KeycloakInstance.KEYCLOAK_SECRET_NAME).build());
+        resourceManager.createResource(extensionContext, SecretUtils.createCopyOfSecret(clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), TEAM_A_CLIENT_SECRET).build());
+        resourceManager.createResource(extensionContext, SecretUtils.createCopyOfSecret(clusterOperator.getDeploymentNamespace(), testStorage.getNamespaceName(), TEAM_B_CLIENT_SECRET).build());
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 1, 1)
             .editSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -177,7 +177,7 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
                     .endMetadata()
                     .build();
 
-        kubeClient(targetNamespace).getClient().secrets().inNamespace(targetNamespace).resource(s).createOrReplace();
+        kubeClient().createSecret(s);
     }
 
     private void deployTestSpecificResources(ExtensionContext extensionContext) {

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -92,6 +92,10 @@
             <artifactId>openshift-model-operatorhub</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-storageclass</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -605,15 +605,23 @@ public class KubeClient {
     /**
      * Method for creating the specified ServiceAccount.
      * In case that the ServiceAccount is already created, it is being updated.
-     * This can be caused by not cleared ServiceAccounts from other tests on in case we shut down the test before the cleanup
-     * phase. It should not have an impact on the functionality, we just update the ServiceAccount.
+     * This can be caused by not cleared ServiceAccounts from other tests or in case we shut down the test before the cleanup
+     * phase.
+     * The skip of the cleanup phase can then break the CO installation - because the resource already exists.
+     * Without the update, we would need to manually remove all existing resources before running the test again.
+     * It should not have an impact on the functionality, we just update the ServiceAccount.
      * @param serviceAccount ServiceAccount that we want to create or update
      */
     public void createOrUpdateServiceAccount(ServiceAccount serviceAccount) {
         try {
             client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).create();
         } catch (KubernetesClientException e) {
-            client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).update();
+            if (e.getCode() == 409) {
+                LOGGER.info("ServiceAccount: {} is already created, going to update it", serviceAccount.getMetadata().getName());
+                client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).update();
+            } else {
+                throw e;
+            }
         }
     }
 
@@ -675,15 +683,23 @@ public class KubeClient {
     /**
      * Method for creating the specified ClusterRole.
      * In case that the ClusterRole is already created, it is being updated.
-     * This can be caused by not cleared ClusterRoles from other tests on in case we shut down the test before the cleanup
-     * phase. It should not have an impact on the functionality, we just update the ClusterRole.
+     * This can be caused by not cleared ClusterRoles from other tests or in case we shut down the test before the cleanup
+     * phase.
+     * The skip of the cleanup phase can then break the CO installation - because the resource already exists.
+     * Without the update, we would need to manually remove all existing resources before running the test again.
+     * It should not have an impact on the functionality, we just update the ClusterRole.
      * @param clusterRole ClusterRole that we want to create or update
      */
     public void createOrUpdateClusterRoles(ClusterRole clusterRole) {
         try {
             client.rbac().clusterRoles().resource(clusterRole).create();
         } catch (KubernetesClientException e) {
-            client.rbac().clusterRoles().resource(clusterRole).update();
+            if (e.getCode() == 409) {
+                LOGGER.info("ClusterRole: {} is already created, going to update it", clusterRole.getMetadata().getName());
+                client.rbac().clusterRoles().resource(clusterRole).update();
+            } else {
+                throw e;
+            }
         }
     }
 
@@ -702,30 +718,46 @@ public class KubeClient {
     /**
      * Method for creating the specified RoleBinding.
      * In case that the RoleBinding is already created, it is being updated.
-     * This can be caused by not cleared RoleBindings from other tests on in case we shut down the test before the cleanup
-     * phase. It should not have an impact on the functionality, we just update the RoleBinding.
+     * This can be caused by not cleared RoleBindings from other tests or in case we shut down the test before the cleanup
+     * phase.
+     * The skip of the cleanup phase can then break the CO installation - because the resource already exists.
+     * Without the update, we would need to manually remove all existing resources before running the test again.
+     * It should not have an impact on the functionality, we just update the RoleBinding.
      * @param roleBinding RoleBinding that we want to create or update
      */
     public void createOrUpdateRoleBinding(RoleBinding roleBinding) {
         try {
             client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).create();
         } catch (KubernetesClientException e) {
-            client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).update();
+            if (e.getCode() == 409) {
+                LOGGER.info("RoleBinding: {} is already created, going to update it", roleBinding.getMetadata().getName());
+                client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).update();
+            } else {
+                throw e;
+            }
         }
     }
 
     /**
      * Method for creating the specified ClusterRoleBinding.
      * In case that the CRB is already created, it is being updated.
-     * This can be caused by not cleared CRBs from other tests on in case we shut down the test before the cleanup
-     * phase. It should not have an impact on the functionality, we just update the CRB.
+     * This can be caused by not cleared CRBs from other tests or in case we shut down the test before the cleanup
+     * phase.
+     * The skip of the cleanup phase can then break the CO installation - because the resource already exists.
+     * Without the update, we would need to manually remove all existing resources before running the test again.
+     * It should not have an impact on the functionality, we just update the CRB.
      * @param clusterRoleBinding ClusterRoleBinding that we want to create or update
      */
     public void createOrUpdateClusterRoleBinding(ClusterRoleBinding clusterRoleBinding) {
         try {
             client.rbac().clusterRoleBindings().resource(clusterRoleBinding).create();
         } catch (KubernetesClientException e) {
-            client.rbac().clusterRoleBindings().resource(clusterRoleBinding).update();
+            if (e.getCode() == 409) {
+                LOGGER.info("ClusterRoleBinding: {} is already created, going to update it", clusterRoleBinding.getMetadata().getName());
+                client.rbac().clusterRoleBindings().resource(clusterRoleBinding).update();
+            } else {
+                throw e;
+            }
         }
     }
 
@@ -752,15 +784,23 @@ public class KubeClient {
     /**
      * Method for creating the specified Role.
      * In case that the Role is already created, it is being updated.
-     * This can be caused by not cleared Roles from other tests on in case we shut down the test before the cleanup
-     * phase. It should not have an impact on the functionality, we just update the Role.
+     * This can be caused by not cleared Roles from other tests or in case we shut down the test before the cleanup
+     * phase.
+     * The skip of the cleanup phase can then break the CO installation - because the resource already exists.
+     * Without the update, we would need to manually remove all existing resources before running the test again.
+     * It should not have an impact on the functionality, we just update the Role.
      * @param role Role that we want to create or update
      */
     public void createOrUpdateRole(Role role) {
         try {
             client.rbac().roles().inNamespace(getNamespace()).resource(role).create();
         } catch (KubernetesClientException e) {
-            client.rbac().roles().inNamespace(getNamespace()).resource(role).update();
+            if (e.getCode() == 409) {
+                LOGGER.info("Role: {} is already created, going to update it", role.getMetadata().getName());
+                client.rbac().roles().inNamespace(getNamespace()).resource(role).update();
+            } else {
+                throw e;
+            }
         }
     }
 
@@ -830,15 +870,23 @@ public class KubeClient {
     /**
      * Method for creating the specified CustomResourceDefinition.
      * In case that the CRD is already created, it is being updated.
-     * This can be caused by not cleared CRDs from other tests on in case we shut down the test before the cleanup
-     * phase. It should not have an impact on the functionality, we just update the CRD.
+     * This can be caused by not cleared CRDs from other tests or in case we shut down the test before the cleanup
+     * phase.
+     * The skip of the cleanup phase can then break the CO installation - because the resource already exists.
+     * Without the update, we would need to manually remove all existing resources before running the test again.
+     * It should not have an impact on the functionality, we just update the CRD.
      * @param resourceDefinition CustomResourceDefinition that we want to create or update
      */
     public void createOrUpdateCustomResourceDefinition(CustomResourceDefinition resourceDefinition) {
         try {
             client.apiextensions().v1().customResourceDefinitions().resource(resourceDefinition).create();
         } catch (KubernetesClientException e) {
-            client.apiextensions().v1().customResourceDefinitions().resource(resourceDefinition).update();
+            if (e.getCode() == 409) {
+                LOGGER.info("CustomResourceDefinition: {} is already created, going to update it", resourceDefinition.getMetadata().getName());
+                client.apiextensions().v1().customResourceDefinitions().resource(resourceDefinition).update();
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.storage.StorageClass;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.PodResource;
@@ -523,6 +524,10 @@ public class KubeClient {
         return client.secrets().inNamespace(secret.getMetadata().getNamespace()).resource(secret).create();
     }
 
+    public Secret updateSecret(Secret secret) {
+        return client.secrets().inNamespace(secret.getMetadata().getNamespace()).resource(secret).update();
+    }
+
     public void patchSecret(String namespaceName, String secretName, Secret secret) {
         client.secrets().inNamespace(namespaceName).withName(secretName).patch(PatchContext.of(PatchType.JSON), secret);
     }
@@ -597,8 +602,12 @@ public class KubeClient {
         return client.serviceAccounts().inNamespace(namespaceName).list().getItems();
     }
 
-    public void createServiceAccount(ServiceAccount serviceAccount) {
-        client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).create();
+    public void createOrUpdateServiceAccount(ServiceAccount serviceAccount) {
+        try {
+            client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).create();
+        } catch (KubernetesClientException e) {
+            client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).update();
+        }
     }
 
     public void deleteServiceAccount(ServiceAccount serviceAccount) {
@@ -656,8 +665,19 @@ public class KubeClient {
         return client.rbac().clusterRoles().list().getItems();
     }
 
-    public void createClusterRoles(ClusterRole clusterRole) {
-        client.rbac().clusterRoles().resource(clusterRole).create();
+    /**
+     * Method for creating the specified ClusterRole.
+     * In case that the ClusterRole is already created, it is being updated.
+     * This can be caused by not cleared ClusterRoles from other tests on in case we shut down the test before the cleanup
+     * phase. It should not have an impact on the functionality, we just update the ClusterRole.
+     * @param clusterRole ClusterRole that we want to create or update
+     */
+    public void createOrUpdateClusterRoles(ClusterRole clusterRole) {
+        try {
+            client.rbac().clusterRoles().resource(clusterRole).create();
+        } catch (KubernetesClientException e) {
+            client.rbac().clusterRoles().resource(clusterRole).update();
+        }
     }
 
     public void deleteClusterRole(ClusterRole clusterRole) {
@@ -672,12 +692,27 @@ public class KubeClient {
     // ---------> ROLE BINDING <---------
     // ==================================
 
-    public void createRoleBinding(RoleBinding roleBinding) {
-        client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).create();
+    public void createOrUpdateRoleBinding(RoleBinding roleBinding) {
+        try {
+            client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).create();
+        } catch (KubernetesClientException e) {
+            client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).update();
+        }
     }
 
-    public void createClusterRoleBinding(ClusterRoleBinding clusterRoleBinding) {
-        client.rbac().clusterRoleBindings().resource(clusterRoleBinding).create();
+    /**
+     * Method for creating the specified ClusterRoleBinding.
+     * In case that the CRB is already created, it is being updated.
+     * This can be caused by not cleared CRBs from other tests on in case we shut down the test before the cleanup
+     * phase. It should not have an impact on the functionality, we just update the CRB.
+     * @param clusterRoleBinding ClusterRoleBinding that we want to create or update
+     */
+    public void createOrUpdateClusterRoleBinding(ClusterRoleBinding clusterRoleBinding) {
+        try {
+            client.rbac().clusterRoleBindings().resource(clusterRoleBinding).create();
+        } catch (KubernetesClientException e) {
+            client.rbac().clusterRoleBindings().resource(clusterRoleBinding).update();
+        }
     }
 
     public void deleteClusterRoleBinding(ClusterRoleBinding clusterRoleBinding) {
@@ -700,12 +735,12 @@ public class KubeClient {
         client.rbac().roleBindings().inNamespace(namespace).withName(name).delete();
     }
 
-    public void createRole(Role role) {
-        client.rbac().roles().inNamespace(getNamespace()).resource(role).create();
-    }
-
-    public void updateRole(Role role) {
-        client.rbac().roles().inNamespace(getNamespace()).resource(role).update();
+    public void createOrUpdateRole(Role role) {
+        try {
+            client.rbac().roles().inNamespace(getNamespace()).resource(role).create();
+        } catch (KubernetesClientException e) {
+            client.rbac().roles().inNamespace(getNamespace()).resource(role).update();
+        }
     }
 
     public Role getRole(String name) {
@@ -771,8 +806,19 @@ public class KubeClient {
     // ---> CUSTOM RESOURCE DEFINITIONS <---
     // =====================================
 
-    public void createCustomResourceDefinition(CustomResourceDefinition resourceDefinition) {
-        client.apiextensions().v1().customResourceDefinitions().resource(resourceDefinition).create();
+    /**
+     * Method for creating the specified CustomResourceDefinition.
+     * In case that the CRD is already created, it is being updated.
+     * This can be caused by not cleared CRDs from other tests on in case we shut down the test before the cleanup
+     * phase. It should not have an impact on the functionality, we just update the CRD.
+     * @param resourceDefinition CustomResourceDefinition that we want to create or update
+     */
+    public void createOrUpdateCustomResourceDefinition(CustomResourceDefinition resourceDefinition) {
+        try {
+            client.apiextensions().v1().customResourceDefinitions().resource(resourceDefinition).create();
+        } catch (KubernetesClientException e) {
+            client.apiextensions().v1().customResourceDefinitions().resource(resourceDefinition).update();
+        }
     }
 
     public void deleteCustomResourceDefinition(CustomResourceDefinition resourceDefinition) {

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -602,6 +602,13 @@ public class KubeClient {
         return client.serviceAccounts().inNamespace(namespaceName).list().getItems();
     }
 
+    /**
+     * Method for creating the specified ServiceAccount.
+     * In case that the ServiceAccount is already created, it is being updated.
+     * This can be caused by not cleared ServiceAccounts from other tests on in case we shut down the test before the cleanup
+     * phase. It should not have an impact on the functionality, we just update the ServiceAccount.
+     * @param serviceAccount ServiceAccount that we want to create or update
+     */
     public void createOrUpdateServiceAccount(ServiceAccount serviceAccount) {
         try {
             client.serviceAccounts().inNamespace(serviceAccount.getMetadata().getNamespace()).resource(serviceAccount).create();
@@ -692,6 +699,13 @@ public class KubeClient {
     // ---------> ROLE BINDING <---------
     // ==================================
 
+    /**
+     * Method for creating the specified RoleBinding.
+     * In case that the RoleBinding is already created, it is being updated.
+     * This can be caused by not cleared RoleBindings from other tests on in case we shut down the test before the cleanup
+     * phase. It should not have an impact on the functionality, we just update the RoleBinding.
+     * @param roleBinding RoleBinding that we want to create or update
+     */
     public void createOrUpdateRoleBinding(RoleBinding roleBinding) {
         try {
             client.rbac().roleBindings().inNamespace(getNamespace()).resource(roleBinding).create();
@@ -735,6 +749,13 @@ public class KubeClient {
         client.rbac().roleBindings().inNamespace(namespace).withName(name).delete();
     }
 
+    /**
+     * Method for creating the specified Role.
+     * In case that the Role is already created, it is being updated.
+     * This can be caused by not cleared Roles from other tests on in case we shut down the test before the cleanup
+     * phase. It should not have an impact on the functionality, we just update the Role.
+     * @param role Role that we want to create or update
+     */
     public void createOrUpdateRole(Role role) {
         try {
             client.rbac().roles().inNamespace(getNamespace()).resource(role).create();

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -4,7 +4,19 @@
  */
 package io.strimzi.test.k8s;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.PersistentVolume;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -83,6 +95,10 @@ public class KubeClient {
     public void createNamespace(String name) {
         Namespace ns = new NamespaceBuilder().withNewMetadata().withName(name).endMetadata().build();
         client.namespaces().resource(ns).create();
+    }
+
+    public void updateNamespace(Namespace namespace) {
+        client.namespaces().resource(namespace).update();
     }
 
     public void deleteNamespace(String name) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the deprecated Fabric8 method `createOrReplace`.
Instead, we should use the `create()` or `update()` methods depending on the use case.
As part of this PR, I'm also adding few methods for creating and updating various resources and changing it in the tests.
Also, some of the resources like ClusterRoles, CRDs, etc., need to have `createOrUpdate` method for updating the resource when it already exists (because of leftovers from different tests etc.).

Fixes #8270 

### Checklist

- [ ] Make sure all tests pass

