### PR TITLE
docs(ssl): removes repeated ssl config examples and cleans up config descriptions

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -10,32 +10,33 @@ Configuration options relate to:
 
 Use the `config` properties to configure Cruise Control options as keys.
 
-Standard Cruise Control configuration may be provided, restricted to those properties not managed directly by Strimzi.
-
-Configuration options that cannot be configured relate to the following:
-
-* Security (Encryption, Authentication, and Authorization)
-* Connection to the Kafka cluster
-* Client ID configuration
-* ZooKeeper connectivity
-* Web server configuration
-* Self healing
-
 The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-You can specify and configure the options listed in the {CruiseControlConfigDocs} with the exception of those options that are managed directly by Strimzi.
-See the description of the `config` property for a list of forbidden prefixes.
+*Exceptions*
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
-All other supported options are passed to Cruise Control.
+You can specify and configure the options listed in the {CruiseControlConfigDocs}.
 
-There are exceptions to the forbidden options.
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
-You can also configure `webserver` properties to enable Cross-Origin Resource Sharing (CORS).
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
+
+* Security (encryption, authentication, and authorization)
+* Connection to the Kafka cluster
+* Client ID configuration
+* ZooKeeper connectivity
+* Web server configuration
+* Self healing
+
+See the description of the `config` property for a list of prefixes for options you cannot change.
+
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to Cruise Control, including two exceptions to the options configured by Strimzi:
+
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
+* Configuration for `webserver` properties to enable Cross-Origin Resource Sharing (CORS)
+
 
 .Example Cruise Control configuration
 [source,yaml,subs="attributes+"]

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -29,10 +29,29 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Web server configuration
 * Self healing
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `bootstrap.servers`
+* `capacity.config.file`
+* `client.id`
+* `failed.brokers.zk.path`
+* `kafka.broker.failure.detection.enable`
+* `metric.reporter.sampler.bootstrap.servers`
+* `network.`
+* `request.reason.required`
+* `security.`
+* `self.healing.`
+* `ssl.`
+* `topic.config.provider.class`
+* `two.step.`
+* `webserver.accesslog.`
+* `webserver.api.urlprefix`
+* `webserver.http.`
+* `webserver.session.path`
+* `zookeeper.`
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to Cruise Control, including two exceptions to the options configured by Strimzi:
+All other supported options are forwarded to Cruise Control, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 * Configuration for `webserver` properties to enable Cross-Origin Resource Sharing (CORS)

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
@@ -16,10 +16,16 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Security (encryption, authentication, and authorization)
 * Consumer group identifier
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `bootstrap.servers`
+* `group.id`
+* `sasl.`
+* `security.`
+* `ssl.` 
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to Kafka Bridge, including the following exception to the options configured by Strimzi:
+All other supported options are forwarded to Kafka Bridge, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
@@ -40,5 +40,5 @@ spec:
 ----
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object.
-If an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
+If an invalid configuration is provided, the Kafka Bridge deployment might not start or might become unstable.
 In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeConsumerSpec.adoc
@@ -6,24 +6,22 @@ The values can be one of the following JSON types:
 * Number
 * Boolean
 
-You can specify and configure the options listed in the {ApacheKafkaConsumerConfig} with the exception of those options which are managed directly by Strimzi.
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+*Exceptions*
 
-* `ssl.`
-* `sasl.`
-* `security.`
-* `bootstrap.servers`
-* `group.id`
+You can specify and configure the options listed in the {ApacheKafkaConsumerConfig}.
 
-When one of the forbidden options is present in the `config` property, it is ignored and a warning message will be printed to the Cluster Operator log file.
-All other options will be passed to Kafka
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
 
-IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object.
-If an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
-Fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.
+* Kafka cluster bootstrap address
+* Security (encryption, authentication, and authorization)
+* Consumer group identifier
 
-There are exceptions to the forbidden options.
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+See the description of the `config` property for a list of prefixes for options you cannot change.
+
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to Kafka Bridge, including the following exception to the options configured by Strimzi:
+
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 
 .Example Kafka Bridge consumer configuration
 [source,yaml,subs="attributes+"]
@@ -38,9 +36,9 @@ spec:
     config:
       auto.offset.reset: earliest
       enable.auto.commit: true
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
-      ssl.endpoint.identification.algorithm: HTTPS
     # ...
 ----
+
+IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object.
+If an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
+In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
@@ -16,10 +16,15 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Security (encryption, authentication, and authorization)
 * Consumer group identifier
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `bootstrap.servers`
+* `sasl.`
+* `security.`
+* `ssl.` 
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to Kafka Bridge, including the following exception to the options configured by Strimzi:
+All other supported options are forwarded to Kafka Bridge, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
@@ -6,23 +6,22 @@ The values can be one of the following JSON types:
 * Number
 * Boolean
 
-You can specify and configure the options listed in the {ApacheKafkaproducerConfig} with the exception of those options which are managed directly by Strimzi.
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+*Exceptions*
 
-* `ssl.`
-* `sasl.`
-* `security.`
-* `bootstrap.servers`
+You can specify and configure the options listed in the {ApacheKafkaproducerConfig}.
 
-When one of the forbidden options is present in the `config` property, it is ignored and a warning message will be printed to the Cluster Operator log file.
-All other options will be passed to Kafka
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
 
-IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object.
-If an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
-Fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.
+* Kafka cluster bootstrap address
+* Security (encryption, authentication, and authorization)
+* Consumer group identifier
 
-There are exceptions to the forbidden options.
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+See the description of the `config` property for a list of prefixes for options you cannot change.
+
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to Kafka Bridge, including the following exception to the options configured by Strimzi:
+
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 
 .Example Kafka Bridge producer configuration
 [source,yaml,subs="attributes+"]
@@ -37,9 +36,9 @@ spec:
     config:
       acks: 1
       delivery.timeout.ms: 300000
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
-      ssl.endpoint.identification.algorithm: HTTPS
     # ...
 ----
+
+IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object.
+If an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
+In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeProducerSpec.adoc
@@ -40,5 +40,5 @@ spec:
 ----
 
 IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object.
-If an invalid configuration is provided, the Kafka Bridge cluster might not start or might become unstable.
+If an invalid configuration is provided, the Kafka Bridge deployment might not start or might become unstable.
 In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Bridge nodes.

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaBridgeSpec.adoc
@@ -3,7 +3,7 @@ Configures a Kafka Bridge cluster.
 Configuration options relate to:
 
 * Kafka cluster bootstrap address
-* Security (Encryption, Authentication, and Authorization)
+* Security (encryption, authentication, and authorization)
 * Consumer configuration
 * Producer configuration
 * HTTP configuration

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc
@@ -48,13 +48,48 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Inter-broker communication
 * ZooKeeper connectivity
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `advertised.`
+* `authorizer.`
+* `broker.`
+* `controller`
+* `cruise.control.metrics.reporter.bootstrap.`
+* `cruise.control.metrics.topic`
+* `host.name`
+* `inter.broker.listener.name`
+* `listener.`
+* `listeners.`
+* `log.dir`
+* `password.`
+* `port`
+* `process.roles`
+* `sasl.`
+* `security.`
+* `servers,node.id`
+* `ssl.`
+* `super.user`
+* `zookeeper.clientCnxnSocket`
+* `zookeeper.connect`
+* `zookeeper.set.acl`
+* `zookeeper.ssl`
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to Kafka, including two exceptions to the options configured by Strimzi:
+All other supported options are forwarded to Kafka, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 * Configuration for the `zookeeper.connection.timeout.ms` property to set the maximum time allowed for establishing a ZooKeeper connection
+* Cruise Control metrics properties: 
+** `cruise.control.metrics.topic.num.partitions`
+** `cruise.control.metrics.topic.replication.factor`
+** `cruise.control.metrics.topic.retention.ms`
+** `cruise.control.metrics.topic.auto.create.retries`
+** `cruise.control.metrics.topic.auto.create.timeout.ms`
+** `cruise.control.metrics.topic.min.insync.replicas`
+* Controller properties:
+** `controller.quorum.election.backoff.max.ms`
+** `controller.quorum.election.timeout.ms`
+** `controller.quorum.fetch.timeout.ms`
 
 .Example Kafka broker configuration
 [source,yaml,subs="attributes+"]

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc
@@ -29,50 +29,32 @@ spec:
 
 Use the `config` properties to configure Kafka broker options as keys.
 
-Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
-
-Configuration options that cannot be configured relate to:
-
-* Security (Encryption, Authentication, and Authorization)
-* Listener configuration
-* Broker ID configuration
-* Configuration of log data directories
-* Inter-broker communication
-* ZooKeeper connectivity
-
 The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-You can specify and configure the options listed in the {ApacheKafkaBrokerConfig} with the exception of those options that are managed directly by Strimzi.
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+*Exceptions*
 
-* `listeners`
-* `advertised.`
-* `broker.`
-* `listener.`
-* `host.name`
-* `port`
-* `inter.broker.listener.name`
-* `sasl.`
-* `ssl.`
-* `security.`
-* `password.`
-* `principal.builder.class`
-* `log.dir`
-* `zookeeper.connect`
-* `zookeeper.set.acl`
-* `authorizer.`
-* `super.user`
+You can specify and configure the options listed in the {ApacheKafkaBrokerConfig}.
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
-All other supported options are passed to Kafka.
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
 
-There are exceptions to the forbidden options.
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
-You can also configure the `zookeeper.connection.timeout.ms` property to set the maximum time allowed for establishing a ZooKeeper connection.
+* Security (encryption, authentication, and authorization)
+* Listener configuration
+* Broker ID configuration
+* Configuration of log data directories
+* Inter-broker communication
+* ZooKeeper connectivity
+
+See the description of the `config` property for a list of prefixes for options you cannot change.
+
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to Kafka, including two exceptions to the options configured by Strimzi:
+
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
+* Configuration for the `zookeeper.connection.timeout.ms` property to set the maximum time allowed for establishing a ZooKeeper connection
 
 .Example Kafka broker configuration
 [source,yaml,subs="attributes+"]
@@ -100,9 +82,6 @@ spec:
       socket.receive.buffer.bytes: 102400
       socket.request.max.bytes: 104857600
       group.initial.rebalance.delay.ms: 0
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
       zookeeper.connection.timeout.ms: 6000
     # ...
 ----

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
@@ -2,40 +2,13 @@ Configures a Kafka Connect cluster.
 
 [id='property-kafka-connect-config-{context}']
 === `config`
-Use the `config` properties to configure Kafka options as keys.
-
-Standard Apache Kafka Connect configuration may be provided, restricted to those properties not managed directly by Strimzi.
-
-Configuration options that cannot be configured relate to:
-
-* Kafka cluster bootstrap address
-* Security (Encryption, Authentication, and Authorization)
-* Listener / REST interface configuration
-* Plugin path configuration
+Use the `config` properties to configure Kafka Connect options as keys.
 
 The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
-
-You can specify and configure the options listed in the {ApacheKafkaConnectConfig} with the exception of those options that are managed directly by Strimzi.
-Specifically, configuration options with keys equal to or starting with one of the following strings are forbidden:
-
-* `ssl.`
-* `sasl.`
-* `security.`
-* `listeners`
-* `plugin.path`
-* `rest.`
-* `bootstrap.servers`
-
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
-All other options are passed to Kafka Connect.
-
-IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object provided.
-When an invalid configuration is provided, the Kafka Connect cluster might not start or might become unstable.
-In this circumstance, fix the configuration in the `KafkaConnect.spec.config` object, then the Cluster Operator can roll out the new configuration to all Kafka Connect nodes.
 
 Certain options have default values:
 
@@ -48,10 +21,23 @@ Certain options have default values:
 
 These options are automatically configured in case they are not present in the `KafkaConnect.spec.config` properties.
 
-There are exceptions to the forbidden options.
-You can use three allowed `ssl` configuration options for client connection using a specific _cipher suite_ for a TLS version.
-A cipher suite combines algorithms for secure connection and data transfer.
-You can also configure the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification.
+*Exceptions*
+
+You can specify and configure the options listed in the {ApacheKafkaConnectConfig}.
+
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
+
+* Kafka cluster bootstrap address
+* Security (encryption, authentication, and authorization)
+* Listener and REST interface configuration
+* Plugin path configuration
+
+See the description of the `config` property for a list of prefixes for options you cannot change.
+
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to Kafka Connect, including the following exception to the options configured by Strimzi:
+
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 
 .Example Kafka Connect configuration
 [source,yaml,subs="attributes+"]
@@ -74,15 +60,12 @@ spec:
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3
-    ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    ssl.enabled.protocols: TLSv1.2
-    ssl.protocol: TLSv1.2
-    ssl.endpoint.identification.algorithm: HTTPS
   # ...
 ----
 
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
-You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endpoint.identification.algorithm` property] to enable or disable hostname verification.
+IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object provided.
+If an invalid configuration is provided, the Kafka Connect cluster might not start or might become unstable.
+In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all Kafka Connect nodes.
 
 [id='property-kafka-connect-logging-{context}']
 === `logging`

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc
@@ -32,10 +32,20 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Listener and REST interface configuration
 * Plugin path configuration
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `bootstrap.servers`
+* `consumer.interceptor.classes`
+* `listeners.`
+* `plugin.path`
+* `producer.interceptor.classes`
+* `rest.`
+* `sasl.`
+* `security.`
+* `ssl.`
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to Kafka Connect, including the following exception to the options configured by Strimzi:
+All other supported options are forwarded to Kafka Connect, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc
@@ -20,43 +20,35 @@ The time interval is set in milliseconds, with a default value of 60,000.
 [id='property-consumer-config-{context}']
 === `config`
 
-Use the `consumer.config` properties to configure Kafka options for the consumer.
+Use the `consumer.config` properties to configure Kafka options for the consumer as keys.
 
-The `config` property contains the Kafka MirrorMaker consumer configuration options as keys, with values set in one of the following JSON types:
+The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
-You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endpoint.identification.algorithm` property] to enable or disable hostname verification.
-
 *Exceptions*
 
 You can specify and configure the options listed in the {ApacheKafkaConsumerConfig}.
 
-However, there are exceptions for options automatically configured and managed directly by Strimzi related to:
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
 
 * Kafka cluster bootstrap address
 * Security (encryption, authentication, and authorization)
 * Consumer group identifier
 * Interceptors
 
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+See the description of the `config` property for a list of prefixes for options you cannot change.
 
-* `bootstrap.servers`
-* `group.id`
-* `interceptor.classes`
-* `ssl.` (xref:con-common-configuration-ssl-reference[not including specific exceptions])
-* `sasl.`
-* `security.`
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to MirrorMaker, including the following exception to the options configured by Strimzi:
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
-All other options are passed to Kafka MirrorMaker.
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 
-IMPORTANT: The Cluster Operator does not validate keys or values in the provided `config` object.
-When an invalid configuration is provided, the Kafka MirrorMaker might not start or might become unstable.
-In such cases, the configuration in the `KafkaMirrorMaker.spec.consumer.config` object should be fixed and the Cluster Operator will roll out the new configuration for Kafka MirrorMaker.
+IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object provided.
+If an invalid configuration is provided, the MirrorMaker cluster might not start or might become unstable.
+In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all MirrorMaker nodes.
 
 [id='property-consumer-group-{context}']
 === `groupId`

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerConsumerSpec.adoc
@@ -39,10 +39,17 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Consumer group identifier
 * Interceptors
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `bootstrap.servers`
+* `group.id`
+* `interceptor.classes`
+* `sasl.`
+* `security.`
+* `ssl.`
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to MirrorMaker, including the following exception to the options configured by Strimzi:
+All other supported options are forwarded to MirrorMaker, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc
@@ -33,10 +33,16 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Security (encryption, authentication, and authorization)
 * Interceptors
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `bootstrap.servers`
+* `interceptor.classes`
+* `sasl.`
+* `security.`
+* `ssl.`
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to MirrorMaker, including the following exception to the options configured by Strimzi:
+All other supported options are forwarded to MirrorMaker, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaMirrorMakerProducerSpec.adoc
@@ -15,38 +15,31 @@ If the `abortOnSendFailure` option is set to `false`, message sending errors are
 [id='property-producer-config-{context}']
 === `config`
 
-Use the `producer.config` properties to configure Kafka options for the producer.
+Use the `producer.config` properties to configure Kafka options for the producer as keys.
 
-The `config` property contains the Kafka MirrorMaker producer configuration options as keys, with values set in one of the following JSON types:
+The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
-You can also xref:con-common-configuration-ssl-reference[configure the `ssl.endpoint.identification.algorithm` property] to enable or disable hostname verification.
-
 *Exceptions*
 
 You can specify and configure the options listed in the {ApacheKafkaProducerConfig}.
 
-However, there are exceptions for options automatically configured and managed directly by Strimzi related to:
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
 
 * Kafka cluster bootstrap address
 * Security (encryption, authentication, and authorization)
 * Interceptors
 
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+See the description of the `config` property for a list of prefixes for options you cannot change.
 
-* `bootstrap.servers`
-* `interceptor.classes`
-* `ssl.` (xref:con-common-configuration-ssl-reference[not including specific exceptions])
-* `sasl.`
-* `security.`
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to MirrorMaker, including the following exception to the options configured by Strimzi:
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
-All other options are passed to Kafka MirrorMaker.
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 
-IMPORTANT: The Cluster Operator does not validate keys or values in the provided `config` object.
-When an invalid configuration is provided, the Kafka MirrorMaker might not start or might become unstable.
-In such cases, the configuration in the `KafkaMirrorMaker.spec.producer.config` object should be fixed and the Cluster Operator will roll out the new configuration for Kafka MirrorMaker.
+IMPORTANT: The Cluster Operator does not validate keys or values in the `config` object provided.
+If an invalid configuration is provided, the MirrorMaker cluster might not start or might become unstable.
+In this case, fix the configuration so that the Cluster Operator can roll out the new configuration to all MirrorMaker nodes.

--- a/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
@@ -5,37 +5,29 @@ Configures a ZooKeeper cluster.
 
 Use the `config` properties to configure ZooKeeper options as keys.
 
-Standard Apache ZooKeeper configuration may be provided, restricted to those properties not managed directly by Strimzi.
-
-Configuration options that cannot be configured relate to:
-
-* Security (Encryption, Authentication, and Authorization)
-* Listener configuration
-* Configuration of data directories
-* ZooKeeper cluster composition
-
 The values can be one of the following JSON types:
 
 * String
 * Number
 * Boolean
 
-You can specify and configure the options listed in the {ApacheZookeeperConfig} with the exception of those managed directly by Strimzi.
-Specifically, all configuration options with keys equal to or starting with one of the following strings are forbidden:
+*Exceptions*
 
-* `server.`
-* `dataDir`
-* `dataLogDir`
-* `clientPort`
-* `authProvider`
-* `quorum.auth`
-* `requireClientAuthScheme`
+You can specify and configure the options listed in the {ApacheZookeeperConfig}.
 
-When a forbidden option is present in the `config` property, it is ignored and a warning message is printed to the Cluster Operator log file.
-All other supported options are passed to ZooKeeper.
+However, Strimzi takes care of configuring and managing options related to the following, which cannot be changed:
 
-There are exceptions to the forbidden options.
-For client connection using a specific _cipher suite_ for a TLS version, you can xref:con-common-configuration-ssl-reference[configure allowed `ssl` properties].
+* Security (encryption, authentication, and authorization)
+* Listener configuration
+* Configuration of data directories
+* ZooKeeper cluster composition
+
+See the description of the `config` property for a list of prefixes for options you cannot change.
+
+If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
+All other supported options are forwarded to ZooKeeper, including the following exception to the options configured by Strimzi:
+
+* Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 
 .Example ZooKeeper configuration
 [source,yaml,subs="attributes+"]
@@ -50,9 +42,6 @@ spec:
     config:
       autopurge.snapRetainCount: 3
       autopurge.purgeInterval: 1
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
     # ...
 ----
 

--- a/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
@@ -22,10 +22,26 @@ However, Strimzi takes care of configuring and managing options related to the f
 * Configuration of data directories
 * ZooKeeper cluster composition
 
-See the description of the `config` property for a list of prefixes for options you cannot change.
+Properties with the following prefixes cannot be set:
+
+* `4lw.commands.whitelist`
+* `authProvider`
+* `clientPort`
+* `dataDir`
+* `dataLogDir`
+* `quorum.auth`
+* `reconfigEnabled`
+* `requireClientAuthScheme`
+* `secureClientPort`
+* `server.`
+* `snapshot.trust.empty`
+* `standaloneEnabled`
+* `serverCnxnFactory`
+* `ssl.`
+* `sslQuorum`
 
 If the `config` property contains an option that cannot be changed, it is disregarded, and a warning message is logged to the Cluster Operator log file.
-All other supported options are forwarded to ZooKeeper, including the following exception to the options configured by Strimzi:
+All other supported options are forwarded to ZooKeeper, including the following exceptions to the options configured by Strimzi:
 
 * Any `ssl` configuration for xref:con-common-configuration-ssl-reference[supported TLS versions and cipher suites]
 

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -5,7 +5,9 @@
 [id='con-common-configuration-properties-{context}']
 == Common configuration properties
 
-Common configuration properties apply to more than one resource.
+[role="_abstract"]
+Use Common configuration properties to configure Strimzi custom resources.
+You add common configuration properties to a custom resource like any other supported configuration for that resource.
 
 [id='con-common-configuration-replicas-{context}']
 === `replicas`
@@ -35,7 +37,7 @@ If deployed by Strimzi but on different Kubernetes clusters, the list content de
 When using Kafka with a Kafka cluster not managed by Strimzi, you can specify the bootstrap servers list according to the configuration of the given cluster.
 
 [id='con-common-configuration-ssl-{context}']
-=== `ssl`
+=== `ssl` (supported TLS versions and cipher suites)
 
 You can incorporate SSL configuration and cipher suite specifications to further secure TLS-based communication between your client application and a Kafka cluster.
 In addition to the standard TLS configuration, you can specify a supported TLS version and enable cipher suites in the configuration for the Kafka broker.

--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -55,54 +55,54 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    replicas: 3 <1>
-    version: {DefaultKafkaVersion} <2>
-    logging: <3>
+    replicas: 3 # <1>
+    version: {DefaultKafkaVersion} # <2>
+    logging: # <3>
       type: inline
       loggers:
         kafka.root.logger.level: "INFO"
-    resources: <4>
+    resources: # <4>
       requests:
         memory: 64Gi
         cpu: "8"
       limits:
         memory: 64Gi
         cpu: "12"
-    readinessProbe: <5>
+    readinessProbe: # <5>
       initialDelaySeconds: 15
       timeoutSeconds: 5
     livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    jvmOptions: <6>
+    jvmOptions: # <6>
       -Xms: 8192m
       -Xmx: 8192m
-    image: my-org/my-image:latest <7>
-    listeners: <8>
-      - name: plain <9>
-        port: 9092 <10>
-        type: internal <11>
-        tls: false <12>
+    image: my-org/my-image:latest # <7>
+    listeners: # <8>
+      - name: plain # <9>
+        port: 9092 # <10>
+        type: internal # <11>
+        tls: false # <12>
         configuration:
-          useServiceDnsDomain: true <13>
+          useServiceDnsDomain: true # <13>
       - name: tls
         port: 9093
         type: internal
         tls: true
-        authentication: <14>
+        authentication: # <14>
           type: tls
-      - name: external <15>
+      - name: external # <15>
         port: 9094
         type: route
         tls: true
         configuration:
-          brokerCertChainAndKey: <16>
+          brokerCertChainAndKey: # <16>
             secretName: my-secret
             certificate: my-certificate.crt
             key: my-key.key
-    authorization: <17>
+    authorization: # <17>
       type: simple
-    config: <18>
+    config: # <18>
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
@@ -110,24 +110,21 @@ spec:
       default.replication.factor: 3
       min.insync.replicas: 2
       inter.broker.protocol.version: "{DefaultInterBrokerVersion}"
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 <19>
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
-    storage: <20>
-      type: persistent-claim <21>
-      size: 10000Gi <22>
-    rack: <23>
+    storage: # <19>
+      type: persistent-claim # <20>
+      size: 10000Gi
+    rack: # <21>
       topologyKey: topology.kubernetes.io/zone
-    metricsConfig: <24>
+    metricsConfig: # <22>
       type: jmxPrometheusExporter
       valueFrom:
-        configMapKeyRef: <25>
+        configMapKeyRef: # <23>
           name: my-config-map
           key: my-key
     # ...
-  zookeeper: <26>
-    replicas: 3 <27>
-    logging: <28>
+  zookeeper: # <24>
+    replicas: 3 # <25>
+    logging: # <26>
       type: inline
       loggers:
         zookeeper.root.logger: "INFO"
@@ -146,8 +143,8 @@ spec:
       size: 1000Gi
     metricsConfig:
       # ...
-  entityOperator: <29>
-    tlsSidecar: <30>
+  entityOperator: # <27>
+    tlsSidecar: # <28>
       resources:
         requests:
           cpu: 200m
@@ -158,7 +155,7 @@ spec:
     topicOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalSeconds: 60
-      logging: <31>
+      logging: # <29>
         type: inline
         loggers:
           rootLogger.level: "INFO"
@@ -172,7 +169,7 @@ spec:
     userOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalSeconds: 60
-      logging: <32>
+      logging: # <30>
         type: inline
         loggers:
           rootLogger.level: INFO
@@ -183,9 +180,9 @@ spec:
         limits:
           memory: 512Mi
           cpu: "1"
-  kafkaExporter: <33>
+  kafkaExporter: # <31>
     # ...
-  cruiseControl: <34>
+  cruiseControl: # <32>
     # ...
 ----
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes].
@@ -206,24 +203,22 @@ spec:
 <16> Optional configuration for a link:{BookURLDeploying}#proc-installing-certs-per-listener-str[Kafka listener certificate] managed by an external CA (certificate authority). The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates on any listener with enabled TLS encryption.
 <17> Authorization xref:type-KafkaClusterSpec-reference[enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker.] Simple authorization uses the `AclAuthorizer` Kafka plugin.
 <18> Broker configuration. xref:property-kafka-config-reference[Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi].
-<19> xref:con-common-configuration-ssl-reference[SSL properties for listeners with TLS encryption enabled to enable a specific _cipher suite_ or TLS version].
-<20> xref:assembly-storage-{context}[Storage] is configured as `ephemeral`, `persistent-claim` or `jbod`.
-<21> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].
-<22> Persistent storage has xref:ref-persistent-storage-{context}[additional configuration options], such as a storage `id` and `class` for dynamic volume provisioning.
-<23> xref:type-Rack-reference[Rack awareness] configuration to spread replicas across different racks, data centers, or availability zones. The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label.
-<24> xref:con-common-configuration-prometheus-reference[Prometheus metrics] enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
-<25> Prometheus rules for exporting metrics to a Grafana dashboard through the Prometheus JMX Exporter, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
-<26> ZooKeeper-specific configuration, which contains properties similar to the Kafka configuration.
-<27> xref:con-common-configuration-replicas-reference[The number of ZooKeeper nodes]. ZooKeeper clusters or ensembles usually run with an odd number of nodes, typically three, five, or seven. The majority of nodes must be available in order to maintain an effective quorum.
+<19> Storage size for xref:proc-resizing-persistent-volumes-{context}[persistent volumes may be increased] and additional xref:proc-adding-volumes-to-jbod-storage-{context}[volumes may be added to JBOD storage].
+<20> Persistent storage has xref:ref-persistent-storage-{context}[additional configuration options], such as a storage `id` and `class` for dynamic volume provisioning.
+<21> xref:type-Rack-reference[Rack awareness] configuration to spread replicas across different racks, data centers, or availability zones. The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label.
+<22> xref:con-common-configuration-prometheus-reference[Prometheus metrics] enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
+<23> Prometheus rules for exporting metrics to a Grafana dashboard through the Prometheus JMX Exporter, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<24> ZooKeeper-specific configuration, which contains properties similar to the Kafka configuration.
+<25> xref:con-common-configuration-replicas-reference[The number of ZooKeeper nodes]. ZooKeeper clusters or ensembles usually run with an odd number of nodes, typically three, five, or seven. The majority of nodes must be available in order to maintain an effective quorum.
 If the ZooKeeper cluster loses its quorum, it will stop responding to clients and the Kafka brokers will stop working.
 Having a stable and highly available ZooKeeper cluster is crucial for Strimzi.
-<28> Specified xref:property-zookeeper-logging-reference[ZooKeeper loggers and log levels].
-<29> Entity Operator configuration, which xref:assembly-kafka-entity-operator-{context}[specifies the configuration for the Topic Operator and User Operator].
-<30> Entity Operator xref:type-TlsSidecar-reference[TLS sidecar configuration]. Entity Operator uses the TLS sidecar for secure communication with ZooKeeper.
-<31> Specified xref:property-topic-operator-logging-reference[Topic Operator loggers and log levels]. This example uses `inline` logging.
-<32> Specified xref:property-user-operator-logging-reference[User Operator loggers and log levels].
-<33> Kafka Exporter configuration. link:{BookURLDeploying}#con-metrics-kafka-exporter-lag-str[Kafka Exporter] is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use. 
-<34> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
+<26> Specified xref:property-zookeeper-logging-reference[ZooKeeper loggers and log levels].
+<27> Entity Operator configuration, which xref:assembly-kafka-entity-operator-{context}[specifies the configuration for the Topic Operator and User Operator].
+<28> Entity Operator xref:type-TlsSidecar-reference[TLS sidecar configuration]. Entity Operator uses the TLS sidecar for secure communication with ZooKeeper.
+<29> Specified xref:property-topic-operator-logging-reference[Topic Operator loggers and log levels]. This example uses `inline` logging.
+<30> Specified xref:property-user-operator-logging-reference[User Operator loggers and log levels].
+<31> Kafka Exporter configuration. link:{BookURLDeploying}#con-metrics-kafka-exporter-lag-str[Kafka Exporter] is an optional component for extracting metrics data from Kafka brokers, in particular consumer lag data. For Kafka Exporter to be able to work properly, consumer groups need to be in use. 
+<32> Optional configuration for Cruise Control, which is used to rebalance the Kafka cluster.
 
 . Create or update the resource:
 +

--- a/documentation/modules/configuring/proc-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker.adoc
@@ -30,32 +30,28 @@ kind: KafkaMirrorMaker
 metadata:
   name: my-mirror-maker
 spec:
-  replicas: 3 <1>
+  replicas: 3 # <1>
   consumer:
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9092 <2>
-    groupId: "my-group" <3>
-    numStreams: 2 <4>
-    offsetCommitInterval: 120000 <5>
-    tls: <6>
+    bootstrapServers: my-source-cluster-kafka-bootstrap:9092 # <2>
+    groupId: "my-group" # <3>
+    numStreams: 2 # <4>
+    offsetCommitInterval: 120000 # <5>
+    tls: # <6>
       trustedCertificates:
       - secretName: my-source-cluster-ca-cert
         certificate: ca.crt
-    authentication: <7>
+    authentication: # <7>
       type: tls
       certificateAndKey:
         secretName: my-source-secret
         certificate: public.crt
         key: private.key
-    config: <8>
+    config: # <8>
       max.poll.records: 100
       receive.buffer.bytes: 32768
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 <9>
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
-      ssl.endpoint.identification.algorithm: HTTPS <10>
   producer:
     bootstrapServers: my-target-cluster-kafka-bootstrap:9092
-    abortOnSendFailure: false <11>
+    abortOnSendFailure: false # <9>
     tls:
       trustedCertificates:
       - secretName: my-target-cluster-ca-cert
@@ -69,39 +65,35 @@ spec:
     config:
       compression.type: gzip
       batch.size: 8192
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 <12>
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
-      ssl.endpoint.identification.algorithm: HTTPS <13>
-  include: "my-topic|other-topic" <14>
-  resources: <15>
+  include: "my-topic|other-topic" # <10>
+  resources: # <11>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <16>
+  logging: # <12>
     type: inline
     loggers:
       mirrormaker.root.logger: "INFO"
-  readinessProbe: <17>
+  readinessProbe: # <13>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  metricsConfig: <18>
+  metricsConfig: # <14>
    type: jmxPrometheusExporter
    valueFrom:
      configMapKeyRef:
        name: my-config-map
        key: my-key
-  jvmOptions: <19>
+  jvmOptions: # <15>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest <20>
-  template: <21>
+  image: my-org/my-image:latest # <16>
+  template: # <17>
     pod:
       affinity:
         podAntiAffinity:
@@ -114,7 +106,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: <22>
+    mirrorMakerContainer: # <18>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -122,7 +114,7 @@ spec:
           value: jaeger-agent-name
         - name: JAEGER_AGENT_PORT
           value: "6831"
-  tracing: <23>
+  tracing: # <19>
     type: jaeger
 ----
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes].
@@ -133,21 +125,17 @@ spec:
 <6> xref:con-common-configuration-trusted-certificates-reference[TLS encryption] with key names under which TLS certificates are stored in X.509 format for consumer or producer. If certificates are stored in the same secret, it can be listed multiple times.
 <7> Authentication for consumer or producer, specified as xref:type-KafkaClientAuthenticationTls-reference[mTLS], xref:type-KafkaClientAuthenticationOAuth-reference[token-based OAuth], SASL-based xref:type-KafkaClientAuthenticationScramSha256-reference[SCRAM-SHA-256]/xref:type-KafkaClientAuthenticationScramSha512-reference[SCRAM-SHA-512], or xref:type-KafkaClientAuthenticationPlain-reference[PLAIN].
 <8> Kafka configuration options for xref:property-consumer-config-reference[consumer] and xref:property-producer-config-reference[producer].
-<9> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
-<10> xref:type-KafkaMirrorMakerConsumerSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
-<11> If the xref:property-producer-abort-on-send-reference[`abortOnSendFailure` property] is set to `true`, Kafka MirrorMaker will exit and the container will restart following a send failure for a message.
-<12> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
-<13> xref:type-KafkaMirrorMakerProducerSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
-<14> A xref:property-mm-include-reference[included topics] mirrored from source to target Kafka cluster.
-<15> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<16> Specified xref:property-mm-loggers-reference[loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. MirrorMaker has a single logger called `mirrormaker.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<17> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<18> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
-<19> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<20> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<21> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<22> Environment variables are set for distributed tracing.
-<23> Distributed tracing is enabled for Jaeger.
+<9> If the xref:property-producer-abort-on-send-reference[`abortOnSendFailure` property] is set to `true`, Kafka MirrorMaker will exit and the container will restart following a send failure for a message.
+<10> A list of xref:property-mm-include-reference[included topics] mirrored from source to target Kafka cluster.
+<11> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<12> Specified xref:property-mm-loggers-reference[loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. MirrorMaker has a single logger called `mirrormaker.root.logger`. You can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<13> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<14> xref:con-common-configuration-prometheus-reference[Prometheus metrics], which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<15> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<16> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<17> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<18> Environment variables are set for distributed tracing.
+<19> Distributed tracing is enabled for Jaeger.
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.
 

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -105,69 +105,65 @@ spec:
       config.storage.replication.factor: 1
       offset.storage.replication.factor: 1
       status.storage.replication.factor: 1
-      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 # <13>
-      ssl.enabled.protocols: TLSv1.2
-      ssl.protocol: TLSv1.2
-      ssl.endpoint.identification.algorithm: HTTPS # <14>
-    tls: # <15>
+    tls: # <13>
       trustedCertificates:
       - certificate: ca.crt
         secretName: my-cluster-target-cluster-ca-cert
-  mirrors: # <16>
-  - sourceCluster: "my-cluster-source" # <17>
-    targetCluster: "my-cluster-target" # <18>
-    sourceConnector: # <19>
-      tasksMax: 10 # <20>
-      autoRestart: # <21>
+  mirrors: # <14>
+  - sourceCluster: "my-cluster-source" # <15>
+    targetCluster: "my-cluster-target" # <16>
+    sourceConnector: # <17>
+      tasksMax: 10 # <18>
+      autoRestart: # <19>
         enabled: true
       config:
-        replication.factor: 1 # <22>
-        offset-syncs.topic.replication.factor: 1 # <23>
-        sync.topic.acls.enabled: "false" # <24>
-        refresh.topics.interval.seconds: 60 # <25>
-        replication.policy.separator: "." # <26>
-        replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy" # <27>
-    heartbeatConnector: # <28>
+        replication.factor: 1 # <20>
+        offset-syncs.topic.replication.factor: 1 # <21>
+        sync.topic.acls.enabled: "false" # <22>
+        refresh.topics.interval.seconds: 60 # <23>
+        replication.policy.separator: "." # <24>
+        replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy" # <25>
+    heartbeatConnector: # <26>
       autoRestart:
         enabled: true
       config:
-        heartbeats.topic.replication.factor: 1 # <29>
-    checkpointConnector: # <30>
+        heartbeats.topic.replication.factor: 1 # <27>
+    checkpointConnector: # <28>
       autoRestart:
         enabled: true
       config:
-        checkpoints.topic.replication.factor: 1 # <31>
-        refresh.groups.interval.seconds: 600 # <32>
-        sync.group.offsets.enabled: true # <33>
-        sync.group.offsets.interval.seconds: 60 # <34>
-        emit.checkpoints.interval.seconds: 60 # <35>
+        checkpoints.topic.replication.factor: 1 # <29>
+        refresh.groups.interval.seconds: 600 # <30>
+        sync.group.offsets.enabled: true # <31>
+        sync.group.offsets.interval.seconds: 60 # <32>
+        emit.checkpoints.interval.seconds: 60 # <33>
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
-    topicsPattern: "topic1|topic2|topic3" # <36>
-    groupsPattern: "group1|group2|group3" # <37>
-  resources: # <38>
+    topicsPattern: "topic1|topic2|topic3" # <34>
+    groupsPattern: "group1|group2|group3" # <35>
+  resources: # <36>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: # <39>
+  logging: # <37>
     type: inline
     loggers:
       connect.root.logger.level: "INFO"
-  readinessProbe: # <40>
+  readinessProbe: # <38>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  jvmOptions: # <41>
+  jvmOptions: # <39>
     "-Xmx": "1g"
     "-Xms": "1g"
-  image: my-org/my-image:latest # <42>
+  image: my-org/my-image:latest # <40>
   rack:
-    topologyKey: topology.kubernetes.io/zone # <43>
-  template: # <44>
+    topologyKey: topology.kubernetes.io/zone # <41>
+  template: # <42>
     pod:
       affinity:
         podAntiAffinity:
@@ -180,7 +176,7 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: # <45>
+    connectContainer: # <43>
       env:
         - name: JAEGER_SERVICE_NAME
           value: my-jaeger-service
@@ -189,8 +185,8 @@ spec:
         - name: JAEGER_AGENT_PORT
           value: "6831"
   tracing:
-    type: jaeger # <46>
-  externalConfiguration: # <47>
+    type: jaeger # <44>
+  externalConfiguration: # <45>
     env:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
@@ -216,42 +212,40 @@ spec:
 <11> xref:con-common-configuration-bootstrap-reference[Bootstrap server] for connection to the target Kafka cluster.
 <12> xref:property-kafka-connect-config-reference[Kafka Connect configuration].
 Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
-<13> xref:con-common-configuration-ssl-reference[SSL properties] for external listeners to run with a specific _cipher suite_ for a TLS version.
-<14> xref:type-KafkaMirrorMaker2ClusterSpec-reference[Hostname verification is enabled] by setting to `HTTPS`. An empty string disables the verification.
-<15> TLS encryption for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
-<16> xref:type-KafkaMirrorMaker2MirrorSpec-reference[MirrorMaker 2 connectors].
-<17> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the source cluster used by the MirrorMaker 2 connectors.
-<18> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the target cluster used by the MirrorMaker 2 connectors.
-<19> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorSourceConnector`] that creates remote topics. The `config` overrides the default configuration options.
-<20> The maximum number of tasks that the connector may create. Tasks handle the data replication and run in parallel. If the infrastructure supports the processing overhead, increasing this value can improve throughput. Kafka Connect distributes the tasks between members of the cluster. If there are more tasks than workers, workers are assigned multiple tasks. For sink connectors, aim to have one task for each topic partition consumed. For source connectors, the number of tasks that can run in parallel may also depend on the external system. The connector creates fewer than the maximum number of tasks if it cannot achieve the parallelism.
-<21> Enables automatic restarts of failed connectors and tasks. Up to seven restart attempts are made, after which restarts must be made manually.
-<22> Replication factor for mirrored topics created at the target cluster.
-<23> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
-<24> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`. This feature is not compatible with the User Operator. If you are using the User Operator, set this property to `false`.
-<25> Optional setting to change the frequency of checks for new topics. The default is for a check every 10 minutes.
-<26> Defines the separator used for the renaming of remote topics.
-<27> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
+<13> TLS encryption for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
+<14> xref:type-KafkaMirrorMaker2MirrorSpec-reference[MirrorMaker 2 connectors].
+<15> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the source cluster used by the MirrorMaker 2 connectors.
+<16> xref:type-KafkaMirrorMaker2MirrorSpec-reference[Cluster alias] for the target cluster used by the MirrorMaker 2 connectors.
+<17> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorSourceConnector`] that creates remote topics. The `config` overrides the default configuration options.
+<18> The maximum number of tasks that the connector may create. Tasks handle the data replication and run in parallel. If the infrastructure supports the processing overhead, increasing this value can improve throughput. Kafka Connect distributes the tasks between members of the cluster. If there are more tasks than workers, workers are assigned multiple tasks. For sink connectors, aim to have one task for each topic partition consumed. For source connectors, the number of tasks that can run in parallel may also depend on the external system. The connector creates fewer than the maximum number of tasks if it cannot achieve the parallelism.
+<19> Enables automatic restarts of failed connectors and tasks. Up to seven restart attempts are made, after which restarts must be made manually.
+<20> Replication factor for mirrored topics created at the target cluster.
+<21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
+<22> When xref:con-mirrormaker-acls-{context}[ACL rules synchronization] is enabled, ACLs are applied to synchronized topics. The default is `true`. This feature is not compatible with the User Operator. If you are using the User Operator, set this property to `false`.
+<23> Optional setting to change the frequency of checks for new topics. The default is for a check every 10 minutes.
+<24> Defines the separator used for the renaming of remote topics.
+<25> Adds a policy that overrides the automatic renaming of remote topics. Instead of prepending the name with the name of the source cluster, the topic retains its original name. This optional setting is useful for active/passive backups and data migration.
 To configure topic offset synchronization, this property must also be set for the `checkpointConnector.config`.
-<28> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
-<29> Replication factor for the heartbeat topic created at the target cluster.
-<30> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
-<31> Replication factor for the checkpoints topic created at the target cluster.
-<32> Optional setting to change the frequency of checks for new consumer groups. The default is for a check every 10 minutes.
-<33> Optional setting to synchronize consumer group offsets, which is useful for recovery in an active/passive configuration. Synchronization is not enabled by default.
-<34> If the synchronization of consumer group offsets is enabled, you can adjust the frequency of the synchronization.
-<35> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.
-<36> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as a comma-separated list or regular expression pattern]. The source connector replicates the specified topics. The checkpoint connector tracks offsets for the specified topics. Here we request three topics by name.
-<37> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as a comma-separated list or regular expression pattern]. The checkpoint connector replicates the specified consumer groups. Here we request three consumer groups by name.
-<38> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
-<39> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<40> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<41> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
-<42> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
-<43> SPECIALIZED OPTION: xref:type-Rack-reference[Rack awareness] configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
-<44> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<45> Environment variables are set for distributed tracing.
-<46> Distributed tracing is enabled for Jaeger.
-<47> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
+<26> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorHeartbeatConnector`] that performs connectivity checks. The `config` overrides the default configuration options.
+<27> Replication factor for the heartbeat topic created at the target cluster.
+<28> xref:type-KafkaMirrorMaker2ConnectorSpec-reference[Configuration for the `MirrorCheckpointConnector`] that tracks offsets. The `config` overrides the default configuration options.
+<29> Replication factor for the checkpoints topic created at the target cluster.
+<30> Optional setting to change the frequency of checks for new consumer groups. The default is for a check every 10 minutes.
+<31> Optional setting to synchronize consumer group offsets, which is useful for recovery in an active/passive configuration. Synchronization is not enabled by default.
+<32> If the synchronization of consumer group offsets is enabled, you can adjust the frequency of the synchronization.
+<33> Adjusts the frequency of checks for offset tracking. If you change the frequency of offset synchronization, you might also need to adjust the frequency of these checks.
+<34> Topic replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as a comma-separated list or regular expression pattern]. The source connector replicates the specified topics. The checkpoint connector tracks offsets for the specified topics. Here we request three topics by name.
+<35> Consumer group replication from the source cluster xref:type-KafkaMirrorMaker2MirrorSpec-reference[defined as a comma-separated list or regular expression pattern]. The checkpoint connector replicates the specified consumer groups. Here we request three consumer groups by name.
+<36> Requests for reservation of xref:con-common-configuration-resources-reference[supported resources], currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
+<37> Specified xref:property-kafka-connect-logging-reference[Kafka Connect loggers and log levels] added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` or `log4j2.properties` key. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<38> xref:con-common-configuration-healthchecks-reference[Healthchecks] to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<39> xref:con-common-configuration-jvm-reference[JVM configuration options] to optimize performance for the Virtual Machine (VM) running Kafka MirrorMaker.
+<40> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
+<41> SPECIALIZED OPTION: xref:type-Rack-reference[Rack awareness] configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
+<42> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<43> Environment variables are set for distributed tracing.
+<44> Distributed tracing is enabled for Jaeger.
+<45> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 You can also use configuration provider plugins to load configuration values from external sources.
 
 . Create or update the resource:


### PR DESCRIPTION
**Documentation**

- Removes repeated example configuration for `ssl` TLS versions and cipher suites
- Streamlines and makes consistent the `config` sections for components in the schema reference, and removes the ssl config as we lonk to the common `ssl` config section


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

