### PR TITLE
Fix `Pod is Unschedulable` error message in Kafka roller

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -495,7 +495,7 @@ public class KafkaRoller {
             // If the pod is unschedulable then deleting it, or trying to open an Admin client to it will make no difference
             // Treat this as fatal because if it's not possible to schedule one pod then it's likely that proceeding
             // and deleting a different pod in the meantime will likely result in another unschedulable pod.
-            throw new FatalProblem("Pod is unschedulable");
+            throw new FatalProblem("Pod is unschedulable or is not starting");
         }
         // Unless the annotation is present, check the pod is at least ready.
         boolean needsRestart = reasonToRestartPod.shouldRestart();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Today, the `KafkaRoller` checks if a pod is stuck and when it is, it throws the error saying that `Pod is Unschedulable`. But being unschedulable is only one of the reasons why it is stuck. Others might be for example `CrashLoopBackoff`, `ImagePullBackoff` or just being stuck in `ContainerCreating` for various reasons.

This PR updates the log message / exception message to use broader `Pod is unschedulable or is not starting` to avoid possible confusion.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally