### PR TITLE
Consider missing pods when rolling the ZooKeeper cluster

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -374,8 +374,10 @@ public class CaReconciler {
     }
 
     /**
-     * Finds the number of current ZooKeeper replicas. We need to find the current number because if new trust should be
-     * rolled out while scaling event is happening, we have to roll out the trust only to the existing pods.
+     * If we need to roll the ZooKeeper cluster to roll out the trust to a new CA private key (i.e. when a CA private
+     * key is replaced), we need to know what the current number of ZooKeeper nodes is. Getting it from the Kafka custom
+     * resource might not be good enough if a scale-up /scale-down is happening at the same time. So we get the
+     * StrimziPodSet and find out the correct number of ZooKeeper nodes from it.
      *
      * @return  Current number of ZooKeeper replicas
      */
@@ -393,7 +395,7 @@ public class CaReconciler {
     }
 
     /**
-     * Checks whether the ZooKeeper cluster needs ot be rolled to trust the new private key. ZooKeeper uses only the
+     * Checks whether the ZooKeeper cluster needs ot be rolled to trust the new CA private key. ZooKeeper uses only the
      * Cluster CA and not the Clients CA. So the rolling happens only when Cluster CA private key changed.
      *
      * @param replicas              Current number of ZooKeeper replicas

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -374,8 +374,8 @@ public class CaReconciler {
     }
 
     /**
-     * If we need to roll the ZooKeeper cluster to roll out the trust to a new CA private key (i.e. when a CA private
-     * key is replaced), we need to know what the current number of ZooKeeper nodes is. Getting it from the Kafka custom
+     * If we need to roll the ZooKeeper cluster to roll out the trust to a new CA certificate when a CA private key is
+     * being replaced, we need to know what the current number of ZooKeeper nodes is. Getting it from the Kafka custom
      * resource might not be good enough if a scale-up /scale-down is happening at the same time. So we get the
      * StrimziPodSet and find out the correct number of ZooKeeper nodes from it.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -725,7 +725,14 @@ public class ZooKeeperReconciler {
      */
     private Future<Void> maybeRollZooKeeper(Function<Pod, List<String>> podNeedsRestart, Secret clusterCaCertSecret, Secret coKeySecret) {
         return new ZooKeeperRoller(podOperator, zooLeaderFinder, operationTimeoutMs)
-                .maybeRollingUpdate(reconciliation, zk.getSelectorLabels(), podNeedsRestart, clusterCaCertSecret, coKeySecret);
+                .maybeRollingUpdate(
+                        reconciliation,
+                        currentReplicas > 0 && currentReplicas < zk.getReplicas() ? currentReplicas : zk.getReplicas(),
+                        zk.getSelectorLabels(),
+                        podNeedsRestart,
+                        clusterCaCertSecret,
+                        coKeySecret
+                );
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.Labels;
@@ -24,10 +25,8 @@ import java.util.stream.Collectors;
  * rolled last.
  */
 public class ZooKeeperRoller {
-
-    private static final long READINESS_POLLING_INTERVAL_MS = 1_000;
-
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ZooKeeperRoller.class.getName());
+    private static final long READINESS_POLLING_INTERVAL_MS = 1_000;
 
     private final PodOperator podOperator;
     private final ZookeeperLeaderFinder leaderFinder;
@@ -36,9 +35,9 @@ public class ZooKeeperRoller {
     /**
      * Constructor
      *
-     * @param podOperator           Pod operator
-     * @param leaderFinder          ZooKeeper Leader Finder
-     * @param operationTimeoutMs    Operation timeout in milliseconds
+     * @param podOperator        Pod operator
+     * @param leaderFinder       ZooKeeper Leader Finder
+     * @param operationTimeoutMs Operation timeout in milliseconds
      */
     public ZooKeeperRoller(PodOperator podOperator, ZookeeperLeaderFinder leaderFinder, long operationTimeoutMs) {
         this.podOperator = podOperator;
@@ -52,30 +51,49 @@ public class ZooKeeperRoller {
      * leader node and roll it last.
      *
      * @param reconciliation    The reconciliation
+     * @param replicas          Number of ZooKeeper replicas to roll
      * @param selectorLabels    The selector labels to find the pods
-     * @param podRestart        Function that returns a list is reasons why the given pod needs to be restarted, or an empty list if the pod does not need to be restarted.
+     * @param podRestart        Function that returns a list is reasons why the given pod needs to be restarted, or an
+     *                          empty list if the pod does not need to be restarted.
      * @param clusterCaSecret   Secret with cluster CA certificates
      * @param coKeySecret       Secret with the Cluster operator certificates
      *
      * @return A future that completes when any necessary rolling has been completed.
      */
-    public Future<Void> maybeRollingUpdate(Reconciliation reconciliation, Labels selectorLabels, Function<Pod, List<String>> podRestart, Secret clusterCaSecret, Secret coKeySecret) {
+    public Future<Void> maybeRollingUpdate(Reconciliation reconciliation, int replicas, Labels selectorLabels, Function<Pod, List<String>> podRestart, Secret clusterCaSecret, Secret coKeySecret) {
         String namespace = reconciliation.namespace();
+
+        // We prepare the list of expected Pods. This is needed as we need to account for pods which might be missing.
+        // We need to wait for them before rolling any running pods to avoid problems.
+        List<String> expectedPodNames = new ArrayList<>();
+        for (int i = 0; i < replicas; i++)  {
+            expectedPodNames.add(KafkaResources.zookeeperPodName(reconciliation.name(), i));
+        }
 
         return podOperator.listAsync(namespace, selectorLabels)
                 .compose(pods -> {
                     ZookeeperClusterRollContext clusterRollContext = new ZookeeperClusterRollContext();
 
-                    for (Pod pod : pods)    {
-                        List<String> restartReasons = podRestart.apply(pod);
-                        final boolean ready = podOperator.isReady(namespace, pod.getMetadata().getName());
-                        ZookeeperPodContext podContext = new ZookeeperPodContext(pod, restartReasons, ready);
-                        if (restartReasons != null && !restartReasons.isEmpty())    {
-                            LOGGER.debugCr(reconciliation, "Pod {} should be rolled due to {}", podContext.getPodName(), restartReasons);
+                    for (String podName : expectedPodNames) {
+                        Pod pod = pods.stream().filter(p -> podName.equals(p.getMetadata().getName())).findFirst().orElse(null);
+
+                        if (pod != null)    {
+                            List<String> restartReasons = podRestart.apply(pod);
+                            final boolean ready = podOperator.isReady(namespace, pod.getMetadata().getName());
+                            ZookeeperPodContext podContext = new ZookeeperPodContext(podName, restartReasons, true, ready);
+                            if (restartReasons != null && !restartReasons.isEmpty())    {
+                                LOGGER.infoCr(reconciliation, "Pod {} should be rolled due to {}", podContext.getPodName(), restartReasons);
+                            } else {
+                                LOGGER.infoCr(reconciliation, "Pod {} does not need to be rolled", podContext.getPodName());
+                            }
+                            clusterRollContext.add(podContext);
                         } else {
-                            LOGGER.debugCr(reconciliation, "Pod {} does not need to be rolled", podContext.getPodName());
+                            // Pod does not exist, but we still add it to the roll context because we should not roll
+                            // any other pods before it is ready
+                            LOGGER.infoCr(reconciliation, "Pod {} does not exist and cannot be rolled", podName);
+                            ZookeeperPodContext podContext = new ZookeeperPodContext(podName, null, false, false);
+                            clusterRollContext.add(podContext);
                         }
-                        clusterRollContext.add(podContext);
                     }
 
                     if (clusterRollContext.requiresRestart())   {
@@ -93,7 +111,7 @@ public class ZooKeeperRoller {
                             Future<Void> fut = Future.succeededFuture();
 
                             // Then roll each non-leader pod => the leader is rolled last
-                            for (ZookeeperPodContext podContext : clusterRollContext.getPodContextsWithNonReadyFirst())  {
+                            for (ZookeeperPodContext podContext : clusterRollContext.getPodContextsWithNonExistingAndNonReadyFirst())  {
                                 if (podContext.requiresRestart() && !podContext.getPodName().equals(leader)) {
                                     LOGGER.debugCr(reconciliation, "Pod {} needs to be restarted", podContext.getPodName());
                                     // roll the pod and wait until it is ready
@@ -148,54 +166,120 @@ public class ZooKeeperRoller {
                 });
     }
 
-    private static class ZookeeperClusterRollContext {
-
+    /**
+     * Internal class which helps to establish which pods need to be rolled and what should be the rolling order
+     */
+    /* test */ static class ZookeeperClusterRollContext {
         private final List<ZookeeperPodContext> podContexts = new ArrayList<>();
 
-        private ZookeeperClusterRollContext() {
+        /**
+         * Constructor
+         */
+        ZookeeperClusterRollContext() {
         }
 
-        public List<ZookeeperPodContext> getPodContextsWithNonReadyFirst() {
-            return podContexts.stream().sorted((contextA, contextB) -> Boolean.compare(contextA.ready, contextB.ready)).collect(Collectors.toList());
+        /**
+         * @return  List of pods to consider for rolling in the right order -> missing pods first, unready next, ready last.
+         */
+        List<ZookeeperPodContext> getPodContextsWithNonExistingAndNonReadyFirst() {
+            return podContexts.stream().sorted(ZookeeperClusterRollContext::findNext).collect(Collectors.toList());
         }
 
-        public void add(final ZookeeperPodContext podContext) {
+        /**
+         * Utility method to help order the pods in the order in which they should be checked for rolling. It is used as
+         * a comparator to compere to ZooKeeperPodContext instances. It compares them in the way that missing pods are
+         * checked first, then unready pods and only at the end the ready pods.
+         *
+         * @param contextA  Context for Pod A
+         * @param contextB  Context for Pod B
+         *
+         * @return  -1 if the Pod from contextA should be rolled first, 0 when their equal in their rolling order and 1
+         *          when the Pod from contextB should be checked first.
+         */
+        private static int findNext(ZookeeperPodContext contextA, ZookeeperPodContext contextB)  {
+            if (!contextA.exists && !contextB.exists)   {
+                return 0;
+            } else if (!contextA.exists)   {
+                return -1;
+            } else if (!contextB.exists)   {
+                return 1;
+            } else {
+                return Boolean.compare(contextA.ready, contextB.ready);
+            }
+        }
+
+        /**
+         * Add a ZooKeeper Pod to the rolling context
+         *
+         * @param podContext    ZooKeeper Pod context representing a pod which should be rolled or considered for rolling
+         */
+        void add(final ZookeeperPodContext podContext) {
             podContexts.add(podContext);
         }
 
-        public boolean requiresRestart() {
+        /**
+         * @return  True if any of the pods in this context requires restart. False otherwise.
+         */
+        boolean requiresRestart() {
             return podContexts.stream().anyMatch(ZookeeperPodContext::requiresRestart);
         }
 
-        public Set<String> podNames() {
+        /**
+         * @return  Set with the names of the ZooKeeper pods in this context
+         */
+        Set<String> podNames() {
             return podContexts.stream().map(ZookeeperPodContext::getPodName).collect(Collectors.toSet());
         }
 
-        public ZookeeperPodContext get(final String podName) {
+        /**
+         * Gets a Pod context for a given pod name
+         *
+         * @param podName   Name of the pod for which we want to retrieve the context
+         *
+         * @return  The ZooKeeper Pod Context
+         */
+        ZookeeperPodContext get(final String podName) {
             return podContexts.stream().filter(podContext -> podContext.getPodName().equals(podName)).findAny().orElse(null);
         }
     }
 
-    private static class ZookeeperPodContext {
-
-        private final Pod pod;
-
+    /**
+     * Internal class which carries the rolling context for a specific ZooKeeper Pod
+     */
+    /* test */ static class ZookeeperPodContext {
+        private final String podName;
+        private final boolean exists;
         private final boolean ready;
-
         private final List<String> reasonsToRestart = new ArrayList<>();
 
-        private ZookeeperPodContext(final Pod pod, final List<String> reasonsToRestart, final boolean ready) {
-            this.pod = pod;
+        /**
+         * Constructs the ZooKeeper Pod Context
+         *
+         * @param podName          Name of this ZooKeeper pod
+         * @param reasonsToRestart List with the reasons why this pod might need to be restarted
+         * @param exists           Flag indicating if this pod exists or not
+         * @param ready            Flag indicating whether this pod is ready or not
+         */
+        ZookeeperPodContext(final String podName, final List<String> reasonsToRestart, final boolean exists, final boolean ready) {
+            this.podName = podName;
+            this.exists = exists;
             this.ready = ready;
+
             if (reasonsToRestart != null) {
                 this.reasonsToRestart.addAll(reasonsToRestart);
             }
         }
 
+        /**
+         * @return Name of this pod
+         */
         String getPodName() {
-            return pod.getMetadata().getName();
+            return podName;
         }
 
+        /**
+         * @return True if this pod requires restart. False otherwise.
+         */
         boolean requiresRestart() {
             return !reasonsToRestart.isEmpty();
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #7685, today, when a Pod is completely missing (e.g. because the Pod YAML is invalid - this could happen by invalid resources in the past and probably still can today for example due to misconfigured affinity etc.), the ZooKeeper Roller didn't consider it in the rolling process. As a result, it could have taken the whole ZooKeeper cluster down one by one by rolling the issue to next pod in every reconciliation.

This PR updates the ZooKeeper Roller to consider missing pods as well. If the pod is completely missing, it will first wait for it to get ready. Then it will consider unready pods (if there are any) and only last the ready pods will be considered.

Thanks to this, if some configuration issue makes to pod missing, the operator will not roll this out to more pods and instead will stop at the first one.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally