### PR TITLE
Add readiness check before we check pods for rolling update

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -602,9 +602,8 @@ public class KafkaAssemblyOperatorPodSetTest {
                     assertThat(zr.maybeRollZooKeeperInvocations, is(1));
 
                     // Scale-up of Kafka is done in one go => we should see two invocations (first from regular patching and second from scale-up)
-                    assertThat(kafkaPodSetCaptor.getAllValues().size(), is(2));
-                    assertThat(kafkaPodSetCaptor.getAllValues().get(0).getSpec().getPods().size(), is(1)); // => first capture is from kafkaPodSet() with old replica count
-                    assertThat(kafkaPodSetCaptor.getAllValues().get(1).getSpec().getPods().size(), is(3)); // => second capture is from kafkaScaleUp() with new replica count
+                    assertThat(kafkaPodSetCaptor.getAllValues().size(), is(1));
+                    assertThat(kafkaPodSetCaptor.getAllValues().get(0).getSpec().getPods().size(), is(3));
 
                     // Still one maybe-roll invocation
                     assertThat(kr.maybeRollKafkaInvocations, is(1));
@@ -844,7 +843,6 @@ public class KafkaAssemblyOperatorPodSetTest {
                     .compose(i -> migrateFromStatefulSetToPodSet())
                     .compose(i -> podSet())
                     .compose(i -> rollingUpdate())
-                    .compose(i -> scaleUp())
                     .compose(i -> sharedKafkaConfigurationCleanup());
         }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Today, the `KafkaRoller` does not handle well when the pods are not ready when the rolling update check starts. When the pods are not ready for example because they are still starting, the Roller will _roll_ them just because they are not ready because it cannot really connect to them. 

That has several side effects. One of them is for example described in [SP#048](https://github.com/strimzi/proposals/blob/main/048-avoid-broker-restarts-when-in-recovery.md) and deals with issues when the broker needs a lot of time to recover files after an unclean shutdown. 

Another one - on which this PR focuses - is the split of PodSet update, rolling update, and scale-up. The reconciliation flow today is as follows:
* (N) Update the PodSet, but do not scale it up (i.e. add any new pods) -> update only the YAMLs for the existing pods. If it is the first reconciliation and the pods are being created, we have to wait for readiness in this step before letting the `KafkaRoller` check the pods.
* (N+1) Check the existing pods for rolling update
* (N+2) Scale up the Kafka cluster (update the PodSet again to add new pods)

This logic was reasonably straightforward with StatefulSets where we had a single template and the scale-up or not was just about setting the right number of replicas. But with StrimziPodSets, this requires more complexity because it is not just changing the number of replicas. It actually needs the new pods to be generated. And in the future with things such as non-continuous node IDs and the KRaft architectures, or things such as node pools, this might become even more complex.

This PR tries to simplify the code by moving more responsibility to the `KafkaRoller`. It first checks for the readiness of the pod and waits for it before it actually tries to connect to the Pod and checks if a rolling update is really needed. If the pod does not become ready in time, it will proceed with the KafkaRoller process as before and decide if the pod needs to be rolled or not (so if the pod is for some reason never getting ready, the roller will still get its change to roll through it).

Thanks to this, we can not remove the separate scale-up step and do the scale-up immediately when updating the PodSet and we save the additional step and the complexity needed to understand which pods need to be included in the pod set at which point. This might consume slightly more CPU cycles as the `KafkaRoller` will now check the scaled-up pods. But the overall reconciliation time might be negligible since today we anyway wait for the pod readiness in a different place.

This might also help with situations when the user scaled down a pod that still had data and made the remaining brokers impossible to roll because of the number of in-sync partitions. Now we will scale up before rolling, so the broker will have a chance to start and re-sync the data.

_Note: This is something that is based on my understanding anyway planned in [SP#048](https://github.com/strimzi/proposals/blob/main/048-avoid-broker-restarts-when-in-recovery.md) where it will also check the recovery progress._ 

----

This PR also unifies the check if the pod is stuck (e.g. Pending because it is not-schedulable etc.). It merges the checks which were directly in the `KafkaRoller` code with the `isPodStuck` methods and uses now the method in all places.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally