### PR TITLE
Set pss-defaults compatible with `restricted`

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -110,9 +110,9 @@ the documentation for more details.
 | `fullReconciliationIntervalMs`       | Full reconciliation interval in milliseconds | 120000                                            |
 | `operationTimeoutMs`                 | Operation timeout in milliseconds         | 300000                                               |
 | `operatorNamespaceLabels`            | Labels of the namespace where the operator runs | `nil`                                          |
-| `podSecurityContext`                 | Cluster Operator pod's security context    | `nil`                                               |
+| `podSecurityContext`                 | Cluster Operator pod's security context    | `{ "fsGroup": 65534, "runAsGroup": 65534, "runAsNonRoot": true, "runAsUser": 65534}` |
 | `priorityClassName`                  | Cluster Operator pod's priority class name | `nil`                                               |
-| `securityContext`                    | Cluster Operator container's security context |  `nil`                                           |
+| `securityContext`                    | Cluster Operator container's security context |  `{ "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": [ "ALL" ] }, "seccompProfile": { "type": "RuntimeDefault" } } }` |
 | `rbac.create`                        | Whether to create RBAC related resources |  `yes`                                                |
 | `serviceAccountCreate`               | Whether to create a serviceaccount |  `yes`                                                      |
 | `serviceAccount`                     | Cluster Operator's service account |  `strimzi-cluster-operator`                                 |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -43,8 +43,20 @@ labels: {}
 nodeSelector: {}
 priorityClassName: ""
 
-podSecurityContext: {}
-securityContext: {}
+podSecurityContext:
+  fsGroup: 65534
+  runAsGroup: 65534
+  runAsNonRoot: true
+  runAsUser: 65534
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 rbac:
   create: yes
 serviceAccountCreate: yes


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Set the security context compatible with https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

That is the current hardening best practices and shouldn't interfere with the `operator`.  This PR does not cover setting similar fields as a default on the CRD resources.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards