### PR TITLE
Push Helm Chart as OCI artifact to Quay.io during the release

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -64,3 +64,17 @@ stages:
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
           architectures: ['amd64', 'arm64', 's390x']
+  # Publishes the Strimzi Helm Chart as an OCI artifact to Quay.io
+  - stage: helm_as_oci_publish
+    displayName: Publish Helm Chart as OCI artifact
+    dependsOn:
+      - prepare_release_artifacts
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    jobs:
+      - template: 'templates/jobs/build/publish_helm_chart_as_oci.yaml'
+        parameters:
+          artifactSource: 'current'
+          artifactProject: 'strimzi'
+          artifactPipeline: ''
+          artifactRunVersion: ''
+          artifactRunId: ''

--- a/.azure/templates/jobs/build/publish_helm_chart_as_oci.yaml
+++ b/.azure/templates/jobs/build/publish_helm_chart_as_oci.yaml
@@ -1,0 +1,40 @@
+jobs:
+  - job: 'push_helm_chart_oci'
+    displayName: 'Push Helm Chart as OCI artifact'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: 'Ubuntu-22.04'
+    # Pipeline steps
+    steps:
+      # Install Prerequisites
+      - template: "../../steps/prerequisites/install_helm.yaml"
+
+      # Unpack the release artifacts
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: '${{ parameters.artifactSource }}'
+          artifact: ReleaseArchives
+          path: $(System.DefaultWorkingDirectory)/
+          project: '${{ parameters.artifactProject }}'
+          pipeline: '${{ parameters.artifactPipeline }}'
+          runVersion: '${{ parameters.artifactRunVersion }}'
+          runId: '${{ parameters.artifactRunId }}'
+      - bash: tar -xvf release.tar
+        displayName: "Untar the release artifacts"
+
+      # Login Helm to the OCI Registry
+      - bash: "helm registry login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY"
+        displayName: "Login to OCI registry"
+        env:
+          DOCKER_USER: $(QUAY_HELM_USER)
+          DOCKER_PASS: $(QUAY_HELM_PASS)
+          DOCKER_REGISTRY: "quay.io"
+
+      # Push the Helm Chart to the OCI Registry
+      - bash: "helm push strimzi-kafka-operator-helm-3-chart-${{ parameters.releaseVersion }}.tgz oci://$DOCKER_REGISTRY/$DOCKER_ORG"
+        displayName: "Push Helm Chart OCI artifact"
+        env:
+          DOCKER_REGISTRY: "quay.io"
+          DOCKER_ORG: "strimzi-helm"

--- a/.azure/templates/steps/prerequisites/install_helm.yaml
+++ b/.azure/templates/steps/prerequisites/install_helm.yaml
@@ -2,4 +2,4 @@ steps:
   - bash: ".azure/scripts/setup-helm.sh"
     displayName: "Install Helm"
     env:
-      TEST_HELM3_VERSION: 'v3.7.2'
+      TEST_HELM3_VERSION: 'v3.12.0'


### PR DESCRIPTION
### Type of change

- Taskj

### Description

Helm charts can be pushed into the Quay.io registry as an OCI artifcat. This PR adds a new stage to the release pipeline to push it there as part of the release. This should allow us in the future to install the artifacts directly from Quay.io without pushing them to some other storage (such as GitHub release) - but at this point in time, it is more experimental step to see what we can do with it. One interesting option would be for example if we can get rid of managing the Helm Chart index.yaml etc.

This PR also updates the Helm version used in our CI to use version which supports the OCI artifacts.