### PR TITLE
[DOC] Add initial Kafka Node Pool documentation

### DIFF
--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -23,6 +23,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 * The `StableConnectIdentities` feature gate is in alpha stage and is disabled by default.
   It is expected to move to beta phase and be enabled by default from Strimzi 0.37.
+* The `KafkaNodePools` feature gate is in alpha stage and is disabled by default.
+  It is expected to move to beta phase and be enabled by default from Strimzi 0.39.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -58,6 +60,11 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`StableConnectIdentities`
 ¦0.34
 ¦0.37 (planned)
+¦ -
+
+¦`KafkaNodePools`
+¦0.36
+¦0.39 (planned)
 ¦ -
 
 |===

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -73,8 +73,6 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 * SCRAM-SHA-512 authentication is not supported.
 * JBOD storage is not supported. 
   The `type: jbod` storage can be used, but the JBOD array can contain only one disk.
-* All Kafka nodes have both the `controller` and `broker` KRaft roles.
-  Kafka clusters with separate `controller` and `broker` nodes are not supported.
 
 .Enabling the UseKRaft feature gate
 To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
@@ -92,3 +90,40 @@ This helps to minimize the number of rebalances of connector tasks.
 To enable the `StableConnectIdentities` feature gate, specify `+StableConnectIdentities` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 IMPORTANT: The `StableConnectIdentities` feature gate must be disabled when downgrading to Strimzi 0.33 and earlier versions.
+
+[id='ref-operator-kafka-node-pools-feature-gate-{context}']
+== (Preview) KafkaNodePools feature gate
+
+The `KafkaNodePools` feature gate has a default state of _disabled_.
+
+The `KafkaNodePools` feature gate introduces a new `KafkaNodePool` custom resource that enables the configuration of different _pools_ of Apache Kafka nodes.
+A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
+Each pool has its own unique configuration, which includes mandatory settings such as the number of replicas, storage configuration, and a list of assigned roles.
+You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool in the `.spec.roles` field.
+When used with ZooKeeper-based Apache Kafka cluster, it must be always set to the `broker` role only.
+When used with the `UseKRaft` feature gate, it can be set to `broker`, `controller`, or both.
+In addition, a node pool can have its own configuration of resource requests and limits, Java JVM options, and resource templates.
+Configuration options not set in the `KafkaNodePool` resource are inherited from the `Kafka` custom resource.
+
+The `KafkaNodePool` resources use a `strimzi.io/cluster` label to indicate to which Kafka cluster they belong.
+The label must be set to the name of the `Kafka` custom resource.
+
+Examples of the `KafkaNodePool` resources can be found in the xref:config-examples-{context}[example configuration files] provided by Strimzi.
+
+.Enabling the KafkaNodePools feature gate
+
+To enable the `KafkaNodePools` feature gate, specify `+KafkaNodePools` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+The `Kafka` custom resource using the node pools must also have the annotation `strimzi.io/node-pools: enabled`.
+
+.Migrating existing Kafka clusters
+
+To migrate existing Kafka clusters to use `KafkaNodePools`, follow these steps:
+
+. Create a new `KafkaNodePool` resource:
+.. Name the resource `kafka` and label it with `strimzi.io/cluster`, pointing to your existing `Kafka` resource.
+.. Set the replica count and storage configuration in the `KafkaNodePool` resource to match your current Kafka cluster.
+.. Set the roles to `broker` in the `KafkaNodePool` resource.
+
+. Enable the `KafkaNodePools` feature gate:
+.. Update the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration to include `+KafkaNodePools`.
+.. Add the `strimzi.io/node-pools: enabled` annotation to your existing `Kafka` custom resource.

--- a/packaging/examples/kafka/nodepools/README.md
+++ b/packaging/examples/kafka/nodepools/README.md
@@ -1,0 +1,30 @@
+# Kafka Node Pool examples
+
+The examples in this directory show how you can use the Kafka node pool to set up your Kafka cluster.
+The Kafka node pools are currently protected by a feature gate `KafkaNodePools` which is in _alpha_ phase and is disabled by default.
+
+_NOTE: Feature gates in the _alpha_ stage should be considered as experimental / in development and should not be used in production._
+_Backward incompatible changes might be made to such feature gates or they might be simply removed._
+
+If you want to try out the `KafkaNodePools` feature gate and the examples from this directory, you have to enable the feature gate first.
+
+## Regular examples
+
+The [`kafka.yaml`](./kafka.yaml) example shows a regular Kafka cluster backed by ZooKeeper.
+This example file deploys a ZooKeeper cluster with 3 nodes and 2 different pools of Kafka brokers.
+Each of the pools has 3 brokers.
+The pools in the example use different storage configuration.
+
+## KRaft (ZooKeeper-less) examples
+
+The KRaft examples show an example of a Kafka cluster in the KRaft mode (i.e. without the ZooKeeper cluster).
+The [`kafka-with-kraft.yaml`](./kafka-with-kraft.yaml) deploys a Kafka cluster with one pool of _KRaft controller_ nodes and one pool of _KRaft broker_ nodes.
+The [`kafka-with-dual-role-kraft-nodes.yaml`](./kafka-with-dual-role-kraft-nodes.yaml) deploys a Kafka cluster with one pool of KRaft nodes that share the _broker_ and _controller_ roles.
+
+_NOTE: To use this example, you have to enable the `UseKRaft` feature gate in addition to the `KafkaNodePools` feature gate._
+
+Please be aware that ZooKeeper-less Kafka is still a work in progress and is still missing many features.
+For example:
+* The controller-only nodes are currently not rolled by Strimzi when their configuration changes due to the limitations of the Kafka Admin API. 
+* SCRAM-SHA-512 is not supported.
+* JBOD storage is not supported (you can use the `type: jbod` storage in the Strimzi custom resources, but it should contain only a single volume)

--- a/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
@@ -1,0 +1,67 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        deleteClaim: false
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    version: 3.4.0
+    # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      inter.broker.protocol.version: "3.4"
+    # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  # The ZooKeeper section is required by the Kafka CRD schema while the UseKRaft feature gate is in alpha phase.
+  # But it will be ignored when running in KRaft mode
+  zookeeper:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    userOperator: {}

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
@@ -1,0 +1,85 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        deleteClaim: false
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: broker
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    version: 3.4.0
+    # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      inter.broker.protocol.version: "3.4"
+    # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  # The ZooKeeper section is required by the Kafka CRD schema while the UseKRaft feature gate is in alpha phase.
+  # But it will be ignored when running in KRaft mode
+  zookeeper:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    userOperator: {}

--- a/packaging/examples/kafka/nodepools/kafka.yaml
+++ b/packaging/examples/kafka/nodepools/kafka.yaml
@@ -1,0 +1,84 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: pool-b
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 200Gi
+        deleteClaim: false
+---
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    version: 3.4.0
+    # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      inter.broker.protocol.version: "3.4"
+    # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the initial examples and documentation for the `KafkaNodePools` feature gate added in the #8551 PR. This is a separate PR to simplify the reviews, but should be merged only after #8551.

### Checklist

- [x] Update documentation