### PR TITLE
Bump Jetty to 9.4.51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
         <opentelemetry.version>1.18.0</opentelemetry.version>
         <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
         <netty.version>4.1.87.Final</netty.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR replaces #8406 and updates Jetty to 9.4.51 to address a minor CVE not really impacting Strimzi (but reported by scanning tools). Unlike the Depndabot PR, it sticks to the same Jetty major version as used by Kafka and thus does nto break anything.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally