### PR TITLE
Refactor `PodSetUtils.mapsToPods` to accept directly the PodSet resource

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodSetUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PodSetUtils.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.strimzi.api.kafka.model.StrimziPodSet;
 
 import java.util.List;
 import java.util.Map;
@@ -67,14 +68,20 @@ public class PodSetUtils {
     }
 
     /**
-     * Converts List of Maps to List of Pods which can be used in StrimziPodSets
+     * Converts a PdoSet to a List of Pods. This is useful when extracting information from the Pods in a PodSet
      *
-     * @param maps  List of Maps which should be converted
+     * @param podSet  PodSet with the Pods
      *
-     * @return      List of Maps with the Pod structures
+     * @return      List of Pods
      */
-    public static List<Pod> mapsToPods(List<Map<String, Object>> maps)  {
-        return maps.stream().map(m -> mapToPod(m)).collect(Collectors.toList());
+    public static List<Pod> podSetToPods(StrimziPodSet podSet)  {
+        if (podSet != null
+                && podSet.getSpec() != null
+                && podSet.getSpec().getPods() != null)   {
+            return podSet.getSpec().getPods().stream().map(m -> mapToPod(m)).toList();
+        } else {
+            return List.of();
+        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -116,7 +116,7 @@ public class KafkaClusterPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(kc.labels.withStrimziPodName(pod.getMetadata().getName()).withStatefulSetPod(pod.getMetadata().getName()).withStrimziPodSetController(kc.getComponentName()).toMap().entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().size(), is(2));
@@ -371,7 +371,7 @@ public class KafkaClusterPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(podAnnos.entrySet()), is(true));
@@ -458,7 +458,7 @@ public class KafkaClusterPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, null, null, brokerId -> new HashMap<>());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(2));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(true));
@@ -479,7 +479,7 @@ public class KafkaClusterPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, null, secrets, brokerId -> new HashMap<>());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(2));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(true));
@@ -509,7 +509,7 @@ public class KafkaClusterPodSetTest {
         StrimziPodSet ps = kc.generatePodSet(3, true, null, List.of(secret1), brokerId -> new HashMap<>());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(1));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(false));
@@ -522,7 +522,7 @@ public class KafkaClusterPodSetTest {
         StrimziPodSet ps = KC.generatePodSet(3, true, null, null, brokerId -> new HashMap<>());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(0));
         }
@@ -534,7 +534,7 @@ public class KafkaClusterPodSetTest {
         StrimziPodSet ps = KC.generatePodSet(3, true, ImagePullPolicy.ALWAYS, null, brokerId -> new HashMap<>());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
         }
@@ -543,7 +543,7 @@ public class KafkaClusterPodSetTest {
         ps = KC.generatePodSet(3, true, ImagePullPolicy.IFNOTPRESENT, null, brokerId -> new HashMap<>());
 
         // We need to loop through the pods to make sure they have the right values
-        pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         }
@@ -563,7 +563,7 @@ public class KafkaClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSet(3, false, null, null, brokerId -> new HashMap<>());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
         }
@@ -583,7 +583,7 @@ public class KafkaClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSet(3, false, null, null, brokerId -> new HashMap<>());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().get(0).getEmptyDir().getSizeLimit(), is(Matchers.nullValue()));
         }
@@ -602,7 +602,7 @@ public class KafkaClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSet(3, false, null, null, brokerId -> new HashMap<>());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().stream().filter(v -> "data".equals(v.getName())).findFirst().orElseThrow().getEmptyDir(), is(notNullValue()));
         }
@@ -620,7 +620,7 @@ public class KafkaClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSet(3, false, null, null, brokerId -> new HashMap<>());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getSecurityContext().getFsGroup(), is(0L));
 
@@ -644,7 +644,7 @@ public class KafkaClusterPodSetTest {
         StrimziPodSet sps = kc.generatePodSet(3, false, null, null, brokerId -> new HashMap<>());
         assertThat(sps.getMetadata().getLabels().get("foo"), is("bar"));
 
-        List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(sps);
         for (Pod pod : pods) {
             assertThat(pod.getMetadata().getLabels().get("foo"), is("bar"));
         }
@@ -654,7 +654,7 @@ public class KafkaClusterPodSetTest {
     public void testDefaultSecurityContext() {
         StrimziPodSet sps = KC.generatePodSet(3, false, null, null, brokerId -> new HashMap<>());
 
-        List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(sps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getSecurityContext().getFsGroup(), is(0L));
             assertThat(pod.getSpec().getContainers().get(0).getSecurityContext(), is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -649,7 +649,7 @@ public class KafkaConnectClusterTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(kc.labels.withStrimziPodName(pod.getMetadata().getName()).withStatefulSetPod(pod.getMetadata().getName()).withStrimziPodSetController(kc.getComponentName()).toMap().entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().size(), is(2));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -100,7 +100,7 @@ public class ZookeeperClusterPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(zc.labels.withStrimziPodName(pod.getMetadata().getName()).withStatefulSetPod(pod.getMetadata().getName()).withStrimziPodSetController(zc.getComponentName()).toMap().entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().size(), is(1));
@@ -288,7 +288,7 @@ public class ZookeeperClusterPodSetTest {
         assertThat(ps.getSpec().getPods().size(), is(3));
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods)  {
             assertThat(pod.getMetadata().getLabels().entrySet().containsAll(podLabels.entrySet()), is(true));
             assertThat(pod.getMetadata().getAnnotations().entrySet().containsAll(podAnnos.entrySet()), is(true));
@@ -376,7 +376,7 @@ public class ZookeeperClusterPodSetTest {
         StrimziPodSet sps = zc.generatePodSet(3, true, null, null, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(sps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(2));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(true));
@@ -397,7 +397,7 @@ public class ZookeeperClusterPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, null, secrets, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(2));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(true));
@@ -427,7 +427,7 @@ public class ZookeeperClusterPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, null, List.of(secret1), podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getImagePullSecrets().size(), is(1));
             assertThat(pod.getSpec().getImagePullSecrets().contains(secret1), is(false));
@@ -443,7 +443,7 @@ public class ZookeeperClusterPodSetTest {
         StrimziPodSet ps = zc.generatePodSet(3, true, ImagePullPolicy.ALWAYS, null, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.ALWAYS.toString()));
         }
@@ -452,7 +452,7 @@ public class ZookeeperClusterPodSetTest {
         ps = zc.generatePodSet(3, true, ImagePullPolicy.IFNOTPRESENT, null, podNum -> Map.of());
 
         // We need to loop through the pods to make sure they have the right values
-        pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getContainers().get(0).getImagePullPolicy(), is(ImagePullPolicy.IFNOTPRESENT.toString()));
         }
@@ -472,7 +472,7 @@ public class ZookeeperClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().get(4).getEmptyDir().getSizeLimit(), is(new Quantity("1", "Gi")));
         }
@@ -492,7 +492,7 @@ public class ZookeeperClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().get(4).getEmptyDir().getSizeLimit(), is(Matchers.nullValue()));
         }
@@ -511,7 +511,7 @@ public class ZookeeperClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getVolumes().stream().filter(v -> "data".equals(v.getName())).findFirst().orElseThrow().getEmptyDir(), is(notNullValue()));
         }
