### PR TITLE
Fix pushing of Helm Charts as OCI artifact

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -73,6 +73,7 @@ stages:
     jobs:
       - template: 'templates/jobs/build/publish_helm_chart_as_oci.yaml'
         parameters:
+          releaseVersion: '${{ parameters.releaseVersion }}'
           artifactSource: 'current'
           artifactProject: 'strimzi'
           artifactPipeline: ''


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a minor issue in #8500 where the release version was not passed to the `helm push` command and the new step for pushing helm to Quay as OCI artifact failed. This PR fixes it.