### PR TITLE
docs(upgrade): clarifies support for kafka versions when upgrading

### DIFF
--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -34,10 +34,8 @@ You can access the CRDs from the {ReleaseDownload} or find them in the `crd` sub
 [id='con-upgrade-cluster-operator-unsupported-kafka-{context}']
 == Upgrading the Cluster Operator returns Kafka version error
 
-If you upgrade the Cluster Operator and get an _unsupported Kafka version_ error, your Kafka cluster deployment has an older Kafka version that is not supported by the new operator version.
-This error applies to all installation methods.
-
-If this error occurs, upgrade Kafka to a supported Kafka version.
+If you upgrade the Cluster Operator to a version that does not support the current version of Kafka you are using, you get an _unsupported Kafka version_ error.
+This error applies to all installation methods and means that you must upgrade Kafka to a supported Kafka version.
 Change the `spec.kafka.version` in the `Kafka` resource to the supported version.
 
 You can use `kubectl` to check for error messages like this in the `status` of the `Kafka` resource.
@@ -45,9 +43,9 @@ You can use `kubectl` to check for error messages like this in the `status` of t
 .Checking the Kafka status for errors
 [source,shell, subs=+quotes]
 ----
-kubectl get kafka _<kafka_cluster_name>_ -n _<namespace>_ -o jsonpath='{.status.conditions}'
+kubectl get kafka <kafka_cluster_name> -n <namespace> -o jsonpath='{.status.conditions}'
 ----
 
-Replace `_<kafka_cluster_name>_` with the name of your Kafka cluster and `_<namespace>_` with the Kubernetes namespace where the pod is running.
+Replace <kafka_cluster_name> with the name of your Kafka cluster and <namespace> with the Kubernetes namespace where the pod is running.
 
 include::../../modules/upgrading/proc-upgrade-cluster-operator.adoc[leveloffset=+1]

--- a/documentation/modules/upgrading/con-upgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-upgrade-paths.adoc
@@ -22,7 +22,7 @@ When upgrading Strimzi, it is important to ensure compatibility with the Kafka v
 
 Multi-version upgrades are possible even if the supported Kafka versions differ between the old and new versions. 
 However, if you attempt to upgrade to a new Strimzi version that does not support the current Kafka version, xref:con-upgrade-cluster-operator-unsupported-kafka-str[an error indicating that the Kafka version is not supported is generated]. 
-In this case, you can upgrade the Kafka version as part of the Strimzi upgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the new Strimzi version.
+In this case, you must upgrade the Kafka version as part of the Strimzi upgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the new Strimzi version.
 
 [NOTE]
 ====

--- a/documentation/modules/upgrading/con-upgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-upgrade-paths.adoc
@@ -6,31 +6,33 @@
 = Strimzi upgrade paths
 
 [role="_abstract"]
-Two Strimzi upgrade paths are possible.
+Two upgrade paths are available for Strimzi.
 
 Incremental upgrade::
-Upgrading Strimzi from the previous minor version to version {ProductVersion}.
+An incremental upgrade involves upgrading Strimzi from the previous minor version to version {ProductVersion}.
 
 Multi-version upgrade::
-Upgrading Strimzi from an old version to version {ProductVersion} within a single upgrade (skipping one or more intermediate versions).
-+
-For example, upgrading from Strimzi 0.24.0 directly to Strimzi {ProductVersion}.
-+
-NOTE: A multi-version Strimzi upgrade might still support the current version of a Kafka deployment.
+A multi-version upgrade involves upgrading an older version of Strimzi to version {ProductVersion} within a single upgrade, skipping one or more intermediate versions. 
+For example, upgrading directly from Strimzi 0.24.0 to Strimzi {ProductVersion} is possible. 
 
 [id='con-upgrade-paths-kafka-versions-{context}']
-== Supported Kafka versions
+== Support for Kafka versions when upgrading
 
-Decide which Kafka version to upgrade to before starting the Strimzi upgrade process.
+When upgrading Strimzi, it is important to ensure compatibility with the Kafka version being used.
+
+Only use a Kafka version that is supported by your version of Strimzi when upgrading. 
+You can upgrade to a higher supported Kafka version, and in some cases, you can also downgrade to an earlier supported Kafka version.
+
+Multi-version upgrades are possible even if the supported Kafka versions differ between the old and new versions. However, if you attempt to upgrade to a new Strimzi version that does not support the current Kafka version, xref:con-upgrade-cluster-operator-unsupported-kafka-str[an error indicating that the Kafka version is not supported is generated]. 
+In this case, you can upgrade the Kafka version as part of the Strimzi upgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the new Strimzi version.
+
+[NOTE]
+====
 You can review supported Kafka versions in the link:https://strimzi.io/downloads/[Supported versions^] table.
 
 * The *Operators* column lists all released Strimzi versions (the Strimzi version is often called the "Operator version").
-
 * The *Kafka versions* column lists the supported Kafka versions for each Strimzi version.
-
-You can only use a Kafka version supported by the version of Strimzi you are using.
-You can upgrade to a higher Kafka version as long as it is supported by your version of Strimzi.
-In some cases, you can also downgrade to a previous supported Kafka version.
+====
 
 [id='con-upgrade-paths-earlier-versions-{context}']
 == Upgrading from a Strimzi version earlier than 0.22

--- a/documentation/modules/upgrading/con-upgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-upgrade-paths.adoc
@@ -13,17 +13,15 @@ An incremental upgrade involves upgrading Strimzi from the previous minor versio
 
 Multi-version upgrade::
 A multi-version upgrade involves upgrading an older version of Strimzi to version {ProductVersion} within a single upgrade, skipping one or more intermediate versions. 
-For example, upgrading directly from Strimzi 0.24.0 to Strimzi {ProductVersion} is possible. 
+For example, upgrading directly from Strimzi 0.30.0 to Strimzi {ProductVersion} is possible. 
 
 [id='con-upgrade-paths-kafka-versions-{context}']
 == Support for Kafka versions when upgrading
 
 When upgrading Strimzi, it is important to ensure compatibility with the Kafka version being used.
 
-Only use a Kafka version that is supported by your version of Strimzi when upgrading. 
-You can upgrade to a higher supported Kafka version, and in some cases, you can also downgrade to an earlier supported Kafka version.
-
-Multi-version upgrades are possible even if the supported Kafka versions differ between the old and new versions. However, if you attempt to upgrade to a new Strimzi version that does not support the current Kafka version, xref:con-upgrade-cluster-operator-unsupported-kafka-str[an error indicating that the Kafka version is not supported is generated]. 
+Multi-version upgrades are possible even if the supported Kafka versions differ between the old and new versions. 
+However, if you attempt to upgrade to a new Strimzi version that does not support the current Kafka version, xref:con-upgrade-cluster-operator-unsupported-kafka-str[an error indicating that the Kafka version is not supported is generated]. 
 In this case, you can upgrade the Kafka version as part of the Strimzi upgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the new Strimzi version.
 
 [NOTE]


### PR DESCRIPTION
**Documentation**

Updates the description of Strimzi upgrade paths and the support for Kafka versions when upgrading.
Clarifies that Strimzi upgrades are possible even when supported Kafka versions differ.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

