### PR TITLE
ST: Increase memory for CO to 512Mi in STs on FIPS clusters

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -455,4 +455,12 @@ public interface Constants {
         ROLE, PATH_TO_LEASE_ROLE,
         ROLE_BINDING, PATH_TO_LEASE_ROLE_BINDING
     );
+
+    /**
+     * Cluster Operator resources config
+     */
+    String CO_REQUESTS_MEMORY = "512Mi";
+    String CO_REQUESTS_CPU = "200m";
+    String CO_LIMITS_MEMORY = "512Mi";
+    String CO_LIMITS_CPU = "1000m";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -140,7 +140,7 @@ public class Environment {
     public static final String ST_FILE_PLUGIN_URL_ENV = "ST_FILE_SINK_PLUGIN_URL";
 
     /**
-     * CO Features gates variable
+     * Resource allocation strategy
      */
     public static final String RESOURCE_ALLOCATION_STRATEGY_ENV = "RESOURCE_ALLOCATION_STRATEGY";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/FIPSNotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/FIPSNotSupportedCondition.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
-
 public class FIPSNotSupportedCondition implements ExecutionCondition {
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/FIPSNotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/FIPSNotSupportedCondition.java
@@ -14,11 +14,7 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 public class FIPSNotSupportedCondition implements ExecutionCondition {
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
-        boolean fipsEnabled = false;
-
-        if (KubeClusterResource.getInstance().isOpenShift()) {
-            fipsEnabled = kubeClient().getConfigMap("kube-system", "cluster-config-v1").getData().get("install-config").contains("fips: true");
-        }
+        boolean fipsEnabled = KubeClusterResource.getInstance().fipsEnabled();
 
         return fipsEnabled ? ConditionEvaluationResult.disabled("Test is disabled") : ConditionEvaluationResult.enabled("Test is enabled");
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -21,6 +21,7 @@ import io.strimzi.systemtest.resources.kubernetes.DeploymentResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -238,7 +239,7 @@ public class BundleResource implements ResourceType<Deployment> {
         clusterOperator.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(envVarsWithoutDuplicates);
 
         // Change default values for Cluster Operator memory when RESOURCE_ALLOCATION_STRATEGY is not set to NOT_SHARED
-        if (Environment.isSharedMemory()) {
+        if (KubeClusterResource.getInstance().fipsEnabled()) {
             ResourceRequirements resourceRequirements = new ResourceRequirementsBuilder()
                 .withRequests(Map.of("memory", new Quantity(Constants.CO_REQUESTS_MEMORY), "cpu", new Quantity(Constants.CO_REQUESTS_CPU)))
                 .withLimits(Map.of("memory", new Quantity(Constants.CO_LIMITS_MEMORY), "cpu", new Quantity(Constants.CO_LIMITS_CPU)))

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
@@ -30,11 +30,6 @@ public class HelmResource implements SpecificResourceType {
     public static final String HELM_CHART = TestUtils.USER_PATH + "/../packaging/helm-charts/helm3/strimzi-kafka-operator/";
     public static final String HELM_RELEASE_NAME = "strimzi-systemtests";
 
-    public static final String REQUESTS_MEMORY = "512Mi";
-    public static final String REQUESTS_CPU = "200m";
-    public static final String LIMITS_MEMORY = "512Mi";
-    public static final String LIMITS_CPU = "1000m";
-
     private String namespaceToWatch;
     private String namespaceInstallTo;
 
@@ -79,10 +74,10 @@ public class HelmResource implements SpecificResourceType {
 
         // Additional config
         values.put("image.imagePullPolicy", Environment.OPERATOR_IMAGE_PULL_POLICY);
-        values.put("resources.requests.memory", REQUESTS_MEMORY);
-        values.put("resources.requests.cpu", REQUESTS_CPU);
-        values.put("resources.limits.memory", LIMITS_MEMORY);
-        values.put("resources.limits.cpu", LIMITS_CPU);
+        values.put("resources.requests.memory", Constants.CO_REQUESTS_MEMORY);
+        values.put("resources.requests.cpu", Constants.CO_REQUESTS_CPU);
+        values.put("resources.limits.memory", Constants.CO_LIMITS_MEMORY);
+        values.put("resources.limits.cpu", Constants.CO_LIMITS_CPU);
         values.put("logLevelOverride", Environment.STRIMZI_LOG_LEVEL);
         values.put("fullReconciliationIntervalMs", Long.toString(reconciliationInterval));
         values.put("operationTimeoutMs", Long.toString(operationTimeout));

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -13,7 +13,6 @@ import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroupBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionBuilder;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.enums.OlmInstallationStrategy;
 import io.strimzi.systemtest.resources.ResourceItem;
 import io.strimzi.systemtest.resources.ResourceManager;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -132,7 +132,7 @@ public class OlmResource implements SpecificResourceType {
             .build();
 
         // Change default values for Cluster Operator memory when RESOURCE_ALLOCATION_STRATEGY is not set to NOT_SHARED
-        if (Environment.isSharedMemory()) {
+        if (KubeClusterResource.getInstance().fipsEnabled()) {
             ResourceRequirements resourceRequirements = new ResourceRequirementsBuilder()
                 .withRequests(Map.of("memory", new Quantity(Constants.CO_REQUESTS_MEMORY), "cpu", new Quantity(Constants.CO_REQUESTS_CPU)))
                 .withLimits(Map.of("memory", new Quantity(Constants.CO_LIMITS_MEMORY), "cpu", new Quantity(Constants.CO_LIMITS_CPU)))

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -112,7 +112,7 @@ class RollingUpdateST extends AbstractST {
             k.getSpec()
                 .getZookeeper()
                 .setResources(new ResourceRequirementsBuilder()
-                    .addToRequests("cpu", new Quantity("W"))
+                    .addToRequests("cpu", new Quantity("100000m"))
                     .build());
         }, testStorage.getNamespaceName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -112,7 +112,7 @@ class RollingUpdateST extends AbstractST {
             k.getSpec()
                 .getZookeeper()
                 .setResources(new ResourceRequirementsBuilder()
-                    .addToRequests("cpu", new Quantity("100000m"))
+                    .addToRequests("cpu", new Quantity("W"))
                     .build());
         }, testStorage.getNamespaceName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -454,6 +454,11 @@ class SecurityST extends AbstractST {
         }
 
         for (int i = 1; i <= expectedRolls; i++) {
+            // In case the first rolling update is finished, shut down cluster operator to see if the rolling update can be finished
+            if (i == 2) {
+                Pod coPod = kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), clusterOperator.getClusterOperatorName()).get(0);
+                kubeClient().deletePod(clusterOperator.getDeploymentNamespace(), coPod);
+            }
             if (!Environment.isKRaftModeEnabled()) {
                 if (zkShouldRoll) {
                     LOGGER.info("Wait for zk to rolling restart ({})...", i);

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -399,4 +399,11 @@ public class KubeClusterResource {
     public static Map<CollectorElement, Set<String>> getMapWithSuiteNamespaces() {
         return MAP_WITH_SUITE_NAMESPACES;
     }
+
+    public boolean fipsEnabled() {
+        if (isOpenShift()) {
+            return kubeClient().getConfigMap("kube-system", "cluster-config-v1").getData().get("install-config").contains("fips: true");
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Cluster Operator memory is now set to 512Mi when fips are enabled on clusters.

It also adds a check for https://github.com/strimzi/strimzi-kafka-operator/pull/8400

### Checklist

- [ ] Make sure all tests pass

