### PR TITLE
Fetch the namespace using the  `get` method instead of typecasting

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -172,7 +172,7 @@ public class UserOperatorConfig {
      * @return         Configuration value w.r.t to the key
      */
     @SuppressWarnings("unchecked")
-    public  <T> T get(ConfigParameter<T> value) {
+    public <T> T get(ConfigParameter<T> value) {
         return (T) this.map.get(value.key());
     }
 
@@ -201,7 +201,7 @@ public class UserOperatorConfig {
      * @return  namespace in which the operator runs and creates resources
      */
     public String getNamespace() {
-        return (String) this.map.get(NAMESPACE.key());
+        return get(NAMESPACE);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Minor Task

### Description

Looks like during refactoring I was fetching the `namespace` from the `Map<String,Object>` and then then typecasting the the object type into string which should not be the case. We have the `get` method which does all this and is being used by all the other properties 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

