### PR TITLE
Remove the incorrect use of `succeedingThenComplete()` in unit and IT tests

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -188,7 +188,7 @@ public class ConnectorMockTest {
         Checkpoint async = testContext.checkpoint();
         // Fail test if watcher closes for any reason
         kafkaConnectOperator.createWatch(NAMESPACE, e -> testContext.failNow(e))
-            .onComplete(testContext.succeedingThenComplete())
+            .onComplete(testContext.succeeding(i -> { }))
             .compose(watch -> {
                 connectWatch = watch;
                 return AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, NAMESPACE, null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -229,7 +229,7 @@ public class KafkaAssemblyOperatorMockTest {
     public void testReconcile(VertxTestContext context) {
         Checkpoint async = context.checkpoint();
         initialReconcile(context)
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> async.flag()));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -118,7 +118,7 @@ public class KafkaConnectApiIT {
                     .put("topic", "my-topic");
                 return client.createOrUpdatePutRequest(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test", o);
             })
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
             .compose(created -> {
 
                 Promise<Map<String, Object>> promise = Promise.promise();
@@ -173,16 +173,16 @@ public class KafkaConnectApiIT {
             .recover(error -> Future.succeededFuture())
 
             .compose(ignored -> client.pause(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
 
             .compose(ignored -> client.resume(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
 
             .compose(ignored -> client.restart("localhost", port, "test", true, true))
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
 
             .compose(ignored -> client.restartTask("localhost", port, "test", 0))
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
 
             .compose(ignored -> {
                 JsonObject o = new JsonObject()
@@ -217,7 +217,7 @@ public class KafkaConnectApiIT {
             .onComplete(context.succeeding(connectorNames -> context.verify(() ->
                     assertThat(connectorNames, is(singletonList("test"))))))
             .compose(connectorNames -> client.delete(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
             .compose(deletedConnector -> client.list(Reconciliation.DUMMY_RECONCILIATION, "localhost", port))
             .onComplete(context.succeeding(connectorNames -> assertThat(connectorNames, is(empty()))))
             .compose(connectorNames -> client.delete(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "never-existed"))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -159,7 +159,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
         Checkpoint async = context.checkpoint();
         createConnectCluster(context, mock, false)
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
             .compose(v -> {
                 LOGGER.info("Reconciling again -> update");
                 return kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME));
@@ -187,7 +187,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
 
         Checkpoint async = context.checkpoint();
         createConnectCluster(context, mock, true)
-                .onComplete(context.succeedingThenComplete())
+                .onComplete(context.succeeding(i -> { }))
                 .compose(v -> {
                     LOGGER.info("Reconciling again -> update");
                     return kco.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -164,7 +164,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
 
         Checkpoint async = context.checkpoint();
         createMirrorMaker2Cluster(context, mock, false)
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
             .compose(i -> {
                 LOGGER.info("Reconciling again -> update");
                 return kco.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicStoreTestBase.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicStoreTestBase.java
@@ -36,7 +36,7 @@ public abstract class TopicStoreTestBase {
 
         // Create the topic
         store.create(topic)
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
 
             // Read the topic
             .compose(v -> store.read(new TopicName(topicName)))
@@ -63,7 +63,7 @@ public abstract class TopicStoreTestBase {
         failedCreateCompleted.future()
                 // update my_topic
                 .compose(v -> store.update(updatedTopic))
-            .onComplete(context.succeedingThenComplete())
+            .onComplete(context.succeeding(i -> { }))
 
             // re-read it and assert equal
             .compose(v -> store.read(new TopicName(topicName)))
@@ -77,7 +77,7 @@ public abstract class TopicStoreTestBase {
 
                 // delete it
                 .compose(v -> store.delete(updatedTopic.getTopicName()))
-                .onComplete(context.succeedingThenComplete())
+                .onComplete(context.succeeding(i -> { }))
 
                 // assert we can't read it again
                 .compose(v -> store.read(new TopicName(topicName)))


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In multiple places of our unit and integration tests, we seem to be using the `succeedingThenComplete()` method in the middle of the test. This method asserts that the future completes successfully and then completes the test. As a result, everything done afterward in the test is ignored.

This PR removes this incorrect use and replaces it with `succeeding(i -> { })` (as `succeeding()` is deprecated and there is no other way to check the successful completion without a handler other than using an empty handler). Where needed, it also fixes the tests to make them actually pass.

In `AbstractCustomResourceOperatorIT` it also removes the unnecessary Kubernetes version check. This was originally intended to check for Kubernetes versions older than 1.11 which did not support the status subresource on custom resources. This check is not needed anymore as we no longer support so old Kube versions.

### Checklist

- [x] Make sure all tests pass