### PR TITLE
docs(otel): updates the config examples to show distributed tracing using open telemetry

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-bridge.adoc
@@ -36,56 +36,56 @@ kind: KafkaBridge
 metadata:
   name: my-bridge
 spec:
-  replicas: 3 <1>
-  bootstrapServers: _<cluster_name>_-cluster-kafka-bootstrap:9092 <2>
-  tls: <3>
+  replicas: 3 # <1>
+  bootstrapServers: _<cluster_name>_-cluster-kafka-bootstrap:9092 # <2>
+  tls: # <3>
     trustedCertificates:
       - secretName: my-cluster-cluster-cert
         certificate: ca.crt
       - secretName: my-cluster-cluster-cert
         certificate: ca2.crt
-  authentication: <4>
+  authentication: # <4>
     type: tls
     certificateAndKey:
       secretName: my-secret
       certificate: public.crt
       key: private.key
-  http: <5>
+  http: # <5>
     port: 8080
-    cors: <6>
+    cors: # <6>
       allowedOrigins: "https://strimzi.io"
       allowedMethods: "GET,POST,PUT,DELETE,OPTIONS,PATCH"
-  consumer: <7>
+  consumer: # <7>
     config:
       auto.offset.reset: earliest
-  producer: <8>
+  producer: # <8>
     config:
       delivery.timeout.ms: 300000
-  resources: <9>
+  resources: # <9>
     requests:
       cpu: "1"
       memory: 2Gi
     limits:
       cpu: "2"
       memory: 2Gi
-  logging: <10>
+  logging: # <10>
     type: inline
     loggers:
       logger.bridge.level: "INFO"
       # enabling DEBUG just for send operation
       logger.send.name: "http.openapi.operation.send"
       logger.send.level: "DEBUG"
-  jvmOptions: <11>
+  jvmOptions: # <11>
     "-Xmx": "1g"
     "-Xms": "1g"
-  readinessProbe: <12>
+  readinessProbe: # <12>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  image: my-org/my-image:latest <13>
-  template: <14>
+  image: my-org/my-image:latest # <13>
+  template: # <14>
     pod:
       affinity:
         podAntiAffinity:
@@ -98,14 +98,14 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    bridgeContainer: <15>
+    bridgeContainer: # <15>
       env:
-        - name: JAEGER_SERVICE_NAME
-          value: my-jaeger-service
-        - name: JAEGER_AGENT_HOST
-          value: jaeger-agent-name
-        - name: JAEGER_AGENT_PORT
-          value: "6831"
+        - name: OTEL_SERVICE_NAME
+          value: my-otel-service
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otlp-host:4317"
+  tracing:
+    type: opentelemetry # <16>
 ----
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes].
 <2> xref:con-common-configuration-bootstrap-reference[Bootstrap server] for connection to the target Kafka cluster. Use the name of the Kafka cluster as the _<cluster_name>_.
@@ -123,6 +123,7 @@ By default, the Kafka Bridge connects to Kafka brokers without authentication.
 <13> Optional: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
 <14> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
 <15> Environment variables are set for distributed tracing.
+<16> Distributed tracing is enabled for OpenTelemetry.
 
 . Create or update the resource:
 +

--- a/documentation/modules/configuring/proc-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect.adoc
@@ -152,12 +152,12 @@ spec:
               topologyKey: "kubernetes.io/hostname"
     connectContainer: # <20>
       env:
-        - name: JAEGER_SERVICE_NAME
-          value: my-jaeger-service
-        - name: JAEGER_AGENT_HOST
-          value: jaeger-agent-name
-        - name: JAEGER_AGENT_PORT
-          value: "6831"
+        - name: OTEL_SERVICE_NAME
+          value: my-otel-service
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otlp-host:4317"
+  tracing:
+    type: opentelemetry # <21>
 ----
 <1> Use `KafkaConnect`.
 <2> Enables KafkaConnectors for the Kafka Connect cluster.
@@ -182,6 +182,7 @@ You can also use configuration provider plugins to load configuration values fro
 <18> SPECIALIZED OPTION: xref:type-Rack-reference[Rack awareness] configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
 <19> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
 <20> Environment variables are set for distributed tracing.
+<21> Distributed tracing is enabled for OpenTelemetry.
 
 . Create or update the resource:
 +

--- a/documentation/modules/configuring/proc-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker.adoc
@@ -108,14 +108,12 @@ spec:
               topologyKey: "kubernetes.io/hostname"
     mirrorMakerContainer: # <18>
       env:
-        - name: JAEGER_SERVICE_NAME
-          value: my-jaeger-service
-        - name: JAEGER_AGENT_HOST
-          value: jaeger-agent-name
-        - name: JAEGER_AGENT_PORT
-          value: "6831"
+        - name: OTEL_SERVICE_NAME
+          value: my-otel-service
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otlp-host:4317"
   tracing: # <19>
-    type: jaeger
+    type: opentelemetry
 ----
 <1> xref:con-common-configuration-replicas-reference[The number of replica nodes].
 <2> xref:con-common-configuration-bootstrap-reference[Bootstrap servers] for consumer and producer.
@@ -135,7 +133,7 @@ spec:
 <16> ADVANCED OPTION: xref:con-common-configuration-images-reference[Container image configuration], which is recommended only in special situations.
 <17> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
 <18> Environment variables are set for distributed tracing.
-<19> Distributed tracing is enabled for Jaeger.
+<19> Distributed tracing is enabled for OpenTelemetry.
 +
 WARNING: With the `abortOnSendFailure` property set to `false`, the producer attempts to send the next message in a topic. The original message might be lost, as there is no attempt to resend a failed message.
 

--- a/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-replication.adoc
@@ -178,14 +178,12 @@ spec:
               topologyKey: "kubernetes.io/hostname"
     connectContainer: # <43>
       env:
-        - name: JAEGER_SERVICE_NAME
-          value: my-jaeger-service
-        - name: JAEGER_AGENT_HOST
-          value: jaeger-agent-name
-        - name: JAEGER_AGENT_PORT
-          value: "6831"
+        - name: OTEL_SERVICE_NAME
+          value: my-otel-service
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otlp-host:4317"
   tracing:
-    type: jaeger # <44>
+    type: opentelemetry # <44>
   externalConfiguration: # <45>
     env:
       - name: AWS_ACCESS_KEY_ID
@@ -244,7 +242,7 @@ To configure topic offset synchronization, this property must also be set for th
 <41> SPECIALIZED OPTION: xref:type-Rack-reference[Rack awareness] configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
 <42> xref:assembly-customizing-kubernetes-resources-str[Template customization]. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
 <43> Environment variables are set for distributed tracing.
-<44> Distributed tracing is enabled for Jaeger.
+<44> Distributed tracing is enabled for OpenTelemetry.
 <45> xref:type-ExternalConfiguration-reference[External configuration] for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
 You can also use configuration provider plugins to load configuration values from external sources.
 


### PR DESCRIPTION
**Documentation**

The support for Jaeger tracing in Strimzi is deprecated, so this updates the documentation to show OpenTelemetry used in the example tracing configuration for MirrorMaker, MM2, Kafka Connect, and Kafka Bridge.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

