### PR TITLE
Fix typo about KR refresh in docs

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -86,7 +86,7 @@ Approving an optimization proposal:: You approve the optimization proposal by se
 Cruise Control applies the proposal to the Kafka cluster and starts a cluster rebalance operation.
 Rejecting an optimization proposal:: If you choose not to approve an optimization proposal,
 you can xref:proc-generating-optimization-proposals-str[change the optimization goals] or xref:rebalance_tuning_options[update any of the rebalance performance tuning options], and then generate another proposal.
-You can use the `strimzi.io/refresh` annotation to generate a new optimization proposal for a `KafkaRebalance` resource.
+You can generate a new optimization proposal for a `KafkaRebalance` resource by setting the `strimzi.io/rebalance` annotation to `refresh`
 
 Use optimization proposals to assess the movements required for a rebalance.
 For example, a summary describes inter-broker and intra-broker movements.

--- a/documentation/modules/cruise-control/con-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-proposals.adoc
@@ -86,7 +86,7 @@ Approving an optimization proposal:: You approve the optimization proposal by se
 Cruise Control applies the proposal to the Kafka cluster and starts a cluster rebalance operation.
 Rejecting an optimization proposal:: If you choose not to approve an optimization proposal,
 you can xref:proc-generating-optimization-proposals-str[change the optimization goals] or xref:rebalance_tuning_options[update any of the rebalance performance tuning options], and then generate another proposal.
-You can generate a new optimization proposal for a `KafkaRebalance` resource by setting the `strimzi.io/rebalance` annotation to `refresh`
+You can generate a new optimization proposal for a `KafkaRebalance` resource by setting the `strimzi.io/rebalance` annotation to `refresh`.
 
 Use optimization proposals to assess the movements required for a rebalance.
 For example, a summary describes inter-broker and intra-broker movements.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fix typo in docs surrounding how to refresh a KafkaRebalance resource

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

