### PR TITLE
Enable the topic operator's ZK-based metadata store unit test

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectCluster.java
@@ -4,12 +4,11 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.strimzi.test.TestUtils;
 import org.apache.kafka.connect.cli.ConnectDistributed;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.Connect;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,7 +35,7 @@ public class ConnectCluster {
 
     public void startup() throws InterruptedException {
         for (int i = 0; i < numNodes; i++) {
-            int port = getFreePort();
+            int port = TestUtils.getFreePort();
 
             Map<String, String> workerProps = new HashMap<>();
             workerProps.put("listeners", "http://localhost:" + port);
@@ -100,18 +99,5 @@ public class ConnectCluster {
      */
     public int getPort(int node) {
         return connectPorts.get(node);
-    }
-
-    /**
-     * Finds a free server port which can be used by the Connect REST API
-     *
-     * @return  A free TCP port
-     */
-    private int getFreePort()   {
-        try (ServerSocket serverSocket = new ServerSocket(0)) {
-            return serverSocket.getLocalPort();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to find free port", e);
-        }
     }
 }

--- a/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
+++ b/test/src/main/java/io/strimzi/test/EmbeddedZooKeeper.java
@@ -9,7 +9,6 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 
@@ -22,7 +21,7 @@ public class EmbeddedZooKeeper {
     public EmbeddedZooKeeper() throws IOException, InterruptedException {
         dir = Files.createTempDirectory("strimzi").toFile();
         zk = new ZooKeeperServer(dir, dir, 1000);
-        start(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        start(new InetSocketAddress("localhost", TestUtils.getFreePort()));
     }
 
     private void start(InetSocketAddress addr) throws IOException, InterruptedException {
@@ -76,5 +75,4 @@ public class EmbeddedZooKeeper {
         InetSocketAddress addr = factory.getLocalAddress();
         return addr.getAddress().getHostAddress() + ":" + addr.getPort();
     }
-
 }

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -35,6 +35,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -429,6 +430,19 @@ public final class TestUtils {
             return Collections.unmodifiableMap(map);
         } else {
             return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Finds a free server port which can be used by the web server
+     *
+     * @return A free TCP port
+     */
+    public static int getFreePort()   {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find free port", e);
         }
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreIT.java
@@ -30,11 +30,6 @@ public class KafkaStreamsTopicStoreIT extends TopicStoreTestBase {
 
     private static KafkaStreamsTopicStoreService service;
 
-    @Override
-    protected boolean canRunTest() {
-        return true;
-    }
-
     static KafkaStreamsTopicStoreService service(Map<String, String> configMap) throws Exception {
         Map<String, String> mergedMap = new HashMap<>(MANDATORY_CONFIG);
         mergedMap.putAll(configMap);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicStoreTestBase.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicStoreTestBase.java
@@ -8,7 +8,6 @@ import io.vertx.core.Promise;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -25,12 +24,8 @@ public abstract class TopicStoreTestBase {
 
     protected TopicStore store;
 
-    protected abstract boolean canRunTest();
-
     @Test
     public void testCrud(VertxTestContext context) {
-        Assumptions.assumeTrue(canRunTest());
-
         Checkpoint async = context.checkpoint();
 
         String topicName = "my_topic_" + ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -24,11 +24,6 @@ public class ZkTopicStoreTest extends TopicStoreTestBase {
     private EmbeddedZooKeeper zkServer;
     private Zk zkClient;
 
-    @Override
-    protected boolean canRunTest() {
-        return true;
-    }
-
     @BeforeAll
     public static void before() {
         vertx = Vertx.vertx();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 public class ZkTopicStoreTest extends TopicStoreTestBase {
     private static Vertx vertx;
-
     private EmbeddedZooKeeper zkServer;
     private Zk zk;
 
@@ -41,9 +40,9 @@ public class ZkTopicStoreTest extends TopicStoreTestBase {
 
     @BeforeEach
     public void setup() throws IOException, InterruptedException {
-        this.zkServer = new EmbeddedZooKeeper();
+        zkServer = new EmbeddedZooKeeper();
         zk = Zk.createSync(vertx, zkServer.getZkConnectString(), 60_000, 10_000);
-        this.store = new ZkTopicStore(zk, "/strimzi/topics");
+        store = new ZkTopicStore(zk, "/strimzi/topics");
     }
 
     @AfterEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/ZkTopicStoreTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import java.io.IOException;
 
 public class ZkTopicStoreTest extends TopicStoreTestBase {
-
     private static Vertx vertx;
 
     private EmbeddedZooKeeper zkServer;
@@ -25,7 +24,7 @@ public class ZkTopicStoreTest extends TopicStoreTestBase {
 
     @Override
     protected boolean canRunTest() {
-        return false; // test was disabled
+        return true;
     }
 
     @BeforeAll

--- a/user-operator/src/test/java/io/strimzi/operator/user/HealthCheckAndMetricsServerTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/HealthCheckAndMetricsServerTest.java
@@ -10,10 +10,10 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
+import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -37,7 +37,7 @@ public class HealthCheckAndMetricsServerTest {
         when(controller.isAlive()).thenReturn(true);
         when(controller.isReady()).thenReturn(true);
 
-        int port = getFreePort();
+        int port = TestUtils.getFreePort();
 
         HealthCheckAndMetricsServer server = new HealthCheckAndMetricsServer(port, controller, metrics);
         server.start();
@@ -77,7 +77,7 @@ public class HealthCheckAndMetricsServerTest {
         when(controller.isAlive()).thenReturn(false);
         when(controller.isReady()).thenReturn(false);
 
-        int port = getFreePort();
+        int port = TestUtils.getFreePort();
 
         HealthCheckAndMetricsServer server = new HealthCheckAndMetricsServer(port, controller, metrics);
         server.start();
@@ -98,19 +98,6 @@ public class HealthCheckAndMetricsServerTest {
             assertThat(response.body().trim(), is("{\"status\": \"not-ok\"}"));
         } finally {
             server.stop();
-        }
-    }
-
-    /**
-     * Finds a free server port which can be used by the web server
-     *
-     * @return  A free TCP port
-     */
-    private int getFreePort()   {
-        try (ServerSocket serverSocket = new ServerSocket(0)) {
-            return serverSocket.getLocalPort();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to find free port", e);
         }
     }
 }


### PR DESCRIPTION
This is still useful because you can enable the ZK based store by setting STRIMZI_USE_ZOOKEEPER_TOPIC_STORE.