### PR TITLE
Add useIncrementalCompilation=false in systemtest build

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -253,6 +253,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <useIncrementalCompilation>false</useIncrementalCompilation>
                             <compilerArgs combine.self="override">
                                 <arg>-Xlint:deprecation</arg>
                             </compilerArgs>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds `<useIncrementalCompilation>false</useIncrementalCompilation>` into systemtest pom into compile part to avoid issues with building the project with `make` and without `make clean` before running the build. 



