### PR TITLE
Add microshift to list of allowed systemtest clusters

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/KubeCluster.java
@@ -57,6 +57,9 @@ public interface KubeCluster {
                 case "minikube":
                     clusters = new KubeCluster[]{new Minikube()};
                     break;
+                case "microshift":
+                    clusters = new KubeCluster[]{new Microshift()};
+                    break;
                 case "kubernetes":
                     clusters = new KubeCluster[]{new Kubernetes()};
                     break;
@@ -65,7 +68,7 @@ public interface KubeCluster {
             }
         }
         if (clusters == null) {
-            clusters = new KubeCluster[]{new Minikube(), new Kubernetes(), new OpenShift()};
+            clusters = new KubeCluster[]{new Minikube(), new Kubernetes(), new OpenShift(), new Microshift()};
         }
         KubeCluster cluster = null;
         for (KubeCluster kc : clusters) {

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Microshift.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Microshift.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.k8s.cluster;
+
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.strimzi.test.executor.Exec;
+import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
+import io.strimzi.test.k8s.cmdClient.Oc;
+import io.strimzi.test.k8s.exceptions.KubeClusterException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A {@link KubeCluster} implementation for any {@code Kubernetes} cluster.
+ */
+public class Microshift implements KubeCluster {
+
+    public static final String CMD = "oc";
+    private static final String OLM_NAMESPACE = "openshift-operators";
+    private static final Logger LOGGER = LogManager.getLogger(Microshift.class);
+
+    @Override
+    public boolean isAvailable() {
+        return Exec.isExecutableOnPath(CMD);
+    }
+
+    @Override
+    public boolean isClusterUp() {
+        List<String> cmd = Arrays.asList(CMD, "cluster-info");
+        try {
+            return Exec.exec(cmd).exitStatus() && Exec.exec(CMD, "api-resources").out().contains("openshift.io");
+        } catch (KubeClusterException e) {
+            LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
+            LOGGER.debug(e);
+            return false;
+        }
+    }
+
+    @Override
+    public KubeCmdClient defaultCmdClient() {
+        return new Oc();
+    }
+
+    @Override
+    public KubeClient defaultClient() {
+        return new KubeClient(new KubernetesClientBuilder().withConfig(CONFIG).build(), "default");
+    }
+
+    public String toString() {
+        return "microshift";
+    }
+
+    @Override
+    public String defaultOlmNamespace() {
+        return OLM_NAMESPACE;
+    }
+}


### PR DESCRIPTION
### Type of change

Add microshift into allowed list of clusters to systemtest

### Description

Currently I'm unable to trigger tests on microshift due to error 
```
NoCluster Unable to find a cluster; tried [minikube, kubectl, oc]
```
This PR adds microshift into list.


