### PR TITLE
Update Fabric8 Kubernetes Client to 6.6.0

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.leaderelection;
 import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Disabled // Disabled because of https://github.com/strimzi/strimzi-kafka-operator/issues/8268
 @EnableKubernetesMockClient(crud = true)
 public class LeaderElectionManagerMockTest {
     private final static String NAMESPACE = "my-le-namespace";
@@ -54,10 +52,10 @@ public class LeaderElectionManagerMockTest {
         le2Leader.await();
         assertThat(getLease().getSpec().getHolderIdentity(), is("le-2"));
 
-        // Stop the second member => the leadership in the lease resource will stay as it was
+        // Stop the second member => the leadership should be released
         le2.stop();
         le2NotLeader.await();
-        assertThat(getLease().getSpec().getHolderIdentity(), anyOf(is("le-2"), nullValue()));
+        assertThat(getLease().getSpec().getHolderIdentity(), anyOf(is(""), nullValue()));
     }
 
     private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Runnable stopLeadershipCallback)   {

--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,9 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.5.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.5.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.5.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.6.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.6.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.6.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.14.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.14.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to 6.6.0. This should resolve #8268 -> the underlying bug was fixed in Fabric8 6.6.0 and this PR re-enabled the test.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally