### PR TITLE
docs(security context): moves content related to security context

### DIFF
--- a/documentation/configuring/configuring.adoc
+++ b/documentation/configuring/configuring.adoc
@@ -10,9 +10,6 @@ include::assemblies/configuring/assembly-overview.adoc[leveloffset=+1]
 
 include::assemblies/configuring/assembly-deployment-configuration.adoc[leveloffset=+1]
 
-//security context for all pods
-include::assemblies/configuring/assembly-security-providers.adoc[leveloffset=+1]
-
 [id='api_reference-{context}']
 :parent-context: {context}
 :context: reference

--- a/documentation/deploying/deploying.adoc
+++ b/documentation/deploying/deploying.adoc
@@ -28,6 +28,8 @@ include::assemblies/deploying/assembly-deploy-client-access.adoc[leveloffset=+1]
 include::assemblies/security/assembly-securing-access.adoc[leveloffset=+1]
 //managing tls certificates
 include::assemblies/security/assembly-security.adoc[leveloffset=+1]
+//security context for all pods
+include::assemblies/configuring/assembly-security-providers.adoc[leveloffset=+1]
 //Scaling clusters
 include::modules/configuring/con-scaling-kafka-clusters.adoc[leveloffset=+1]
 //Using Cruise Control for rebalancing

--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -147,5 +147,4 @@ A `LocalHost` profile uses a profile defined in a file on the node.
 
 * {K8sSecurityContext} on Kubernetes
 * {K8sSecurityStandards} on Kubernetes (including profile descriptions)
-* xref:type-ContainerTemplate-reference[]
 


### PR DESCRIPTION
### Type of change

**Documentation**
Content from the Configuring guide is being moved to the Deploying guide.
The Configuring guide is being positioned as a pure schema reference guide.
Instructions to deploy, configure and administer Strimzi will sit together in the Deploying guide.

This PR moves content related to applying security context, which is presented as a separate section.

![image](https://github.com/strimzi/strimzi-kafka-operator/assets/47596553/8baf3e06-4d34-4fd8-a333-e5126f07f1dd)


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

