### PR TITLE
docs(connectors): corrects connector.client.config.override.policy default value

### DIFF
--- a/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
+++ b/documentation/modules/deploying/con-securing-kafka-connect-api.adoc
@@ -52,7 +52,7 @@ spec:
 Only allow trusted login modules and follow the latest advice from Kafka for the version you are using.
 As a best practice, you should explicitly disallow insecure login modules in your Kafka Connect configuration by using the `org.apache.kafka.disallowed.login.modules` system property.
 
-`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `None` (default) to prevent connector configurations from overriding the Kafka Connect configuration and the consumers and producers it uses. 
+`connector.client.config.override.policy`:: Set the `connector.client.config.override.policy` property to `None` to prevent connector configurations from overriding the Kafka Connect configuration and the consumers and producers it uses. 
 +
 .Example configuration to specify connector override policy
 [source,yaml,subs=attributes+]


### PR DESCRIPTION
**Documentation**

Fixes description of  the`connector.client.config.override.policy property`, where the docs incorrectly stated that  `None ` is the default value. Default is `All`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

