### PR TITLE
Add datasource to all panels that missing it in Kafka Bridge and Kafka Exporter dashboards

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -3020,6 +3020,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -3104,6 +3105,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -3188,6 +3190,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 8,

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -59,6 +59,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -140,6 +141,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -221,6 +223,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -302,6 +305,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -383,6 +387,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -464,6 +469,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "description": "Number of partitions which are at their minimum in sync replica count (| ISR | == | min.insync.replicas |)",
       "format": "none",
       "gauge": {
@@ -546,6 +552,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "description": "Number of partitions which are under their minimum in sync replica count (| ISR | < | min.insync.replicas |)",
       "format": "none",
       "gauge": {
@@ -628,6 +635,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -976,6 +984,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1024,7 +1033,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "decimals": 0,
+          "decimals": 2,
           "pattern": "/.*/",
           "thresholds": [],
           "type": "number",
@@ -1049,6 +1058,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1097,7 +1107,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "decimals": 0,
+          "decimals": 2,
           "pattern": "/.*/",
           "thresholds": [],
           "type": "number",
@@ -1122,6 +1132,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1195,6 +1206,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1243,7 +1255,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "decimals": 0,
+          "decimals": 2,
           "pattern": "/.*/",
           "thresholds": [],
           "type": "number",
@@ -1268,6 +1280,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1316,7 +1329,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "decimals": 0,
+          "decimals": 2,
           "pattern": "/.*/",
           "thresholds": [],
           "type": "number",


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

KafkaBridge and KafkaExporter were missing datasource configuration in several places what lead to wrong values when dashboards were loaded manually via UI or via JSON config in Grafana CR via Operator. This PR should fix it.

fix https://github.com/strimzi/strimzi-kafka-operator/issues/8306

Tested with Grafana 9.4.7

Before fix:
![image](https://user-images.githubusercontent.com/9933303/228815396-ba0644e2-650c-42c9-a7c6-8971749c372b.png)

After fix:
![image](https://user-images.githubusercontent.com/9933303/228815260-8382f994-2bf8-4593-a00a-85fe5e37646f.png)

### Checklist

- [x] Supply screenshots for visual changes, such as Grafana dashboards

