### PR TITLE
[WIP]Adds proper error message when Cruise Control fails to generate the rebalance proposal

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -877,7 +877,8 @@ public class KafkaRebalanceAssemblyOperator
                                             }
                                         })
                                         .onFailure(e -> {
-                                            LOGGER.errorCr(reconciliation, "Cruise Control getting rebalance proposal failed", e.getCause());
+                                            System.out.println(e.getMessage() + "hi");
+                                            LOGGER.errorCr(reconciliation, "Cruise Control getting rebalance proposal failed: " + e.getMessage());
                                             vertx.cancelTimer(t);
                                             p.fail(e.getCause());
                                         });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRestException.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRestException.java
@@ -16,4 +16,14 @@ public class CruiseControlRestException extends RuntimeException {
     public CruiseControlRestException(String message) {
         super(message);
     }
+
+    /**
+     * Constructor
+     *
+     * @param cause Error cause
+     * @param message   Error message
+     */
+    public CruiseControlRestException(Throwable cause, String message) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

For eg. 

The logs will look like this 

```
2023-05-31 10:01:47 ERROR KafkaRebalanceAssemblyOperator:881 - Reconciliation #40(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Cruise Control getting rebalance proposal failed: Error for request:my-cluster-cruise-control.myproject.svc:9090/kafkacruisecontrol/rebalance?json=true&dryrun=true&verbose=true&skip_hard_goal_check=false&rebalance_disk=false. Server returned: Error processing POST request '/rebalance' due to: 'com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException: [RackAwareGoal] Insufficient number of racks to distribute each replica (Current: 1, Needed: 3). Add at least 2 racks with brokers. Add at least 2 racks with brokers.'.
2023-05-31 10:01:47 ERROR KafkaRebalanceAssemblyOperator:485 - Reconciliation #40(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance): Status updated to [NotReady] due to error: com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

