### PR TITLE
Fix log levels in `ZooKeeperRoller` log messages

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -82,15 +82,15 @@ public class ZooKeeperRoller {
                             final boolean ready = podOperator.isReady(namespace, pod.getMetadata().getName());
                             ZookeeperPodContext podContext = new ZookeeperPodContext(podName, restartReasons, true, ready);
                             if (restartReasons != null && !restartReasons.isEmpty())    {
-                                LOGGER.infoCr(reconciliation, "Pod {} should be rolled due to {}", podContext.getPodName(), restartReasons);
+                                LOGGER.debugCr(reconciliation, "Pod {} should be rolled due to {}", podContext.getPodName(), restartReasons);
                             } else {
-                                LOGGER.infoCr(reconciliation, "Pod {} does not need to be rolled", podContext.getPodName());
+                                LOGGER.debugCr(reconciliation, "Pod {} does not need to be rolled", podContext.getPodName());
                             }
                             clusterRollContext.add(podContext);
                         } else {
                             // Pod does not exist, but we still add it to the roll context because we should not roll
                             // any other pods before it is ready
-                            LOGGER.infoCr(reconciliation, "Pod {} does not exist and cannot be rolled", podName);
+                            LOGGER.debugCr(reconciliation, "Pod {} does not exist and cannot be rolled", podName);
                             ZookeeperPodContext podContext = new ZookeeperPodContext(podName, null, false, false);
                             clusterRollContext.add(podContext);
                         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #8429 I by mistake left some log messages at the `INFO` log level where I set them for debugging purposes. As a result, every reconciliation now logs the follwoing:

```
2023-04-27 15:04:46 INFO  AbstractOperator:239 - Reconciliation #43(timer) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2023-04-27 15:04:46 INFO  ZooKeeperRoller:87 - Reconciliation #43(timer) Kafka(myproject/my-cluster): Pod my-cluster-zookeeper-0 does not need to be rolled
2023-04-27 15:04:46 INFO  ZooKeeperRoller:87 - Reconciliation #43(timer) Kafka(myproject/my-cluster): Pod my-cluster-zookeeper-1 does not need to be rolled
2023-04-27 15:04:46 INFO  ZooKeeperRoller:87 - Reconciliation #43(timer) Kafka(myproject/my-cluster): Pod my-cluster-zookeeper-2 does not need to be rolled
2023-04-27 15:04:48 INFO  AbstractOperator:510 - Reconciliation #43(timer) Kafka(myproject/my-cluster): reconciled
```

This PR reverts them back to debug level.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally