### PR TITLE
Fix StringIndexOutOfBoundsException on openShiftBuildWaitForFinish

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -379,7 +379,7 @@ public class ConnectBuildOperator {
                                 && build.getStatus().getOutput().getTo().getImageDigest() != null) {
                             String digest = "@" + build.getStatus().getOutput().getTo().getImageDigest();
                             String image = build.getStatus().getOutputDockerImageReference();
-                            String tag = image.substring(image.lastIndexOf(":"));
+                            String tag = image.lastIndexOf(":") != -1 ? image.substring(image.lastIndexOf(":")) : "latest";
 
                             String imageWithDigest = image.replace(tag, digest);
 


### PR DESCRIPTION
This change fixes #8472.

I think skipping the tag is completely fine (the build works) and latest should be used as default.