### PR TITLE
[ST] watcher AllNamespacesIsolated and MultipleNamespaceIsolated refactor

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.watcher;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
+import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,9 +29,11 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
         LOGGER.info("Creating Cluster Operator which will watch over all namespaces");
 
         clusterOperator.unInstall();
+
+        cluster.createNamespaces(CollectorElement.createCollectorElement(this.getClass().getName()), clusterOperator.getDeploymentNamespace(), Arrays.asList(PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE));
+
         clusterOperator = clusterOperator.defaultInstallation()
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
-            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
             .createInstallation()
             .runInstallation();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceIsolatedST.java
@@ -4,30 +4,9 @@
  */
 package io.strimzi.systemtest.watcher;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.KafkaUser;
-import io.strimzi.api.kafka.model.status.Condition;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
-import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
-import io.strimzi.systemtest.cli.KafkaCmdClient;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
-import io.strimzi.systemtest.resources.crd.KafkaUserResource;
-import io.strimzi.systemtest.storage.TestStorage;
-import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
-import io.strimzi.systemtest.templates.specific.ScraperTemplates;
-import io.strimzi.systemtest.utils.ClientUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,20 +14,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Arrays;
-import java.util.List;
 
-import static io.strimzi.systemtest.Constants.ACCEPTANCE;
-import static io.strimzi.systemtest.Constants.CONNECT;
-import static io.strimzi.systemtest.Constants.CONNECTOR_OPERATOR;
-import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
-import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
@@ -56,166 +23,16 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 class AllNamespaceIsolatedST extends AbstractNamespaceST {
 
     private static final Logger LOGGER = LogManager.getLogger(AllNamespaceIsolatedST.class);
-    private static final String THIRD_NAMESPACE = "third-namespace-test";
-    private String scraperPodName;
 
-    /**
-     * Test the case where the TO is configured to watch a different namespace that it is deployed in
-     */
-    @IsolatedTest
-    @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test case")
-    void testTopicOperatorWatchingOtherNamespace(ExtensionContext extensionContext) {
-        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-
-        LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
-        String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
-        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(THIRD_NAMESPACE, scraperPodName, KafkaResources.plainBootstrapAddress(MAIN_NAMESPACE_CLUSTER_NAME));
-        assertThat(topics, not(hasItems(TOPIC_NAME)));
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(MAIN_NAMESPACE_CLUSTER_NAME, topicName, SECOND_NAMESPACE).build());
-        KafkaTopicResource.kafkaTopicClient().inNamespace(SECOND_NAMESPACE).withName(topicName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        cluster.setNamespace(previousNamespace);
-    }
-
-    /**
-     * Test the case when Kafka will be deployed in different namespace than CO
-     */
-    @IsolatedTest
-    @Tag(ACCEPTANCE)
-    void testKafkaInDifferentNsThanClusterOperator() {
-        LOGGER.info("Deploying Kafka cluster in different namespace than CO when CO watches all namespaces");
-        checkKafkaInDiffNamespaceThanCO(SECOND_CLUSTER_NAME, SECOND_NAMESPACE);
-    }
-
-    /**
-     * Test the case when MirrorMaker will be deployed in different namespace than CO when CO watches all namespaces
-     */
-    @IsolatedTest
-    @Tag(MIRROR_MAKER)
-    void testDeployMirrorMakerAcrossMultipleNamespace(ExtensionContext extensionContext) {
-        LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches all namespaces");
-        checkMirrorMakerForKafkaInDifNamespaceThanCO(extensionContext, SECOND_CLUSTER_NAME);
-    }
-
-    @IsolatedTest
-    @Tag(CONNECT)
-    @Tag(CONNECTOR_OPERATOR)
-    @Tag(CONNECT_COMPONENTS)
-    void testDeployKafkaConnectAndKafkaConnectorInOtherNamespaceThanCO(ExtensionContext extensionContext) {
-        String kafkaConnectName = mapWithClusterNames.get(extensionContext.getDisplayName()) + "kafka-connect";
-
-        String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
-        // Deploy Kafka Connect in other namespace than CO
-        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnectWithFilePlugin(kafkaConnectName, SECOND_NAMESPACE, SECOND_CLUSTER_NAME, 1)
-            .editMetadata()
-                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
-            .endMetadata()
-            .build());
-        // Deploy Kafka Connector
-        deployKafkaConnectorWithSink(extensionContext, kafkaConnectName);
-
-        cluster.setNamespace(previousNamespace);
-    }
-
-    @IsolatedTest
-    void testUOWatchingOtherNamespace(ExtensionContext extensionContext) {
-        String previousNamespace = cluster.setNamespace(SECOND_NAMESPACE);
-        LOGGER.info("Creating user in other namespace than CO and Kafka cluster with UO");
-        resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(cluster.getNamespace(), MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).build());
-
-        cluster.setNamespace(previousNamespace);
-    }
-
-    @IsolatedTest
-    void testUserInDifferentNamespace(ExtensionContext extensionContext) {
-        final TestStorage testStorage = new TestStorage(extensionContext, SECOND_NAMESPACE);
-        String startingNamespace = cluster.setNamespace(SECOND_NAMESPACE);
-
-        KafkaUser user = KafkaUserTemplates.tlsUser(testStorage.getNamespaceName(), MAIN_NAMESPACE_CLUSTER_NAME, USER_NAME).build();
-
-        resourceManager.createResource(extensionContext, user);
-
-        Condition kafkaCondition = KafkaUserResource.kafkaUserClient().inNamespace(SECOND_NAMESPACE).withName(USER_NAME)
-                .get().getStatus().getConditions().get(0);
-        LOGGER.info("KafkaUser condition status: {}", kafkaCondition.getStatus());
-        LOGGER.info("KafkaUser condition type: {}", kafkaCondition.getType());
-
-        assertThat(kafkaCondition.getType(), is(Ready.toString()));
-
-        List<Secret> secretsOfSecondNamespace = kubeClient(SECOND_NAMESPACE).listSecrets();
-
-        cluster.setNamespace(THIRD_NAMESPACE);
-
-        for (Secret s : secretsOfSecondNamespace) {
-            if (s.getMetadata().getName().equals(USER_NAME)) {
-                LOGGER.info("Copying secret {} from namespace {} to namespace {}", s, SECOND_NAMESPACE, THIRD_NAMESPACE);
-                copySecret(s, THIRD_NAMESPACE, USER_NAME);
-            }
-        }
-
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(TOPIC_NAME)
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(MAIN_NAMESPACE_CLUSTER_NAME))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(THIRD_NAMESPACE)
-            .withUsername(USER_NAME)
-            .build();
-
-        resourceManager.createResource(extensionContext, kafkaClients.producerTlsStrimzi(MAIN_NAMESPACE_CLUSTER_NAME), kafkaClients.consumerTlsStrimzi(MAIN_NAMESPACE_CLUSTER_NAME));
-        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), THIRD_NAMESPACE, testStorage.getMessageCount());
-
-        cluster.setNamespace(startingNamespace);
-    }
-
-    void copySecret(Secret sourceSecret, String targetNamespace, String targetName) {
-        Secret s = new SecretBuilder(sourceSecret)
-                    .withNewMetadata()
-                        .withName(targetName)
-                        .withNamespace(targetNamespace)
-                    .endMetadata()
-                    .build();
-
-        kubeClient().createSecret(s);
-    }
-
-    private void deployTestSpecificResources(ExtensionContext extensionContext) {
-        LOGGER.info("Creating resources before the test class");
-
-        final String scraperName = MAIN_NAMESPACE_CLUSTER_NAME + "-" + Constants.SCRAPER_NAME;
+    private void deployTestSpecificClusterOperator() {
+        LOGGER.info("Creating Cluster Operator which will watch over all namespaces");
 
         clusterOperator.unInstall();
         clusterOperator = clusterOperator.defaultInstallation()
             .withWatchingNamespaces(Constants.WATCH_ALL_NAMESPACES)
-            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), SECOND_NAMESPACE, THIRD_NAMESPACE))
+            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
             .createInstallation()
             .runInstallation();
-
-        String previousNamespace = cluster.setNamespace(THIRD_NAMESPACE);
-
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(MAIN_NAMESPACE_CLUSTER_NAME, 1)
-            .editSpec()
-                .editEntityOperator()
-                    .editTopicOperator()
-                        .withWatchedNamespace(SECOND_NAMESPACE)
-                    .endTopicOperator()
-                    .editUserOperator()
-                        .withWatchedNamespace(SECOND_NAMESPACE)
-                    .endUserOperator()
-                .endEntityOperator()
-            .endSpec()
-            .build(),
-            ScraperTemplates.scraperPod(THIRD_NAMESPACE, scraperName).build()
-        );
-
-        scraperPodName = kubeClient().listPodsByPrefixInName(THIRD_NAMESPACE, scraperName).get(0).getMetadata().getName();
-
-        cluster.setNamespace(SECOND_NAMESPACE);
-        // Deploy Kafka in other namespace than CO
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(SECOND_CLUSTER_NAME, 1).build());
-
-        cluster.setNamespace(previousNamespace);
     }
 
     @BeforeAll
@@ -223,6 +40,9 @@ class AllNamespaceIsolatedST extends AbstractNamespaceST {
         // Strimzi is deployed with cluster-wide access in this class STRIMZI_RBAC_SCOPE=NAMESPACE won't work
         assumeFalse(Environment.isNamespaceRbacScope());
 
-        deployTestSpecificResources(extensionContext);
+        deployTestSpecificClusterOperator();
+
+        LOGGER.info("deploy all other resources (Kafka Cluster and Scrapper) for testing namespaces");
+        deployAdditionalGenericResourcesForAbstractNamespaceST(extensionContext);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceIsolatedST.java
@@ -4,19 +4,9 @@
  */
 package io.strimzi.systemtest.watcher;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.BeforeAllOnce;
-import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
-import io.strimzi.systemtest.cli.KafkaCmdClient;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
-import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.templates.crd.KafkaTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
-import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -24,91 +14,34 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Arrays;
-import java.util.List;
 
-import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.Constants.INFRA_NAMESPACE;
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.not;
 
 @Tag(REGRESSION)
 @IsolatedSuite
 class MultipleNamespaceIsolatedST extends AbstractNamespaceST {
 
     private static final Logger LOGGER = LogManager.getLogger(MultipleNamespaceIsolatedST.class);
-    private String scraperPodName;
 
-    /**
-     * Test the case where the TO is configured to watch a different namespace that it is deployed in
-     */
-    @IsolatedTest
-    @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test case")
-    void testTopicOperatorWatchingOtherNamespace(ExtensionContext extensionContext) {
-        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
+    private void deployTestSpecificClusterOperator() {
+        LOGGER.info("Creating Cluster Operator which will watch over multiple namespaces");
 
-        LOGGER.info("Deploying TO to watch a different namespace that it is deployed in");
-        cluster.setNamespace(SECOND_NAMESPACE);
-        List<String> topics = KafkaCmdClient.listTopicsUsingPodCli(SECOND_NAMESPACE, scraperPodName, KafkaResources.plainBootstrapAddress(MAIN_NAMESPACE_CLUSTER_NAME));
-        assertThat(topics, not(hasItems(topicName)));
-
-        resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(MAIN_NAMESPACE_CLUSTER_NAME, topicName, clusterOperator.getDeploymentNamespace()).build());
-        KafkaTopicResource.kafkaTopicClient().inNamespace(clusterOperator.getDeploymentNamespace()).withName(topicName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-    }
-
-    /**
-     * Test the case when Kafka will be deployed in different namespace than CO
-     */
-    @IsolatedTest
-    void testKafkaInDifferentNsThanClusterOperator() {
-        LOGGER.info("Deploying Kafka in different namespace than CO when CO watches multiple namespaces");
-        checkKafkaInDiffNamespaceThanCO(MAIN_NAMESPACE_CLUSTER_NAME, SECOND_NAMESPACE);
-    }
-
-    /**
-     * Test the case when MirrorMaker will be deployed in different namespace across multiple namespaces
-     */
-    @IsolatedTest
-    @Tag(MIRROR_MAKER)
-    void testDeployMirrorMakerAcrossMultipleNamespace(ExtensionContext extensionContext) {
-        LOGGER.info("Deploying KafkaMirrorMaker in different namespace than CO when CO watches multiple namespaces");
-        checkMirrorMakerForKafkaInDifNamespaceThanCO(extensionContext, MAIN_NAMESPACE_CLUSTER_NAME);
-    }
-
-    @BeforeAll
-    void setupEnvironment(ExtensionContext extensionContext) {
-        deployTestSpecificResources(extensionContext);
-    }
-
-    private void deployTestSpecificResources(ExtensionContext extensionContext) {
-        final String scraperName = MAIN_NAMESPACE_CLUSTER_NAME + "-" + Constants.SCRAPER_NAME;
         clusterOperator.unInstall();
         clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
             .withNamespace(INFRA_NAMESPACE)
-            .withWatchingNamespaces(String.join(",", INFRA_NAMESPACE, SECOND_NAMESPACE))
-            .withBindingsNamespaces(Arrays.asList(INFRA_NAMESPACE, SECOND_NAMESPACE))
+            .withWatchingNamespaces(String.join(",", INFRA_NAMESPACE, PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
+            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
             .createInstallation()
             .runInstallation();
+    }
 
-        cluster.setNamespace(SECOND_NAMESPACE);
+    @BeforeAll
+    void setupEnvironment(ExtensionContext extensionContext) {
+        deployTestSpecificClusterOperator();
 
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(MAIN_NAMESPACE_CLUSTER_NAME, 3)
-            .editSpec()
-                .editEntityOperator()
-                    .editTopicOperator()
-                        .withWatchedNamespace(clusterOperator.getDeploymentNamespace())
-                    .endTopicOperator()
-                .endEntityOperator()
-            .endSpec()
-            .build(),
-            ScraperTemplates.scraperPod(SECOND_NAMESPACE, scraperName).build()
-        );
-
-        scraperPodName = kubeClient().listPodsByPrefixInName(SECOND_NAMESPACE, scraperName).get(0).getMetadata().getName();
-
-        cluster.setNamespace(clusterOperator.getDeploymentNamespace());
+        LOGGER.info("deploy all other resources (Kafka Cluster and Scrapper) for testing namespaces");
+        deployAdditionalGenericResourcesForAbstractNamespaceST(extensionContext);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceIsolatedST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.watcher;
 import io.strimzi.systemtest.BeforeAllOnce;
 import io.strimzi.systemtest.annotations.IsolatedSuite;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
+import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,11 +29,13 @@ class MultipleNamespaceIsolatedST extends AbstractNamespaceST {
         LOGGER.info("Creating Cluster Operator which will watch over multiple namespaces");
 
         clusterOperator.unInstall();
+
+        cluster.createNamespaces(CollectorElement.createCollectorElement(this.getClass().getName()), clusterOperator.getDeploymentNamespace(), Arrays.asList(PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE));
+
         clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(BeforeAllOnce.getSharedExtensionContext())
             .withNamespace(INFRA_NAMESPACE)
             .withWatchingNamespaces(String.join(",", INFRA_NAMESPACE, PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
-            .withBindingsNamespaces(Arrays.asList(clusterOperator.getDeploymentNamespace(), PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE))
             .createInstallation()
             .runInstallation();
     }


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

- **Migration of  tests into `AbstractNamespaceST`**:  `AllNamespaceIsolatedST` and `MultipleNamespaceIsolatedST` both extend `AbstractNamespaceST` most of tests can be placed here (`AbstractNamespaceST`) due to DRY principle. 
- **mirror maker 2** instead of mirror maker 1 tested now.
- less important improvements:
  - updated some outdated checks which actually always passed, and addition of news, including tests to cover components such as Kafka Bridge or Cruise Control. 
  - removal of redundant namespaces and several outdated naming conventions
  - creation of fewer Kafkas
  - added documentation

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation

fixes  https://github.com/strimzi/strimzi-kafka-operator/issues/8262 , https://github.com/strimzi/strimzi-kafka-operator/issues/8263

