### PR TITLE
docs(feature gates): updates for adoption of strimzipodset resource

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
@@ -38,11 +38,13 @@ kubectl get pods -n _<my_cluster_operator_namespace>_
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME              READY  STATUS   RESTARTS
-my-bridge-bridge  1/1    Running  0
+NAME                       READY  STATUS   RESTARTS
+my-bridge-bridge-<pod_id>  1/1    Running  0
 ----
 +
 `my-bridge` is the name of the Kafka Bridge cluster.
++
+A pod ID identifies each pod created.
 +
 With the default deployment, you install a single Kafka Bridge pod.
 +

--- a/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
@@ -32,20 +32,22 @@ kubectl apply -f examples/bridge/kafka-bridge.yaml
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl get deployments -n _<my_cluster_operator_namespace>_
+kubectl get pods -n _<my_cluster_operator_namespace>_
 ----
 +
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME              READY  UP-TO-DATE  AVAILABLE
-my-bridge-bridge  1/1    1           1
+NAME              READY  STATUS   RESTARTS
+my-bridge-bridge  1/1    Running  0
 ----
 +
 `my-bridge` is the name of the Kafka Bridge cluster.
 +
+With the default deployment, you install a single Kafka Bridge pod.
++
 `READY` shows the number of replicas that are ready/expected.
-The deployment is successful when the `AVAILABLE` output shows `1`.
+The deployment is successful when the `STATUS` shows as `Running`.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-cluster.adoc
@@ -103,7 +103,9 @@ my-cluster-zookeeper-2      1/1     Running   0
 +
 `my-cluster` is the name of the Kafka cluster.
 +
-With the default deployment, you install an Entity Operator cluster, 3 Kafka pods, and 3 ZooKeeper pods.
+A sequential index number starting with `0` identifies each Kafka and ZooKeeper pod created.
++
+With the default deployment, you create an Entity Operator cluster, 3 Kafka pods, and 3 ZooKeeper pods.
 +
 `READY` shows the number of replicas that are ready/expected.
 The deployment is successful when the `STATUS` shows as `Running`.

--- a/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 This procedure shows how to deploy a Kafka Connect cluster to your Kubernetes cluster using the Cluster Operator.
 
-A Kafka Connect cluster is implemented as a `Deployment` with a configurable number of nodes (also called _workers_) that distribute the workload of connectors as _tasks_ so that the message flow is highly scalable and reliable.
+A Kafka Connect cluster deployment is implemented with a configurable number of nodes (also called _workers_) that distribute the workload of connectors as _tasks_ so that the message flow is highly scalable and reliable.
 
 The deployment uses a YAML file to provide the specification to create a `KafkaConnect` resource.
 
@@ -36,20 +36,24 @@ kubectl apply -f examples/connect/kafka-connect.yaml
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl get deployments -n _<my_cluster_operator_namespace>_
+kubectl get pods -n _<my_cluster_operator_namespace>_
 ----
 +
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                        READY  UP-TO-DATE  AVAILABLE
-my-connect-cluster-connect  1/1    1           1
+NAME                          READY  STATUS   RESTARTS
+my-connect-cluster-connect-0  1/1    Running  0
 ----
 +
 `my-connect-cluster` is the name of the Kafka Connect cluster.
 +
+A sequential index number starting with `0` identifies each Kafka Connect pod created.
++
+With the default deployment, you create a single Kafka Connect pod.
++
 `READY` shows the number of replicas that are ready/expected.
-The deployment is successful when the `AVAILABLE` output shows `1`.
+The deployment is successful when the `STATUS` shows as `Running`.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect.adoc
@@ -42,13 +42,13 @@ kubectl get pods -n _<my_cluster_operator_namespace>_
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                          READY  STATUS   RESTARTS
-my-connect-cluster-connect-0  1/1    Running  0
+NAME                                 READY  STATUS   RESTARTS
+my-connect-cluster-connect-<pod_id>  1/1    Running  0
 ----
 +
 `my-connect-cluster` is the name of the Kafka Connect cluster.
 +
-A sequential index number starting with `0` identifies each Kafka Connect pod created.
+A pod ID identifies each pod created.
 +
 With the default deployment, you create a single Kafka Connect pod.
 +

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -53,15 +53,15 @@ kubectl get pods -n _<my_cluster_operator_namespace>_
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                           READY  STATUS   RESTARTS
-my-mirror-maker-mirror-maker   1/1    Running  1
-my-mm2-cluster-mirrormaker2-0  1/1    Running  1
+NAME                                    READY  STATUS   RESTARTS
+my-mirror-maker-mirror-maker-<pod_id>   1/1    Running  1
+my-mm2-cluster-mirrormaker2-<pod_id>            1/1    Running  1
 ----
 +
 `my-mirror-maker` is the name of the Kafka MirrorMaker cluster. 
 `my-mm2-cluster` is the name of the Kafka MirrorMaker 2 cluster.
 +
-A sequential index number starting with `0` identifies each MirrorMaker 2 pod created.
+A pod ID identifies each pod created.
 +
 With the default deployment, you install a single MirrorMaker or MirrorMaker 2 pod.
 +

--- a/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-mirror-maker.adoc
@@ -47,22 +47,26 @@ kubectl apply -f examples/mirror-maker/kafka-mirror-maker-2.yaml
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl get deployments -n _<my_cluster_operator_namespace>_
+kubectl get pods -n _<my_cluster_operator_namespace>_
 ----
 +
 .Output shows the deployment name and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                          READY  UP-TO-DATE  AVAILABLE
-my-mirror-maker-mirror-maker  1/1    1           1
-my-mm2-cluster-mirrormaker2   1/1    1           1
+NAME                           READY  STATUS   RESTARTS
+my-mirror-maker-mirror-maker   1/1    Running  1
+my-mm2-cluster-mirrormaker2-0  1/1    Running  1
 ----
 +
-`my-mirror-maker` is the name of the Kafka MirrorMaker cluster.
+`my-mirror-maker` is the name of the Kafka MirrorMaker cluster. 
 `my-mm2-cluster` is the name of the Kafka MirrorMaker 2 cluster.
 +
+A sequential index number starting with `0` identifies each MirrorMaker 2 pod created.
++
+With the default deployment, you install a single MirrorMaker or MirrorMaker 2 pod.
++
 `READY` shows the number of replicas that are ready/expected.
-The deployment is successful when the `AVAILABLE` output shows `1`.
+The deployment is successful when the `STATUS` shows as `Running`.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
+++ b/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
@@ -20,14 +20,14 @@ kubectl get pods -o name
 
 pod/kafka-consumer
 # ...
-pod/my-bridge-bridge-7cbd55496b-nclrt
+pod/my-bridge-bridge-<pod_id>
 ----
 
 . Connect to the Kafka Bridge pod on port `8080`:
 +
 [source,shell,subs=attributes+]
 ----
-kubectl port-forward pod/my-bridge-bridge-7cbd55496b-nclrt 8080:8080 &
+kubectl port-forward pod/my-bridge-bridge-<pod_id> 8080:8080 &
 ----
 +
 NOTE: If port 8080 on your local machine is already in use, use an alternative HTTP port, such as `8008`.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -45,7 +45,7 @@ For example, when you change service account labels or annotations using the `te
 The `UseStrimziPodSets` feature gate has moved to GA, which means it is now permanently enabled and cannot be disabled.
 Support for `StatefulSets` has been removed and Strimzi is now always using `StrimziPodSets` to manage Kafka and ZooKeeper pods.
 
-IMPORTANT: With the `UseStrimziPodSets` feature gate permanently enabled, it is no longer possible to downgrade directly between Strimzi 0.27 or earlier and Strimzi 0.35 and newer.
+IMPORTANT: With the `UseStrimziPodSets` feature gate permanently enabled, it is no longer possible to downgrade directly from Strimzi 0.35 and newer to Strimzi 0.27 or earlier.
 You have to first downgrade through one of the Strimzi versions in-between, disable the `USeStrimziPodSets` feature gate, and then downgrade to Strimzi 0.27 or earlier.
 
 [id='ref-operator-use-kraft-feature-gate-{context}']

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -31,7 +31,7 @@ With `ControlPlaneListener` enabled, the connections between the Kafka controlle
 Replication of data between brokers, as well as internal connections from Strimzi operators, Cruise Control, or the Kafka Exporter use the _replication listener_ on port 9091.
 
 IMPORTANT: With the `ControlPlaneListener` feature gate permanently enabled, it is no longer possible to upgrade or downgrade directly between Strimzi 0.22 and earlier and Strimzi 0.32 and newer.
-You have to upgrade or downgrade through one of the Strimzi versions in between.
+You have to first upgrade or downgrade through one of the Strimzi versions in-between, disable the `ControlPlaneListener` feature gate, and then downgrade or upgrade (with the feature gate enabled) to the target version.
 
 == ServiceAccountPatching feature gate
 
@@ -45,8 +45,8 @@ For example, when you change service account labels or annotations using the `te
 The `UseStrimziPodSets` feature gate has moved to GA, which means it is now permanently enabled and cannot be disabled.
 Support for `StatefulSets` has been removed and Strimzi is now always using `StrimziPodSets` to manage Kafka and ZooKeeper pods.
 
-IMPORTANT: Downgrade to Strimzi 0.27 and earlier versions is not possible when using `StrimziPodSets`.
-If you need to downgrade to Strimzi 0.27 or earlier, you have to first downgrade to Strimzi 0.28 - 0.34, disable the `USeStrimziPodSets` feature gate and only then downgrade to Strimzi 0.27 or earlier.
+IMPORTANT: With the `UseStrimziPodSets` feature gate permanently enabled, it is no longer possible to downgrade directly between Strimzi 0.27 or earlier and Strimzi 0.35 and newer.
+You have to first downgrade through one of the Strimzi versions in-between, disable the `USeStrimziPodSets` feature gate, and then downgrade to Strimzi 0.27 or earlier.
 
 [id='ref-operator-use-kraft-feature-gate-{context}']
 == (Preview) UseKRaft feature gate
@@ -76,7 +76,7 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 * All Kafka nodes have both the `controller` and `broker` KRaft roles.
   Kafka clusters with separate `controller` and `broker` nodes are not supported.
 
-.Enabling the UseStrimziPodSets feature gate
+.Enabling the UseKRaft feature gate
 To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 [id='ref-operator-stable-connect-identities-feature-gate-{context}']
@@ -84,7 +84,7 @@ To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATU
 
 The `StableConnectIdentities` feature gate has a default state of _disabled_.
 
-The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes Deployment resources.
+The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes `Deployment` resources.
 `StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
 This helps to minimize the number of rebalances of connector tasks.
 

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -15,6 +15,11 @@ This procedure describes how to downgrade a Cluster Operator deployment to a pre
 * An existing Cluster Operator deployment is available.
 * You have xref:downloads-{context}[downloaded the installation files for the previous version].
 
+.Before you begin
+
+Check the downgrade requirements of the xref:ref-operator-cluster-feature-gates-{context}[Strimzi feature gates].
+If a feature gate is permanently enabled, you may need to downgrade to a version that allows you to disable it before downgrading to your target version. 
+
 .Procedure
 
 . Take note of any configuration changes made to the existing Cluster Operator resources (in the `/install/cluster-operator` directory).


### PR DESCRIPTION
**Documentation**

Updates from the adoption of the `StrimziPodSet` resource

- The deployment verification checks switch to checks on pods rather than deployment resources
- Upgrade/downgrade notes for feature gates made consistent
- The downgrade  section includes a note to check on feature gate downgrade requirements

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

