### PR TITLE
Documentation update (#6940)

### DIFF
--- a/documentation/modules/security/proc-installing-certs-per-listener.adoc
+++ b/documentation/modules/security/proc-installing-certs-per-listener.adoc
@@ -39,6 +39,8 @@ If you are not using a self-signed certificate, you can provide a certificate th
 
 You can only use the `brokerCertChainAndKey` properties if TLS encryption (`tls: true`) is configured for the listener.
 
+NOTE: Strimzi does not support the use of encrypted private keys for TLS. The private key stored in the secret must be unencrypted for this to work.
+
 .Procedure
 
 . Create a `Secret` containing your private key and server certificate:


### PR DESCRIPTION
### Documentation

### Description

This is a documentation update for issue #6940: 'Update Documentation To Reflect Lack Of Support For TLS With Encrypted Private Keys' .

Added a NOTE in the relevant part of the docs to make this clear to users that this is the case.

### Checklist

- [ x] Update documentation


