### PR TITLE
Reduce polling timer delay for KafkaRebalanceAssemblyOperator tests

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -179,6 +179,10 @@ public class KafkaRebalanceAssemblyOperator
         this.secretOperations = supplier.secretOperations;
     }
 
+    protected long rebalancePollingTimerDelay() {
+        return REBALANCE_POLLING_TIMER_MS;
+    }
+
     /**
      * Provides an implementation of the Cruise Control API client
      *
@@ -843,7 +847,7 @@ public class KafkaRebalanceAssemblyOperator
         Promise<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> p = Promise.promise();
         if (rebalanceAnnotation == KafkaRebalanceAnnotation.none) {
             LOGGER.debugCr(reconciliation, "Starting Cruise Control rebalance proposal request timer");
-            vertx.setPeriodic(REBALANCE_POLLING_TIMER_MS, t ->
+            vertx.setPeriodic(rebalancePollingTimerDelay(), t ->
                 kafkaRebalanceOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName())
                     .onSuccess(currentKafkaRebalance -> {
                         // Checking that the resource was not deleted between periodic polls
@@ -975,7 +979,7 @@ public class KafkaRebalanceAssemblyOperator
             LOGGER.infoCr(reconciliation, "Starting Cruise Control rebalance user task status timer");
             String sessionId = kafkaRebalance.getStatus().getSessionId();
             AtomicInteger ccApiErrorCount = new AtomicInteger();
-            vertx.setPeriodic(REBALANCE_POLLING_TIMER_MS, t -> {
+            vertx.setPeriodic(rebalancePollingTimerDelay(), t -> {
                 // Check that we have not already failed to contact the API beyond the allowed number of times.
                 if (ccApiErrorCount.get() >= MAX_API_RETRIES) {
                     vertx.cancelTimer(t);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -169,6 +169,11 @@ public class KafkaRebalanceAssemblyOperatorTest {
             public CruiseControlApi cruiseControlClientProvider(Secret ccSecret, Secret ccApiSecret, boolean apiAuthEnabled, boolean apiSslEnabled) {
                 return new CruiseControlApiImpl(vertx, 1, ccSecret, ccApiSecret, true, true);
             }
+
+            @Override
+            protected long rebalancePollingTimerDelay() {
+                return 100;
+            }
         };
 
         mockRebalanceOps = supplier.kafkaRebalanceOperator;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Test Enhancement

### Description

Override/reduce polling timer delay from 5s to 100ms for KafkaRebalanceAssemblyOperator tests

Fixes #8219 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

