### PR TITLE
ST: Prefix olm related test classes with Olm string to make more readable

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAllNamespaceIsolatedST.java
@@ -13,18 +13,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.util.Collections;
-
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
+import static io.strimzi.systemtest.Constants.WATCH_ALL_NAMESPACES;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag(OLM)
 @IsolatedSuite
-public class SingleNamespaceIsolatedST extends OlmAbstractST {
+public class OlmAllNamespaceIsolatedST extends OlmAbstractST {
 
     public static final String NAMESPACE = "olm-namespace";
 
@@ -85,13 +84,12 @@ public class SingleNamespaceIsolatedST extends OlmAbstractST {
         // delete shared ClusterOperator
         clusterOperator.unInstall();
         clusterOperator = clusterOperator.defaultInstallation()
-            .withNamespace(NAMESPACE)
-            .withWatchingNamespaces(NAMESPACE)
-            .withBindingsNamespaces(Collections.singletonList(NAMESPACE))
+            .withNamespace(cluster.getDefaultOlmNamespace())
+            .withWatchingNamespaces(WATCH_ALL_NAMESPACES)
             .createInstallation()
             // run always OLM installation
             .runOlmInstallation();
 
-        cluster.setNamespace(NAMESPACE);
+        cluster.setNamespace(clusterOperator.getDeploymentNamespace());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmSingleNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmSingleNamespaceIsolatedST.java
@@ -13,17 +13,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Collections;
+
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
-import static io.strimzi.systemtest.Constants.WATCH_ALL_NAMESPACES;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag(OLM)
 @IsolatedSuite
-public class AllNamespacesIsolatedST extends OlmAbstractST {
+public class OlmSingleNamespaceIsolatedST extends OlmAbstractST {
 
     public static final String NAMESPACE = "olm-namespace";
 
@@ -84,12 +85,13 @@ public class AllNamespacesIsolatedST extends OlmAbstractST {
         // delete shared ClusterOperator
         clusterOperator.unInstall();
         clusterOperator = clusterOperator.defaultInstallation()
-            .withNamespace(cluster.getDefaultOlmNamespace())
-            .withWatchingNamespaces(WATCH_ALL_NAMESPACES)
+            .withNamespace(NAMESPACE)
+            .withWatchingNamespaces(NAMESPACE)
+            .withBindingsNamespaces(Collections.singletonList(NAMESPACE))
             .createInstallation()
             // run always OLM installation
             .runOlmInstallation();
 
-        cluster.setNamespace(clusterOperator.getDeploymentNamespace());
+        cluster.setNamespace(NAMESPACE);
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR renames OLM related test classes. Prefix `Olm` is added to distinguish the classes from classes with very similar names.

### Checklist

- [ ] Make sure all tests pass
- [ ] Update documentation

