### PR TITLE
ST: Allow users to use any registry for connect build specified via env var

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -395,7 +395,11 @@ If you want to use private registries, before executing the tests, you have to c
 
 For tests that use `KafkaConnect` build feature, users can use their own registry to where the result image will be pushed.
 The config is specified by two env variables: `CONNECT_BUILD_IMAGE_PATH` and `CONNECT_BUILD_REGISTRY_SECRET`.
-`CONNECT_BUILD_IMAGE_PATH` has to be in format `<REGISTRY>/<ORGANIZATION>/<IMAGE_NAME>`. 
+`CONNECT_BUILD_IMAGE_PATH` has to be in format `<REGISTRY>/<ORGANIZATION>/<IMAGE_NAME>`.
+The image format has to be without floating tag.
+This is needed because our tests can be executed in parallel so each connect build needs unique tag.
+The tag is generated and appended by tests during the execution.
+
 In case the registry needs authorization, users can specify push-secret by `CONNECT_BUILD_REGISTRY_SECRET`.
 Secret name should reference to k8s secret in `default` namespace.
 In case any of the env vars are not specified, default Minikube or OpenShift registries will be used.

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -351,32 +351,34 @@ Loading of system configuration has the following priority order:
 
 All environment variables are defined in [Environment](systemtest/src/main/java/io/strimzi/systemtest/Environment.java) class:
 
-| Name                                   | Description                                                                                                                          | Default                                        |
-|:---------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|
-| DOCKER_ORG                             | Specify the organization/repo containing the image used in system tests                                                              | strimzi                                        |
-| DOCKER_TAG                             | Specify the image tags used in system tests                                                                                          | latest                                         |
-| DOCKER_REGISTRY                        | Specify the docker registry used in system tests                                                                                     | quay.io                                        |
-| BRIDGE_IMAGE                           | Specify the Kafka bridge image used in system tests                                                                                  | quay.io/strimzi/kafka-bridge:latest            |
-| TEST_LOG_DIR                           | Directory for storing logs collected during the tests                                                                                | ../systemtest/target/logs/                     |
-| ST_KAFKA_VERSION                       | Kafka version used in images during the system tests                                                                                 | 2.3.0                                          |
-| STRIMZI_LOG_LEVEL                      | Log level for the cluster operator                                                                                                   | DEBUG                                          |
-| STRIMZI_COMPONENTS_LOG_LEVEL           | Log level for the components                                                                                                         | INFO                                           |
-| KUBERNETES_DOMAIN                      | Cluster domain                                                                                                                       | .nip.io                                        |
-| TEST_CLUSTER_CONTEXT                   | context which will be used to reach the cluster*                                                                                     | currently active Kubernetes context            |
-| TEST_CLUSTER_USER                      | Default user which will be used for command-line admin operations                                                                    | developer                                      |
-| SKIP_TEARDOWN                          | Variable for skip teardown phase for more debug if needed                                                                            | false                                          |
-| OPERATOR_IMAGE_PULL_POLICY             | Image Pull Policy for Operator image                                                                                                 | Always                                         |
-| COMPONENTS_IMAGE_PULL_POLICY           | Image Pull Policy for Kafka, Bridge, etc.                                                                                            | IfNotPresent                                   |
-| STRIMZI_TEST_LOG_LEVEL                 | Log level for system tests                                                                                                           | INFO                                           |
-| STRIMZI_TEST_ROOT_LOG_LEVEL            | Root Log level for system tests                                                                                                      | DEBUG                                          |
-| STRIMZI_RBAC_SCOPE                     | Set to 'CLUSTER' or 'NAMESPACE' to deploy the operator with ClusterRole or Roles, respectively                                       | cluster                                        |
-| OLM_OPERATOR_NAME                      | Operator name in manifests CSV                                                                                                       | strimzi                                        |
-| OLM_SOURCE_NAME                        | CatalogSource name which contains desired operator                                                                                   | strimzi-source                                 |
-| OLM_APP_BUNDLE_PREFIX                  | CSV bundle name                                                                                                                      | strimzi                                        |
-| OLM_OPERATOR_VERSION                   | Version of the operator which will be installed                                                                                      | v0.16.2                                        |
-| DEFAULT_TO_DENY_NETWORK_POLICIES       | Determines how will be network policies set - to deny-all (true) or allow-all (false)                                                | true                                           |
-| STRIMZI_EXEC_MAX_LOG_OUTPUT_CHARACTERS | Set maximum count of characters printed from [Executor](test/src/main/java/io/strimzi/test/executor/Exec.java) stdout and stderr     | 20000                                          |
-| CLUSTER_OPERATOR_INSTALL_TYPE          | Specify how the CO will be deployed. `OLM` option will install operator via OLM, and you just need to set other `OLM` env variables. | bundle                                         |
+| Name                                   | Description                                                                                                                                           | Default                             |
+|:---------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------|
+| DOCKER_ORG                             | Specify the organization/repo containing the image used in system tests                                                                               | strimzi                             |
+| DOCKER_TAG                             | Specify the image tags used in system tests                                                                                                           | latest                              |
+| DOCKER_REGISTRY                        | Specify the docker registry used in system tests                                                                                                      | quay.io                             |
+| BRIDGE_IMAGE                           | Specify the Kafka bridge image used in system tests                                                                                                   | quay.io/strimzi/kafka-bridge:latest |
+| TEST_LOG_DIR                           | Directory for storing logs collected during the tests                                                                                                 | ../systemtest/target/logs/          |
+| ST_KAFKA_VERSION                       | Kafka version used in images during the system tests                                                                                                  | 2.3.0                               |
+| STRIMZI_LOG_LEVEL                      | Log level for the cluster operator                                                                                                                    | DEBUG                               |
+| STRIMZI_COMPONENTS_LOG_LEVEL           | Log level for the components                                                                                                                          | INFO                                |
+| KUBERNETES_DOMAIN                      | Cluster domain                                                                                                                                        | .nip.io                             |
+| TEST_CLUSTER_CONTEXT                   | context which will be used to reach the cluster*                                                                                                      | currently active Kubernetes context |
+| TEST_CLUSTER_USER                      | Default user which will be used for command-line admin operations                                                                                     | developer                           |
+| SKIP_TEARDOWN                          | Variable for skip teardown phase for more debug if needed                                                                                             | false                               |
+| OPERATOR_IMAGE_PULL_POLICY             | Image Pull Policy for Operator image                                                                                                                  | Always                              |
+| COMPONENTS_IMAGE_PULL_POLICY           | Image Pull Policy for Kafka, Bridge, etc.                                                                                                             | IfNotPresent                        |
+| STRIMZI_TEST_LOG_LEVEL                 | Log level for system tests                                                                                                                            | INFO                                |
+| STRIMZI_TEST_ROOT_LOG_LEVEL            | Root Log level for system tests                                                                                                                       | DEBUG                               |
+| STRIMZI_RBAC_SCOPE                     | Set to 'CLUSTER' or 'NAMESPACE' to deploy the operator with ClusterRole or Roles, respectively                                                        | cluster                             |
+| OLM_OPERATOR_NAME                      | Operator name in manifests CSV                                                                                                                        | strimzi                             |
+| OLM_SOURCE_NAME                        | CatalogSource name which contains desired operator                                                                                                    | strimzi-source                      |
+| OLM_APP_BUNDLE_PREFIX                  | CSV bundle name                                                                                                                                       | strimzi                             |
+| OLM_OPERATOR_VERSION                   | Version of the operator which will be installed                                                                                                       | v0.16.2                             |
+| DEFAULT_TO_DENY_NETWORK_POLICIES       | Determines how will be network policies set - to deny-all (true) or allow-all (false)                                                                 | true                                |
+| STRIMZI_EXEC_MAX_LOG_OUTPUT_CHARACTERS | Set maximum count of characters printed from [Executor](test/src/main/java/io/strimzi/test/executor/Exec.java) stdout and stderr                      | 20000                               |
+| CLUSTER_OPERATOR_INSTALL_TYPE          | Specify how the CO will be deployed. `OLM` option will install operator via OLM, and you just need to set other `OLM` env variables.                  | bundle                              |
+| CONNECT_BUILD_REGISTRY                 | Specify the registry together with org used by KafkaConnect build. For example `quay.io/strimzi`                                                      | empty                               |
+| CONNECT_BUILD_REGISTRY_SECRET          | Specify the registry secret used by KafkaConnect build. It has to be k8s secret deployed in `default` namespace and systemtests will handle the rest. | empty                               |
 
 If you want to use your images with a different tag or from a separate repository, you can use `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` environment variables.
 
@@ -390,6 +392,13 @@ To set the custom Kafka version in system tests, you need to set the Environment
 
 If you want to use private registries, before executing the tests, you have to create a secret and then specify the name of the created secret in the env variable called
 `SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET` with the container registry credentials to be able to pull images. Note that a secret has to be created in the `default` namespace.
+
+For tests that use `KafkaConnect` build feature, users can use their own registry to where the result image will be pushed.
+The config is specified by two env variables: `CONNECT_BUILD_REGISTRY` and `CONNECT_BUILD_REGISTRY_SECRET`.
+`CONNECT_BUILD_REGISTRY` has to be in format `<REGISTRY>/<ORGANIZATION>`. 
+In case the registry needs authorization, users can specify push-secret by `CONNECT_BUILD_REGISTRY_SECRET`.
+Secret name should reference to k8s secret in `default` namespace.
+In case any of the env vars are not specified, default Minikube or OpenShift registries will be used.
 
 ##### Cluster Operator Log level
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -377,7 +377,7 @@ All environment variables are defined in [Environment](systemtest/src/main/java/
 | DEFAULT_TO_DENY_NETWORK_POLICIES       | Determines how will be network policies set - to deny-all (true) or allow-all (false)                                                                 | true                                |
 | STRIMZI_EXEC_MAX_LOG_OUTPUT_CHARACTERS | Set maximum count of characters printed from [Executor](test/src/main/java/io/strimzi/test/executor/Exec.java) stdout and stderr                      | 20000                               |
 | CLUSTER_OPERATOR_INSTALL_TYPE          | Specify how the CO will be deployed. `OLM` option will install operator via OLM, and you just need to set other `OLM` env variables.                  | bundle                              |
-| CONNECT_BUILD_REGISTRY                 | Specify the registry together with org used by KafkaConnect build. For example `quay.io/strimzi`                                                      | empty                               |
+| CONNECT_BUILD_IMAGE_PATH               | Specify the registry together with org used by KafkaConnect build. For example `quay.io/strimzi/custom-connect-build`                                 | empty                               |
 | CONNECT_BUILD_REGISTRY_SECRET          | Specify the registry secret used by KafkaConnect build. It has to be k8s secret deployed in `default` namespace and systemtests will handle the rest. | empty                               |
 
 If you want to use your images with a different tag or from a separate repository, you can use `DOCKER_REGISTRY`, `DOCKER_ORG` and `DOCKER_TAG` environment variables.
@@ -394,8 +394,8 @@ If you want to use private registries, before executing the tests, you have to c
 `SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET` with the container registry credentials to be able to pull images. Note that a secret has to be created in the `default` namespace.
 
 For tests that use `KafkaConnect` build feature, users can use their own registry to where the result image will be pushed.
-The config is specified by two env variables: `CONNECT_BUILD_REGISTRY` and `CONNECT_BUILD_REGISTRY_SECRET`.
-`CONNECT_BUILD_REGISTRY` has to be in format `<REGISTRY>/<ORGANIZATION>`. 
+The config is specified by two env variables: `CONNECT_BUILD_IMAGE_PATH` and `CONNECT_BUILD_REGISTRY_SECRET`.
+`CONNECT_BUILD_IMAGE_PATH` has to be in format `<REGISTRY>/<ORGANIZATION>/<IMAGE_NAME>`. 
 In case the registry needs authorization, users can specify push-secret by `CONNECT_BUILD_REGISTRY_SECRET`.
 Secret name should reference to k8s secret in `default` namespace.
 In case any of the env vars are not specified, default Minikube or OpenShift registries will be used.

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -463,4 +463,9 @@ public interface Constants {
     String CO_REQUESTS_CPU = "200m";
     String CO_LIMITS_MEMORY = "512Mi";
     String CO_LIMITS_CPU = "1000m";
+
+    /**
+     * Connect build image name
+     */
+    String ST_CONNECT_BUILD_IMAGE_NAME = "strimzi-sts-connect-build";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -147,7 +147,7 @@ public class Environment {
     /**
      * User specific registry for Connect build
      */
-    public static final String CONNECT_BUILD_REGISTRY_ENV = "CONNECT_BUILD_REGISTRY";
+    public static final String CONNECT_BUILD_IMAGE_PATH_ENV = "CONNECT_BUILD_IMAGE_PATH";
     public static final String CONNECT_BUILD_REGISTRY_SECRET_ENV = "CONNECT_BUILD_REGISTRY_SECRET";
 
     /**
@@ -226,7 +226,7 @@ public class Environment {
     // Connect build related variables
     public static final String ST_FILE_PLUGIN_URL = getOrDefault(ST_FILE_PLUGIN_URL_ENV, ST_FILE_PLUGIN_URL_DEFAULT);
 
-    public static final String CONNECT_BUILD_REGISTRY = getOrDefault(CONNECT_BUILD_REGISTRY_ENV, "");
+    public static final String CONNECT_BUILD_IMAGE_PATH = getOrDefault(CONNECT_BUILD_IMAGE_PATH_ENV, "");
     public static final String CONNECT_BUILD_REGISTRY_SECRET = getOrDefault(CONNECT_BUILD_REGISTRY_SECRET_ENV, "");
 
     private Environment() { }
@@ -299,8 +299,8 @@ public class Environment {
     }
 
     public static String getImageOutputRegistry(String namespace, String imageName, String tag) {
-        if (!Environment.CONNECT_BUILD_REGISTRY.isEmpty()) {
-            return Environment.CONNECT_BUILD_REGISTRY + "/" + imageName + ":" + tag;
+        if (!Environment.CONNECT_BUILD_IMAGE_PATH.isEmpty()) {
+            return Environment.CONNECT_BUILD_IMAGE_PATH + ":" + tag;
         } else {
             return getImageOutputRegistry() + "/" + namespace + "/" + imageName + ":" + tag;
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -145,6 +145,12 @@ public class Environment {
     public static final String RESOURCE_ALLOCATION_STRATEGY_ENV = "RESOURCE_ALLOCATION_STRATEGY";
 
     /**
+     * User specific registry for Connect build
+     */
+    public static final String CONNECT_BUILD_REGISTRY_ENV = "CONNECT_BUILD_REGISTRY";
+    public static final String CONNECT_BUILD_REGISTRY_SECRET_ENV = "CONNECT_BUILD_REGISTRY_SECRET";
+
+    /**
      * Defaults
      */
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";
@@ -220,6 +226,9 @@ public class Environment {
     // Connect build related variables
     public static final String ST_FILE_PLUGIN_URL = getOrDefault(ST_FILE_PLUGIN_URL_ENV, ST_FILE_PLUGIN_URL_DEFAULT);
 
+    public static final String CONNECT_BUILD_REGISTRY = getOrDefault(CONNECT_BUILD_REGISTRY_ENV, "");
+    public static final String CONNECT_BUILD_REGISTRY_SECRET = getOrDefault(CONNECT_BUILD_REGISTRY_SECRET_ENV, "");
+
     private Environment() { }
 
     static {
@@ -286,6 +295,14 @@ public class Environment {
             } else {
                 return service.getSpec().getClusterIP() + ":" + service.getSpec().getPorts().stream().filter(servicePort -> servicePort.getName().equals("http")).findFirst().orElseThrow().getPort();
             }
+        }
+    }
+
+    public static String getImageOutputRegistry(String namespace, String imageName, String tag) {
+        if (!Environment.CONNECT_BUILD_REGISTRY.isEmpty()) {
+            return Environment.CONNECT_BUILD_REGISTRY + "/" + imageName + ":" + tag;
+        } else {
+            return getImageOutputRegistry() + "/" + namespace + "/" + imageName + ":" + tag;
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
@@ -138,7 +138,7 @@ public class TestSuiteNamespaceManager {
                 if (ExecutionListener.hasSuiteParallelOrIsolatedTest(extensionContext)) {
                     KubeClusterResource.getInstance().createNamespace(CollectorElement.createCollectorElement(testSuite), namespaceName);
                     NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceName));
-                    StUtils.copyImagePullSecret(namespaceName);
+                    StUtils.copyImagePullSecrets(namespaceName);
                 } else {
                     LOGGER.info("We are not gonna create additional namespace: {}, because test suite: {} does not " +
                         "contains @ParallelTest or @IsolatedTest.", namespaceName, requiredClassName);
@@ -170,7 +170,7 @@ public class TestSuiteNamespaceManager {
 
                 KubeClusterResource.getInstance().createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()), namespaceTestCase);
                 NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceTestCase));
-                StUtils.copyImagePullSecret(namespaceTestCase);
+                StUtils.copyImagePullSecrets(namespaceTestCase);
             }
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -255,7 +255,7 @@ public class SetupClusterOperator {
             cluster.setNamespace(namespaceInstallTo);
             cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
             extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
-            StUtils.copyImagePullSecret(namespaceInstallTo);
+            StUtils.copyImagePullSecrets(namespaceInstallTo);
         }
 
         OlmConfiguration olmConfiguration = new OlmConfigurationBuilder()
@@ -382,7 +382,7 @@ public class SetupClusterOperator {
             cluster.setNamespace(namespaceInstallTo);
             cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
             extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, false);
-            StUtils.copyImagePullSecret(namespaceInstallTo);
+            StUtils.copyImagePullSecrets(namespaceInstallTo);
         } else {
             LOGGER.info("Environment for ClusterOperator was already prepared! Going to install it now.");
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -435,7 +435,7 @@ public class StUtils {
      * Copies the image pull secret from the default namespace to the specified target namespace.
      * @param namespace the target namespace
      */
-    public static void copyImagePullSecret(String namespace) {
+    public static void copyImagePullSecrets(String namespace) {
         if (Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET != null && !Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET.isEmpty()) {
             LOGGER.info("Checking if secret {} is in the default namespace", Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET);
             if (kubeClient("default").getSecret(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET) == null) {
@@ -448,6 +448,24 @@ public class StUtils {
                 .withKind("Secret")
                 .withNewMetadata()
                     .withName(Environment.SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withType("kubernetes.io/dockerconfigjson")
+                .withData(Collections.singletonMap(".dockerconfigjson", pullSecret.getData().get(".dockerconfigjson")))
+                .build());
+        }
+        if (Environment.CONNECT_BUILD_REGISTRY_SECRET != null && !Environment.CONNECT_BUILD_REGISTRY_SECRET.isEmpty()) {
+            LOGGER.info("Checking if secret {} is in the default namespace", Environment.CONNECT_BUILD_REGISTRY_SECRET);
+            if (kubeClient("default").getSecret(Environment.CONNECT_BUILD_REGISTRY_SECRET) == null) {
+                throw new RuntimeException(Environment.CONNECT_BUILD_REGISTRY_SECRET + " is not in the default namespace!");
+            }
+            LOGGER.info("Creating pull secret {}/{}", namespace, Environment.CONNECT_BUILD_REGISTRY_SECRET);
+            Secret pullSecret = kubeClient("default").getSecret(Environment.CONNECT_BUILD_REGISTRY_SECRET);
+            kubeClient(namespace).createSecret(new SecretBuilder()
+                .withApiVersion("v1")
+                .withKind("Secret")
+                .withNewMetadata()
+                    .withName(Environment.CONNECT_BUILD_REGISTRY_SECRET)
                     .withNamespace(namespace)
                 .endMetadata()
                 .withType("kubernetes.io/dockerconfigjson")

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderIsolatedST.java
@@ -96,8 +96,6 @@ class ConnectBuilderIsolatedST extends AbstractST {
     private static final String PLUGIN_WITH_OTHER_TYPE_NAME = "plugin-with-other-type";
     private static final String PLUGIN_WITH_MAVEN_NAME = "connector-from-maven";
 
-    private String outputRegistry = "";
-
     private static final Plugin PLUGIN_WITH_TAR_AND_JAR = new PluginBuilder()
         .withName(PLUGIN_WITH_TAR_AND_JAR_NAME)
         .withArtifacts(
@@ -165,9 +163,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
             .editOrNewSpec()
                 .withNewBuild()
                     .withPlugins(pluginWithWrongChecksum)
-                    .withNewDockerOutput()
-                        .withImage(imageName)
-                    .endDockerOutput()
+                    .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
             .endSpec()
             .build());
@@ -233,9 +229,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .withNewBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR, PLUGIN_WITH_ZIP)
-                    .withNewDockerOutput()
-                        .withImage(imageName)
-                    .endDockerOutput()
+                    .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
                 .withNewInlineLogging()
                     .addToLoggers("connect.root.logger.level", "INFO")
@@ -344,9 +338,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .withNewBuild()
                     .withPlugins(PLUGIN_WITH_TAR_AND_JAR)
-                    .withNewDockerOutput()
-                        .withImage(imageName)
-                    .endDockerOutput()
+                    .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
                 .withNewInlineLogging()
                     .addToLoggers("connect.root.logger.level", "INFO")
@@ -430,9 +422,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                     .withNewBuild()
                         .withPlugins(PLUGIN_WITH_OTHER_TYPE)
-                        .withNewDockerOutput()
-                            .withImage(imageName)
-                        .endDockerOutput()
+                        .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageName))
                 .endBuild()
             .endSpec()
             .build());
@@ -490,9 +480,7 @@ class ConnectBuilderIsolatedST extends AbstractST {
                     .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                     .withNewBuild()
                         .withPlugins(PLUGIN_WITH_MAVEN_TYPE)
-                        .withNewDockerOutput()
-                            .withImage(imageName)
-                        .endDockerOutput()
+                        .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageName))
                     .endBuild()
                 .endSpec()
                 .build());
@@ -527,7 +515,8 @@ class ConnectBuilderIsolatedST extends AbstractST {
 
     private String getImageNameForTestCase() {
         int randomNum = new Random().nextInt(Integer.MAX_VALUE);
-        return outputRegistry + "/connect-build-" + randomNum + ":latest";
+        return Environment.getImageOutputRegistry(clusterOperator.getDeploymentNamespace(), Constants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(randomNum));
+
     }
 
     @BeforeAll
@@ -537,8 +526,6 @@ class ConnectBuilderIsolatedST extends AbstractST {
             .withOperationTimeout(Constants.CO_OPERATION_TIMEOUT_SHORT)
             .createInstallation()
             .runInstallation();
-
-        outputRegistry = Environment.getImageOutputRegistry() + "/" +  clusterOperator.getDeploymentNamespace();
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterOperator.getDeploymentNamespace(), 3).build());
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -36,7 +36,6 @@ import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
 import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
 import io.strimzi.api.kafka.model.template.DeploymentStrategy;
 import io.strimzi.operator.common.Annotations;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
@@ -607,7 +606,7 @@ class ConnectIsolatedST extends AbstractST {
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3).build());
 
-        String imageName = Environment.getImageOutputRegistry() + "/" + testStorage.getNamespaceName() + "/connect-" + Util.hashStub(String.valueOf(new Random().nextInt(Integer.MAX_VALUE))) + ":latest";
+        final String imageFullPath = Environment.getImageOutputRegistry(testStorage.getNamespaceName(), Constants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
 
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build());
 
@@ -631,9 +630,7 @@ class ConnectIsolatedST extends AbstractST {
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .withNewBuild()
                     .withPlugins(echoSinkPlugin)
-                    .withNewDockerOutput()
-                        .withImage(imageName)
-                    .endDockerOutput()
+                    .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageFullPath))
                 .endBuild()
             .endSpec()
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -706,8 +706,8 @@ public class MetricsIsolatedST extends AbstractST {
         clusterOperator.unInstall();
         cluster.createNamespaces(CollectorElement.createCollectorElement(this.getClass().getName()), clusterOperator.getDeploymentNamespace(), Arrays.asList(namespaceFirst, namespaceSecond));
         // Copy pull secret into newly created namespaces
-        StUtils.copyImagePullSecret(namespaceFirst);
-        StUtils.copyImagePullSecret(namespaceSecond);
+        StUtils.copyImagePullSecrets(namespaceFirst);
+        StUtils.copyImagePullSecrets(namespaceSecond);
 
         clusterOperator = clusterOperator.defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -99,7 +99,7 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
         deployCOInNamespace(extensionContext, SECOND_CO_NAME, SECOND_NAMESPACE, Collections.singletonList(SECOND_CO_SELECTOR_ENV), true);
 
         cluster.createNamespace(DEFAULT_NAMESPACE);
-        StUtils.copyImagePullSecret(DEFAULT_NAMESPACE);
+        StUtils.copyImagePullSecrets(DEFAULT_NAMESPACE);
         cluster.setNamespace(DEFAULT_NAMESPACE);
 
         LOGGER.info("Deploying Kafka without CR selector");

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
@@ -265,7 +265,7 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
 
         // Recreate namespace
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
-        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecrets(clusterOperator.getDeploymentNamespace());
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -135,7 +135,7 @@ public class OauthAbstractST extends AbstractST {
         // (f.e., our `infra-namespace`)
         if (kubeClient().getNamespace(clusterOperator.getDeploymentNamespace()) == null) {
             cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), clusterOperator.getDeploymentNamespace());
-            StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
+            StUtils.copyImagePullSecrets(clusterOperator.getDeploymentNamespace());
         }
 
         SetupKeycloak.deployKeycloakOperator(extensionContext, clusterOperator.getDeploymentNamespace(), namespace);

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/HelmChartIsolatedST.java
@@ -64,7 +64,7 @@ class HelmChartIsolatedST extends AbstractST {
 
         LOGGER.info("Creating resources before the test class");
         cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()), clusterOperator.getDeploymentNamespace());
-        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecrets(clusterOperator.getDeploymentNamespace());
         // Helm CO created
         helmResource.create(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificIsolatedST.java
@@ -258,7 +258,7 @@ public class SpecificIsolatedST extends AbstractST {
         clusterOperator.unInstall();
         // create namespace, where we will be able to deploy Custom Resources
         cluster.createNamespace(CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()), namespaceWhereCreationOfCustomResourcesIsApproved);
-        StUtils.copyImagePullSecret(namespaceWhereCreationOfCustomResourcesIsApproved);
+        StUtils.copyImagePullSecrets(namespaceWhereCreationOfCustomResourcesIsApproved);
         clusterOperator = clusterOperator.defaultInstallation()
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
             // use our pre-defined Roles

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -18,7 +18,6 @@ import io.strimzi.api.kafka.model.connect.build.JarArtifactBuilder;
 import io.strimzi.api.kafka.model.connect.build.Plugin;
 import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.operator.common.Annotations;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -529,7 +528,7 @@ public class AbstractUpgradeST extends AbstractST {
                     )
                     .build();
 
-                final String imageName = Environment.getImageOutputRegistry() + "/" + testStorage.getNamespaceName() + "/connect-" + Util.hashStub(String.valueOf(new Random().nextInt(Integer.MAX_VALUE))) + ":latest";
+                final String imageFullPath = Environment.getImageOutputRegistry(testStorage.getNamespaceName(), io.strimzi.systemtest.Constants.ST_CONNECT_BUILD_IMAGE_NAME, String.valueOf(new Random().nextInt(Integer.MAX_VALUE)));
 
                 KafkaConnect kafkaConnect = new KafkaConnectBuilder(TestUtils.configFromYaml(kafkaConnectYaml, KafkaConnect.class))
                     .editMetadata()
@@ -539,9 +538,7 @@ public class AbstractUpgradeST extends AbstractST {
                     .editSpec()
                         .editOrNewBuild()
                             .withPlugins(fileSinkPlugin)
-                            .withNewDockerOutput()
-                                .withImage(imageName)
-                            .endDockerOutput()
+                            .withDockerOutput(KafkaConnectTemplates.dockerOutput(imageFullPath))
                         .endBuild()
                         .addToConfig("key.converter.schemas.enable", false)
                         .addToConfig("value.converter.schemas.enable", false)

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
@@ -89,7 +89,7 @@ public class StrimziDowngradeIsolatedST extends AbstractUpgradeST {
     @BeforeEach
     void setupEnvironment() {
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
-        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecrets(clusterOperator.getDeploymentNamespace());
     }
 
     @AfterEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -196,7 +196,7 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
     @BeforeEach
     void setupEnvironment() {
         cluster.createNamespace(clusterOperator.getDeploymentNamespace());
-        StUtils.copyImagePullSecret(clusterOperator.getDeploymentNamespace());
+        StUtils.copyImagePullSecrets(clusterOperator.getDeploymentNamespace());
     }
 
     protected void afterEachMayOverride(ExtensionContext extensionContext) throws Exception {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR enables usage of user-defined registries for KafkaConnect build in systemtest package. 

Resolve https://github.com/strimzi/strimzi-kafka-operator/issues/8277

### Checklist

- [ ] Make sure all tests pass

