### PR TITLE
Adds proper error message when Cruise Control fails to generate the `rebalance` proposal

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -877,9 +877,9 @@ public class KafkaRebalanceAssemblyOperator
                                             }
                                         })
                                         .onFailure(e -> {
-                                            LOGGER.errorCr(reconciliation, "Cruise Control getting rebalance proposal failed", e.getCause());
+                                            LOGGER.errorCr(reconciliation, "Cruise Control getting rebalance proposal failed");
                                             vertx.cancelTimer(t);
-                                            p.fail(e.getCause());
+                                            p.fail(e);
                                         });
                                 }
                             } else {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR fixed #8444. This fix adds proper error message when Cruise Control fails to generate the `rebalance` proposal. 
The error is also propagated to the  `kafkaRebalance` status. 

For eg. 

In the `KafkaRebalance` status we will get something like
```
status:
  conditions:
  - lastTransitionTime: "2023-05-05T08:08:07.066887167Z"
    message: 'Error for request: my-cluster-cruise-control.myproject.svc:9090/kafkacruisecontrol/rebalance?json=true&dryrun=true&verbose=true&skip_hard_goal_check=false&rebalance_disk=false.
      Server returned: Error processing POST request ''/rebalance'' due to: ''com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException:
      [RackAwareGoal] Insufficient number of racks to distribute each replica (Current:
      1, Needed: 3). Add at least 2 racks with brokers. Add at least 2 racks with
      brokers.''.'
    reason: CruiseControlRestException
    status: "True"
    type: NotReady
  observedGeneration: 1
```
and log will look like

```
ERROR KafkaRebalanceAssemblyOperator:880 - Reconciliation #1(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Cruise Control getting rebalance proposal failed
ERROR KafkaRebalanceAssemblyOperator:485 - Reconciliation #1(test-trigger) KafkaRebalance(cruise-control-namespace/my-rebalance): Status updated to [NotReady] due to error:Error for request: my-cluster-cruise-control.myproject.svc:9090/kafkacruisecontrol/rebalance?json=true&dryrun=true&verbose=true&skip_hard_goal_check=false&rebalance_disk=false.
      Server returned: Error processing POST request ''/rebalance'' due to: ''com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException:
      [RackAwareGoal] Insufficient number of racks to distribute each replica (Current:
      1, Needed: 3). Add at least 2 racks with brokers. Add at least 2 racks with
      brokers
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

