### PR TITLE
ST: Resolve several openshift-related issues in system tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
@@ -148,12 +148,14 @@ public class SetupKeycloak {
     private static void deleteKeycloak(String namespaceName) {
         LOGGER.info("Deleting Keycloak in namespace {}", namespaceName);
         cmdKubeClient(namespaceName).delete(KEYCLOAK_INSTANCE_FILE_PATH);
+        kubeClient().deleteSecret(namespaceName, KEYCLOAK_SECRET_NAME);
         DeploymentUtils.waitForDeploymentDeletion(namespaceName, KEYCLOAK_DEPLOYMENT_NAME);
     }
 
     private static void deletePostgres(String namespaceName) {
         LOGGER.info("Deleting Postgres in namespace {}", namespaceName);
         cmdKubeClient(namespaceName).delete(POSTGRES_FILE_PATH);
+        kubeClient().deleteSecret(namespaceName, POSTGRES_SECRET_NAME);
         DeploymentUtils.waitForDeploymentDeletion(namespaceName, "postgres");
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/KeycloakUtils.java
@@ -25,7 +25,7 @@ public class KeycloakUtils {
      * @return user token
      */
     public static String getToken(String namespaceName, String baseURI, String userName, String password) {
-        String coPodName = kubeClient(namespaceName).getClusterOperatorPodName();
+        String coPodName = kubeClient().getClusterOperatorPodName(namespaceName);
         return new JsonObject(
             cmdKubeClient(namespaceName).execInPod(
                 coPodName,

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1961,6 +1961,10 @@ public class ListenersST extends AbstractST {
         resourceManager.createResource(extensionContext, kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForConsumerClientSuccess(testStorage);
 
+        // Delete already existing secrets
+        kubeClient().deleteSecret(testStorage.getNamespaceName(), clusterCustomCertServer1);
+        kubeClient().deleteSecret(testStorage.getNamespaceName(), clusterCustomCertServer2);
+        // Create secrets with new values (update)
         SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
         SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1397,6 +1397,9 @@ class LoggingChangeST extends AbstractST {
             .endSpec()
             .build();
 
+        LOGGER.info("Deploying network policies for KafkaConnect");
+        NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, connect, KafkaConnectResources.deploymentName(testStorage.getClusterName()));
+
         resourceManager.createResource(extensionContext,
             connect,
             ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -1397,14 +1397,15 @@ class LoggingChangeST extends AbstractST {
             .endSpec()
             .build();
 
-        LOGGER.info("Deploying network policies for KafkaConnect");
-        NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, connect, KafkaConnectResources.deploymentName(testStorage.getClusterName()));
-
         resourceManager.createResource(extensionContext,
             connect,
             ScraperTemplates.scraperPod(testStorage.getNamespaceName(), testStorage.getScraperName()).build(),
             KafkaConnectorTemplates.defaultKafkaConnector(testStorage.getClusterName(), testStorage.getClusterName(), 1).build()
         );
+
+        LOGGER.info("Deploying network policies for KafkaConnect");
+        NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, connect, KafkaConnectResources.deploymentName(testStorage.getClusterName()));
+
 
         String connectorClassName = "org.apache.kafka.connect.file.FileStreamSourceConnector";
         final String scraperPodName = PodUtils.getPodsByPrefixInNameWithDynamicWait(testStorage.getNamespaceName(), testStorage.getScraperName()).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -268,7 +268,7 @@ public class MetricsIsolatedST extends AbstractST {
 
         if (Environment.isStableConnectIdentitiesEnabled()) {
             // check StrimziPodSet metrics in CO
-            assertMetricCountHigherThan(clusterOperatorCollector, getResourceMetricPattern(StrimziPodSet.RESOURCE_KIND, namespaceFirst), 1);
+            assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(StrimziPodSet.RESOURCE_KIND, namespaceFirst), 1);
             assertCoMetricResources(clusterOperatorCollector, StrimziPodSet.RESOURCE_KIND, namespaceSecond, 1);
         }
     }
@@ -512,7 +512,7 @@ public class MetricsIsolatedST extends AbstractST {
 
         if (Environment.isStableConnectIdentitiesEnabled()) {
             // check StrimziPodSet metrics in CO
-            assertMetricCountHigherThan(clusterOperatorCollector, getResourceMetricPattern(StrimziPodSet.RESOURCE_KIND, namespaceFirst), 1);
+            assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(StrimziPodSet.RESOURCE_KIND, namespaceFirst), 1);
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -105,6 +105,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * @description This test suite is designed for testing metrics exposed by operators and operands.
@@ -700,6 +701,8 @@ public class MetricsIsolatedST extends AbstractST {
 
     @BeforeAll
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
+        // Metrics tests are not designed to run with namespace RBAC scope.
+        assumeFalse(Environment.isNamespaceRbacScope());
         clusterOperator.unInstall();
         cluster.createNamespaces(CollectorElement.createCollectorElement(this.getClass().getName()), clusterOperator.getDeploymentNamespace(), Arrays.asList(namespaceFirst, namespaceSecond));
         // Copy pull secret into newly created namespaces

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -237,8 +237,6 @@ public class TopicST extends AbstractST {
                 .endSpec()
                 .build());
 
-        assertThat(true, is(false));
-
         Properties properties = new Properties();
 
         properties.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaResource.kafkaClient().inNamespace(namespace)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -237,6 +237,8 @@ public class TopicST extends AbstractST {
                 .endSpec()
                 .build());
 
+        assertThat(true, is(false));
+
         Properties properties = new Properties();
 
         properties.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaResource.kafkaClient().inNamespace(namespace)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesIsolatedST.java
@@ -245,6 +245,7 @@ public class NetworkPoliciesIsolatedST extends AbstractST {
 
         String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
+        clusterOperator.unInstall();
         clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
             .withNamespace(clusterOperator.getDeploymentNamespace())

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Node;
@@ -917,7 +918,7 @@ public class KubeClient {
      * @return cluster operator pod name
      */
     public String getClusterOperatorPodName(final String namespaceName) {
-        LabelSelector selector = kubeClient(namespaceName).getDeploymentSelectors(namespaceName, "strimzi-cluster-operator");
+        LabelSelector selector = new LabelSelectorBuilder().withMatchLabels(Map.of("strimzi.io/kind", "cluster-operator")).build();
         return kubeClient(namespaceName).listPods(namespaceName, selector).get(0).getMetadata().getName();
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the following issues:
- installation of Keycloak when we use `CLUSTER_OEPRATOR_INSTALL_TYPE=olm` -> CO deployment has a different name and that caused issues when getting the CO pod name (as part of it I also fixed deletion of keycloak related secrets)
- Delete secrets in ListeneresST for test with Route -> this caused issues only on OpenShift because we use `create` instead of `createOrReplace` due to fabric8 changes
- In `LoggingChangeST` we didn't deploy network policies to access KafkaConnect API from our scrapper pod
- `MetricsIsolatedST` are not designed to run with `STRIMZI_RBAC_SCAPE=NAMESPACE`. We moved several metrics test cases into specific classes, so the metrics should be tested there anyway.


### Checklist

- [ ] Make sure all tests pass