@@ -529,7 +529,7 @@ public class ZookeeperClusterPodSetTest {
 
         // Test generated SPS
         StrimziPodSet ps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
-        List<Pod> pods = PodSetUtils.mapsToPods(ps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(ps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getSecurityContext().getFsGroup(), is(0L));
 
@@ -553,7 +553,7 @@ public class ZookeeperClusterPodSetTest {
         StrimziPodSet sps = zc.generatePodSet(3, false, null, null, podNum -> Map.of());
         assertThat(sps.getMetadata().getLabels().get("foo"), is("bar"));
 
-        List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(sps);
         for (Pod pod : pods) {
             assertThat(pod.getMetadata().getLabels().get("foo"), is("bar"));
         }
@@ -563,7 +563,7 @@ public class ZookeeperClusterPodSetTest {
     public void testDefaultSecurityContext() {
         StrimziPodSet sps = ZC.generatePodSet(3, false, null, null, podNum -> Map.of());
 
-        List<Pod> pods = PodSetUtils.mapsToPods(sps.getSpec().getPods());
+        List<Pod> pods = PodSetUtils.podSetToPods(sps);
         for (Pod pod : pods) {
             assertThat(pod.getSpec().getSecurityContext().getFsGroup(), is(0L));
             assertThat(pod.getSpec().getContainers().get(0).getSecurityContext(), is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -755,7 +755,7 @@ public class KafkaAssemblyOperatorPodSetTest {
 
     // Internal utility methods
     private Pod podFromPodSet(StrimziPodSet podSet, String name) {
-        return PodSetUtils.mapsToPods(podSet.getSpec().getPods()).stream().filter(p -> name.equals(p.getMetadata().getName())).findFirst().orElse(null);
+        return PodSetUtils.podSetToPods(podSet).stream().filter(p -> name.equals(p.getMetadata().getName())).findFirst().orElse(null);
     }
 
     static class MockKafkaAssemblyOperator extends KafkaAssemblyOperator  {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -215,7 +215,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
     public void testScaleCluster(VertxTestContext context)  {
         KafkaConnect connect = new KafkaConnectBuilder(CONNECT).build();
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(1, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -311,7 +311,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                 .build();
 
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -406,7 +406,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                 .endSpec()
                 .build();
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -514,7 +514,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                 .endSpec()
                 .build();
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
         Pod terminatedBuildPod = new PodBuilder()
                 .withNewMetadata()
                     .withName(KafkaConnectResources.buildPodName(NAME))
@@ -616,7 +616,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     assertThat(podSet.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE), is("my-connect-build@sha256:blablabla"));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
 
-                    for (Pod pod : PodSetUtils.mapsToPods(podSet.getSpec().getPods()))  {
+                    for (Pod pod : PodSetUtils.podSetToPods(podSet))  {
                         assertThat(pod.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("a324347c751944b0"));
                         assertThat(pod.getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
                     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -221,7 +221,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
     public void testScaleCluster(VertxTestContext context)  {
         KafkaMirrorMaker2 mm2 = new KafkaMirrorMaker2Builder(MM2).build();
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(1, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -323,7 +323,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
                 .build();
 
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
@@ -424,7 +424,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
                 .endSpec()
                 .build();
         StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
-        List<Pod> oldPods = PodSetUtils.mapsToPods(oldPodSet.getSpec().getPods());
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PartialRollingUpdateMockTest.java
@@ -198,7 +198,7 @@ public class PartialRollingUpdateMockTest {
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
 
             StrimziPodSet kafkaPodSet = supplier.strimziPodSetOperator.client().inNamespace(NAMESPACE).withName(KafkaResources.kafkaStatefulSetName(CLUSTER_NAME)).get();
-            List<Pod> kafkaPodsFromPodSet = PodSetUtils.mapsToPods(kafkaPodSet.getSpec().getPods());
+            List<Pod> kafkaPodsFromPodSet = PodSetUtils.podSetToPods(kafkaPodSet);
 
             for (int i = 0; i <= 4; i++) {
                 int finalI = i;
@@ -264,7 +264,7 @@ public class PartialRollingUpdateMockTest {
             context.verify(() -> assertThat(ar.succeeded(), is(true)));
 
             StrimziPodSet zooPodSet = supplier.strimziPodSetOperator.client().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).get();
-            List<Pod> zooPodsFromPodSet = PodSetUtils.mapsToPods(zooPodSet.getSpec().getPods());
+            List<Pod> zooPodsFromPodSet = PodSetUtils.podSetToPods(zooPodSet);
 
             for (int i = 0; i <= 2; i++) {
                 int finalI = i;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `PodSetUtils.mapsToPods` currently accepts the Map from `spec.pods` as the input parameter and returns a list of Pods. However, in all the places where we call the method, we have the PodSet and have to extract the pod maps from it first.

This Pr changes this method to accept directly the PodSet and do the null checks and extract the maps on its own.

### Checklist

- [x] Make sure all tests pass