### PR TITLE
Print systemtests env ordered

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -226,7 +226,9 @@ public class Environment {
         String debugFormat = "{}: {}";
         LOGGER.info("Used environment variables:");
         LOGGER.info(debugFormat, "CONFIG", config);
-        VALUES.forEach((key, value) -> LOGGER.info(debugFormat, key, value));
+        VALUES.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> LOGGER.info(debugFormat, entry.getKey(), entry.getValue()));
     }
 
     public static boolean isOlmInstall() {


### PR DESCRIPTION
### Type of change

- Enhancement

### Description
Print env vars during systemtest run in order to better visibility configuration of systemtests


