### PR TITLE
Consistent logging of the rolling reasons

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -447,7 +447,7 @@ public class CaReconciler {
         return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
                 .compose(dep -> {
                     if (dep != null) {
-                        LOGGER.infoCr(reconciliation, "Rolling Deployment {} to {}", deploymentName, reason);
+                        LOGGER.infoCr(reconciliation, "Rolling Deployment {}. Reasons: {}", deploymentName, reason);
                         return deploymentOperator.rollingUpdate(reconciliation, reconciliation.namespace(), deploymentName, operationTimeoutMs);
                     } else {
                         return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -447,7 +447,7 @@ public class CaReconciler {
         return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
                 .compose(dep -> {
                     if (dep != null) {
-                        LOGGER.infoCr(reconciliation, "Rolling Deployment {}. Reasons: {}", deploymentName, reason);
+                        LOGGER.infoCr(reconciliation, "Rolling Deployment {} due to {}", deploymentName, reason);
                         return deploymentOperator.rollingUpdate(reconciliation, reconciliation.namespace(), deploymentName, operationTimeoutMs);
                     } else {
                         return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -171,7 +171,7 @@ public class ReconcilerUtils {
         }
 
         if (restartReasons.shouldRestart()) {
-            LOGGER.debugCr(reconciliation, "Rolling pod {}. Reasons: {}",
+            LOGGER.debugCr(reconciliation, "Rolling Pod {} due to {}",
                     pod.getMetadata().getName(), restartReasons.getAllReasonNotes());
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -171,7 +171,7 @@ public class ReconcilerUtils {
         }
 
         if (restartReasons.shouldRestart()) {
-            LOGGER.debugCr(reconciliation, "Rolling pod {} due to {}",
+            LOGGER.debugCr(reconciliation, "Rolling pod {}. Reasons: {}",
                     pod.getMetadata().getName(), restartReasons.getAllReasonNotes());
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -544,7 +544,7 @@ public class KafkaRoller {
                 needsReconfig = true;
             }
         } else if (needsRestart) {
-            LOGGER.infoCr(reconciliation, "Pod {} needs to be restarted. Reason: {}", nodeRef, reasonToRestartPod.getAllReasonNotes());
+            LOGGER.infoCr(reconciliation, "Pod {} needs to be restarted. Reasons: {}", nodeRef, reasonToRestartPod.getAllReasonNotes());
         }
 
         restartContext.needsRestart = needsRestart;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -544,7 +544,7 @@ public class KafkaRoller {
                 needsReconfig = true;
             }
         } else if (needsRestart) {
-            LOGGER.infoCr(reconciliation, "Pod {} needs to be restarted. Reasons: {}", nodeRef, reasonToRestartPod.getAllReasonNotes());
+            LOGGER.infoCr(reconciliation, "Rolling Pod {} due to {}", nodeRef, reasonToRestartPod.getAllReasonNotes());
         }
 
         restartContext.needsRestart = needsRestart;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -139,7 +139,7 @@ public class ZooKeeperRoller {
      * @return a Future which completes when the given (possibly recreated) pod is ready.
      */
     Future<Void> restartPod(Reconciliation reconciliation, String podName, List<String> reasons) {
-        LOGGER.infoCr(reconciliation, "Rolling pod {} due to {}", podName, reasons);
+        LOGGER.infoCr(reconciliation, "Rolling pod {}. Reasons: {}", podName, reasons);
         return podOperator.getAsync(reconciliation.namespace(), podName)
                 .compose(pod -> podOperator.restart(reconciliation, pod, operationTimeoutMs))
                 .compose(ignore -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -139,7 +139,7 @@ public class ZooKeeperRoller {
      * @return a Future which completes when the given (possibly recreated) pod is ready.
      */
     Future<Void> restartPod(Reconciliation reconciliation, String podName, List<String> reasons) {
-        LOGGER.infoCr(reconciliation, "Rolling pod {}. Reasons: {}", podName, reasons);
+        LOGGER.infoCr(reconciliation, "Rolling Pod {} due to {}", podName, reasons);
         return podOperator.getAsync(reconciliation.namespace(), podName)
                 .compose(pod -> podOperator.restart(reconciliation, pod, operationTimeoutMs))
                 .compose(ignore -> {


### PR DESCRIPTION
This trivial PR just makes consistent the logging of the rolling reasons across different components which could run a roll of pods (ZooKeeper, Kafka, EO, ...).
It takes the `KafkaRoller` as a reference (just moving from singular to plural with "Reasons", as they could be more than one).