### PR TITLE
Update Fabric8 Kubernetes Client to 6.6.1

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableNamespacedResourceOperator.java
@@ -113,8 +113,7 @@ public abstract class AbstractScalableNamespacedResourceOperator<C extends Kuber
                         while (nextReplicas > scaleTo) {
                             nextReplicas--;
                             LOGGER.infoCr(reconciliation, "Scaling down from {} to {}", nextReplicas + 1, nextReplicas);
-                            // When scaling to 0, we cannot wait for it because of https://github.com/fabric8io/kubernetes-client/issues/5102
-                            resource(namespace, name).scale(nextReplicas, nextReplicas != 0);
+                            resource(namespace, name).scale(nextReplicas, true);
                         }
                     }
                     future.complete(nextReplicas);

--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,9 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.6.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.6.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.6.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.6.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.6.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.6.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.14.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.14.2</fasterxml.jackson-databind.version>

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -79,8 +79,7 @@ class RecoveryIsolatedST extends AbstractST {
         String kafkaName = KafkaResources.kafkaStatefulSetName(sharedClusterName);
         String kafkaUid = StrimziPodSetUtils.getStrimziPodSetUID(clusterOperator.getDeploymentNamespace(), kafkaName);
 
-        // When scaling to 0, we cannot wait for it because of https://github.com/fabric8io/kubernetes-client/issues/5102
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).withName(Constants.STRIMZI_DEPLOYMENT_NAME).scale(0, false);
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).withName(Constants.STRIMZI_DEPLOYMENT_NAME).scale(0, true);
         StrimziPodSetUtils.deleteStrimziPodSet(clusterOperator.getDeploymentNamespace(), kafkaName);
 
         PodUtils.waitForPodsWithPrefixDeletion(kafkaName);
@@ -98,8 +97,7 @@ class RecoveryIsolatedST extends AbstractST {
         String zookeeperName = KafkaResources.zookeeperStatefulSetName(sharedClusterName);
         String zookeeperUid = StrimziPodSetUtils.getStrimziPodSetUID(clusterOperator.getDeploymentNamespace(), zookeeperName);
 
-        // When scaling to 0, we cannot wait for it because of https://github.com/fabric8io/kubernetes-client/issues/5102
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).withName(Constants.STRIMZI_DEPLOYMENT_NAME).scale(0, false);
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).withName(Constants.STRIMZI_DEPLOYMENT_NAME).scale(0, true);
         StrimziPodSetUtils.deleteStrimziPodSet(clusterOperator.getDeploymentNamespace(), zookeeperName);
 
         PodUtils.waitForPodsWithPrefixDeletion(zookeeperName);


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to version 6.6.1. This version fixes the bug we found in 6.6.0 which is covered by #8486.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging