### PR TITLE
[ST] Merging tests which remove parts of Entity Operator into 1 test. 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PersistentVolumeClaimUtils.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -90,8 +89,8 @@ public class PersistentVolumeClaimUtils {
         );
     }
 
-    public static void waitForJbodStorageDeletion(String namespaceName, int volumesCount, String clusterName, SingleVolumeStorage... volumes) {
-        int numberOfPVCWhichShouldBeDeleted = Arrays.stream(volumes).filter(
+    public static void waitForJbodStorageDeletion(String namespaceName, int volumesCount, String clusterName, List<SingleVolumeStorage> volumes) {
+        int numberOfPVCWhichShouldBeDeleted = volumes.stream().filter(
             singleVolumeStorage -> ((PersistentClaimStorage) singleVolumeStorage).isDeleteClaim()
         ).collect(Collectors.toList()).size();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -15,7 +15,6 @@ import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.Container;
 import io.strimzi.api.kafka.KafkaTopicList;
-import io.strimzi.api.kafka.model.EntityTopicOperatorSpec;
 import io.strimzi.api.kafka.model.EntityUserOperatorSpec;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -61,8 +60,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -232,66 +229,27 @@ class KafkaST extends AbstractST {
         DeploymentUtils.waitForNoRollingUpdate(namespaceName, eoDepName, eoPods);
     }
 
-    @ParallelNamespaceTest
-    @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test class")
-    void testRemoveTopicOperatorFromEntityOperator(ExtensionContext extensionContext) {
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(namespace, extensionContext);
-        final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-
-        LOGGER.info("Deploying Kafka cluster {}", clusterName);
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3).build());
-        String eoPodName = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName))
-            .get(0).getMetadata().getName();
-
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getEntityOperator().setTopicOperator(null), namespaceName);
-        //Waiting when EO pod will be recreated without TO
-        PodUtils.deletePodWithWait(namespaceName, eoPodName);
-        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
-        PodUtils.waitUntilPodContainersCount(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
-
-        //Checking that TO was removed
-        kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName)).forEach(pod -> {
-            pod.getSpec().getContainers().forEach(container -> {
-                assertThat(container.getName(), not(containsString("topic-operator")));
-            });
-        });
-
-        eoPodName = kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName))
-                .get(0).getMetadata().getName();
-
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getEntityOperator().setTopicOperator(new EntityTopicOperatorSpec()), namespaceName);
-        //Waiting when EO pod will be recreated with TO
-        PodUtils.deletePodWithWait(namespaceName, eoPodName);
-        DeploymentUtils.waitForDeploymentAndPodsReady(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
-
-        //Checking that TO was created
-        kubeClient(namespaceName).listPodsByPrefixInName(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName)).forEach(pod -> {
-            pod.getSpec().getContainers().forEach(container -> {
-                assertThat(container.getName(), anyOf(
-                    containsString("topic-operator"),
-                    containsString("user-operator"),
-                    containsString("tls-sidecar"))
-                );
-            });
-        });
-    }
-
     /**
      * @description This test case verifies the correct deployment of Entity Operator, i.e., including both User Operator and Topic Operator.
      * Entity Operator is firstly modified to exclude User Operator, afterwards it is modified to default configuration, which includes User Operator.
+     * The next step is removal of Topic Operator itself and finally, also removing User Operator, with Topic Operator being already removed.
      *
      * @steps
-     *  1. - Deploy Kafka with default configuration.
-     *     - Kafka is deployed, entity operator comprises both TopicOperator and User Operator.
-     *  2. - Remove User Operator from the Kafka Custom Resource specification.
-     *     - Entity Operator is redeployed without the User Operator, no other action take place inside the given Kafka cluster.
-     *  3. - Modify configuration of the Kafka Custom Resource by specifying default Entity Operator.
-     *     - Entity Operator is redeployed, comprising User Operator as well.
+     *  1. - Deploy Kafka with Entity Operator set.
+     *     - Kafka is deployed, and Entity Operator consist of both Topic and User Operators
+     *  2. - Remove User Operator from the Kafka specification
+     *     - User Operator container is deleted
+     *  3. - Set User Operator back in the Kafka specification
+     *     - User Operator container is recreated
+     *  4. - Remove Topic Operator from the Kafka specification
+     *     - Topic Operator container is removed Entity Operator
+     *  5. - Remove User Operator from the Kafka specification
+     *     - Entity Operator Pod is removed, as there are no other containers present.
      *
      * @usecase
-     *  - entity-operator
-     *  - topic-operator
-     *  - user-operator
+     *  - Entity Operator
+     *  - Topic Operator
+     *  - User Operator
      */
     @ParallelNamespaceTest
     void testRemoveComponentsFromEntityOperator(ExtensionContext extensionContext) {
@@ -470,7 +428,7 @@ class KafkaST extends AbstractST {
         cmdKubeClient(namespaceName).deleteByName("kafka", clusterName);
 
         LOGGER.info("Wait for PVCs deletion");
-        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(namespaceName, volumesCount, clusterName, idZeroVolumeModified, idOneVolumeOriginal);
+        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(namespaceName, volumesCount, clusterName, List.of(idZeroVolumeModified, idOneVolumeOriginal));
 
         LOGGER.info("Verify that PVC which are supposed to remain, really persist even after Kafka cluster un-deployment");
         List<String> remainingPVCNames =  kubeClient().listPersistentVolumeClaims(namespaceName, clusterName).stream().map(e -> e.getMetadata().getName()).toList();


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

tests: 
- `testRemoveTopicOperatorFromEntityOperator`
- `testRemoveUserOperatorFromEntityOperator`
- `testRemoveUserAndTopicOperatorsFromEntityOperator`

merged into the single test (`testRemoveComponentsFromEntityOperator`). 

Operators are firstly deleted one by one, later both of them are removed. After Consideration regarding additional checks of Operators really being removed, these checks were not implemented as they would not result in much additional value and cost extra time (need for waiting) or additional confusing error logs. 

### Checklist


- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation

Fixes:  https://github.com/strimzi/strimzi-kafka-operator/issues/8258

