### PR TITLE
Update keycloak version to 21.0.0 on s390x pipeline

### DIFF
--- a/.jenkins/scripts/build_keycloak_opa-s390x.sh
+++ b/.jenkins/scripts/build_keycloak_opa-s390x.sh
@@ -2,12 +2,12 @@
 
 eval $(minikube docker-env)
 
-sed -i 's#kubectl apply -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/\${KEYCLOAK_VERSION}/deploy/operator.yaml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/\${KEYCLOAK_VERSION}/deploy/operator.yaml | sed "s\#Always\#IfNotPresent\#g" | kubectl apply -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
-sed -i 's#kubectl delete -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f https://github.com/keycloak/keycloak-operator/raw/\${KEYCLOAK_VERSION}/deploy/operator.yaml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-operator/\${KEYCLOAK_VERSION}/deploy/operator.yaml | sed "s\#Always\#IfNotPresent\#g" | kubectl delete -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
+sed -i 's#kubernetes.yml#kubernetes.yml | sed "s\#Always\#IfNotPresent\#g"#g' systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh
+sed -i 's#kubectl delete -n ${KEYCLOAK_OPERATOR_NAMESPACE} -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/kubernetes.yml#curl -s https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/kubernetes.yml | sed "s\#Always\#IfNotPresent\#g" | kubectl delete -n \${KEYCLOAK_OPERATOR_NAMESPACE} -f -#g' systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh
 sed -i '/.*openpolicyagent\/opa.*/ a \          imagePullPolicy: IfNotPresent' systemtest/src/test/resources/opa/opa.yaml 
 
-docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/keycloak-15.0.2.tar.gz
+docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/keycloak-21.0.0.tar.gz
 docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/keycloak-init-container-master.tar.gz
-docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/keycloak-operator-15.0.2.tar.gz
+docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/keycloak-operator-21.0.0.tar.gz
 docker load < $HOME/$S390X_IMAGE_TARBALL_DIR/opa-latest.tar.gz
         


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Since https://github.com/strimzi/strimzi-kafka-operator/pull/8167 has updated keycloak version to 21.0.0, this PR is to update  keycloak version on s390x Jenkins pipeline.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

