### PR TITLE
Use `reconcile(...)` instead of `deleteAsync(...)` to delete the old shared configuration map

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -877,7 +877,11 @@ public class KafkaReconciler {
      * @return  Future which returns when the shared configuration config map is deleted
      */
     protected Future<Void> sharedKafkaConfigurationCleanup() {
-        return configMapOperator.deleteAsync(reconciliation, reconciliation.namespace(), KafkaResources.kafkaMetricsAndLogConfigMapName(reconciliation.name()), true);
+        // We use reconcile() instead of deleteAsync() because reconcile first checks if the deletion is needed.
+        // Deleting resource which likely does not exist would cause more load on the Kubernetes API then trying to get
+        // it first because of the watch if it was deleted etc.
+        return configMapOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaMetricsAndLogConfigMapName(reconciliation.name()), null)
+                .map((Void) null);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -262,11 +262,10 @@ public class KafkaAssemblyOperatorPodSetTest {
                     assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSet, "my-cluster-kafka-1")), is(RestartReasons.empty()));
                     assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSet, "my-cluster-kafka-2")), is(RestartReasons.empty()));
 
-                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(3));
-                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2")));
+                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(4));
+                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2", "my-cluster-kafka-config")));
 
-                    assertThat(cmDeletionCaptor.getAllValues().size(), is(1));
-                    assertThat(cmDeletionCaptor.getAllValues().get(0), is("my-cluster-kafka-config"));
+                    assertThat(cmDeletionCaptor.getAllValues().size(), is(0));
 
                     async.flag();
                 })));
@@ -370,11 +369,10 @@ public class KafkaAssemblyOperatorPodSetTest {
                     assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSet, "my-cluster-kafka-1")), is(RestartReasons.empty()));
                     assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSet, "my-cluster-kafka-2")), is(RestartReasons.empty()));
 
-                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(3));
-                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2")));
+                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(4));
+                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2", "my-cluster-kafka-config")));
 
-                    assertThat(cmDeletionCaptor.getAllValues().size(), is(1));
-                    assertThat(cmDeletionCaptor.getAllValues().get(0), is("my-cluster-kafka-config"));
+                    assertThat(cmDeletionCaptor.getAllValues().size(), is(0));
 
                     async.flag();
                 })));
@@ -609,12 +607,11 @@ public class KafkaAssemblyOperatorPodSetTest {
                     assertThat(kr.maybeRollKafkaInvocations, is(1));
 
                     // CMs for all pods are reconciled
-                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(3));
-                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2")));
+                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(4));
+                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2", "my-cluster-kafka-config")));
 
                     // Only the shared CM is deleted
-                    assertThat(cmDeletionCaptor.getAllValues().size(), is(1));
-                    assertThat(cmDeletionCaptor.getAllValues().get(0), is("my-cluster-kafka-config"));
+                    assertThat(cmDeletionCaptor.getAllValues().size(), is(0));
 
                     async.flag();
                 })));
@@ -741,13 +738,13 @@ public class KafkaAssemblyOperatorPodSetTest {
                     // Still one maybe-roll invocation
                     assertThat(kr.maybeRollKafkaInvocations, is(1));
 
-                    // CMs for all remaining pods are reconciled
-                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(3));
-                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2")));
+                    // CMs for all remaining pods + the old shared config CM are reconciled
+                    assertThat(cmReconciliationCaptor.getAllValues().size(), is(4));
+                    assertThat(cmReconciliationCaptor.getAllValues(), is(List.of("my-cluster-kafka-0", "my-cluster-kafka-1", "my-cluster-kafka-2", "my-cluster-kafka-config")));
 
-                    // The shared CM + the CMs for scaled down pods are deleted
-                    assertThat(cmDeletionCaptor.getAllValues().size(), is(3));
-                    assertThat(cmDeletionCaptor.getAllValues(), is(List.of("my-cluster-kafka-3", "my-cluster-kafka-4", "my-cluster-kafka-config")));
+                    // The  CMs for scaled down pods are deleted
+                    assertThat(cmDeletionCaptor.getAllValues().size(), is(2));
+                    assertThat(cmDeletionCaptor.getAllValues(), is(List.of("my-cluster-kafka-3", "my-cluster-kafka-4")));
 
                     async.flag();
                 })));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In every reconciliation loop, we make sure the old shared broker configuration Config Map is deleted. In reality, we will delete it once during the migration from StatefulSets, and most of the reconciliations it will not exist anymore. 

This is not efficient, because although we now we want it deleted, calling `deleteAsync` makes use of the deletion watch. So it establishes the watch and deletes the config map which does not exist in most cases. This PR changes this call to use `reconcile` with `null` desired value. This as a result deletes the config map as well if it still exists. But checks first whether it exists. So in most cases, it should simply do one GET call instead of a watch and a DELETE call nd be more resource efficient.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally