### PR TITLE
[DOCS] Fix CC capacity docs

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -151,13 +151,13 @@ spec:
 [id='property-cruise-control-broker-capacity-{context}']
 === brokerCapacity
 
-Cruise Control uses capacity limits to determine if optimization goals for resource distribution are being broken.
+Cruise Control uses capacity limits to determine if optimization goals for resource capacity limits are being broken.
 There are four goals of this type:
 
-* `DiskUsageDistributionGoal`            - Disk utilization distribution
-* `CpuUsageDistributionGoal`             - CPU utilization distribution
-* `NetworkInboundUsageDistributionGoal`  - Network inbound utilization distribution
-* `NetworkOutboundUsageDistributionGoal` - Network outbound utilization distribution
+* `DiskCapacityGoal`            - Disk utilization capacity
+* `CpuCapacityGoal`             - CPU utilization capacity
+* `NetworkInboundCapacityGoal`  - Network inbound utilization capacity
+* `NetworkOutboundCapacityGoal` - Network outbound utilization capacity
 
 You specify capacity limits for Kafka broker resources in the `brokerCapacity` property in `Kafka.spec.cruiseControl` .
 They are enabled by default and you can change their default values.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fixing the documentation surrounding Cruise Control capacity goals. 

The documentation mixed information about resource distribution and resource capacity goals when the section is only concerned about resource capacity goals.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

