### PR TITLE
Returning 204 No Content on status check endpoints

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -326,9 +326,9 @@ public class Main {
         vertx.createHttpServer()
                 .requestHandler(request -> {
                     if (request.path().equals("/healthy")) {
-                        request.response().setStatusCode(200).end();
+                        request.response().setStatusCode(204).end();
                     } else if (request.path().equals("/ready")) {
-                        request.response().setStatusCode(200).end();
+                        request.response().setStatusCode(204).end();
                     } else if (request.path().equals("/metrics")) {
                         PrometheusMeterRegistry metrics = (PrometheusMeterRegistry) metricsProvider.meterRegistry();
                         request.response().setStatusCode(200)

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -441,10 +441,10 @@ public class Session extends AbstractVerticle {
                          .requestHandler(request -> {
                              switch (request.path()) {
                                  case "/healthy":
-                                     request.response().setStatusCode(tos.isAlive() ? 200 : 500).end();
+                                     request.response().setStatusCode(tos.isAlive() ? 204 : 500).end();
                                      break;
                                  case "/ready":
-                                     request.response().setStatusCode(tos.isReady() ? 200 : 500).end();
+                                     request.response().setStatusCode(tos.isReady() ? 204 : 500).end();
                                      break;
                                  case "/metrics":
                                      request.response().setStatusCode(200).end(metricsRegistry.scrape());


### PR DESCRIPTION
This PR is about the status check endpoints (ready and healthy) to return `204` instead of `200` because no content is provided (it mostly aligns with what we have on the bridge with this PR https://github.com/strimzi/strimzi-kafka-bridge/pull/800).