### PR TITLE
Removed the force-renewal CA cert for upgrades from Strimzi 0.6.0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -93,7 +93,7 @@ public class ClusterCa extends Ca {
         super(reconciliation, certManager, passwordGenerator,
                 "cluster-ca",
                 AbstractModel.clusterCaCertSecretName(clusterName),
-                forceRenewal(clusterCaCert, clusterCaKey, "cluster-ca.key"),
+                clusterCaCert,
                 AbstractModel.clusterCaKeySecretName(clusterName),
                 clusterCaKey, validityDays, renewalDays, generateCa, policy);
         this.clusterName = clusterName;

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
@@ -183,19 +182,6 @@ public abstract class Ca {
     private final PasswordGenerator passwordGenerator;
     protected final Reconciliation reconciliation;
     private Clock clock;
-
-    /**
-     * Set the {@code strimzi.io/force-renew} annotation on the given {@code caCert} if the given {@code caKey} has
-     * the given {@code key}.
-     *
-     * This is used to force certificate renewal when upgrading from a Strimzi 0.6.0 Secret.
-     */
-    protected static Secret forceRenewal(Secret caCert, Secret caKey, String key) {
-        if (caCert != null && caKey != null && caKey.getData() != null && caKey.getData().containsKey(key)) {
-            caCert = new SecretBuilder(caCert).editMetadata().addToAnnotations(ANNO_STRIMZI_IO_FORCE_RENEW, "true").endMetadata().build();
-        }
-        return caCert;
-    }
 
     enum RenewalType {
         NOOP() {

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/ClientsCa.java
@@ -36,7 +36,7 @@ public class ClientsCa extends Ca {
                      int validityDays, int renewalDays, boolean generateCa, CertificateExpirationPolicy policy) {
         super(reconciliation, certManager, passwordGenerator,
                 "clients-ca", caCertSecretName,
-                forceRenewal(clientsCaCert, clientsCaKey, "clients-ca.key"), caSecretKeyName,
+                clientsCaCert, caSecretKeyName,
                 clientsCaKey, validityDays, renewalDays, generateCa, policy);
     }
 


### PR DESCRIPTION
This PR fixes #8420.
We don't need to force a CA cert renewal on CAs model classes creation because it was needed for upgrading from pretty old Strimzi version (0.6.0) which we don't care anymore.