### PR TITLE
Update Prometheus JMX Exporter to address SnakeYAML CVE

### DIFF
--- a/docker-images/artifacts/build.sh
+++ b/docker-images/artifacts/build.sh
@@ -136,6 +136,8 @@ function fetch_and_unpack_kafka_binaries {
             ./extract-jars.sh "$dist_dir/libs" "$unzipped_dir"
             ./find-colliding-classes.sh "$unzipped_dir" | awk '{print $1}' | $SORT | $UNIQ > "$ignorelist_file" || true
             rm -rf $unzipped_dir
+            # Add ignored 3rd party libraries
+            cat kafka-thirdparty-libs/${version_libs[$kafka_version]}/ignorelist >> $ignorelist_file
         fi
 
         # We extracted the files, so we just keep the archive and the ignorelist

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/ignorelist
@@ -1,0 +1,2 @@
+jmx_prometheus_javaagent-0.18.0.jar
+snakeyaml-2.0.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -23,7 +23,7 @@
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-        <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
+        <jmx-prometheus-javaagent.version>0.18.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <jaeger-client.version>1.8.1</jaeger-client.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/ignorelist
@@ -1,0 +1,2 @@
+jmx_prometheus_javaagent-0.18.0.jar
+snakeyaml-2.0.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -23,7 +23,7 @@
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-        <jmx-prometheus-javaagent.version>0.17.2</jmx-prometheus-javaagent.version>
+        <jmx-prometheus-javaagent.version>0.18.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <jaeger-client.version>1.8.1</jaeger-client.version>

--- a/docker-images/kafka-based/find-classpath-collision.sh
+++ b/docker-images/kafka-based/find-classpath-collision.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 image=$1 #strimzi/kafka:latest-kafka-2.2.1
 image_jar_dir=$2 #/opt/kafka/libs
-whilelist_file=$3
+ignorelist_file=$3
 DOCKER_CMD=${DOCKER_CMD:-docker}
 
 jars_dir=$(mktemp -d)
@@ -19,13 +19,13 @@ ${DOCKER_CMD} rm temp-container-name > /dev/null
 $(dirname $0)/../artifacts/extract-jars.sh "$jars_dir" "$classes_root"
 
 collisions=$($(dirname "$0")/../artifacts/find-colliding-classes.sh "$classes_root" | awk '{printf("%s\t%s\n",$1,$2);}' | \
-    grep -vFf "$whilelist_file")
+    grep -vFf "$ignorelist_file")
 
 if [ "$collisions" != "" ] ; then
   echo "ERROR: Different class files with same name from different jars found!"
   echo "$collisions"
   echo "(Ignoring jars from Kafka distribution containing different class files with same name:"
-  sed -e 's/^/  /' "$whilelist_file"
+  sed -e 's/^/  /' "$ignorelist_file"
   echo ")"
   echo "It's likely that either two third party jars are using different versions "
   echo "of a common (transitive) dependency or a single third party jar is using a"


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Prometheus JMX Exporter to a new version 0.18.0. It includes a new version of SnakeYAML 2.0 which addresses some CVEs.

Prometheus JMX Exporter shades SnakeYAML 2.0 into its own fat jar. So the detection of duplicate JARs detects that and fails the build. So this PR also adds a new `ignorelist` to list these JARs and make the build pass despite this conflict. It also renames the `whilelist` (type for `whitelist`?) to `ignorelist` which is also how the files are named.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally