### PR TITLE
Refactor the manual Pod and PVC deletion through annotation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -103,7 +103,6 @@ public class KafkaReconciler {
     private final Vertx vertx;
     private final long operationTimeoutMs;
     /* test */ final KafkaCluster kafka;
-    private final Storage oldStorage;
     private final ClusterCa clusterCa;
     private final ClientsCa clientsCa;
     private final List<String> maintenanceWindows;
@@ -190,7 +189,6 @@ public class KafkaReconciler {
             this.kafka.setLogMessageFormatVersion(versionChange.logMessageFormatVersion());
         }
 
-        this.oldStorage = oldStorage;
         this.currentReplicas = currentReplicas;
         this.clusterCa = clusterCa;
         this.clientsCa = clientsCa;
@@ -287,11 +285,10 @@ public class KafkaReconciler {
                 reconciliation,
                 KafkaResources.kafkaStatefulSetName(reconciliation.name()),
                 kafka.getSelectorLabels(),
-                operationTimeoutMs,
                 strimziPodSetOperator,
                 podOperator,
                 pvcOperator
-        ).maybeManualPodCleaning(kafka.generatePersistentVolumeClaims(oldStorage));
+        ).maybeManualPodCleaning();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -241,11 +241,10 @@ public class ZooKeeperReconciler {
                 reconciliation,
                 KafkaResources.zookeeperStatefulSetName(reconciliation.name()),
                 zk.getSelectorLabels(),
-                operationTimeoutMs,
                 strimziPodSetOperator,
                 podOperator,
                 pvcOperator
-        ).maybeManualPodCleaning(zk.generatePersistentVolumeClaims());
+        ).maybeManualPodCleaning();
     }
 
     /**

--- a/documentation/modules/configuring/proc-manual-delete-pod-pvc-kafka.adoc
+++ b/documentation/modules/configuring/proc-manual-delete-pod-pvc-kafka.adoc
@@ -9,7 +9,8 @@ This procedure describes how to delete an existing Kafka node by using a Kuberne
 Deleting a Kafka node consists of deleting both the `Pod` on which the Kafka broker is running and the related `PersistentVolumeClaim` (if the cluster was deployed with persistent storage).
 After deletion, the `Pod` and its related `PersistentVolumeClaim` are recreated automatically.
 
-WARNING: Deleting a `PersistentVolumeClaim` can cause permanent data loss. The following procedure should only be performed if you have encountered storage issues.
+WARNING: Deleting a `PersistentVolumeClaim` can cause permanent data loss and the availability of your cluster cannot be guaranteed.
+The following procedure should only be performed if you have encountered storage issues.
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-manual-delete-pod-pvc-zookeeper.adoc
+++ b/documentation/modules/configuring/proc-manual-delete-pod-pvc-zookeeper.adoc
@@ -9,7 +9,8 @@ This procedure describes how to delete an existing ZooKeeper node by using a Kub
 Deleting a ZooKeeper node consists of deleting both the `Pod` on which ZooKeeper is running and the related `PersistentVolumeClaim` (if the cluster was deployed with persistent storage).
 After deletion, the `Pod` and its related `PersistentVolumeClaim` are recreated automatically.
 
-WARNING: Deleting a `PersistentVolumeClaim` can cause permanent data loss. The following procedure should only be performed if you have encountered storage issues.
+WARNING: Deleting a `PersistentVolumeClaim` can cause permanent data loss and the availability of your cluster cannot be guaranteed.
+The following procedure should only be performed if you have encountered storage issues.
 
 .Prerequisites
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Users can use annotation to request the operator to delete a specific Pod and PVC. The way this worked in the past was that we did a non-cascading deletion of the StatefulSet (or later removed the Pod from the PodSet), then deleted the PVCs and then in the same reconciliation step we again recreated the PVCs and the original Pod.

The recreation of the PVCs and the old Pod was complicated because it was possible that the storage configuration changed in the custom resource in the meantime. So we had to recreate it with the old configuration. For that, we needed to:
* Store the old storage configuration
* Have a way to recreate the old PVCs

This PR changes how we do the cleanup -> it does not recreate the Pod and the PVCs and leaves that to the regular PodSet reconciliation. That way, we remove some unnecessary logic and possibly also remove unnecessary rolling update.

It also improves the documentation by adding a clarification that cluster availability might not be maintained when using this annotation as it is not using the rollers to delete the pod and PVCs. This is just a docs clarification - it was the case already before, so it is not a new thing with this reconciliation.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally