### PR TITLE
Avoid null error log

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -412,7 +412,11 @@ public class KafkaRoller {
         } catch (ForceableProblem e) {
             if (isPodStuck(pod) || restartContext.backOff.done() || e.forceNow) {
                 if (canRoll(nodeRef, 60_000, TimeUnit.MILLISECONDS, true, restartContext)) {
-                    LOGGER.warnCr(reconciliation, "Pod {} will be force-rolled, due to error: {}", nodeRef, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+                    String errorMsg = e.getMessage();
+                    if (e.getCause() != null) {
+                        errorMsg += ", caused by:" + (e.getCause().getMessage() != null ? e.getCause().getMessage() : e.getCause());
+                    }
+                    LOGGER.warnCr(reconciliation, "Pod {} will be force-rolled, due to error: {}", nodeRef, errorMsg);
                     restartContext.restartReasons.add(RestartReason.POD_FORCE_RESTART_ON_ERROR);
                     restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS, restartContext);
                 } else {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement 

### Description

While checking logs, I saw this line in CO:
```
WARN  KafkaRoller:415 - ... Pod my-cluster-ce79efc2-kafka-3/3 will be force-rolled, due to error: null
```
It is meaningless to print this warning log. After investigation, found the error is:
```
ForceableProblem: Error getting broker config
caused by: java.util.concurrent.TimeoutException
```
Because the `TimeoutException` has no message, it output `null` in log. After this PR, the log will show:
```
Pod my-cluster-ce79efc2-kafka-3/3 will be force-rolled, due to error: Error getting broker config, caused by java.util.concurrent.TimeoutException
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [v ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

