### PR TITLE
Improve Mirror Maker examples

### DIFF
--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -5,30 +5,33 @@ metadata:
 spec:
   version: 3.4.0
   replicas: 1
-  connectCluster: "my-target-cluster"
+  connectCluster: "cluster-b" # Must be the target custer
   clusters:
-  - alias: "my-source-cluster"
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
-  - alias: "my-target-cluster"
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+  - alias: "cluster-a" # Source cluster
+    bootstrapServers: cluster-a-kafka-bootstrap:9092
+  - alias: "cluster-b" # Target cluster
+    bootstrapServers: cluster-b-kafka-bootstrap:9092
     config:
       # -1 means it will use the default replication factor configured in the broker
       config.storage.replication.factor: -1
       offset.storage.replication.factor: -1
       status.storage.replication.factor: -1
   mirrors:
-  - sourceCluster: "my-source-cluster"
-    targetCluster: "my-target-cluster"
+  - sourceCluster: "cluster-a"
+    targetCluster: "cluster-b"
     sourceConnector:
+      tasksMax: 1
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
     heartbeatConnector:
+      tasksMax: 1
       config:
         heartbeats.topic.replication.factor: 1
     checkpointConnector:
+      tasksMax: 1
       config:
         checkpoints.topic.replication.factor: 1
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -5,29 +5,32 @@ metadata:
 spec:
   version: 3.4.0
   replicas: 1
-  connectCluster: "my-target-cluster"
+  connectCluster: "cluster-b" # Must be the target custer
   clusters:
-  - alias: "my-source-cluster"
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
-  - alias: "my-target-cluster"
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+  - alias: "cluster-a" # Source cluster
+    bootstrapServers: cluster-a-kafka-bootstrap:9092
+  - alias: "cluster-b" # Target cluster
+    bootstrapServers: cluster-b-kafka-bootstrap:9092
     config:
       # -1 means it will use the default replication factor configured in the broker
       config.storage.replication.factor: -1
       offset.storage.replication.factor: -1
       status.storage.replication.factor: -1
   mirrors:
-  - sourceCluster: "my-source-cluster"
-    targetCluster: "my-target-cluster"
+  - sourceCluster: "cluster-a"
+    targetCluster: "cluster-b"
     sourceConnector:
+      tasksMax: 1
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
     heartbeatConnector:
+      tasksMax: 1
       config:
         heartbeats.topic.replication.factor: 1
     checkpointConnector:
+      tasksMax: 1
       config:
         checkpoints.topic.replication.factor: 1
         sync.group.offsets.enabled: "true"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
@@ -5,19 +5,19 @@ metadata:
 spec:
   version: 3.4.0
   replicas: 1
-  connectCluster: "my-target-cluster"
+  connectCluster: "cluster-b" # Must be the target custer
   clusters:
-  - alias: "my-source-cluster"
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9093
+  - alias: "cluster-a" # Source cluster
+    bootstrapServers: cluster-a-kafka-bootstrap:9093
     tls:
       trustedCertificates:
-        - secretName: my-source-cluster-cluster-ca-cert
+        - secretName: cluster-a-cluster-ca-cert
           certificate: ca.crt
-  - alias: "my-target-cluster"
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9093
+  - alias: "cluster-b" # Target cluster
+    bootstrapServers: cluster-b-kafka-bootstrap:9093
     tls:
       trustedCertificates:
-        - secretName: my-target-cluster-cluster-ca-cert
+        - secretName: cluster-b-cluster-ca-cert
           certificate: ca.crt
     config:
       # -1 means it will use the default replication factor configured in the broker
@@ -25,17 +25,20 @@ spec:
       offset.storage.replication.factor: -1
       status.storage.replication.factor: -1
   mirrors:
-  - sourceCluster: "my-source-cluster"
-    targetCluster: "my-target-cluster"
+  - sourceCluster: "cluster-a"
+    targetCluster: "cluster-b"
     sourceConnector:
+      tasksMax: 1
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
     heartbeatConnector:
+      tasksMax: 1
       config:
         heartbeats.topic.replication.factor: 1
     checkpointConnector:
+      tasksMax: 1
       config:
         checkpoints.topic.replication.factor: 1
     topicsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
@@ -5,29 +5,32 @@ metadata:
 spec:
   version: 3.4.0
   replicas: 1
-  connectCluster: "my-target-cluster"
+  connectCluster: "cluster-b" # Must be the target custer
   clusters:
-  - alias: "my-source-cluster"
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
-  - alias: "my-target-cluster"
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+  - alias: "cluster-a" # Source cluster
+    bootstrapServers: cluster-a-kafka-bootstrap:9092
+  - alias: "cluster-b" # Target cluster
+    bootstrapServers: cluster-b-kafka-bootstrap:9092
     config:
       # -1 means it will use the default replication factor configured in the broker
       config.storage.replication.factor: -1
       offset.storage.replication.factor: -1
       status.storage.replication.factor: -1
   mirrors:
-  - sourceCluster: "my-source-cluster"
-    targetCluster: "my-target-cluster"
+  - sourceCluster: "cluster-a"
+    targetCluster: "cluster-b"
     sourceConnector:
+      tasksMax: 1
       config:
         replication.factor: 1
         offset-syncs.topic.replication.factor: 1
         sync.topic.acls.enabled: "false"
     heartbeatConnector:
+      tasksMax: 1
       config:
         heartbeats.topic.replication.factor: 1
     checkpointConnector:
+      tasksMax: 1
       config:
         checkpoints.topic.replication.factor: 1
     topicsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-tls.yaml
@@ -6,16 +6,16 @@ spec:
   version: 3.4.0
   replicas: 1
   consumer:
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9093
-    groupId: my-source-group-id
+    bootstrapServers: cluster-a-kafka-bootstrap:9093 # Source cluster
+    groupId: cluster-a-group-id
     tls:
       trustedCertificates:
-        - secretName: my-source-cluster-cluster-ca-cert
+        - secretName: cluster-a-cluster-ca-cert
           certificate: ca.crt
   producer:
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9093
+    bootstrapServers: cluster-b-kafka-bootstrap:9093 # Target cluster
     tls:
       trustedCertificates:
-        - secretName: my-target-cluster-cluster-ca-cert
+        - secretName: cluster-b-cluster-ca-cert
           certificate: ca.crt
   include: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker.yaml
@@ -6,8 +6,8 @@ spec:
   version: 3.4.0
   replicas: 1
   consumer:
-    bootstrapServers: my-source-cluster-kafka-bootstrap:9092
-    groupId: my-source-group-id
+    bootstrapServers: cluster-a-kafka-bootstrap:9092 # Source cluster
+    groupId: cluster-a-group-id
   producer:
-    bootstrapServers: my-target-cluster-kafka-bootstrap:9092
+    bootstrapServers: cluster-b-kafka-bootstrap:9092 # Target cluster
   include: ".*"

--- a/packaging/examples/mirror-maker/kafka-source.yaml
+++ b/packaging/examples/mirror-maker/kafka-source.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: my-source-cluster
+  name: cluster-a
 spec:
   kafka:
     version: 3.4.0

--- a/packaging/examples/mirror-maker/kafka-target.yaml
+++ b/packaging/examples/mirror-maker/kafka-target.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: my-target-cluster
+  name: cluster-b
 spec:
   kafka:
     version: 3.4.0
@@ -25,10 +25,10 @@ spec:
     storage:
       type: jbod
       volumes:
-      - id: 0
-        type: persistent-claim
-        size: 100Gi
-        deleteClaim: false
+        - id: 0
+          type: persistent-claim
+          size: 100Gi
+          deleteClaim: false
   zookeeper:
     replicas: 1
     storage:

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: my-source-cluster
+  name: cluster-a
 spec:
   kafka:
     version: 3.4.0
@@ -43,7 +43,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: my-target-cluster
+  name: cluster-b
 spec:
   kafka:
     version: 3.4.0
@@ -84,9 +84,9 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
-  name: my-source-user
+  name: cluster-a-user
   labels:
-    strimzi.io/cluster: my-source-cluster
+    strimzi.io/cluster: cluster-a
 spec:
   authentication:
     type: scram-sha-512
@@ -96,7 +96,7 @@ spec:
       # MirrorSourceConnector
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
+          name: mm2-offset-syncs.cluster-b.internal
         operations:
           - Create
           - DescribeConfigs
@@ -120,7 +120,7 @@ spec:
           - Describe
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
+          name: mm2-offset-syncs.cluster-b.internal
         operations:
           - Read
 ---
@@ -128,9 +128,9 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
-  name: my-target-user
+  name: cluster-b-user
   labels:
-    strimzi.io/cluster: my-target-cluster
+    strimzi.io/cluster: cluster-b
 spec:
   authentication:
     type: scram-sha-512
@@ -186,7 +186,7 @@ spec:
           - Describe
       - resource:
           type: topic
-          name: my-source-cluster.checkpoints.internal
+          name: cluster-a.checkpoints.internal
         operations:
           - Create
           - Describe
@@ -196,7 +196,7 @@ spec:
           name: "*"
         operations:
           - Read
-          - Decribe
+          - Describe
       - resource: # Needed for every topic which is mirrored
           type: topic
           name: "*"
@@ -219,31 +219,31 @@ metadata:
 spec:
   version: 3.4.0
   replicas: 1
-  connectCluster: "my-target-cluster"
+  connectCluster: "cluster-b" # Must be the target custer
   clusters:
-    - alias: "my-source-cluster"
-      bootstrapServers: my-source-cluster-kafka-bootstrap:9093
+    - alias: "cluster-a" # Source cluster
+      bootstrapServers: cluster-a-kafka-bootstrap:9093
       tls:
         trustedCertificates:
-          - secretName: my-source-cluster-cluster-ca-cert
+          - secretName: cluster-a-cluster-ca-cert
             certificate: ca.crt
       authentication:
         type: scram-sha-512
-        username: my-source-user
+        username: cluster-a-user
         passwordSecret:
-          secretName: my-source-user
+          secretName: cluster-a-user
           password: password
-    - alias: "my-target-cluster"
-      bootstrapServers: my-target-cluster-kafka-bootstrap:9093
+    - alias: "cluster-b" # Target cluster
+      bootstrapServers: cluster-b-kafka-bootstrap:9093
       tls:
         trustedCertificates:
-          - secretName: my-target-cluster-cluster-ca-cert
+          - secretName: cluster-b-cluster-ca-cert
             certificate: ca.crt
       authentication:
         type: scram-sha-512
-        username: my-target-user
+        username: cluster-b-user
         passwordSecret:
-          secretName: my-target-user
+          secretName: cluster-b-user
           password: password
       config:
         # -1 means it will use the default replication factor configured in the broker
@@ -251,17 +251,20 @@ spec:
         offset.storage.replication.factor: -1
         status.storage.replication.factor: -1
   mirrors:
-    - sourceCluster: "my-source-cluster"
-      targetCluster: "my-target-cluster"
+    - sourceCluster: "cluster-a"
+      targetCluster: "cluster-b"
       sourceConnector:
+        tasksMax: 1
         config:
           replication.factor: 1
           offset-syncs.topic.replication.factor: 1
           sync.topic.acls.enabled: "false"
       heartbeatConnector:
+        tasksMax: 1
         config:
           heartbeats.topic.replication.factor: 1
       checkpointConnector:
+        tasksMax: 1
         config:
           checkpoints.topic.replication.factor: 1
           sync.group.offsets.enabled: "true"

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: my-source-cluster
+  name: cluster-a
 spec:
   kafka:
     version: 3.4.0
@@ -43,7 +43,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: my-target-cluster
+  name: cluster-b
 spec:
   kafka:
     version: 3.4.0
@@ -84,9 +84,9 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
-  name: my-source-user
+  name: cluster-a-user
   labels:
-    strimzi.io/cluster: my-source-cluster
+    strimzi.io/cluster: cluster-a
 spec:
   authentication:
     type: tls
@@ -96,7 +96,7 @@ spec:
       # MirrorSourceConnector
       - resource: # Not needed if offset-syncs.topic.location=target
           type: topic
-          name: mm2-offset-syncs.my-target-cluster.internal
+          name: mm2-offset-syncs.cluster-b.internal
         operations:
           - Read
           - DescribeConfigs
@@ -123,9 +123,9 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
-  name: my-target-user
+  name: cluster-b-user
   labels:
-    strimzi.io/cluster: my-target-cluster
+    strimzi.io/cluster: cluster-b
 spec:
   authentication:
     type: tls
@@ -182,7 +182,7 @@ spec:
           - Describe
       - resource:
           type: topic
-          name: my-source-cluster.checkpoints.internal
+          name: cluster-a.checkpoints.internal
         operations:
           - Describe
           - Write
@@ -211,30 +211,30 @@ metadata:
 spec:
   version: 3.4.0
   replicas: 1
-  connectCluster: "my-target-cluster"
+  connectCluster: "cluster-b" # Must be the target custer
   clusters:
-    - alias: "my-source-cluster"
-      bootstrapServers: my-source-cluster-kafka-bootstrap:9093
+    - alias: "cluster-a"  # Source cluster
+      bootstrapServers: cluster-a-kafka-bootstrap:9093
       tls:
         trustedCertificates:
-          - secretName: my-source-cluster-cluster-ca-cert
+          - secretName: cluster-a-cluster-ca-cert
             certificate: ca.crt
       authentication:
         type: tls
         certificateAndKey:
-          secretName: my-source-user
+          secretName: cluster-a-user
           certificate: user.crt
           key: user.key
-    - alias: "my-target-cluster"
-      bootstrapServers: my-target-cluster-kafka-bootstrap:9093
+    - alias: "cluster-b" # Target cluster
+      bootstrapServers: cluster-b-kafka-bootstrap:9093
       tls:
         trustedCertificates:
-          - secretName: my-target-cluster-cluster-ca-cert
+          - secretName: cluster-b-cluster-ca-cert
             certificate: ca.crt
       authentication:
         type: tls
         certificateAndKey:
-          secretName: my-target-user
+          secretName: cluster-b-user
           certificate: user.crt
           key: user.key
       config:
@@ -243,17 +243,20 @@ spec:
         offset.storage.replication.factor: -1
         status.storage.replication.factor: -1
   mirrors:
-    - sourceCluster: "my-source-cluster"
-      targetCluster: "my-target-cluster"
+    - sourceCluster: "cluster-a"
+      targetCluster: "cluster-b"
       sourceConnector:
+        tasksMax: 1
         config:
           replication.factor: 1
           offset-syncs.topic.replication.factor: 1
           sync.topic.acls.enabled: "false"
       heartbeatConnector:
+        tasksMax: 1
         config:
           heartbeats.topic.replication.factor: 1
       checkpointConnector:
+        tasksMax: 1
         config:
           checkpoints.topic.replication.factor: 1
           sync.group.offsets.enabled: "true"


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR tries to improve the Mirror Maker examples.
* It renames the Kafka clusters from `my-source-cluster` and `my-target-cluster` to `cluster-a` and `cluster-b`. This should hopefully make it more clear that the cluster aliases should not be named based on source and target but rather based on what they are.
* To the Mirror Maker 2 examples, it adds the `tasksMax` fields with the default value `1`. This should help to make it clear where should it be and that it s something that might be configured to improve performance.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally