### PR TITLE
docs(volumes): clarifies no risk to data loss when resizing PVs

### DIFF
--- a/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
@@ -6,8 +6,9 @@
 = Resizing persistent volumes
 
 [role="_abstract"]
-You can provision increased storage capacity by increasing the size of the persistent volumes used by an existing Strimzi cluster.
-Resizing persistent volumes is supported in clusters that use either a single persistent volume or multiple persistent volumes in a JBOD storage configuration.
+Persistent volumes used by a Strimzi cluster can be resized without any risk of data loss. 
+This capability allows for expanding storage capacity by increasing the size of existing persistent volumes. 
+Resizing is supported in clusters with either a single persistent volume or multiple persistent volumes configured in JBOD storage.
 
 NOTE: You can increase but not decrease the size of persistent volumes.
 Decreasing the size of persistent volumes is not currently supported in Kubernetes.

--- a/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
@@ -10,7 +10,7 @@ Persistent volumes used by a cluster can be resized without any risk of data los
 Following a configuration update to change the size of the storage, Strimzi instructs the storage infrastructure to make the change. 
 Storage expansion is supported in Strimzi clusters that use a single persistent volume per-broker or multiple persistent volumes per-broker that use JBOD storage. 
 
-NOTE: Storage reduction is only possible with JBOD, and only after moving all partitions to other volumes within the same broker (intra-broker) or to other brokers within the same cluster (intra-cluster).
+NOTE: Storage reduction is only possible with JBOD. You can remove a disk after moving all partitions on the disk to other volumes within the same broker (intra-broker) or to other brokers within the same cluster (intra-cluster).
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
@@ -6,12 +6,11 @@
 = Resizing persistent volumes
 
 [role="_abstract"]
-Persistent volumes used by a Strimzi cluster can be resized without any risk of data loss. 
-This capability allows for expanding storage capacity by increasing the size of existing persistent volumes. 
-Resizing is supported in clusters with either a single persistent volume or multiple persistent volumes configured in JBOD storage.
+Persistent volumes used by a cluster can be resized without any risk of data loss, as long as the storage infrastructure supports it. 
+Following a configuration update to change the size of the storage, Strimzi instructs the storage infrastructure to make the change. 
+Storage expansion is supported in Strimzi clusters that use a single persistent volume per-broker or multiple persistent volumes per-broker that use JBOD storage. 
 
-NOTE: You can increase but not decrease the size of persistent volumes.
-Decreasing the size of persistent volumes is not currently supported in Kubernetes.
+NOTE: Storage reduction is only possible with JBOD, and only after moving all partitions to other volumes within the same broker (intra-broker) or to other brokers within the same cluster (intra-cluster).
 
 .Prerequisites
 

--- a/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
+++ b/documentation/modules/configuring/proc-resizing-persistent-volumes.adoc
@@ -8,9 +8,12 @@
 [role="_abstract"]
 Persistent volumes used by a cluster can be resized without any risk of data loss, as long as the storage infrastructure supports it. 
 Following a configuration update to change the size of the storage, Strimzi instructs the storage infrastructure to make the change. 
-Storage expansion is supported in Strimzi clusters that use a single persistent volume per-broker or multiple persistent volumes per-broker that use JBOD storage. 
+Storage expansion is supported in Strimzi clusters that use persistent-claim volumes. 
 
-NOTE: Storage reduction is only possible with JBOD. You can remove a disk after moving all partitions on the disk to other volumes within the same broker (intra-broker) or to other brokers within the same cluster (intra-cluster).
+Storage reduction is only possible when using multiple disks per broker.
+You can remove a disk after moving all partitions on the disk to other volumes within the same broker (intra-broker) or to other brokers within the same cluster (intra-cluster).
+
+IMPORTANT: You cannot decrease the size of persistent volumes because it is not currently supported in Kubernetes.
 
 .Prerequisites
 


### PR DESCRIPTION
### Documentation

Update to docs that makes it clear that resizing persistent volumes presents no risk to data loss

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

