### PR TITLE
docs(zookeeper): adds a description of zookeeper default values

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.ZookeeperClusterSpec.adoc
@@ -57,7 +57,7 @@ spec:
     # ...
     config:
       autopurge.snapRetainCount: 3
-      autopurge.purgeInterval: 1
+      autopurge.purgeInterval: 2
     # ...
 ----
 

--- a/documentation/assemblies/configuring/assembly-config-kafka.adoc
+++ b/documentation/assemblies/configuring/assembly-config-kafka.adoc
@@ -27,6 +27,8 @@ For more information, see link:{BookURLDeploying}#proc-renewing-ca-certs-manuall
 
 //procedure to configure Kafka
 include::../../modules/configuring/proc-config-kafka.adoc[leveloffset=+1]
+//zookeeper's default configuration
+include::../../modules/configuring/con-zookeeper-default-config.adoc[leveloffset=+2]
 //entity operator config
 include::assembly-kafka-entity-operator.adoc[leveloffset=+1]
 //storage considerations

--- a/documentation/modules/configuring/con-zookeeper-default-config.adoc
+++ b/documentation/modules/configuring/con-zookeeper-default-config.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// assembly-config-kafka.adoc
+
+[id='con-zookeeper-default-config-{context}']
+= Default ZooKeeper configuration values
+
+[role="_abstract"]
+When deploying ZooKeeper with Strimzi, some of the default configuration set by Strimzi differs from the standard ZooKeeper defaults. 
+This is because Strimzi sets a number of ZooKeeper properties with values that are optimized for running ZooKeeper within a Kubernetes environment. 
+
+The default configuration for key ZooKeeper properties in Strimzi is as follows:
+
+.Default ZooKeeper Properties in Strimzi 
+[cols="2m,1a,3",options="header"]
+|===
+
+|Property
+|Default value
+|Description
+
+|tickTime
+|2000
+|The length of a single tick in milliseconds, which determines the length of a session timeout.
+
+|initLimit
+|5
+|The maximum number of ticks that a follower is allowed to fall behind the leader in a ZooKeeper cluster.
+
+|syncLimit
+|2
+|The maximum number of ticks that a follower is allowed to be out of sync with the leader in a ZooKeeper cluster.
+
+|autopurge.purgeInterval
+|1
+|Enables the `autopurge` feature and sets the time interval in hours for purging the server-side ZooKeeper transaction log.
+
+|admin.enableServer
+|false
+|Flag to disable the ZooKeeper admin server. The admin server is not used by Strimzi.
+
+|===
+
+IMPORTANT: Modifying these default values as `zookeeper.config` in the `Kafka` custom resource may impact the behavior and performance of your ZooKeeper cluster.


### PR DESCRIPTION
**Documentation**

Adds a description of the default values assigned to ZooKeeper properties.
Added as a sub-section of [Configuring Kafka](https://strimzi.io/docs/operators/latest/configuring.html#proc-config-kafka-str)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

