### PR TITLE
docs(mm2): deciding when to use the heartbeat connector

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-replication.adoc
@@ -3,7 +3,7 @@
 // assembly-config-mirrormaker2.adoc
 
 [id='con-mirrormaker-{context}']
-= MirrorMaker 2 data replication
+= Replicating data using MirrorMaker 2
 
 [role="_abstract"]
 Data replication across clusters supports scenarios that require:
@@ -69,13 +69,19 @@ Because the synchronization is time-based, any switchover by consumers to a pass
 
 NOTE: If you have an application written in Java, you can use the `RemoteClusterUtils.java` utility to synchronize offsets through the application. The utility fetches remote offsets for a consumer group from the `checkpoints` topic. 
 
-== Connectivity checks
+== Deciding when to use the heartbeat connector
 
-`MirrorHeartbeatConnector` emits _heartbeats_ to check connectivity between clusters.
+The heartbeat connector emits heartbeats to check connectivity between source and target Kafka clusters.
+An internal heartbeat topic is replicated from the source cluster, which means that the heartbeat connector must be connected to the source cluster. 
+A target cluster uses the heartbeat topic to perform the following checks:
 
-An internal `heartbeat` topic is replicated from the source cluster.
-Target clusters use the `heartbeat` topic to check the following:
+* Identify all source clusters it is mirroring data from
+* Check that the Kafka Connect worker managing connectivity between clusters is running
+* Verify that the source cluster is available
 
-* The connector managing connectivity between clusters is running
-* The source cluster is available
+You can use the heartbeat connector to monitor the liveness and latency of the mirroring process.
+This helps to make sure that the process is not stuck or has stopped for any reason. 
+However, using the heartbeat connector is not always necessary and can be left out of the MirrorMaker 2 configuration. 
+For example, if your deployment has low network latency or a small number of topics, you might prefer to monitor the mirroring process using log messages or other monitoring tools. 
+Heartbeats are enabled by default, but you can set the `emit.heartbeats.enabled` property of the heartbeat connector to `false` if you do not want to use them.
 

--- a/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2-tasks-max.adoc
@@ -28,7 +28,7 @@ When setting a maximum number of tasks, consider the number of partitions and th
 If the infrastructure supports the processing overhead, increasing the number of tasks can improve throughput and latency.
 For example, adding more tasks reduces the time taken to poll the source cluster when there is a high number of partitions or consumer groups.  
 
-Increasing the number of tasks for the checkpoint connector is useful when you have a large number of partitions.
+Increasing the number of tasks for the source connector is useful when you have a large number of partitions.
 
 .Increasing the number of tasks for the source connector
 [source,yaml,subs="+quotes,attributes"]


### PR DESCRIPTION
**Documentation**

Use of the MM2 heartbeat connector is not always needed.
This update introduces a new section to the doc called **Deciding when to use the heartbeat connector**.
The section explains what the heartbeat connector does, and why you might want to use it or not use it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

