### PR TITLE
Remove the deprecated Fabric8 replace() method and replace it with update()

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorCustomCertMockTest.java
@@ -201,7 +201,7 @@ public class KafkaAssemblyOperatorCustomCertMockTest {
                 })))
                 .compose(i -> {
                     // Update the custom listener certificate secret
-                    client.secrets().inNamespace(NAMESPACE).resource(getUpdatedSecret()).replace();
+                    client.secrets().inNamespace(NAMESPACE).resource(getUpdatedSecret()).update();
                     return Future.succeededFuture();
                 })
                 // The second loop should update the pods to have the new hash stub from the updated secret => which means they were rolled

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerMockTest.java
@@ -389,7 +389,7 @@ public class StrimziPodSetControllerMockTest {
 
             // Scale-up the pod-set
             Pod pod2 = pod(pod2Name, KAFKA_NAME, podSetName, "Kafka");
-            podSetOp().inNamespace(NAMESPACE).resource(podSet(podSetName, KAFKA_NAME, "Kafka", pod1, pod2)).replace();
+            podSetOp().inNamespace(NAMESPACE).resource(podSet(podSetName, KAFKA_NAME, "Kafka", pod1, pod2)).update();
 
             // Wait until the new pod is ready
             TestUtils.waitFor(
@@ -413,7 +413,7 @@ public class StrimziPodSetControllerMockTest {
                     () -> context.failNow("Pod stats do not match"));
 
             // Scale-down the pod-set
-            podSetOp().inNamespace(NAMESPACE).resource(podSet(podSetName, KAFKA_NAME, "Kafka", pod1)).replace();
+            podSetOp().inNamespace(NAMESPACE).resource(podSet(podSetName, KAFKA_NAME, "Kafka", pod1)).update();
 
             // Wait until the pod is deleted
             TestUtils.waitFor(
@@ -487,7 +487,7 @@ public class StrimziPodSetControllerMockTest {
             Pod updatedPod = pod(podName, KAFKA_NAME, podSetName, "Kafka");
             updatedPod.getMetadata().getAnnotations().put(PodRevision.STRIMZI_REVISION_ANNOTATION, "new-revision");
             updatedPod.getSpec().setTerminationGracePeriodSeconds(1L);
-            podSetOp().inNamespace(NAMESPACE).resource(podSet(podSetName, KAFKA_NAME, "Kafka", updatedPod)).replace();
+            podSetOp().inNamespace(NAMESPACE).resource(podSet(podSetName, KAFKA_NAME, "Kafka", updatedPod)).update();
 
             // Check status of the PodSet
             TestUtils.waitFor(

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -366,7 +366,7 @@ public class ResourceManager {
     public static <T extends CustomResource, L extends DefaultKubernetesResourceList<T>> void replaceCrdResource(Class<T> crdClass, Class<L> listClass, String resourceName, Consumer<T> editor, String namespace) {
         T toBeReplaced = Crds.operation(kubeClient().getClient(), crdClass, listClass).inNamespace(namespace).withName(resourceName).get();
         editor.accept(toBeReplaced);
-        Crds.operation(kubeClient().getClient(), crdClass, listClass).inNamespace(namespace).resource(toBeReplaced).replace();
+        Crds.operation(kubeClient().getClient(), crdClass, listClass).inNamespace(namespace).resource(toBeReplaced).update();
     }
 
     public void deleteResources(ExtensionContext testContext) throws Exception {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -42,7 +42,7 @@ public class DeploymentResource implements ResourceType<Deployment> {
     public static void replaceDeployment(String deploymentName, Consumer<Deployment> editor, String namespaceName) {
         Deployment toBeReplaced = ResourceManager.kubeClient().getClient().resources(Deployment.class, DeploymentList.class).inNamespace(namespaceName).withName(deploymentName).get();
         editor.accept(toBeReplaced);
-        ResourceManager.kubeClient().getClient().resources(Deployment.class, DeploymentList.class).inNamespace(namespaceName).resource(toBeReplaced).replace();
+        ResourceManager.kubeClient().getClient().resources(Deployment.class, DeploymentList.class).inNamespace(namespaceName).resource(toBeReplaced).update();
     }
 
     public static Deployment getDeploymentFromYaml(String yamlPath) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -225,7 +225,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).replace();
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
 
         coPod = DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
         connectPods = RollingUpdateUtils.waitTillComponentHasRolled(clusterOperator.getDeploymentNamespace(), connectLabelSelector, connectReplicas, connectPods);
@@ -236,7 +236,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).replace();
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
 
         DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
         RollingUpdateUtils.waitTillComponentHasRolled(clusterOperator.getDeploymentNamespace(), connectLabelSelector, connectReplicas, connectPods);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMockIT.java
@@ -181,7 +181,7 @@ public class TopicOperatorMockIT {
 
     private void updateInKube(KafkaTopic topic) {
         LOGGER.info("Updating topic {} in kube", topic.getMetadata().getName());
-        Crds.topicOperation(client).resource(topic).replace();
+        Crds.topicOperation(client).resource(topic).update();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The #8310 is removing deprecated `createOrReplace()` from the project and this PR takes care of the `replace()` method, which is also deprecated in the Fabric8 6.5.0. 
It replaces the `replace()` method with `update()` on a few places in tests.

After these two PRs all deprecated methods should be removed. 

### Checklist

- [ ] Make sure all tests pass