### PR TITLE
ST: Check that operatorVersion is emptyString instead of null after fixing spotbugs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
@@ -59,7 +59,7 @@ public class OlmConfiguration {
     }
 
     public void setOperatorVersion(String operatorVersion) {
-        this.operatorVersion = operatorVersion.isEmpty() ? Environment.OLM_OPERATOR_LATEST_RELEASE_VERSION : operatorVersion;
+        this.operatorVersion = operatorVersion != null && operatorVersion.isEmpty() ? Environment.OLM_OPERATOR_LATEST_RELEASE_VERSION : operatorVersion;
     }
 
     public String getOperatorVersion() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/configuration/OlmConfiguration.java
@@ -59,7 +59,7 @@ public class OlmConfiguration {
     }
 
     public void setOperatorVersion(String operatorVersion) {
-        this.operatorVersion = operatorVersion == null ? Environment.OLM_OPERATOR_LATEST_RELEASE_VERSION : operatorVersion;
+        this.operatorVersion = operatorVersion.isEmpty() ? Environment.OLM_OPERATOR_LATEST_RELEASE_VERSION : operatorVersion;
     }
 
     public String getOperatorVersion() {


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

When we deploy CO via OLm we check the configuration against initialized values and because I changed the init value for operatorVersion to fix spotbugs error to empty string, the check should count with that as well. This PR fixes the bug when the check resulted in wrong value and subscription contained wrong values.

### Checklist

- [ ] Make sure all tests pass


