### PR TITLE
Add tag for tests which are not supported on arm

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -363,6 +363,11 @@ public interface Constants {
      */
     String ROUTE = "route";
 
+    /**
+     * Tag for tests, without ARM,AARCH64 support
+     */
+    String ARM_UNSUPPORTED = "armunsupported";
+
     String ISOLATED_TEST = "isolatedtest";
     String PARALLEL_TEST = "paralleltest";
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -366,7 +366,7 @@ public interface Constants {
     /**
      * Tag for tests, without ARM,AARCH64 support
      */
-    String ARM_UNSUPPORTED = "armunsupported";
+    String ARM64_UNSUPPORTED = "arm64unsupported";
 
     String ISOLATED_TEST = "isolatedtest";
     String PARALLEL_TEST = "paralleltest";

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
@@ -31,12 +31,14 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.IOException;
 
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
+@Tag(ARM_UNSUPPORTED)
 @ParallelSuite
 public class OpaIntegrationST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(OpaIntegrationST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
@@ -31,14 +31,12 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.IOException;
 
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
-@Tag(ARM_UNSUPPORTED)
 @ParallelSuite
 public class OpaIntegrationST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(OpaIntegrationST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
+import static io.strimzi.systemtest.Constants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
-@Tag(ARM_UNSUPPORTED)
+@Tag(ARM64_UNSUPPORTED)
 public class OauthAbstractST extends AbstractST {
 
     protected static final Logger LOGGER = LogManager.getLogger(OauthAbstractST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 
@@ -40,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
+@Tag(ARM_UNSUPPORTED)
 public class OauthAbstractST extends AbstractST {
 
     protected static final Logger LOGGER = LogManager.getLogger(OauthAbstractST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
@@ -51,7 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
+import static io.strimzi.systemtest.Constants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(OAUTH)
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
-@Tag(ARM_UNSUPPORTED)
+@Tag(ARM64_UNSUPPORTED)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @IsolatedSuite
 @KRaftNotSupported("OAuth is not supported by KRaft mode and is used in this test case")

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationIsolatedST.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -59,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(OAUTH)
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
+@Tag(ARM_UNSUPPORTED)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @IsolatedSuite
 @KRaftNotSupported("OAuth is not supported by KRaft mode and is used in this test case")

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsIsolatedST.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.time.Duration;
 
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -60,6 +61,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
+@Tag(ARM_UNSUPPORTED)
 @IsolatedSuite
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthPasswordGrantsIsolatedST extends OauthAbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsIsolatedST.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.time.Duration;
 
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
+import static io.strimzi.systemtest.Constants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -61,7 +61,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
-@Tag(ARM_UNSUPPORTED)
+@Tag(ARM64_UNSUPPORTED)
 @IsolatedSuite
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthPasswordGrantsIsolatedST extends OauthAbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -60,7 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
+import static io.strimzi.systemtest.Constants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -79,7 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
-@Tag(ARM_UNSUPPORTED)
+@Tag(ARM64_UNSUPPORTED)
 @IsolatedSuite
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthPlainIsolatedST extends OauthAbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainIsolatedST.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -78,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
+@Tag(ARM_UNSUPPORTED)
 @IsolatedSuite
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthPlainIsolatedST extends OauthAbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
+import static io.strimzi.systemtest.Constants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -47,7 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
-@Tag(ARM_UNSUPPORTED)
+@Tag(ARM64_UNSUPPORTED)
 @IsolatedSuite
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthScopeIsolatedST extends OauthAbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.OAUTH;
 import static io.strimzi.systemtest.Constants.REGRESSION;
@@ -46,6 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
+@Tag(ARM_UNSUPPORTED)
 @IsolatedSuite
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthScopeIsolatedST extends OauthAbstractST {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
-import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
+import static io.strimzi.systemtest.Constants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -66,7 +66,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @Tag(OAUTH)
 @Tag(REGRESSION)
 @Tag(ACCEPTANCE)
-@Tag(ARM_UNSUPPORTED)
+@Tag(ARM64_UNSUPPORTED)
 @IsolatedSuite
 @KRaftNotSupported("OAuth is not supported by KRaft mode and is used in this test case")
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsIsolatedST.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
+import static io.strimzi.systemtest.Constants.ARM_UNSUPPORTED;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
@@ -65,6 +66,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @Tag(OAUTH)
 @Tag(REGRESSION)
 @Tag(ACCEPTANCE)
+@Tag(ARM_UNSUPPORTED)
 @IsolatedSuite
 @KRaftNotSupported("OAuth is not supported by KRaft mode and is used in this test case")
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")

--- a/systemtest/src/test/resources/opa/opa.yaml
+++ b/systemtest/src/test/resources/opa/opa.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: opa
       containers:
         - name: opa
-          image: openpolicyagent/opa:latest
+          image: openpolicyagent/opa:latest-static
           ports:
             - name: http
               containerPort: 8181


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Due to missing support of dependencies for systemtests like `keycloak` on arm64/aarch64 we need to exclude these tests when we run them on ARM clusters. So I introduced tag `armunsupported` to allow us exclude these tests.


