### PR TITLE
[systemtest] Add profiles for upgrade and olm-acceptance

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -344,6 +344,14 @@
         </profile>
 
         <profile>
+            <id>upgrade</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>upgrade</groups>
+            </properties>
+        </profile>
+
+        <profile>
             <id>operators</id>
             <properties>
                 <skipTests>false</skipTests>
@@ -544,5 +552,18 @@
                 </groups>
             </properties>
         </profile>
+
+        <profile>
+            <id>olm_acceptance</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>
+                    acceptance,
+                    olm,
+                    olmupgrade
+                </groups>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -554,7 +554,7 @@
         </profile>
 
         <profile>
-            <id>olm_acceptance</id>
+            <id>olm_acceptance_upgrade</id>
             <properties>
                 <skipTests>false</skipTests>
                 <groups>


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This small PR adds two new profiles to the `systemtest/pom.xml` file - `upgrade` and `olm_acceptance_upgrade`.
The profiles will be useful when running the tests on our automation. 

### Checklist

- [ ] Make sure all tests pass
