### PR TITLE
[ST] Removal of duplicate tests, merging some tests together.

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.systemtest.utils.kubeUtils.objects;
 
-import io.strimzi.api.kafka.model.storage.JbodStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -89,8 +90,8 @@ public class PersistentVolumeClaimUtils {
         );
     }
 
-    public static void waitForJbodStorageDeletion(String namespaceName, int volumesCount, JbodStorage jbodStorage, String clusterName) {
-        int numberOfPVCWhichShouldBeDeleted = jbodStorage.getVolumes().stream().filter(
+    public static void waitForJbodStorageDeletion(String namespaceName, int volumesCount, String clusterName, SingleVolumeStorage... volumes) {
+        int numberOfPVCWhichShouldBeDeleted = Arrays.stream(volumes).filter(
             singleVolumeStorage -> ((PersistentClaimStorage) singleVolumeStorage).isDeleteClaim()
         ).collect(Collectors.toList()).size();
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

changes in `KafkaST` discussed on triage. 
removal of tests: 
- `testCustomAndUpdatedValues`, `testPersistentStorageSize`  due to it being covered on UT/IT levels
-  `testEntityOperatorWithoutTopicOperator `, `testEntityOperatorWithoutUserOperator`,  `testEntityOperatorWithoutUserAndTopicOperators `,  `testKafkaJBODDeleteClaimsTrue`, and `testKafkaJBODDeleteClaimsFalse` being duplicates

merge of `testConsumerOffsetFiles` into `testMessagesAreStoredInDiskAndConsumerOffsetFiles` as they test similar thing and this can save time needed to deploy extra Kafka instance.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation

fixes https://github.com/strimzi/strimzi-kafka-operator/issues/8257
