### PR TITLE
Refactor the default replicas handling in `AbstractModel` classes

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -30,7 +30,7 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     private static final long serialVersionUID = 1L;
 
     private Logging logging;
-    private Integer replicas;
+    private int replicas = 3;
     private String version;
     private String image;
     private ResourceRequirements resources;
@@ -45,10 +45,15 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     private String clientRackInitImage;
     private Rack rack;
 
-    @Description("The number of pods in the Kafka Connect group.")
+    @Description("The number of pods in the Kafka Connect group. " +
+            "Defaults to `3`.")
     @JsonProperty(defaultValue = "3")
-    public Integer getReplicas() {
+    public int getReplicas() {
         return replicas;
+    }
+
+    public void setReplicas(int replicas) {
+        this.replicas = replicas;
     }
 
     @Description("Logging configuration for Kafka Connect")
@@ -61,10 +66,6 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     @Override
     public void setLogging(Logging logging) {
         this.logging = logging;
-    }
-
-    public void setReplicas(Integer replicas) {
-        this.replicas = replicas;
     }
 
     @Description("The Kafka Connect version. Defaults to {DefaultKafkaVersion}. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaBridgeSpec.java
@@ -54,7 +54,8 @@ public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, Has
     private String clientRackInitImage;
     private Rack rack;
 
-    @Description("The number of pods in the `Deployment`.")
+    @Description("The number of pods in the `Deployment`.  " +
+            "Defaults to `1`.")
     @Minimum(0)
     @JsonProperty(defaultValue = "1")
     public int getReplicas() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ZookeeperClusterSpec.java
@@ -44,8 +44,6 @@ public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigur
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, " +
             "ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification";
 
-    public static final int DEFAULT_REPLICAS = 3;
-
     protected SingleVolumeStorage storage;
     private Map<String, Object> config = new HashMap<>(0);
     private Logging logging;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -80,9 +80,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_NAME = "kafka-metrics-and-logging";
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_MOUNT = "/opt/strimzi/custom-config/";
 
-    // Configuration defaults
-    protected static final int DEFAULT_REPLICAS = 1;
-
     // Cluster Operator environment variables for custom discovery labels and annotations
     protected static final String CO_ENV_VAR_CUSTOM_SERVICE_LABELS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS";
     protected static final String CO_ENV_VAR_CUSTOM_SERVICE_ANNOTATIONS = "STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS";
@@ -162,8 +159,6 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
      */
     private KafkaBridgeCluster(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, KafkaBridgeResources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE);
-
-        this.replicas = DEFAULT_REPLICAS;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -230,9 +230,6 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
     private ResourceTemplate templatePerBrokerIngress;
     private ContainerTemplate templateInitContainer;
 
-    // Configuration defaults
-    private static final int DEFAULT_REPLICAS = 3;
-
     private static final Map<String, String> DEFAULT_POD_LABELS = new HashMap<>();
     static {
         String value = System.getenv(CO_ENV_VAR_CUSTOM_KAFKA_POD_LABELS);
@@ -249,8 +246,6 @@ public class KafkaCluster extends AbstractStatefulModel implements SupportsMetri
      */
     private KafkaCluster(Reconciliation reconciliation, HasMetadata resource) {
         super(reconciliation, resource, KafkaResources.kafkaStatefulSetName(resource.getMetadata().getName()), COMPONENT_TYPE);
-
-        this.replicas = DEFAULT_REPLICAS;
 
         this.initImage = System.getenv().getOrDefault(ClusterOperatorConfig.STRIMZI_DEFAULT_KAFKA_INIT_IMAGE, "quay.io/strimzi/operator:latest");
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -220,7 +220,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                                                                 KafkaVersion.Lookup versions,
                                                                 C result) {
         result.replicas = spec.getReplicas();
-        //result.replicas = spec.getReplicas() != null && spec.getReplicas() >= 0 ? spec.getReplicas() : DEFAULT_REPLICAS;
         result.tracing = spec.getTracing();
 
         // Might already contain configuration from Mirror Maker 2 which extends Connect

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -104,7 +104,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected static final String LOG_AND_METRICS_CONFIG_VOLUME_MOUNT = "/opt/kafka/custom-config/";
 
     // Configuration defaults
-    /* test */ static final int DEFAULT_REPLICAS = 3;
     private static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder().withInitialDelaySeconds(5).withInitialDelaySeconds(60).build();
 
     // Kafka Connect configuration keys (EnvVariables)
@@ -188,7 +187,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
 
         this.serviceName = KafkaConnectResources.serviceName(cluster);
         this.loggingAndMetricsConfigMapName = KafkaConnectResources.metricsAndLogConfigMapName(cluster);
-        this.replicas = DEFAULT_REPLICAS;
     }
 
     /**
@@ -221,7 +219,8 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                                                                 KafkaConnectSpec spec,
                                                                 KafkaVersion.Lookup versions,
                                                                 C result) {
-        result.replicas = spec.getReplicas() != null && spec.getReplicas() >= 0 ? spec.getReplicas() : DEFAULT_REPLICAS;
+        result.replicas = spec.getReplicas();
+        //result.replicas = spec.getReplicas() != null && spec.getReplicas() >= 0 ? spec.getReplicas() : DEFAULT_REPLICAS;
         result.tracing = spec.getTracing();
 
         // Might already contain configuration from Mirror Maker 2 which extends Connect

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -147,7 +147,6 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsM
         super(reconciliation, resource, KafkaResources.zookeeperStatefulSetName(resource.getMetadata().getName()), COMPONENT_TYPE);
 
         this.image = null;
-        this.replicas = ZookeeperClusterSpec.DEFAULT_REPLICAS;
         this.isSnapshotCheckEnabled = DEFAULT_ZOOKEEPER_SNAPSHOT_CHECK_ENABLED;
     }
 
@@ -181,9 +180,7 @@ public class ZookeeperCluster extends AbstractStatefulModel implements SupportsM
         ZookeeperClusterSpec zookeeperClusterSpec = kafkaAssembly.getSpec().getZookeeper();
 
         int replicas = zookeeperClusterSpec.getReplicas();
-        if (replicas <= 0) {
-            replicas = ZookeeperClusterSpec.DEFAULT_REPLICAS;
-        }
+
         if (replicas == 1 && zookeeperClusterSpec.getStorage() != null && "ephemeral".equals(zookeeperClusterSpec.getStorage().getType())) {
             LOGGER.warnCr(reconciliation, "A ZooKeeper cluster with a single replica and ephemeral storage will be in a defective state after any restart or rolling update. It is recommended that a minimum of three replicas are used.");
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -148,7 +148,7 @@ public class KafkaBridgeClusterTest {
         KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ResourceUtils.createEmptyKafkaBridge(namespace, cluster));
 
         assertThat(kbc.image, is("quay.io/strimzi/kafka-bridge:latest"));
-        assertThat(kbc.getReplicas(), is(KafkaBridgeCluster.DEFAULT_REPLICAS));
+        assertThat(kbc.getReplicas(), is(1));
         assertThat(kbc.readinessProbeOptions.getInitialDelaySeconds(), is(15));
         assertThat(kbc.readinessProbeOptions.getTimeoutSeconds(), is(5));
         assertThat(kbc.livenessProbeOptions.getInitialDelaySeconds(), is(15));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -205,7 +205,7 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ResourceUtils.createEmptyKafkaConnect(namespace, clusterName), VERSIONS);
 
         assertThat(kc.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_CONNECT_IMAGE));
-        assertThat(kc.getReplicas(), is(KafkaConnectCluster.DEFAULT_REPLICAS));
+        assertThat(kc.getReplicas(), is(3));
         assertThat(kc.readinessProbeOptions.getInitialDelaySeconds(), is(60));
         assertThat(kc.readinessProbeOptions.getTimeoutSeconds(), is(5));
         assertThat(kc.livenessProbeOptions.getInitialDelaySeconds(), is(60));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -206,7 +206,7 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, clusterName), VERSIONS);
 
         assertThat(kmm2.image, is(KafkaVersionTestUtils.DEFAULT_KAFKA_CONNECT_IMAGE));
-        assertThat(kmm2.getReplicas(), is(KafkaMirrorMaker2Cluster.DEFAULT_REPLICAS));
+        assertThat(kmm2.getReplicas(), is(3));
         assertThat(kmm2.readinessProbeOptions.getInitialDelaySeconds(), is(60));
         assertThat(kmm2.readinessProbeOptions.getTimeoutSeconds(), is(5));
         assertThat(kmm2.livenessProbeOptions.getInitialDelaySeconds(), is(60));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1698,7 +1698,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |Property                      |Description
 |version                1.2+<.<a|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas               1.2+<.<a|The number of pods in the Kafka Connect group.
+|replicas               1.2+<.<a|The number of pods in the Kafka Connect group. Defaults to `3`.
 |integer
 |image                  1.2+<.<a|The docker image for the pods.
 |string
@@ -2856,7 +2856,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                    |Description
-|replicas             1.2+<.<a|The number of pods in the `Deployment`.
+|replicas             1.2+<.<a|The number of pods in the `Deployment`.  Defaults to `1`.
 |integer
 |image                1.2+<.<a|The docker image for the pods.
 |string
@@ -3154,7 +3154,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |Property                      |Description
 |version                1.2+<.<a|The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
 |string
-|replicas               1.2+<.<a|The number of pods in the Kafka Connect group.
+|replicas               1.2+<.<a|The number of pods in the Kafka Connect group. Defaults to `3`.
 |integer
 |image                  1.2+<.<a|The docker image for the pods.
 |string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -51,7 +51,7 @@ spec:
                   description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
                 replicas:
                   type: integer
-                  description: The number of pods in the Kafka Connect group.
+                  description: The number of pods in the Kafka Connect group. Defaults to `3`.
                 image:
                   type: string
                   description: The docker image for the pods.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -54,7 +54,7 @@ spec:
                 replicas:
                   type: integer
                   minimum: 0
-                  description: The number of pods in the `Deployment`.
+                  description: The number of pods in the `Deployment`.  Defaults to `1`.
                 image:
                   type: string
                   description: The docker image for the pods.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -51,7 +51,7 @@ spec:
                   description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
                 replicas:
                   type: integer
-                  description: The number of pods in the Kafka Connect group.
+                  description: The number of pods in the Kafka Connect group. Defaults to `3`.
                 image:
                   type: string
                   description: The docker image for the pods.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -50,7 +50,7 @@ spec:
                 description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
               replicas:
                 type: integer
-                description: The number of pods in the Kafka Connect group.
+                description: The number of pods in the Kafka Connect group. Defaults to `3`.
               image:
                 type: string
                 description: The docker image for the pods.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -53,7 +53,7 @@ spec:
               replicas:
                 type: integer
                 minimum: 0
-                description: The number of pods in the `Deployment`.
+                description: The number of pods in the `Deployment`.  Defaults to `1`.
               image:
                 type: string
                 description: The docker image for the pods.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -50,7 +50,7 @@ spec:
                 description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
               replicas:
                 type: integer
-                description: The number of pods in the Kafka Connect group.
+                description: The number of pods in the Kafka Connect group. Defaults to `3`.
               image:
                 type: string
                 description: The docker image for the pods.


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors the handling of the default number of replicas in the `AbstractModel` and its subclasses. In many cases, we have some `DEFAULT_REPLICAS` field with a default number of replicas. However, this is often used in the constructor and immediately overwritten in the `fromCrd` method, so it actually does not add any real value. This PR tries to remove the unneeded fields.

Unfortunately, some of our CRDs such as KafkaConnect does not set the `.spec.replicas` field as required, so it might not be set by the user. But we can set the default number of replicas in the `api` class by using an integer and setting a default value there. It also updates the docs where it specifies the default values.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally