### PR TITLE
Update json-path dependency to 2.8.0 for sub-dependency CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
         <netty.version>4.1.87.Final</netty.version>
         <micrometer.version>1.9.5</micrometer.version>
-        <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
+        <jayway-jsonpath.version>2.8.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>
 


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Mitigates CVE-2023-1370, which is found in json-smart, which is a sub-dependency of the com.jayway.jsonpath:json-path dependency. This only affects the test and systemtest modules, and has been showing up in our internal repo scans.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

