### PR TITLE
ST: Copy pull secrets in systemtests right after every creation of namespace

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
@@ -138,9 +138,7 @@ public class TestSuiteNamespaceManager {
                 if (ExecutionListener.hasSuiteParallelOrIsolatedTest(extensionContext)) {
                     KubeClusterResource.getInstance().createNamespace(CollectorElement.createCollectorElement(testSuite), namespaceName);
                     NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceName));
-                    if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
-                        StUtils.copyImagePullSecret(namespaceName);
-                    }
+                    StUtils.copyImagePullSecret(namespaceName);
                 } else {
                     LOGGER.info("We are not gonna create additional namespace: {}, because test suite: {} does not " +
                         "contains @ParallelTest or @IsolatedTest.", namespaceName, requiredClassName);
@@ -172,9 +170,7 @@ public class TestSuiteNamespaceManager {
 
                 KubeClusterResource.getInstance().createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()), namespaceTestCase);
                 NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceTestCase));
-                if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
-                    StUtils.copyImagePullSecret(namespaceTestCase);
-                }
+                StUtils.copyImagePullSecret(namespaceTestCase);
             }
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -255,6 +255,7 @@ public class SetupClusterOperator {
             cluster.setNamespace(namespaceInstallTo);
             cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
             extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
+            StUtils.copyImagePullSecret(namespaceInstallTo);
         }
 
         OlmConfiguration olmConfiguration = new OlmConfigurationBuilder()
@@ -381,9 +382,7 @@ public class SetupClusterOperator {
             cluster.setNamespace(namespaceInstallTo);
             cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
             extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
-            if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
-                StUtils.copyImagePullSecret(namespaceInstallTo);
-            }
+            StUtils.copyImagePullSecret(namespaceInstallTo);
         } else {
             LOGGER.info("Environment for ClusterOperator was already prepared! Going to install it now.");
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -436,12 +436,14 @@ public class StUtils {
      * @param namespace the target namespace
      */
     public static void copyImagePullSecret(String namespace) {
-        LOGGER.info("Checking if secret {} is in the default namespace", Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
-        if (kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET) == null) {
-            throw new RuntimeException(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET + " is not in the default namespace!");
-        }
-        Secret pullSecret = kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
-        kubeClient(namespace).createSecret(new SecretBuilder()
+        if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
+            LOGGER.info("Checking if secret {} is in the default namespace", Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
+            if (kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET) == null) {
+                throw new RuntimeException(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET + " is not in the default namespace!");
+            }
+            LOGGER.info("Creating pull secret {}/{}", namespace, Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
+            Secret pullSecret = kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
+            kubeClient(namespace).createSecret(new SecretBuilder()
                 .withApiVersion("v1")
                 .withKind("Secret")
                 .withNewMetadata()
@@ -451,6 +453,7 @@ public class StUtils {
                 .withType("kubernetes.io/dockerconfigjson")
                 .withData(Collections.singletonMap(".dockerconfigjson", pullSecret.getData().get(".dockerconfigjson")))
                 .build());
+        }
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -702,6 +702,9 @@ public class MetricsIsolatedST extends AbstractST {
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
         clusterOperator.unInstall();
         cluster.createNamespaces(CollectorElement.createCollectorElement(this.getClass().getName()), clusterOperator.getDeploymentNamespace(), Arrays.asList(namespaceFirst, namespaceSecond));
+        // Copy pull secret into newly created namespaces
+        StUtils.copyImagePullSecret(namespaceFirst);
+        StUtils.copyImagePullSecret(namespaceSecond);
 
         clusterOperator = clusterOperator.defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -33,6 +33,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.kubernetes.ClusterRoleBindingTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
@@ -98,6 +99,7 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
         deployCOInNamespace(extensionContext, SECOND_CO_NAME, SECOND_NAMESPACE, Collections.singletonList(SECOND_CO_SELECTOR_ENV), true);
 
         cluster.createNamespace(DEFAULT_NAMESPACE);
+        StUtils.copyImagePullSecret(DEFAULT_NAMESPACE);
         cluster.setNamespace(DEFAULT_NAMESPACE);
 
         LOGGER.info("Deploying Kafka without CR selector");

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
@@ -26,6 +26,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
@@ -264,6 +265,7 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
 
         // Recreate namespace
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -15,6 +15,7 @@ import io.strimzi.systemtest.enums.DefaultNetworkPolicy;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
 import io.strimzi.systemtest.resources.keycloak.SetupKeycloak;
 import io.strimzi.systemtest.templates.kubernetes.NetworkPolicyTemplates;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.logs.CollectorElement;
@@ -134,6 +135,7 @@ public class OauthAbstractST extends AbstractST {
         // (f.e., our `infra-namespace`)
         if (kubeClient().getNamespace(clusterOperator.getDeploymentNamespace()) == null) {
             cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), clusterOperator.getDeploymentNamespace());
+            StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
         }
 
         SetupKeycloak.deployKeycloakOperator(extensionContext, clusterOperator.getDeploymentNamespace(), namespace);

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartIsolatedST.java
@@ -16,6 +16,7 @@ import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,6 +64,7 @@ class HelmChartIsolatedST extends AbstractST {
 
         LOGGER.info("Creating resources before the test class");
         cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
         // Helm CO created
         helmResource.create(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
@@ -23,6 +23,7 @@ import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.kubernetes.ClusterRoleBindingTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.test.TestUtils;
@@ -257,6 +258,7 @@ public class SpecificIsolatedST extends AbstractST {
         clusterOperator.unInstall();
         // create namespace, where we will be able to deploy Custom Resources
         cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()), namespaceWhereCreationOfCustomResourcesIsApproved);
+        StUtils.copyImagePullSecret(namespaceWhereCreationOfCustomResourcesIsApproved);
         clusterOperator = clusterOperator.defaultInstallation()
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
             // use our pre-defined Roles

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/TracingAbstractST.java
@@ -33,6 +33,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.TracingUtils;
 import io.strimzi.test.TestUtils;
@@ -572,6 +573,7 @@ public abstract class TracingAbstractST extends AbstractST {
     private void deployCertManager(ExtensionContext extensionContext) {
         // create namespace `cert-manager` and add it to stack, to collect logs from it
         cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), CERT_MANAGER_NAMESPACE);
+        StUtils.copyImagePullSecret(CERT_MANAGER_NAMESPACE);
 
         LOGGER.info("Deploying CertManager from {}", certManagerPath);
         // because we don't want to apply CertManager's file to specific namespace, passing the empty String will do the trick

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
@@ -89,6 +89,7 @@ public class StrimziDowngradeIsolatedST extends AbstractUpgradeST {
     @BeforeEach
     void setupEnvironment() {
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
     }
 
     @AfterEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -196,6 +196,7 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
     @BeforeEach
     void setupEnvironment() {
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
     }
 
     protected void afterEachMayOverride(ExtensionContext extensionContext) throws Exception {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR address issue that pull secret specified by env var `SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET` is not copied to all namespaces managed by systemtests. 

This solution is not ideal, but currently, it is not possible to make it more user-friendly without bigger changes into the STs. 

### Checklist

- [ ] Make sure all tests pass

