### PR TITLE
[systemtest] Disable scale up tests for KRaft

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -17,6 +17,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -161,6 +162,7 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
 
     @IsolatedTest
     @Tag(CRUISE_CONTROL)
+    @KRaftNotSupported("The scaling of the Kafka pods is not working properly at the moment")
     void testKafkaCCAndRebalanceWithMultipleCOs(ExtensionContext extensionContext) {
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
         LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -246,6 +246,7 @@ class RollingUpdateST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
     @Tag(COMPONENT_SCALING)
+    @KRaftNotSupported("The scaling of the Kafka pods is not working properly at the moment")
     void testKafkaAndZookeeperScaleUpScaleDown(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, namespace);
 


### PR DESCRIPTION
### Type of change

- Disable test

### Description

This small PR disables test `testKafkaAndZookeeperScaleUpScaleDown` that is not working properly with KRaft enabled.
It seems that there is an issue with the consumer connection to the scaled Kafka cluster, which needs to be investigated further.

### Checklist

- [ ] Make sure all tests pass
