### PR TITLE
Use `Set` instead of `List` to pass the `NodeRef` objects around

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -169,7 +169,7 @@ public class ClusterCa extends Ca {
         LOGGER.debugCr(reconciliation, "{}: Reconciling Cruise Control certificates", this);
         return maybeCopyOrGenerateCerts(
             reconciliation,
-            List.of(new NodeRef("cruise-control", 0)),
+            Set.of(new NodeRef("cruise-control", 0)),
             subjectFn,
             cruiseControlSecret,
             isMaintenanceTimeWindowsSatisfied);
@@ -178,7 +178,7 @@ public class ClusterCa extends Ca {
     protected Map<String, CertAndKey> generateZkCerts(
             String namespace,
             String crName,
-            List<NodeRef> nodes,
+            Set<NodeRef> nodes,
             boolean isMaintenanceTimeWindowsSatisfied
     ) throws IOException {
         DnsNameGenerator zkDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperServiceName(crName));
@@ -213,7 +213,7 @@ public class ClusterCa extends Ca {
     protected Map<String, CertAndKey> generateBrokerCerts(
             String namespace,
             String crName,
-            List<NodeRef> nodes,
+            Set<NodeRef> nodes,
             Set<String> externalBootstrapAddresses,
             Map<Integer, Set<String>> externalAddresses,
             boolean isMaintenanceTimeWindowsSatisfied
@@ -292,7 +292,7 @@ public class ClusterCa extends Ca {
      */
     /* test */ Map<String, CertAndKey> maybeCopyOrGenerateCerts(
             Reconciliation reconciliation,
-            List<NodeRef> nodes,
+            Set<NodeRef> nodes,
             Function<NodeRef, Subject> subjectFn,
             Secret secret,
             boolean isMaintenanceTimeWindowsSatisfied

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -93,6 +93,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -433,9 +434,9 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
      * Generates list of references to Kafka nodes for this Kafka cluster. The references contain both the pod name and
      * the ID of the Kafka node.
      *
-     * @return  List with Kafka node references
+     * @return  Set of Kafka node references
      */
-    private List<NodeRef> nodes() {
+    private Set<NodeRef> nodes() {
         return nodes(cluster, replicas);
     }
 
@@ -445,10 +446,10 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
      * @param cluster   Name of the Kafka cluster
      * @param replicas  Number of replicas
      *
-     * @return  List with Kafka node references
+     * @return  Set of Kafka node references
      */
-    public static List<NodeRef> nodes(String cluster, int replicas) {
-        ArrayList<NodeRef> podNames = new ArrayList<>(replicas);
+    public static Set<NodeRef> nodes(String cluster, int replicas) {
+        Set<NodeRef> podNames = new LinkedHashSet<>(replicas);
 
         for (int nodeId = 0; nodeId < replicas; nodeId++) {
             podNames.add(new NodeRef(KafkaResources.kafkaPodName(cluster, nodeId), nodeId));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Shared methods for working with Persistent Volume Claims
@@ -46,7 +47,7 @@ public class PersistentVolumeClaimUtils {
      */
     public static List<PersistentVolumeClaim> createPersistentVolumeClaims(
             String namespace,
-            List<NodeRef> nodes,
+            Set<NodeRef> nodes,
             Storage storage,
             boolean jbod,
             Labels labels,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -56,8 +56,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
@@ -624,10 +626,10 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsM
     }
 
     /**
-     * @return  List of node references for this ZooKeeper cluster
+     * @return  Set of node references for this ZooKeeper cluster
      */
-    private List<NodeRef> nodes()   {
-        List<NodeRef> nodes = new ArrayList<>();
+    private Set<NodeRef> nodes()   {
+        Set<NodeRef> nodes = new LinkedHashSet<>();
 
         for (int i = 0; i < replicas; i++)  {
             nodes.add(new NodeRef(getPodName(i), i));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -354,7 +354,7 @@ public class Capacity {
             // requires a distinct broker capacity entry for every broker because the
             // Kafka volume paths are not homogeneous across brokers and include
             // the broker pod index in their names.
-            List<NodeRef> nodeList = KafkaCluster.nodes(reconciliation.name(), replicas);
+            Set<NodeRef> nodeList = KafkaCluster.nodes(reconciliation.name(), replicas);
             for (NodeRef node : nodeList)   {
                 disk = processDisk(storage, node.nodeId());
                 BrokerCapacity broker = new BrokerCapacity(node.nodeId(), cpu, disk, inboundNetwork, outboundNetwork);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -53,6 +53,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -391,18 +392,18 @@ public class CaReconciler {
         }
     }
 
-    private Future<List<NodeRef>> getKafkaReplicas() {
+    private Future<Set<NodeRef>> getKafkaReplicas() {
         return strimziPodSetOperator.getAsync(reconciliation.namespace(), KafkaResources.kafkaStatefulSetName(reconciliation.name()))
                                     .compose(podSet -> {
                                         if (podSet != null) {
                                             return Future.succeededFuture(KafkaCluster.nodes(reconciliation.name(), podSet.getSpec().getPods().size()));
                                         } else {
-                                            return Future.succeededFuture(List.of());
+                                            return Future.succeededFuture(Set.of());
                                         }
                                     });
     }
 
-    private Future<Void> rollKafkaBrokers(List<NodeRef> nodes, RestartReasons podRollReasons) {
+    private Future<Void> rollKafkaBrokers(Set<NodeRef> nodes, RestartReasons podRollReasons) {
         return new KafkaRoller(
                 reconciliation,
                 vertx,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -20,8 +20,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -33,11 +34,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @ExtendWith(VertxExtension.class)
 public class ClusterCaRenewalTest {
     private static final Function<NodeRef, Subject> SUBJECT_FN = node -> new Subject.Builder().build();
-    private static final List<NodeRef> NODES = List.of(
-            new NodeRef("pod0", 0),
-            new NodeRef("pod1", 1),
-            new NodeRef("pod2", 2)
-    );
+    private static final Set<NodeRef> NODES = new LinkedHashSet<>();
+    // LinkedHashSet is used to maintain ordering and have predictable test results
+    static {
+        NODES.add(new NodeRef("pod0", 0));
+        NODES.add(new NodeRef("pod1", 1));
+        NODES.add(new NodeRef("pod2", 2));
+    }
 
     @ParallelTest
     public void renewalOfCertificatesWithNullSecret() throws IOException {
@@ -403,7 +406,7 @@ public class ClusterCaRenewalTest {
 
         Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(
                 Reconciliation.DUMMY_RECONCILIATION,
-                List.of(new NodeRef("pod1", 1)),
+                Set.of(new NodeRef("pod1", 1)),
                 SUBJECT_FN,
                 initialSecret,
                 true);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -21,8 +21,10 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -56,11 +58,14 @@ public class PersistentVolumeClaimUtilsTest {
             .withStorageClass("my-storage-class")
             .withSize("100Gi")
             .build();
-    private final static List<NodeRef> SINGLE_NODE = List.of(new NodeRef(NAME + "-" + 0, 0));
-    private final static List<NodeRef> THREE_NODES = List.of(
-            new NodeRef(NAME + "-" + 0, 0),
-            new NodeRef(NAME + "-" + 1, 1),
-            new NodeRef(NAME + "-" + 2, 2));
+    private final static Set<NodeRef> SINGLE_NODE = Set.of(new NodeRef(NAME + "-" + 0, 0));
+    // LinkedHashSet is used to maintain ordering and have predictable test results
+    private final static Set<NodeRef> THREE_NODES = new LinkedHashSet<>();
+    static {
+        THREE_NODES.add(new NodeRef(NAME + "-" + 0, 0));
+        THREE_NODES.add(new NodeRef(NAME + "-" + 1, 1));
+        THREE_NODES.add(new NodeRef(NAME + "-" + 2, 2));
+    }
 
     @ParallelTest
     public void testEphemeralStorage()  {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -244,8 +245,8 @@ public class KafkaRollerTest {
                 singletonList(2));
     }
 
-    public List<NodeRef> addPodNames(int replicas) {
-        ArrayList<NodeRef> podNames = new ArrayList<>(replicas);
+    public Set<NodeRef> addPodNames(int replicas) {
+        Set<NodeRef> podNames = new LinkedHashSet<>(replicas);
 
         for (int podId = 0; podId < replicas; podId++) {
             podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), podId), podId));
@@ -254,8 +255,8 @@ public class KafkaRollerTest {
         return podNames;
     }
 
-    public List<NodeRef> addDisconnectedPodNames(int replicas) {
-        ArrayList<NodeRef> podNames = new ArrayList<>(replicas);
+    public Set<NodeRef> addDisconnectedPodNames(int replicas) {
+        Set<NodeRef> podNames = new LinkedHashSet<>(replicas);
 
         podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 10), 10));
         podNames.add(new NodeRef(KafkaResources.kafkaPodName(clusterName(), 200), 200));
@@ -625,7 +626,7 @@ public class KafkaRollerTest {
 
         int controllerCall;
         private final IdentityHashMap<Admin, Throwable> unclosedAdminClients;
-        private final Function<List<NodeRef>, RuntimeException> acOpenException;
+        private final Function<Set<NodeRef>, RuntimeException> acOpenException;
         private final Throwable acCloseException;
         private final Function<Integer, Future<Boolean>> canRollFn;
         private final Function<Integer, Throwable> controllerException;
@@ -637,9 +638,9 @@ public class KafkaRollerTest {
         private final List<String> tcpProbes = new ArrayList<>();
 
         @SuppressWarnings("checkstyle:ParameterNumber")
-        private TestingKafkaRoller(Secret clusterCaCertSecret, Secret coKeySecret, List<NodeRef> nodes,
+        private TestingKafkaRoller(Secret clusterCaCertSecret, Secret coKeySecret, Set<NodeRef> nodes,
                                    PodOperator podOps,
-                                   Function<List<NodeRef>, RuntimeException> acOpenException,
+                                   Function<Set<NodeRef>, RuntimeException> acOpenException,
                                    Throwable acCloseException,
                                    Function<Integer, Throwable> controllerException,
                                    Function<Integer, ForceableProblem> alterConfigsException,
@@ -680,7 +681,7 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected Admin adminClient(List<NodeRef> nodes, boolean b) throws ForceableProblem, FatalProblem {
+        protected Admin adminClient(Set<NodeRef> nodes, boolean b) throws ForceableProblem, FatalProblem {
             if (delegateAdminClientCall) {
                 return super.adminClient(nodes, b);
             }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

When introducing the NodeRef objects and passing the around in the Cluster Operator instead of always generating again pod names from replicas and node IDs from pod names, I used `List` which was already used in the `KafkaRoller`. However, the nodes and thus also the `NodeRef` objects should be always unique. So it seems to make more sense to use `Set` to pass them around? In particular, `LinkedHashSet` is used to maintain the insertion order.

WDYT @ppatierno? Does Set make more sense here?

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally