### PR TITLE
[ST] Potential fix for OlmUpgrade.

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -363,7 +363,7 @@ public class SetupClusterOperator {
         }
 
         updateSubscription(olmConfiguration);
-        OlmUtils.waitUntilInstallPlanContainingCertainCsvIsPresent(namespaceInstallTo, olmConfiguration.getCsvName());
+        OlmUtils.waitUntilNonUsedInstallPlanWithSpecificCsvIsPresentAndApprove(namespaceInstallTo, olmConfiguration.getCsvName());
         DeploymentUtils.waitForDeploymentAndPodsReady(namespaceInstallTo, olmConfiguration.getOlmOperatorDeploymentName(), 1);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
@@ -20,7 +20,7 @@ public class OlmConfiguration {
     private String featureGates = Environment.STRIMZI_FEATURE_GATES;
     private String olmAppBundlePrefix = Environment.OLM_APP_BUNDLE_PREFIX;
     private String olmOperatorName = Environment.OLM_OPERATOR_NAME;
-    private String olmOperatorDeploymentName = Environment.OLM_OPERATOR_DEPLOYMENT_NAME;
+    private String olmOperatorDeploymentNamePrefix = Environment.OLM_OPERATOR_DEPLOYMENT_NAME;
     private String olmSourceName = Environment.OLM_SOURCE_NAME;
     private String olmSourceNamespace = Environment.OLM_SOURCE_NAMESPACE;
     private String operatorVersion;
@@ -110,7 +110,7 @@ public class OlmConfiguration {
     }
 
     public String getOlmOperatorDeploymentName() {
-        return olmOperatorDeploymentName + "-v" + operatorVersion;
+        return olmOperatorDeploymentNamePrefix + "-v" + operatorVersion;
     }
 
     public String getOlmOperatorName() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
@@ -18,7 +18,7 @@ public class OlmConfiguration {
     private ExtensionContext extensionContext;
     private String namespaceName;
     private String featureGates = Environment.STRIMZI_FEATURE_GATES;
-    private String olmAppBundlePrefix = Environment.OLM_OPERATOR_DEPLOYMENT_NAME;
+    private String olmAppBundlePrefix = Environment.OLM_APP_BUNDLE_PREFIX;
     private String olmOperatorName = Environment.OLM_OPERATOR_NAME;
     private String olmSourceName = Environment.OLM_SOURCE_NAME;
     private String olmSourceNamespace = Environment.OLM_SOURCE_NAMESPACE;
@@ -109,7 +109,7 @@ public class OlmConfiguration {
     }
 
     public String getOlmOperatorDeploymentName() {
-        return olmAppBundlePrefix + "-v" + operatorVersion;
+        return Environment.OLM_OPERATOR_DEPLOYMENT_NAME + "-v" + operatorVersion;
     }
 
     public String getOlmOperatorName() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
@@ -20,6 +20,7 @@ public class OlmConfiguration {
     private String featureGates = Environment.STRIMZI_FEATURE_GATES;
     private String olmAppBundlePrefix = Environment.OLM_APP_BUNDLE_PREFIX;
     private String olmOperatorName = Environment.OLM_OPERATOR_NAME;
+    private String olmOperatorDeploymentName = Environment.OLM_OPERATOR_DEPLOYMENT_NAME;
     private String olmSourceName = Environment.OLM_SOURCE_NAME;
     private String olmSourceNamespace = Environment.OLM_SOURCE_NAMESPACE;
     private String operatorVersion;
@@ -109,7 +110,7 @@ public class OlmConfiguration {
     }
 
     public String getOlmOperatorDeploymentName() {
-        return Environment.OLM_OPERATOR_DEPLOYMENT_NAME + "-v" + operatorVersion;
+        return olmOperatorDeploymentName + "-v" + operatorVersion;
     }
 
     public String getOlmOperatorName() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
@@ -18,7 +18,7 @@ public class OlmConfiguration {
     private ExtensionContext extensionContext;
     private String namespaceName;
     private String featureGates = Environment.STRIMZI_FEATURE_GATES;
-    private String olmAppBundlePrefix = Environment.OLM_APP_BUNDLE_PREFIX;
+    private String olmAppBundlePrefix = Environment.OLM_OPERATOR_DEPLOYMENT_NAME;
     private String olmOperatorName = Environment.OLM_OPERATOR_NAME;
     private String olmSourceName = Environment.OLM_SOURCE_NAME;
     private String olmSourceNamespace = Environment.OLM_SOURCE_NAMESPACE;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/OlmUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/OlmUtils.java
@@ -24,16 +24,13 @@ public class OlmUtils {
             () -> kubeClient().getNonApprovedInstallPlan(namespaceName) != null);
     }
 
-    public static void waitUntilInstallPlanContainingCertainCsvIsPresent(String namespaceName, String csvName) {
+    public static void waitUntilNonUsedInstallPlanWithSpecificCsvIsPresentAndApprove(String namespaceName, String csvName) {
         TestUtils.waitFor(String.format("non used install plan with CSV: {} to be present", csvName), Constants.OLM_UPGRADE_INSTALL_PLAN_POLL, Constants.OLM_UPGRADE_INSTALL_PLAN_TIMEOUT,
             () -> {
                 if (kubeClient().getNonApprovedInstallPlan(namespaceName) != null) {
                     InstallPlan installPlan = kubeClient().getNonApprovedInstallPlan(namespaceName);
-                    kubeClient().approveInstallPlan(namespaceName, installPlan.getMetadata().getName());
-                    String currentCsv = installPlan.getSpec().getClusterServiceVersionNames().get(0).toString();
-
-                    LOGGER.info("Waiting for CSV: {} to be present in InstallPlan, current CSV: {}", csvName, currentCsv);
-                    if (currentCsv.contains(csvName)) {
+                    if (installPlan.getSpec().getClusterServiceVersionNames().get(0).toString().contains(csvName)) {
+                        kubeClient().approveInstallPlan(namespaceName, installPlan.getMetadata().getName());
                         return true;
                     }
                 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR contains small change for OlmUpgradeIsolatedST. The original concept was to upgrade from 'any' olm operator version to the latest released one. This was done in a cycle using wait an iterating through all the installplans with versions between the starting and the latest. That could potentially invoke some issues with long waiting time and leave operator at some point with rolling update, while newer operator is being installed which could mean unstable behavior. So this PR should remove this long rolling cycle of upgrades and allow upgrade up to the next specified version.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

