### PR TITLE
docs(downgrade): updates the warning on downgrade approaches

### DIFF
--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -17,9 +17,9 @@ If you used the YAML installation files to install Strimzi, you can use the YAML
 If the previous version of Strimzi does not support the version of Kafka you are using,
 you can also downgrade Kafka as long as the log message format versions appended to messages match.
 
-WARNING: If you deployed Strimzi using another installation method, use a supported approach to downgrade Strimzi.
-Do not use the downgrade instructions provided here. 
-For example, if you installed Strimzi using the Operator Lifecycle Manager (OLM), you can downgrade by changing the deployment channel to an earlier version of Strimzi. 
+WARNING: The following downgrade instructions are only suitable if you installed Strimzi using the installation files. 
+If you used a different method like {OperatorHub}, refer to their downgrade instructions. 
+To ensure a successful downgrade process, it is essential to use a supported approach.
 
 //steps to downgrade the operators
 include::../../modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
**Documentation**

The warning given in the docs on downgrading Strimzi could be misinterpreted.
For example, changing the channel in the OLM is not all that is needed.
It is likely that the operator and all files need to be deleted and then the Strimzi operator reinstalled at an earlier version.
This PR updates the warning to make it clear that the downgrade approach should be supported for the installation method used with reference to the instructions provided by that method. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

