### PR TITLE
[ST] UserST, improve checks and move testUOListeningOnlyUsersInSameCluster from KafkaST to UserST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -220,4 +220,25 @@ public class SecretUtils {
                 .withNamespace(toNamespace)
             .endMetadata();
     }
+
+    /**
+     * Method which waits for {@code secretName} Secret in {@code namespace} namespace to have
+     * label with {@code labelKey} key and {@code labelValue} value.
+     *
+     * @param namespace name of namespace
+     * @param secretName name of Secret
+     * @param labelKey label key
+     * @param labelValue label value
+     */
+    public static void waitForSpecificLabelKeyValue(String secretName, String namespace, String labelKey, String labelValue) {
+        LOGGER.info("Wait for Secret: {}/{} (Corresponding to KafkaUser) to have expected label: {}={}", namespace, secretName, labelKey, labelValue);
+        TestUtils.waitFor("Wait for the Secret {}: {}/{} to exist while also having label to corresponding Kafka cluster", Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> kubeClient().listSecrets(namespace)
+                .stream()
+                .anyMatch(secret -> secretName.equals(secret.getMetadata().getName())
+                    && secret.getMetadata().getLabels().containsKey(Labels.STRIMZI_CLUSTER_LABEL)
+                    && secret.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL).equals(labelValue)
+                )
+        );
+    }
 }


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

modification and relocation of `testUOListeningOnlyUsersInSameCluster`
- moved from `KafkaST` to `UserST` 
- add check of Secret labels when KafkaUser is watched by User Operator.  (Internal client being used)
- add check that Kafka user is really created as result of actions performed by relevant User Operator. (User with quota is used, in order for it to be listed with a usage of script `kafka-config.sh`, this in turn limits the test to work only with kraft disabled (more at https://issues.apache.org/jira/browse/KAFKA-13964, which actually still seems to be an issue), 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation

fixes https://github.com/strimzi/strimzi-kafka-operator/issues/8260