### PR TITLE
Add trailing dot to the DNS name pattern used by CertManager

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
@@ -30,7 +30,7 @@ public class IpAndDnsValidation {
                 "[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d])";
         // a trailing dot that can be used to force FQDN resolutions, reducing
         // the internal DNS server load (kube-dns pods) and application latency
-        String trailingDot = "(\\.?)";
+        String trailingDot = "\\.?";
         DNS_NAME = Pattern.compile("^" + dnsLabel + "(\\." + dnsLabel + ")*" + trailingDot);
     }
 

--- a/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
@@ -28,7 +28,10 @@ public class IpAndDnsValidation {
                 "[a-zA-Z\\d]|" +
                 // followed by more labels of same
                 "[a-zA-Z\\d][a-zA-Z\\d\\-]{0,61}[a-zA-Z\\d])";
-        DNS_NAME = Pattern.compile("^" + dnsLabel + "(\\." + dnsLabel + ")*");
+        // a trailing dot that can be used to force FQDN resolutions, reducing
+        // the internal DNS server load (kube-dns pods) and application latency
+        String trailingDot = "(\\.?)";
+        DNS_NAME = Pattern.compile("^" + dnsLabel + "(\\." + dnsLabel + ")*" + trailingDot);
     }
 
     // Pattern used to normalize the segments of the IPv6 address

--- a/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/IpAndDnsValidationTest.java
@@ -49,6 +49,10 @@ public class IpAndDnsValidationTest {
 
         assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("example:com"), is(false));
         assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongexample.com"), is(false));
+
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("example.com."), is(true));
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("example.com.."), is(false));
+        assertThat(IpAndDnsValidation.isValidDnsNameOrWildcard("*.example.com."), is(true));
     }
 
     @Test

--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
@@ -301,7 +301,8 @@ public class OpenSslCertManagerIT {
                 .withCommonName("MyCommonName")
                 .withOrganizationName("MyOrganization")
                 .addDnsName("example1.com")
-                .addDnsName("example2.com").build();
+                .addDnsName("example2.com")
+                .addDnsName("example3.com.").build();
 
         File cert = Files.createTempFile("crt-", ".crt").toFile();
 

--- a/certificate-manager/src/test/java/io/strimzi/certs/SubjectTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SubjectTest.java
@@ -77,8 +77,10 @@ public class SubjectTest {
     public void testDnsValidation() {
         new Subject.Builder().addDnsName("example.com");
         new Subject.Builder().addDnsName("*.example.com");
-        assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("foo.*.example.come"));
+        new Subject.Builder().addDnsName("example.io.");
+        assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("foo.*.example.com"));
         assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("54t8g#'/.l"));
+        assertThrows(IllegalArgumentException.class, () -> new Subject.Builder().addDnsName("example.io.."));
     }
 
     @Test


### PR DESCRIPTION
By default, the /etc/resolv.conf of each container looks like this:

```sh
search test.svc.cluster.local svc.cluster.local cluster.local us-east-2.compute.internal
nameserver 172.30.0.10
options ndots:5
```

The ndots option sets a threshold for the number of dots which must appear in the host name before a FQDN search will be made. If the host name contains less than 5 dots, the resolution will sequentially go through all local search domains first and, in case none succeed, will resolve it as a FDQN only at last.

It turns out that adding a trailing dot to the host name forces the FQDN resolution on the upstream DNS server, thus reducing internal DNS server load (kube-dns pods) and application latency.

You can also use the dnsConfig pod property to reduce the ndots value for your application, but that would be impractical when having lots of client applications, where some of them could be by a third party.

Note that TLS handshake with trailing dot only works with recent JDK versions (8u372+, 11.0.19+, 17.0.6+).

https://bugs.openjdk.org/browse/JDK-8065422

This should fix #8520.