### PR TITLE
ST: Update CruiseControl max.tasks to avoid occasional issues with parallel execution, also fix asserts in metrics and upgrade

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -118,7 +118,14 @@ public class KafkaTemplates {
 
     public static KafkaBuilder kafkaWithCruiseControl(String name, int kafkaReplicas, int zookeeperReplicas) {
         Kafka kafka = getKafkaFromYaml(Constants.PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG);
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas);
+
+        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
+                .editSpec()
+                    .editCruiseControl()
+                        // Extend active users tasks as we
+                        .addToConfig("max.active.user.tasks", 10)
+                    .endCruiseControl()
+                .endSpec();
     }
 
     public static KafkaBuilder kafkaWithMetricsAndCruiseControlWithMetrics(String name, String namespaceName, int kafkaReplicas, int zookeeperReplicas) {
@@ -166,6 +173,8 @@ public class KafkaTemplates {
                 .endKafkaExporter()
                 .withNewCruiseControl()
                     .withMetricsConfig(jmxPrometheusExporterMetrics)
+                    // Extend active users tasks as we
+                    .addToConfig("max.active.user.tasks", 10)
                 .endCruiseControl()
                 .editKafka()
                     .withNewJmxPrometheusExporterMetricsConfig()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -178,7 +178,7 @@ public class SecretUtils {
 
         LOGGER.info("Waiting for Secret {}/{} to be deleted", namespace, secretName);
         TestUtils.waitFor(String.format("Deletion of Secret %s#%s", namespace, secretName), Constants.GLOBAL_POLL_INTERVAL, DELETION_TIMEOUT,
-            () -> kubeClient().getSecret(secretName) == null);
+            () -> kubeClient().getSecret(namespace, secretName) == null);
 
         LOGGER.info("Secret {}/{} successfully deleted", namespace, secretName);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -61,7 +61,6 @@ import static io.strimzi.systemtest.Constants.SANITY;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -278,7 +277,8 @@ public class CruiseControlST extends AbstractST {
         LOGGER.info("Check for default CruiseControl replicaMovementStrategy in pod configuration file.");
         Map<String, Object> actualStrategies = KafkaResource.kafkaClient().inNamespace(namespaceName)
             .withName(clusterName).get().getSpec().getCruiseControl().getConfig();
-        assertThat(actualStrategies, anEmptyMap());
+        // Check that config contains only configurations for max.active.user.tasks
+        assertThat(actualStrategies.size(), is(1));
 
         String ccConfFileContent = cmdKubeClient(namespaceName).execInPodContainer(ccPodName, Constants.CRUISE_CONTROL_CONTAINER_NAME, "cat", Constants.CRUISE_CONTROL_CONFIGURATION_FILE_PATH).out();
         assertThat(ccConfFileContent, not(containsString(replicaMovementStrategies)));

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1962,8 +1962,8 @@ public class ListenersST extends AbstractST {
         ClientUtils.waitForConsumerClientSuccess(testStorage);
 
         // Delete already existing secrets
-        kubeClient().deleteSecret(testStorage.getNamespaceName(), clusterCustomCertServer1);
-        kubeClient().deleteSecret(testStorage.getNamespaceName(), clusterCustomCertServer2);
+        SecretUtils.deleteSecretWithWait(testStorage.getNamespaceName(), clusterCustomCertServer1);
+        SecretUtils.deleteSecretWithWait(testStorage.getNamespaceName(), clusterCustomCertServer2);
         // Create secrets with new values (update)
         SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
         SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -1962,8 +1962,8 @@ public class ListenersST extends AbstractST {
         ClientUtils.waitForConsumerClientSuccess(testStorage);
 
         // Delete already existing secrets
-        SecretUtils.deleteSecretWithWait(testStorage.getNamespaceName(), clusterCustomCertServer1);
-        SecretUtils.deleteSecretWithWait(testStorage.getNamespaceName(), clusterCustomCertServer2);
+        SecretUtils.deleteSecretWithWait(clusterCustomCertServer1, testStorage.getNamespaceName());
+        SecretUtils.deleteSecretWithWait(clusterCustomCertServer2, testStorage.getNamespaceName());
         // Create secrets with new values (update)
         SecretUtils.createCustomSecret(clusterCustomCertServer1, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey2);
         SecretUtils.createCustomSecret(clusterCustomCertServer2, testStorage.getClusterName(), testStorage.getNamespaceName(), strimziCertAndKey1);

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -269,7 +269,7 @@ public class MetricsIsolatedST extends AbstractST {
         if (Environment.isStableConnectIdentitiesEnabled()) {
             // check StrimziPodSet metrics in CO
             assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(StrimziPodSet.RESOURCE_KIND, namespaceFirst), 1);
-            assertCoMetricResources(clusterOperatorCollector, StrimziPodSet.RESOURCE_KIND, namespaceSecond, 1);
+            assertMetricValueHigherThan(clusterOperatorCollector, getResourceMetricPattern(StrimziPodSet.RESOURCE_KIND, namespaceSecond), 0);
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -599,7 +600,7 @@ public class AbstractUpgradeST extends AbstractST {
         logPodImages(clusterName);
 
         // Verify FileSink KafkaConnector before upgrade
-        String connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), clusterName + "-connect").get(0).getMetadata().getName();
+        String connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND)).get(0).getMetadata().getName();
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
 
         // Upgrade CO to HEAD and wait for readiness of ClusterOperator
@@ -616,7 +617,7 @@ public class AbstractUpgradeST extends AbstractST {
         // Verify that Producer finish successfully
         ClientUtils.waitForProducerClientSuccess(testStorage);
         // Verify FileSink KafkaConnector
-        connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+        connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND)).get(0).getMetadata().getName();
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
 
         // Verify that pods are stable

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -616,7 +616,7 @@ public class AbstractUpgradeST extends AbstractST {
         // Verify that Producer finish successfully
         ClientUtils.waitForProducerClientSuccess(testStorage);
         // Verify FileSink KafkaConnector
-        connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), clusterName + "-connect").get(0).getMetadata().getName();
+        connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
 
         // Verify that pods are stable


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Update `max.active.user.tasks` to 10 to avoid issues with multiple API calls when parallel execution. This PR also resolves feature-gates asserts problems with MetricsST and during upgrade.

### Checklist

- [ ] Write tests
