### PR TITLE
using `TARGETOS` and `TARGETARCH` to identify platform

### DIFF
--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -382,20 +382,28 @@ the commit if errors are detected:
 ./tools/git-hooks/checkstyle-pre-commit
 ```
 
-## Building container images for other platforms with Docker `buildx`
+## Building container images for other platforms
 
-Docker supports building images for different platforms using the `docker buildx` command. If you want to use it to
-build Strimzi images, you can just set the environment variable `DOCKER_BUILDX` to `buildx`, set the environment
-variable `DOCKER_BUILD_ARGS` to pass additional build options such as the platform and run the build. For example
-following can be used to build Strimzi images for Linux on Arm64 / AArch64:
+Docker and Podman supports building images for different platforms. Strimzi relies on `TARGETOS` and `TARGETARCH` 
+arguments to identify which platform of binary should be used when building the image. Please make sure the version of 
+docker or podman used is supporting this feature, otherwise, it'll default to use `linux/amd64` binaries.
+If you want to build Strimzi images for other platforms, you can set the environment variable `DOCKER_BUILD_ARGS`
+to pass additional build options such as the platform and run the build.
+For example, following can be used to build Strimzi images for Linux on Arm64 / AArch64:
+
+```
+export DOCKER_BUILD_ARGS="--platform linux/arm64"
+make all
+```
+
+Docker also supports building images for different platforms using the `docker buildx` command. If you want to use this
+command, please set both `DOCKER_BUILDX` and `DOCKER_BUILD_ARGS` environment variables like this:
 
 ```
 export DOCKER_BUILDX=buildx
 export DOCKER_BUILD_ARGS="--platform linux/amd64 --load"
 make all
 ```
-
-_Note: Strimzi currently does not officially support any other platforms then Linux on `amd64`._
 
 ## Adding support for new Kafka versions
 

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -393,15 +393,6 @@ For example, following can be used to build Strimzi images for Linux on Arm64 / 
 DOCKER_PLATFORM="--platform linux/arm64" make all
 ```
 
-Docker also supports building images for different platforms using the `docker buildx` command. If you want to use this
-command, please set both `DOCKER_BUILDX` and `DOCKER_BUILD_ARGS` environment variables like this:
-
-```
-export DOCKER_BUILDX=buildx
-export DOCKER_BUILD_ARGS="--platform linux/amd64 --load"
-make all
-```
-
 ## Adding support for new Kafka versions
 
 Following steps are needed to add support for new Kafka releases:

--- a/development-docs/DEV_GUIDE.md
+++ b/development-docs/DEV_GUIDE.md
@@ -384,16 +384,13 @@ the commit if errors are detected:
 
 ## Building container images for other platforms
 
-Docker and Podman supports building images for different platforms. Strimzi relies on `TARGETOS` and `TARGETARCH` 
-arguments to identify which platform of binary should be used when building the image. Please make sure the version of 
-docker or podman used is supporting this feature, otherwise, it'll default to use `linux/amd64` binaries.
-If you want to build Strimzi images for other platforms, you can set the environment variable `DOCKER_BUILD_ARGS`
-to pass additional build options such as the platform and run the build.
+Docker and Podman supports building images for different platforms.
+If you want to build Strimzi images for other platforms, you can set the environment variable `DOCKER_PLATFORM`
+to pass additional build options and run the build.
 For example, following can be used to build Strimzi images for Linux on Arm64 / AArch64:
 
 ```
-export DOCKER_BUILD_ARGS="--platform linux/arm64"
-make all
+DOCKER_PLATFORM="--platform linux/arm64" make all
 ```
 
 Docker also supports building images for different platforms using the `docker buildx` command. If you want to use this

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -3,7 +3,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 
 ARG JAVA_VERSION=17
-ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 USER root
 
@@ -23,18 +24,18 @@ ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e
 ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
 ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
 
-RUN echo $TARGETPLATFORM
+RUN echo "${TARGETOS}/${TARGETARCH}"
 
 RUN set -ex; \
-    if [[ ${TARGETPLATFORM} = "linux/ppc64le" ]]; then \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
         curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
         echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
         chmod +x /usr/bin/tini; \
-    elif [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
         curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
         echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
         chmod +x /usr/bin/tini; \
-    elif [[ ${TARGETPLATFORM} = "linux/s390x" ]]; then \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
         curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
         echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
         chmod +x /usr/bin/tini; \

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -24,8 +24,6 @@ ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e
 ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
 ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
 
-RUN echo "${TARGETOS}/${TARGETARCH}"
-
 RUN set -ex; \
     if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
         curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -6,7 +6,8 @@ ARG KAFKA_DIST_DIR
 ARG KAFKA_VERSION
 ARG THIRD_PARTY_LIBS
 ARG strimzi_version
-ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install gettext nmap-ncat stunnel net-tools unzip hostname findutils tar \
     && microdnf clean all
@@ -36,21 +37,21 @@ ENV KAFKA_EXPORTER_CHECKSUM_PPC64LE="0eaee79659b0988d65f61a93e5f4df35caa9a74eaa6
 ENV KAFKA_EXPORTER_CHECKSUM_S390X="2a4bf6ad41941d62341c3b13dd05dc115c92461d3ae664809c7b3afbec2f90fd01c561be327fb96e9aa4a7f6e7b10830ceac059cb7801fef557124b803d07b4f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-s390x.tar.gz"
 
 RUN set -ex; \
-    if [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
         curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_ARM64 > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \
         tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-arm64.tar.gz*; \
-    elif [[ ${TARGETPLATFORM} = "linux/ppc64le" ]]; then \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
         curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_PPC64LE > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz.sha512; \
         mkdir $KAFKA_EXPORTER_HOME; \
         tar xvfz kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz -C $KAFKA_EXPORTER_HOME --strip-components=1; \
         rm -f kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-ppc64le.tar.gz*; \
-    elif [[ ${TARGETPLATFORM} = "linux/s390x" ]]; then \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
         curl -LO https://github.com/danielqsj/kafka_exporter/releases/download/v${KAFKA_EXPORTER_VERSION}/kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-s390x.tar.gz; \
         echo $KAFKA_EXPORTER_CHECKSUM_S390X > kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-s390x.tar.gz.sha512; \
         sha512sum --check kafka_exporter-${KAFKA_EXPORTER_VERSION}.linux-s390x.tar.gz.sha512; \


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Build
- Documentation

### Description


We have some places want to add binaries into images based on the target platform, like here, adding `tini`

https://github.com/strimzi/strimzi-kafka-operator/blob/5eec9a36519d2012f3578115aeb0bf77e34a270a/docker-images/base/Dockerfile#L29-L33

And here, adding kafka exporter:

https://github.com/strimzi/strimzi-kafka-operator/blob/5eec9a36519d2012f3578115aeb0bf77e34a270a/docker-images/kafka-based/kafka/Dockerfile#L39-L43

It'll download based on the `TARGETPLATFORM` argument, but when using `podman` on M1 macbook without setting the `--platform` option, the `TARGETPLATFORM` will be set as `linux/arm64/v8`. This is actually a correct platform config from this [doc](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope)

```
TARGETPLATFORM - platform of the build result. Eg linux/amd64, linux/arm/v7, windows/amd64.
TARGETOS - OS component of TARGETPLATFORM
TARGETARCH - architecture component of TARGETPLATFORM
TARGETVARIANT - variant component of TARGETPLATFORM
```

That is, the `TARGETPLATFORM` `linux/arm64/v8` is a combo of `TARGETOS`(linux)/`TARGETARCH`(arm64)/`TARGETVARIANT`(v8). Since we only care about `TARGETOS` and `TARGETARCH`, we should identify by these 2 arguments, instead of the `TARGETPLATFORM`.

This PR also make the dev_guide more clear to help users building images for other platforms.

Tested with `podman` (server Podman Engine: v4.5.0) and `docker` (server Docker Engine v24.0.1) 
```
$ podman  build  --build-arg strimzi_version=0.36.0-SNAPSHOT -t strimzi/base:latest .
...
STEP 14/15: RUN echo "${TARGETOS}/${TARGETARCH}"
linux/arm64

$ docker  build   --build-arg strimzi_version=0.36.0-SNAPSHOT -t strimzi/base:latest ./
...
STEP 14/15: RUN echo "${TARGETOS}/${TARGETARCH}"
linux/arm64
```


```
$ podman  build --platform linux/arm64/v8 --build-arg strimzi_version=0.36.0-SNAPSHOT -t strimzi/base:latest .
...
STEP 14/15: RUN echo "${TARGETOS}/${TARGETARCH}"
linux/arm64

$ docker  build --platform linux/arm64/v8   --build-arg strimzi_version=0.36.0-SNAPSHOT -t strimzi/base:latest ./
...
STEP 14/15: RUN echo "${TARGETOS}/${TARGETARCH}"
linux/arm64
```

```
$ podman  build --platform linux/amd64 --build-arg strimzi_version=0.36.0-SNAPSHOT -t strimzi/base:latest .
...
STEP 14/15: RUN echo "${TARGETOS}/${TARGETARCH}"
linux/amd64
```
Note: using docker run the above command will fail in my env with arch type unexecutable error, unrelated to this change.
```
> [2/4] RUN microdnf update     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-17-openjdk-headless openssl shadow-utils     && microdnf reinstall -y tzdata     && microdnf clean all:
#0 0.124 exec /bin/sh: exec format error
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [v] Make sure all tests pass
- [v] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

