### PR TITLE
ST: Collect logs also from previous instance of the pods in case the pod was restarted

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -343,6 +343,14 @@ public class LogCollector {
             LOGGER.warn("Unable to collect log from pod: {} and container: {} - pod container is not initialized", podName, containerStatus.getName());
         }
 
+        // Collect logs from previous version of the container
+        try {
+            String terminatedLog = kubeClient.getPodResource(namespace, podName).inContainer(containerStatus.getName()).terminated().getLog();
+            writeFile(path + "/logs-pod-" + podName + "-container-" + containerStatus.getName() + ".terminated.log", terminatedLog);
+        } catch (RuntimeException e) {
+            // For most of the pods it will fail as it doesn't have restarted container, so we just want to skip the exception
+        }
+
         // Describe all pods
         String describe = cmdKubeClient(namespace).describe("pod", podName);
         writeFile(path + "/describe-pod-" + podName + "-container-" + containerStatus.getName() + ".log", describe);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, our log collector doesn't care about restarted pods and it will get logs only from the running containers. This PR changes it and logs will be collected also from the previous instance of the containers. 

### Checklist

- [ ] Make sure all tests pass

