### PR TITLE
docs(pdb): updates to handling of pod disruption budget with template config

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate.adoc
@@ -1,8 +1,15 @@
-Strimzi creates a `PodDisruptionBudget` for every new `StrimziPodSet` or `Deployment`.
-By default, pod disruption budgets only allow a single pod to be unavailable at a given time.
-You can increase the amount of unavailable pods allowed by changing the default value of the `maxUnavailable` property.
+A `PodDisruptionBudget` (PDB) is a Kubernetes resource that ensures high availability by specifying the minimum number of pods that must be available during planned maintenance or upgrades.
+Strimzi creates a PDB for every new `StrimziPodSet` or `Deployment`. 
+By default, the PDB allows only one pod to be unavailable at any given time.
+You can increase the number of unavailable pods allowed by changing the default value of the `maxUnavailable` property.
 
-.An example of `PodDisruptionBudget` template
+`StrimziPodSet` custom resources manage pods using a custom controller that cannot use the `maxUnavailable` value directly.
+Instead, the `maxUnavailable` value is converted to a `minAvailable` value, which effectively serves the same purpose, as illustrated in the following examples:
+
+* If there are three broker pods and the `maxUnavailable` property is set to `1` in the `Kafka` resource, the `minAvailable` setting is `2`, allowing one pod to be unavailable. 
+* If there are zero broker pods and the `maxUnavailable` property is set to `0` (zero), the `minAvailable` setting is also `0` (zero), allowing zero pods to be unavailable.
+
+.Example `PodDisruptionBudget` template configuration
 [source,yaml,subs=attributes+]
 ----
 # ...

--- a/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-deploying.adoc
@@ -8,6 +8,14 @@
 [role="_abstract"] 
 Deploy the Strimzi Drain Cleaner to the Kubernetes cluster where the Cluster Operator and Kafka cluster are running.
 
+Strimzi sets a default `PodDisruptionBudget` (PDB) that allows only one Kafka or ZooKeeper pod to be unavailable at any given time.
+To use the Drain Cleaner for planned maintenance or upgrades, you must set a PDB of zero.
+This is to prevent voluntary evictions of pods, and ensure that the Kafka or ZooKeeper cluster remains available.
+You do this by setting the `maxUnavailable` value to zero in the `Kafka` or `ZooKeeper` template. 
+`StrimziPodSet` custom resources manage Kafka and ZooKeeper pods using a custom controller that cannot use the `maxUnavailable` value directly.
+Instead, the `maxUnavailable` value is converted to a `minAvailable` value.
+If the `maxUnavailable` property is set to `0` (zero), the `minAvailable` setting is also `0` (zero), allowing zero pods to be unavailable.
+
 .Prerequisites
 
 * You have xref:drain-cleaner-prereqs-str[downloaded the Strimzi Drain Cleaner deployment files].
@@ -64,7 +72,7 @@ spec:
 
 .Procedure
 
-. Configure a pod disruption budget of `0` (zero) for your Kafka deployment using `template` settings in the `Kafka` resource.
+. Configure a pod disruption budget (PDB) of `0` (zero) for your Kafka deployment using `template` settings in the `Kafka` resource.
 +
 .Specifying a pod disruption budget
 [source,yaml,subs=attributes+]
@@ -88,8 +96,8 @@ spec:
   # ...
 ----
 +
-Reducing the maximum pod disruption budget to zero prevents Kubernetes from automatically evicting the pods in case of voluntary disruptions,
-leaving the Strimzi Drain Cleaner and Strimzi Cluster Operator to roll the pod which will be scheduled by Kubernetes on a different worker node.
+A PDB of zero prevents the automatic eviction of pods in case of planned disruptions,
+leaving the Strimzi Drain Cleaner and Cluster Operator to roll the pods on different worker nodes.
 +
 Add the same configuration for ZooKeeper if you want to use Strimzi Drain Cleaner to drain ZooKeeper nodes.
 

--- a/documentation/modules/upgrading/con-upgrade-cluster.adoc
+++ b/documentation/modules/upgrading/con-upgrade-cluster.adoc
@@ -18,7 +18,11 @@ You can employ one of the following strategies:
 .. Using the Strimzi Drain Cleaner
 .. Manually by applying an annotation to your pod
 
-You have to configure the pod disruption budget before using one of the methods to roll your pods.
+When using either of the methods to roll the pods, you must set a pod disruption budget of zero using the `maxUnavailable` property.
+
+NOTE: `StrimziPodSet` custom resources manage Kafka and ZooKeeper pods using a custom controller that cannot use the `maxUnavailable` value directly.
+Instead, the `maxUnavailable` value is converted to a `minAvailable` value.
+If the `maxUnavailable` property is set to `0` (zero), the `minAvailable` setting is also `0` (zero), allowing zero pods to be unavailable.
 
 For Kafka to stay operational, topics must also be replicated for high availability.
 This requires topic configuration that specifies a replication factor of at least 3 and a minimum number of in-sync replicas to 1 less than the replication factor.
@@ -45,7 +49,7 @@ In a highly available environment, the Cluster Operator maintains a minimum numb
 
 == Rolling pods using the Strimzi Drain Cleaner
 
-You can use the Strimzi Drain Cleaner tool to evict nodes during an upgrade.
+You can use the xref:assembly-drain-cleaner-{context}[Strimzi Drain Cleaner] to evict nodes during an upgrade.
 The Strimzi Drain Cleaner annotates pods with a rolling update pod annotation.
 This informs the Cluster Operator to perform a rolling update of an evicted pod.
 
@@ -55,8 +59,8 @@ During planned maintenance of Kafka broker pods, a pod disruption budget ensures
 You specify a pod disruption budget using a `template` customization for a Kafka component.
 By default, pod disruption budgets allow only a single pod to be unavailable at a given time.
 
-To do this, you set `maxUnavailable` to `0` (zero).
-Reducing the maximum pod disruption budget to zero prevents voluntary disruptions, so pods must be evicted manually.
+In order to use the Drain Cleaner to roll pods, you set `maxUnavailable` to `0` (zero).
+Reducing the pod disruption budget to zero prevents voluntary disruptions, so pods must be evicted manually.
 
 .Specifying a pod disruption budget
 [source,yaml,subs=attributes+]


### PR DESCRIPTION
**Documentation**

* Updates the [PodDisruptionBudgetTemplate schema reference](https://strimzi.io/docs/operators/in-development/configuring.html#type-PodDisruptionBudgetTemplate-reference) to explain that when configuring `maxUnavailable` the operator recalculates as  minAvailable, with examples and rationale.
* Updates the following sections to explain what happens with the `maxUnavailable` set at zero:
    * [Upgrading Kubernetes with minimal downtime](https://strimzi.io/docs/operators/in-development/deploying.html#con-upgrade-cluster-str)
    * [Evicting pods with the Strimzi Drain Cleaner](https://strimzi.io/docs/operators/in-development/deploying.html#assembly-drain-cleaner-str)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

