### PR TITLE
Refactor informer handling in `UserController` and `StrimziPodSetController`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
 public class StrimziPodSetController implements Runnable {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StrimziPodSetController.class);
 
-    private static final long DEFAULT_RESYNC_PERIOD = 5 * 60 * 1_000L; // 5 minutes by default
+    private static final long DEFAULT_RESYNC_PERIOD_MS = 5 * 60 * 1_000L; // 5 minutes by default
     private static final LabelSelector POD_LABEL_SELECTOR = new LabelSelectorBuilder()
             .withMatchExpressions(new LabelSelectorRequirement(Labels.STRIMZI_KIND_LABEL, "Exists", null))
             .build();
@@ -127,19 +127,19 @@ public class StrimziPodSetController implements Runnable {
 
         // Kafka, KafkaConnect and KafkaMirrorMaker2 informers and listers are used to get the CRs quickly.
         // This is needed for verification of the CR selector labels.
-        this.kafkaInformer = kafkaOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap(), DEFAULT_RESYNC_PERIOD);
+        this.kafkaInformer = kafkaOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap(), DEFAULT_RESYNC_PERIOD_MS);
         this.kafkaLister = new Lister<>(kafkaInformer.getIndexer());
-        this.kafkaConnectInformer = kafkaConnectOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap(), DEFAULT_RESYNC_PERIOD);
+        this.kafkaConnectInformer = kafkaConnectOperator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap(), DEFAULT_RESYNC_PERIOD_MS);
         this.kafkaConnectLister = new Lister<>(kafkaConnectInformer.getIndexer());
-        this.kafkaMirrorMaker2Informer = kafkaMirrorMaker2Operator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap(), DEFAULT_RESYNC_PERIOD);
+        this.kafkaMirrorMaker2Informer = kafkaMirrorMaker2Operator.informer(watchedNamespace, (crSelectorLabels == null) ? Map.of() : crSelectorLabels.toMap(), DEFAULT_RESYNC_PERIOD_MS);
         this.kafkaMirrorMaker2Lister = new Lister<>(kafkaMirrorMaker2Informer.getIndexer());
 
         // StrimziPodSet informer and lister is used to get events about StrimziPodSet and get StrimziPodSet quickly
-        this.strimziPodSetInformer = strimziPodSetOperator.informer(watchedNamespace, DEFAULT_RESYNC_PERIOD);
+        this.strimziPodSetInformer = strimziPodSetOperator.informer(watchedNamespace, DEFAULT_RESYNC_PERIOD_MS);
         this.strimziPodSetLister = new Lister<>(strimziPodSetInformer.getIndexer());
 
         // Pod informer and lister is used to get events about pods and get pods quickly
-        this.podInformer = podOperator.informer(watchedNamespace, POD_LABEL_SELECTOR, DEFAULT_RESYNC_PERIOD);
+        this.podInformer = podOperator.informer(watchedNamespace, POD_LABEL_SELECTOR, DEFAULT_RESYNC_PERIOD_MS);
         this.podLister = new Lister<>(podInformer.getIndexer());
 
         this.controllerThread = new Thread(this, "StrimziPodSetController");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -143,7 +144,7 @@ public class ClusterOperatorTest {
                 }).when(mockWatch).close();
                 return mockWatch;
             });
-            when(mockNamespacedCms.inform()).thenAnswer(i -> {
+            when(mockNamespacedCms.runnableInformer(anyLong())).thenAnswer(i -> {
                 numInformers.getAndIncrement();
                 return mockCmInformer;
             });
@@ -156,7 +157,7 @@ public class ClusterOperatorTest {
             SharedIndexInformer mockPodInformer = mock(SharedIndexInformer.class);
             MixedOperation mockNamespacedPods = mock(MixedOperation.class);
             when(mockPodInformer.getIndexer()).thenReturn(mockPodIndexer);
-            when(mockNamespacedPods.inform()).thenAnswer(i -> {
+            when(mockNamespacedPods.runnableInformer(anyLong())).thenAnswer(i -> {
                 numInformers.getAndIncrement();
                 return mockPodInformer;
             });
@@ -236,7 +237,7 @@ public class ClusterOperatorTest {
             }).when(mockWatch).close();
             return mockWatch;
         });
-        when(mockFilteredCms.inform()).thenAnswer(i -> {
+        when(mockFilteredCms.runnableInformer(anyLong())).thenAnswer(i -> {
             numInformers.getAndIncrement();
             return mockCmInformer;
         });
@@ -252,7 +253,7 @@ public class ClusterOperatorTest {
         when(mockFilteredPods.withLabelSelector(any(LabelSelector.class))).thenReturn(mockFilteredPods);
         when(mockPods.inAnyNamespace()).thenReturn(mockFilteredPods);
         when(mockPodInformer.getIndexer()).thenReturn(mockPodIndexer);
-        when(mockFilteredPods.inform()).thenAnswer(i -> {
+        when(mockFilteredPods.runnableInformer(anyLong())).thenAnswer(i -> {
             numInformers.getAndIncrement();
             return mockPodInformer;
         });

--- a/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Utilities for working with informers
+ */
+public class InformerUtils {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(InformerUtils.class);
+
+    /**
+     * Logs exceptions in the informers to give us a better overview of what is happening.
+     *
+     * @param type          Type of the informer
+     * @param isStarted     Flag indicating whether the informer is already started
+     * @param throwable     Throwable describing the exception which occurred
+     *
+     * @return  Boolean indicating whether the informer should retry or not.
+     */
+    public static boolean loggingExceptionHandler(String type, boolean isStarted, Throwable throwable) {
+        LOGGER.warnOp("Caught exception in the " + type + " informer which is " + (isStarted ? "started" : "not started"), throwable);
+        // We always want the informer to retry => we just want to log the error
+        return true;
+    }
+
+    /**
+     * Synchronously stops one or more informers. It will stop them and then wait for the specified timeout for them to
+     * actually stop.
+     *
+     * @param timeoutMillis     Timeout in milliseconds for how long we will wait for each informer to stop
+     * @param informers         Informers which should be stopped.
+     */
+    public static void stopAll(long timeoutMillis, SharedIndexInformer<?>... informers) {
+        LOGGER.infoOp("Stopping informers");
+        for (SharedIndexInformer<?> informer : informers)    {
+            informer.stop();
+        }
+
+        try {
+            for (SharedIndexInformer<?> informer : informers)    {
+                informer.stopped().toCompletableFuture().get(timeoutMillis, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            // We just log the error as we are anyway shutting down
+            LOGGER.warnOp("Interrupted while waiting for the informers to stop", e);
+        }
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
@@ -32,8 +32,8 @@ public class InformerUtils {
     }
 
     /**
-     * Synchronously stops one or more informers. It will stop them and then wait for the specified timeout for them to
-     * actually stop.
+     * Synchronously stops one or more informers. It will stop them and then wait for up to the specified timeout for
+     * each of them to actually stop.
      *
      * @param timeoutMs     Timeout in milliseconds for how long we will wait for each informer to stop
      * @param informers     Informers which should be stopped.

--- a/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
@@ -26,7 +26,7 @@ public class InformerUtils {
      * @return  Boolean indicating whether the informer should retry or not.
      */
     public static boolean loggingExceptionHandler(String type, boolean isStarted, Throwable throwable) {
-        LOGGER.warnOp("Caught exception in the " + type + " informer which is " + (isStarted ? "started" : "not started"), throwable);
+        LOGGER.errorOp("Caught exception in the " + type + " informer which is " + (isStarted ? "started" : "not started"), throwable);
         // We always want the informer to retry => we just want to log the error
         return true;
     }
@@ -35,10 +35,10 @@ public class InformerUtils {
      * Synchronously stops one or more informers. It will stop them and then wait for the specified timeout for them to
      * actually stop.
      *
-     * @param timeoutMillis     Timeout in milliseconds for how long we will wait for each informer to stop
-     * @param informers         Informers which should be stopped.
+     * @param timeoutMs     Timeout in milliseconds for how long we will wait for each informer to stop
+     * @param informers     Informers which should be stopped.
      */
-    public static void stopAll(long timeoutMillis, SharedIndexInformer<?>... informers) {
+    public static void stopAll(long timeoutMs, SharedIndexInformer<?>... informers) {
         LOGGER.infoOp("Stopping informers");
         for (SharedIndexInformer<?> informer : informers)    {
             informer.stop();
@@ -46,11 +46,11 @@ public class InformerUtils {
 
         try {
             for (SharedIndexInformer<?> informer : informers)    {
-                informer.stopped().toCompletableFuture().get(timeoutMillis, TimeUnit.MILLISECONDS);
+                informer.stopped().toCompletableFuture().get(timeoutMs, TimeUnit.MILLISECONDS);
             }
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             // We just log the error as we are anyway shutting down
-            LOGGER.warnOp("Interrupted while waiting for the informers to stop", e);
+            LOGGER.warnOp("Failed to wait for the informers to stop", e);
         }
     }
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -413,12 +413,12 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * informer returned by this method is not running and has to be started by the code using it.
      *
      * @param namespace         Namespace on which to inform
-     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
      *
      * @return          Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, long resyncInterval)   {
-        return runnableInformer(applyNamespace(namespace), resyncInterval);
+    public SharedIndexInformer<T> informer(String namespace, long resyncIntervalMs)   {
+        return runnableInformer(applyNamespace(namespace), resyncIntervalMs);
     }
 
     /**
@@ -428,12 +428,12 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      *
      * @param namespace         Namespace on which to inform
      * @param selectorLabels    Selector which should be matched by the resources
-     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
      *
      * @return                  Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncInterval)   {
-        return runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncInterval);
+    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncIntervalMs)   {
+        return runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncIntervalMs);
     }
 
     /**
@@ -443,24 +443,24 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      *
      * @param namespace         Namespace on which to inform
      * @param labelSelector     Labels Selector which should be matched by the resources
-     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
      *
      * @return                  Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector, long resyncInterval)   {
-        return runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncInterval);
+    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector, long resyncIntervalMs)   {
+        return runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncIntervalMs);
     }
 
     /**
      * Creates a runnable informer. Runnable informer is not running yet and need to be started by the code using it.
      *
      * @param informable        Instance of the Informable interface for creating informers
-     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
      *
      * @return  Runnable informer
      */
-    private SharedIndexInformer<T> runnableInformer(Informable<T> informable, long resyncInterval)  {
-        return informable.runnableInformer(resyncInterval);
+    private SharedIndexInformer<T> runnableInformer(Informable<T> informable, long resyncIntervalMs)  {
+        return informable.runnableInformer(resyncIntervalMs);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.Informable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
@@ -49,7 +50,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractNamespacedResourceOperator.class);
 
     /**
-     * Marker for indication "all namesapces" => this is used for example when creating watches to create a cluster
+     * Marker for indication "all namespaces" => this is used for example when creating watches to create a cluster
      * wide watch.
      */
     public final static String ANY_NAMESPACE = "*";
@@ -193,7 +194,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * @param reconciliation The reconciliation
      * @param namespace Namespace of the resource which should be deleted
      * @param name Name of the resource which should be deleted
-     * @param cascading Defines whether the delete should be cascading or not (e.g. whether a STS deletion should delete pods etc.)
+     * @param cascading Defines whether the deletion should be cascading or not (e.g. whether an STS deletion should delete pods etc.)
      *
      * @return A future which will be completed on the context thread
      *         once the resource has been deleted.
@@ -250,7 +251,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
     }
 
     /**
-     * Method for patching or replacing a resource. By default is using JSON-type patch. Overriding this method can be
+     * Method for patching or replacing a resource. By default, is using JSON-type patch. Overriding this method can be
      * used to use replace instead of patch or different patch strategies.
      *
      * @param namespace     Namespace of the resource
@@ -408,52 +409,58 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
     }
 
     /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide).
+     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide). The
+     * informer returned by this method is not running and has to be started by the code using it.
      *
-     * @param namespace Namespace on which to inform
+     * @param namespace         Namespace on which to inform
+     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
      *
      * @return          Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace)   {
-        if (ANY_NAMESPACE.equals(namespace))    {
-            return operation().inAnyNamespace().inform();
-        } else {
-            return operation().inNamespace(namespace).inform();
-        }
+    public SharedIndexInformer<T> informer(String namespace, long resyncInterval)   {
+        return runnableInformer(applyNamespace(namespace), resyncInterval);
     }
 
     /**
      * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
-     * matching the selector.
+     * matching the selector. The informer returned by this method is not running and has to be started by the code
+     * using it.
      *
      * @param namespace         Namespace on which to inform
      * @param selectorLabels    Selector which should be matched by the resources
+     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
      *
      * @return                  Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels)   {
-        if (ANY_NAMESPACE.equals(namespace))    {
-            return operation().inAnyNamespace().withLabels(selectorLabels).inform();
-        } else {
-            return operation().inNamespace(namespace).withLabels(selectorLabels).inform();
-        }
+    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncInterval)   {
+        return runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncInterval);
     }
 
     /**
      * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
-     * matching the selector.
+     * matching the selector. The informer returned by this method is not running and has to be started by the code
+     * using it.
      *
      * @param namespace         Namespace on which to inform
      * @param labelSelector     Labels Selector which should be matched by the resources
+     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
      *
      * @return                  Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector)   {
-        if (ANY_NAMESPACE.equals(namespace))    {
-            return operation().inAnyNamespace().withLabelSelector(labelSelector).inform();
-        } else {
-            return operation().inNamespace(namespace).withLabelSelector(labelSelector).inform();
-        }
+    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector, long resyncInterval)   {
+        return runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncInterval);
+    }
+
+    /**
+     * Creates a runnable informer. Runnable informer is not running yet and need to be started by the code using it.
+     *
+     * @param informable        Instance of the Informable interface for creating informers
+     * @param resyncInterval    The interval in which the resyncInterval of the informer should happen in milliseconds
+     *
+     * @return  Runnable informer
+     */
+    private SharedIndexInformer<T> runnableInformer(Informable<T> informable, long resyncInterval)  {
+        return informable.runnableInformer(resyncInterval);
     }
 
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
@@ -170,6 +170,8 @@ public class UserController {
             }
         });
 
+        // Can't stop the informers before the controller, because the controllers depend on the indexers, which depend
+        // on the informers. So stopping the informers first would break the controller and cause errors.
         InformerUtils.stopAll(5_000L, userInformer, secretInformer);
     }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeoutException;
 public class UserController {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(UserController.class);
     private static final String RESOURCE_KIND = "KafkaUser";
-    private static final long DEFAULT_RESYNC_PERIOD = 5 * 60 * 1_000L; // 5 minutes by default
+    private static final long DEFAULT_RESYNC_PERIOD_MS = 5 * 60 * 1_000L; // 5 minutes by default
 
     private final KafkaUserOperator userOperator;
     private final ControllerMetricsHolder metrics;
@@ -93,11 +93,11 @@ public class UserController {
         this.workQueue = new ControllerQueue(config.getWorkQueueSize(), this.metrics);
 
         // Secret informer and lister is used to get events about Secrets and get Secrets quickly
-        this.secretInformer = client.secrets().inNamespace(watchedNamespace).withLabels(secretSelector).runnableInformer(DEFAULT_RESYNC_PERIOD);
+        this.secretInformer = client.secrets().inNamespace(watchedNamespace).withLabels(secretSelector).runnableInformer(DEFAULT_RESYNC_PERIOD_MS);
         Lister<Secret> secretLister = new Lister<>(secretInformer.getIndexer());
 
         // KafkaUser informer and lister is used to get events about Users and get Users quickly
-        this.userInformer = Crds.kafkaUserOperation(client).inNamespace(watchedNamespace).withLabels(userSelector).runnableInformer(DEFAULT_RESYNC_PERIOD);
+        this.userInformer = Crds.kafkaUserOperation(client).inNamespace(watchedNamespace).withLabels(userSelector).runnableInformer(DEFAULT_RESYNC_PERIOD_MS);
         Lister<KafkaUser> userLister = new Lister<>(userInformer.getIndexer());
 
         // Creates the scheduled executor service used for periodical reconciliations and progress warnings


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors the informer handling in the `UserController` and in the `StrimziPodSetController`. It applies the following changes:
* Uses Fabric8 to create _runnable_ informers => _runnable_ informers are not started by default and they are started only by us. That gives us better control over the lifecycle of the informer and allows us to configure things that are not configurable once the informer is started. This allows us also to actually enable the re-sync (which we configured before, but was not really used). 
* Adds synchronous stopping of the informers. Before this PR, we _requested_ the informers to stop, but did not wait for them to actually stop.
* It adds an exception handler to log any possible exception. In previous Strimzi versions, there were some issues reported when the informer stopped working. This might help us to debug it more if it happens again (although it might have been caused by Fabric8 bugs fixed in the meantime as well, so it might not reproduce anymore).
* It creates new `InformerUtils` method shared between the `StrimziPodSetController` and the `UserController` for some of the logic shared by both (`UserController` does not use Vert.x and the Resource Operator classes, so it could not be placed there).
* Refactors the event handlers in both controllers into separate inner classes to make the logic of starting the controllers shorter and easier to read what it does without studying the (sometimes) long event handler code.

This PR does not add any new tests as it just refactors the existing functionality - so it is covered by the existing tests.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally