### PR TITLE
Fix certificate key replacement issue when Cluster Operator crashes after the trust is established

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -314,6 +314,7 @@ public class ClusterCa extends Ca {
                     && secret != null && secret.getData() != null // Secret exists and has some data
                     && secretEntryExists(secret, podName, SecretEntry.CRT) // The secret has the public key for this pod
                     && secretEntryExists(secret, podName, SecretEntry.KEY) // The secret has the private key for this pod
+                    && !hasCaCertGenerationChanged(secret) // The generation on the Secret is the same as the CA has
             )   {
                 // A certificate for this node already exists, so we will try to reuse it
                 LOGGER.debugCr(reconciliation, "Certificate for node {} already exists", node);

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -1052,9 +1051,7 @@ public abstract class Ca {
      */
     protected boolean hasCaCertGenerationChanged(Secret secret) {
         if (secret != null) {
-            String caCertGenerationAnno = Optional.ofNullable(secret.getMetadata().getAnnotations())
-                    .map(annotations -> annotations.get(caCertGenerationAnnotation()))
-                    .orElse(null);
+            String caCertGenerationAnno = Annotations.stringAnnotation(secret, caCertGenerationAnnotation(), null);
             int currentCaCertGeneration = certGeneration();
             LOGGER.debugOp("Secret {}/{} generation anno = {}, current CA generation = {}",
                     secret.getMetadata().getNamespace(), secret.getMetadata().getName(), caCertGenerationAnno, currentCaCertGeneration);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When a Cluster CA private key is replaced, the operator needs to follow through a series of three different rolling updates:
1) First rolling update establishes the trust to the new CA while still using the old server certificates and trusting the old CA as well
2) Second rolling update issues and rolls out the new server certificates signed by the new CA (while still trusting the old CA as well)
3) Third rolling update removes the trust in the old CA

When the operator crashes between the first and second step or during the second step, it will not roll out the new server certificates signed by the new CA, but it will instead just silently bump the CA generation IDs in the secret annotations. That will cause the operands still use the old server certificates even after phase 2. That will work seemingly fine as we still trust the old CA. But in phase 3, we remove the trust in the old CA and thus break the operands.

This PR adds additional check of the secret annotation to trigger the renewal after such CO failure and make it possible to recover from it.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally