### PR TITLE
Update Cruise Control to 2.5.112

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.3.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.112</cruise-control.version>
+        <cruise-control.version>2.5.122</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.112</cruise-control.version>
+        <cruise-control.version>2.5.122</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.112</cruise-control.version>
+        <cruise-control.version>2.5.122</cruise-control.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description

Third times a charm ;-)

This PR bumps used Cruise Control version from 2.5.112 to 2.5.122.

Cruise Control 2.5.122 resolves the bug preventing previous upgrades #8181 and #8438

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

