### PR TITLE
Remove unused `idOfPod(...)` method from `ModelUtils` class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -609,17 +609,6 @@ public class ModelUtils {
     }
 
     /**
-     * Returns the id of a pod given the pod name
-     *
-     * @param podName   Name of pod
-     *
-     * @return          Id of the pod
-     */
-    public static int idOfPod(String podName)  {
-        return Integer.parseInt(podName.substring(podName.lastIndexOf("-") + 1));
-    }
-
-    /**
      * Generates all possible DNS names for a Kubernetes service:
      *     - service-name
      *     - service-name.namespace


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR removes the unused `idOfPod(...)` method from the `ModelUtils` class in the Cluster Operator. There is a similar method in `ReconcilerUtils` if needed (which is actually used => that is why I decided to remove this one.