### PR TITLE
Fix NPE in Kafka Connect Build when the underlying OCP Build resource doesn't exist

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuildUtils.java
@@ -68,7 +68,8 @@ public class KafkaConnectBuildUtils {
      * @return      True if the Build is complete with error, false otherwise
      */
     public static boolean buildFailed(Build build)   {
-        return build.getStatus() != null
+        return build != null
+                && build.getStatus() != null
                 && ("Failed".equals(build.getStatus().getPhase()) || "Error".equals(build.getStatus().getPhase()) || "Cancelled".equals(build.getStatus().getPhase()));
     }
 
@@ -80,7 +81,9 @@ public class KafkaConnectBuildUtils {
      * @return      True if the Build is complete with success, false otherwise
      */
     public static boolean buildSucceeded(Build build)   {
-        return build.getStatus() != null && "Complete".equals(build.getStatus().getPhase());
+        return build != null
+                && build.getStatus() != null
+                && "Complete".equals(build.getStatus().getPhase());
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using Kafka Connect Build on OpenShift and the underlying `Build` resource does not exist, the operator might end up throwing NPEs:

```
2023-04-14 15:28:06 ERROR AbstractOperator:439 - Reconciliation #21(watch) KafkaConnect(myproject/my-connect): Reconciliation completion handler failed
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://172.30.0.1:443/apis/kafka.strimzi.io/v1beta2/namespaces/myproject/kafkaconnects/my-connect. Message: Unauthorized! Configured service account doesn't have access. Service account may have been revoked. Unauthorized.
	at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:238) ~[io.fabric8.kubernetes-client-api-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:546) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:566) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleGet(OperationSupport.java:492) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handleGet(BaseOperation.java:745) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.requireFromServer(BaseOperation.java:186) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.get(BaseOperation.java:142) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.get(BaseOperation.java:93) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.strimzi.operator.common.operator.resource.AbstractNamespacedResourceOperator.get(AbstractNamespacedResourceOperator.java:291) ~[io.strimzi.operator-common-0.35.0-SNAPSHOT.jar:0.35.0-SNAPSHOT]
	at io.strimzi.operator.common.AbstractOperator.updateResourceState(AbstractOperator.java:546) ~[io.strimzi.operator-common-0.35.0-SNAPSHOT.jar:0.35.0-SNAPSHOT]
	at io.strimzi.operator.common.AbstractOperator.handleResult(AbstractOperator.java:522) ~[io.strimzi.operator-common-0.35.0-SNAPSHOT.jar:0.35.0-SNAPSHOT]
	at io.strimzi.operator.common.AbstractOperator.lambda$reconcile$8(AbstractOperator.java:292) ~[io.strimzi.operator-common-0.35.0-SNAPSHOT.jar:0.35.0-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$3.onFailure(FutureImpl.java:153) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.vertx.core.impl.future.PromiseImpl.tryFail(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.vertx.core.Promise.fail(Promise.java:89) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.strimzi.operator.common.AbstractOperator.lambda$handleSafely$16(AbstractOperator.java:437) ~[io.strimzi.operator-common-0.35.0-SNAPSHOT.jar:0.35.0-SNAPSHOT]
	at io.vertx.core.impl.future.FailedFuture.onFailure(FailedFuture.java:91) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.strimzi.operator.common.AbstractOperator.lambda$withLock$15(AbstractOperator.java:385) ~[io.strimzi.operator-common-0.35.0-SNAPSHOT.jar:0.35.0-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.3.8.jar:4.3.8]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[io.netty.netty-common-4.1.87.Final.jar:4.1.87.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[io.netty.netty-common-4.1.87.Final.jar:4.1.87.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty.netty-common-4.1.87.Final.jar:4.1.87.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.87.Final.jar:4.1.87.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.87.Final.jar:4.1.87.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.87.Final.jar:4.1.87.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.87.Final.jar:4.1.87.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://172.30.0.1:443/apis/kafka.strimzi.io/v1beta2/namespaces/myproject/kafkaconnects/my-connect. Message: Unauthorized! Configured service account doesn't have access. Service account may have been revoked. Unauthorized.
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:701) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:681) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.assertResponseCode(OperationSupport.java:628) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.lambda$handleResponse$0(OperationSupport.java:591) ~[io.fabric8.kubernetes-client-6.5.1.jar:?]
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
	at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$5(StandardHttpClient.java:120) ~[io.fabric8.kubernetes-client-api-6.5.1.jar:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
	at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$5(StandardHttpClient.java:120) ~[io.fabric8.kubernetes-client-api-6.5.1.jar:?]
	at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$retryWithExponentialBackoff$7(StandardHttpClient.java:159) ~[io.fabric8.kubernetes-client-api-6.5.1.jar:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:614) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:844) ~[?:?]
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
	... 1 more
```

This PR adds additional checks that the Build is not null to avoid the NPEs.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally